### PR TITLE
MPT-32 run external-james test when JAMES_ADDRESS env is set

### DIFF
--- a/mpt/impl/imap-mailbox/external-james/pom.xml
+++ b/mpt/impl/imap-mailbox/external-james/pom.xml
@@ -157,6 +157,17 @@
                 </plugins>
             </build>
         </profile>
+	<profile>
+          <id>test-external-james</id>
+	  <activation>
+	      <property>
+		  <name>!env.JAMES_ADDRESS</name>
+	      </property>
+	  </activation>
+	  <properties>
+	    <skipTests>true</skipTests>
+	  </properties>
+        </profile>
         <profile>
             <id>disable-animal-sniffer</id>
             <activation>

--- a/mpt/pom.xml
+++ b/mpt/pom.xml
@@ -95,7 +95,7 @@
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <derby.version>10.9.1.0</derby.version>
-        <guice.version>3.0</guice.version>
+        <guice.version>4.0</guice.version>
         <h2.version>1.3.170</h2.version>
         <hadoop.version>1.0.1</hadoop.version>
         <hbase.version>0.94.27</hbase.version>


### PR DESCRIPTION
	Switch to Guice 4 because exception in java 8 lambda
	breaks Guice 3 error reporting.