### PR TITLE
MPT-33 introduce namespace support feature and run related tests only…

### DIFF
--- a/mpt/core/src/main/java/org/apache/james/mpt/api/HostSystem.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/api/HostSystem.java
@@ -35,6 +35,8 @@ import org.apache.james.mpt.host.ExternalHostSystem;
  */
 public interface HostSystem extends SessionFactory {
 
+    String NAMESPACE_SUPPORT = "namespace-support";
+    
     /**
      * Add a user for testing.
      * 

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxTestModule.java
@@ -26,12 +26,14 @@ import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystem;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 public class CassandraMailboxTestModule extends AbstractModule {
 
     @Override
     protected void configure() {
         bind(HostSystem.class).to(ImapHostSystem.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 
     @Provides

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/AuthenticatedState.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/AuthenticatedState.java
@@ -24,14 +24,21 @@ import java.util.Locale;
 import javax.inject.Inject;
 
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mpt.api.HostSystem;
 import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.suite.base.BaseAuthenticatedState;
+import org.junit.Assume;
 import org.junit.Test;
+
+import com.google.inject.name.Named;
 
 public class AuthenticatedState extends BaseAuthenticatedState {
     
     @Inject
     private static ImapHostSystem system;
+    @Inject @Named(HostSystem.NAMESPACE_SUPPORT)
+    private Boolean namespaceSupport;
+
     
     public AuthenticatedState() throws Exception {
         super(system);
@@ -324,18 +331,21 @@ public class AuthenticatedState extends BaseAuthenticatedState {
 
     @Test
     public void listShouldNotListMailboxWithOtherNamspaceUS() throws Exception {
+        Assume.assumeTrue(namespaceSupport);
         system.createMailbox(new MailboxPath("#namespace", USER, "Other"));
         scriptTest("ListMailboxes", Locale.US);
     }
 
     @Test
     public void listShouldNotListMailboxWithOtherNamspaceITALY() throws Exception {
+        Assume.assumeTrue(namespaceSupport);
         system.createMailbox(new MailboxPath("#namespace", USER, "Other"));
         scriptTest("ListMailboxes", Locale.ITALY);
     }
 
     @Test
     public void listShouldNotListMailboxWithOtherNamspaceKOREA() throws Exception {
+        Assume.assumeTrue(namespaceSupport);
         system.createMailbox(new MailboxPath("#namespace", USER, "Other"));
         scriptTest("ListMailboxes", Locale.KOREA);
     }

--- a/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/CyrusMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/CyrusMailboxTestModule.java
@@ -11,7 +11,9 @@ import org.apache.james.mpt.imapmailbox.cyrus.host.CyrusUserAdder;
 import org.apache.james.mpt.imapmailbox.cyrus.host.Docker;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
 import com.spotify.docker.client.messages.ContainerCreation;
+
 import org.apache.james.mpt.imapmailbox.cyrus.host.GrantRightsOnCyrusHost;
 import org.apache.james.mpt.imapmailbox.cyrus.host.MailboxMessageAppenderOnCyrusHost;
 
@@ -27,5 +29,6 @@ public class CyrusMailboxTestModule extends AbstractModule {
         bind(UserAdder.class).to(CyrusUserAdder.class);
         bind(GrantRightsOnHost.class).to(GrantRightsOnCyrusHost.class);
         bind(MailboxMessageAppender.class).to(MailboxMessageAppenderOnCyrusHost.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 }

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/ElasticSearchMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/ElasticSearchMailboxTestModule.java
@@ -20,6 +20,8 @@
 package org.apache.james.mpt.imapmailbox.elasticsearch;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
 import org.apache.james.mpt.api.HostSystem;
 import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.elasticsearch.host.ElasticSearchHostSystem;
@@ -29,5 +31,6 @@ public class ElasticSearchMailboxTestModule extends AbstractModule {
     protected void configure() {
         bind(ImapHostSystem.class).to(ElasticSearchHostSystem.class);
         bind(HostSystem.class).to(ElasticSearchHostSystem.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 }

--- a/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/ExternalJamesModule.java
+++ b/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/ExternalJamesModule.java
@@ -20,6 +20,8 @@
 package org.apache.james.mpt.imapmailbox.external.james;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
 import org.apache.james.mpt.api.HostSystem;
 import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.api.UserAdder;
@@ -35,6 +37,7 @@ public class ExternalJamesModule extends AbstractModule {
         bind(HostSystem.class).to(ExternalJamesHostSystem.class);
         bind(ExternalHostSystem.class).to(ExternalJamesHostSystem.class);
         bind(UserAdder.class).to(ExternalJamesUserAdder.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 
 }

--- a/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/HBaseMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/HBaseMailboxTestModule.java
@@ -7,12 +7,14 @@ import org.apache.james.mpt.imapmailbox.hbase.host.HBaseHostSystem;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 public class HBaseMailboxTestModule extends AbstractModule {
 
     @Override
     protected void configure() {
         bind(HostSystem.class).to(ImapHostSystem.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 
     @Provides

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxTestModule.java
@@ -25,12 +25,14 @@ import org.apache.james.mpt.imapmailbox.inmemory.host.InMemoryHostSystem;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 public class InMemoryMailboxTestModule extends AbstractModule {
 
     @Override
     protected void configure() {
         bind(HostSystem.class).to(ImapHostSystem.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 
     @Provides

--- a/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/JcrMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/JcrMailboxTestModule.java
@@ -25,12 +25,14 @@ import org.apache.james.mpt.imapmailbox.jcr.host.JCRHostSystem;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 public class JcrMailboxTestModule extends AbstractModule {
 
     @Override
     protected void configure() {
         bind(HostSystem.class).to(ImapHostSystem.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 
     @Provides

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/JpaMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/JpaMailboxTestModule.java
@@ -25,12 +25,14 @@ import org.apache.james.mpt.imapmailbox.jpa.host.JPAHostSystem;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 public class JpaMailboxTestModule extends AbstractModule {
 
     @Override
     protected void configure() {
         bind(HostSystem.class).to(ImapHostSystem.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(true);
     }
 
     @Provides

--- a/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/MaildirMailboxTestModule.java
+++ b/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/MaildirMailboxTestModule.java
@@ -25,12 +25,14 @@ import org.apache.james.mpt.imapmailbox.maildir.host.MaildirHostSystem;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 public class MaildirMailboxTestModule extends AbstractModule {
 
     @Override
     protected void configure() {
         bind(HostSystem.class).to(ImapHostSystem.class);
+        bindConstant().annotatedWith(Names.named(HostSystem.NAMESPACE_SUPPORT)).to(false);
     }
 
     @Provides


### PR DESCRIPTION
… when supported

	This uses junit Assume that allowes to disable a test when a
	condition if false.

	TestModules have to define a boolean to advertise support of namespace.