### PR TITLE
JAMES-1624 move add-to-repo action to install phase

### DIFF
--- a/server/karaf/distribution/pom.xml
+++ b/server/karaf/distribution/pom.xml
@@ -121,7 +121,7 @@
                 <executions>
                     <execution>
                         <id>add-features-to-repo</id>
-                        <phase>compile</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>add-features-to-repo</goal>
                         </goals>


### PR DESCRIPTION
	This tasks takes artifacts from maven repository and put them in
	target/ directory. It actually needs these artifacts to be installed,
	and it obviously fails if they are missing.