### PR TITLE
Mailbox 257

### DIFF
--- a/mailbox/tool/pom.xml
+++ b/mailbox/tool/pom.xml
@@ -53,12 +53,6 @@
             <artifactId>slf4j-simple</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.james</groupId>
-            <artifactId>apache-james-mailbox-api</artifactId>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-annotation_1.0_spec</artifactId>
         </dependency>
@@ -69,6 +63,23 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-james-mailbox-store</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/FakeReIndexer.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/FakeReIndexer.java
@@ -1,0 +1,36 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxPath;
+
+public class FakeReIndexer implements ReIndexer {
+
+    @Override
+    public void reIndex(MailboxPath path) throws MailboxException {
+        throw new MailboxException("Not implemented");
+    }
+
+    @Override
+    public void reIndex() throws MailboxException {
+        throw new MailboxException("Not implemented");
+    }
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/ReIndexer.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/ReIndexer.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxPath;
+
+public interface ReIndexer {
+
+    void reIndex(MailboxPath path) throws MailboxException;
+
+    void reIndex() throws MailboxException;
+
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/ReIndexerImpl.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/ReIndexerImpl.java
@@ -1,0 +1,138 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer;
+
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.indexer.events.FlagsMessageEvent;
+import org.apache.james.mailbox.indexer.events.ImpactingEventType;
+import org.apache.james.mailbox.indexer.events.ImpactingMessageEvent;
+import org.apache.james.mailbox.indexer.registrations.GlobalRegistration;
+import org.apache.james.mailbox.indexer.registrations.MailboxRegistration;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.model.Mailbox;
+import org.apache.james.mailbox.store.mail.model.MailboxId;
+import org.apache.james.mailbox.store.mail.model.Message;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Note about live re-indexation handling :
+ *
+ *  - Data races may arise... If you modify the stored value between the received event check and the index operation,
+ *  you have an inconsistent behavior.
+ *
+ *  This class is more about supporting changes in real time for future indexed values. If you change a flags / delete
+ *  mails for instance, you will see it in the indexed value !
+ *
+ *  Why only care about updates and deletions ? Additions are already handled by the indexer that behaves normaly. We
+ *  should just "adapt" our indexed value to the latest value, if any. The normal indexer will take care of new stuff.
+ */
+public class ReIndexerImpl<Id extends MailboxId> implements ReIndexer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReIndexerImpl.class);
+    public static final int LIMIT = 0;
+
+    private final MailboxManager mailboxManager;
+    private final ListeningMessageSearchIndex<Id> messageSearchIndex;
+    private final MailboxSessionMapperFactory<Id> mailboxSessionMapperFactory;
+
+    public ReIndexerImpl(MailboxManager mailboxManager,
+                         ListeningMessageSearchIndex<Id> messageSearchIndex,
+                         MailboxSessionMapperFactory<Id> mailboxSessionMapperFactory) {
+        this.mailboxManager = mailboxManager;
+        this.messageSearchIndex = messageSearchIndex;
+        this.mailboxSessionMapperFactory = mailboxSessionMapperFactory;
+    }
+
+    public void reIndex(MailboxPath path) throws MailboxException {
+        MailboxSession mailboxSession = mailboxManager.createSystemSession("re-indexing", LOGGER);
+        reIndex(path, mailboxSession);
+    }
+
+
+    public synchronized void reIndex() throws MailboxException {
+        MailboxSession mailboxSession = mailboxManager.createSystemSession("re-indexing", LOGGER);
+        List<MailboxPath> mailboxPaths = mailboxManager.list(mailboxSession);
+        GlobalRegistration globalRegistration = new GlobalRegistration();
+        mailboxManager.addGlobalListener(globalRegistration, mailboxSession);
+        for (MailboxPath mailboxPath : mailboxPaths) {
+            if (globalRegistration.indexThisPath(mailboxPath)) {
+                reIndex(mailboxPath, mailboxSession);
+            }
+        }
+        mailboxManager.removeGlobalListener(globalRegistration, mailboxSession);
+    }
+
+    private void reIndex(MailboxPath path, MailboxSession mailboxSession) throws MailboxException {
+        MailboxRegistration mailboxRegistration = new MailboxRegistration(path);
+        mailboxManager.addListener(path, mailboxRegistration, mailboxSession);
+        LOGGER.info("Intend to reindex " + path);
+        Mailbox<Id> mailbox = mailboxSessionMapperFactory.getMailboxMapper(mailboxSession).findMailboxByPath(path);
+        messageSearchIndex.delete(mailboxSession, mailbox, MessageRange.all());
+        handleIterations(mailboxSession,
+            mailboxRegistration,
+            mailbox,
+            mailboxSessionMapperFactory.getMessageMapper(mailboxSession)
+                .findInMailbox(mailbox,
+                    MessageRange.all(),
+                    MessageMapper.FetchType.Full,
+                    LIMIT));
+        mailboxManager.removeListener(path, mailboxRegistration, mailboxSession);
+        LOGGER.info("Finish to reindex " + path);
+    }
+
+    private void handleIterations(MailboxSession mailboxSession, MailboxRegistration mailboxRegistration, Mailbox<Id> mailbox, Iterator<Message<Id>> iterator) throws MailboxException {
+        while (iterator.hasNext()) {
+            Message<Id> message = iterator.next();
+            ImpactingMessageEvent impactingMessageEvent = findMostRelevant(mailboxRegistration.getImpactingEvents(message.getUid()));
+            if (impactingMessageEvent == null) {
+                messageSearchIndex.add(mailboxSession, mailbox, message);
+            } else if (impactingMessageEvent instanceof FlagsMessageEvent) {
+                message.setFlags(((FlagsMessageEvent) impactingMessageEvent).getFlags());
+                messageSearchIndex.add(mailboxSession, mailbox, message);
+            }
+        }
+    }
+
+    private ImpactingMessageEvent findMostRelevant(Collection<ImpactingMessageEvent> messageEvents) {
+        if (messageEvents == null) {
+            return null;
+        }
+        ImpactingMessageEvent last = null;
+        for (ImpactingMessageEvent impactingMessageEvent : messageEvents) {
+            if (impactingMessageEvent.getType().equals(ImpactingEventType.Deletion)) {
+                return impactingMessageEvent;
+            }
+            last = impactingMessageEvent;
+        }
+        return last;
+    }
+
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/FlagsMessageEvent.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/FlagsMessageEvent.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer.events;
+
+import org.apache.james.mailbox.model.MailboxPath;
+
+import javax.mail.Flags;
+
+public class FlagsMessageEvent implements ImpactingMessageEvent {
+
+    private final MailboxPath mailboxPath;
+    private final long uid;
+    private final Flags flags;
+
+    public FlagsMessageEvent(MailboxPath mailboxPath, long uid, Flags flags) {
+        this.mailboxPath = mailboxPath;
+        this.uid = uid;
+        this.flags = flags;
+    }
+
+    @Override
+    public long getUid() {
+        return uid;
+    }
+
+    @Override
+    public MailboxPath getMailboxPath() {
+        return mailboxPath;
+    }
+
+    @Override
+    public ImpactingEventType getType() {
+        return ImpactingEventType.FlagsUpdate;
+    }
+
+    public Flags getFlags() {
+        return flags;
+    }
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/ImpactingEvent.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/ImpactingEvent.java
@@ -1,0 +1,30 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer.events;
+
+import org.apache.james.mailbox.model.MailboxPath;
+
+public interface ImpactingEvent {
+
+    MailboxPath getMailboxPath();
+
+    ImpactingEventType getType();
+
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/ImpactingEventType.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/ImpactingEventType.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer.events;
+
+public enum ImpactingEventType {
+    Deletion,
+    FlagsUpdate,
+    MailboxDeletion,
+    MailboxRename
+
+    /*
+    Note : additions are never impacting as it is well handled in real time by the existing indexer
+     */
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/ImpactingMessageEvent.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/ImpactingMessageEvent.java
@@ -1,0 +1,26 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer.events;
+
+public interface ImpactingMessageEvent extends ImpactingEvent {
+
+    long getUid();
+
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/MessageDeletedEvent.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/events/MessageDeletedEvent.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer.events;
+
+import org.apache.james.mailbox.model.MailboxPath;
+
+public class MessageDeletedEvent implements ImpactingMessageEvent {
+
+    private final MailboxPath mailboxPath;
+    private final long uid;
+
+    public MessageDeletedEvent(MailboxPath mailboxPath, long uid) {
+        this.mailboxPath = mailboxPath;
+        this.uid = uid;
+    }
+
+    @Override
+    public long getUid() {
+        return uid;
+    }
+
+    @Override
+    public MailboxPath getMailboxPath() {
+        return mailboxPath;
+    }
+
+    @Override
+    public ImpactingEventType getType() {
+        return ImpactingEventType.Deletion;
+    }
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/registrations/GlobalRegistration.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/registrations/GlobalRegistration.java
@@ -1,0 +1,47 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer.registrations;
+
+import org.apache.james.mailbox.MailboxListener;
+import org.apache.james.mailbox.model.MailboxPath;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class GlobalRegistration implements MailboxListener {
+
+    private final ConcurrentHashMap<MailboxPath, Boolean> impactingEvents;
+
+    public GlobalRegistration() {
+        this.impactingEvents = new ConcurrentHashMap<MailboxPath, Boolean>();
+    }
+
+    public boolean indexThisPath(MailboxPath mailboxPath) {
+        return impactingEvents.get(mailboxPath) != null;
+    }
+
+    @Override
+    public void event(Event event) {
+        if (event instanceof MailboxDeletion) {
+            impactingEvents.putIfAbsent(event.getMailboxPath(), true);
+        } else if (event instanceof Expunged) {
+            impactingEvents.putIfAbsent(event.getMailboxPath(), true);
+        }
+    }
+}

--- a/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/registrations/MailboxRegistration.java
+++ b/mailbox/tool/src/main/java/org/apache/james/mailbox/indexer/registrations/MailboxRegistration.java
@@ -1,0 +1,62 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer.registrations;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import org.apache.james.mailbox.MailboxListener;
+import org.apache.james.mailbox.indexer.events.FlagsMessageEvent;
+import org.apache.james.mailbox.indexer.events.ImpactingMessageEvent;
+import org.apache.james.mailbox.indexer.events.MessageDeletedEvent;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.UpdatedFlags;
+
+import java.util.Collection;
+
+public class MailboxRegistration implements MailboxListener {
+
+    private final Multimap<Long, ImpactingMessageEvent> impactingMessageEvents;
+    private final MailboxPath mailboxPath;
+
+    public MailboxRegistration(MailboxPath mailboxPath) {
+        this.impactingMessageEvents = Multimaps.synchronizedMultimap(ArrayListMultimap.<Long, ImpactingMessageEvent>create());
+        this.mailboxPath = mailboxPath;
+    }
+
+    public Collection<ImpactingMessageEvent> getImpactingEvents(long uid) {
+        return ImmutableList.copyOf(impactingMessageEvents.get(uid));
+    }
+
+    @Override
+    public void event(Event event) {
+        if (event instanceof FlagsUpdated) {
+            for (UpdatedFlags updatedFlags : ((FlagsUpdated) event).getUpdatedFlags()) {
+                impactingMessageEvents.put(updatedFlags.getUid(), new FlagsMessageEvent(mailboxPath, updatedFlags.getUid(), updatedFlags.getNewFlags()));
+            }
+        } else if (event instanceof Expunged) {
+            for (Long uid: ((Expunged) event).getUids()) {
+                impactingMessageEvents.put(uid, new MessageDeletedEvent(mailboxPath, uid));
+            }
+        }
+    }
+
+}

--- a/mailbox/tool/src/main/resources/META-INF/spring/mailbox-tools.xml
+++ b/mailbox/tool/src/main/resources/META-INF/spring/mailbox-tools.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id ="reindexer-impl" class="org.apache.james.mailbox.indexer.ReIndexerImpl" lazy-init="true">
+        <constructor-arg index="0" ref="mailboxmanager"/>
+        <constructor-arg index="1" ref="indexer"/>
+        <constructor-arg index="2" ref="messageMapperFactory"/>
+    </bean>
+
+    <bean id ="fake-reindexer" class="org.apache.james.mailbox.indexer.FakeReIndexer" lazy-init="true"/>
+
+</beans>

--- a/mailbox/tool/src/test/java/org/apache/james/mailbox/indexer/ReIndexerImplTest.java
+++ b/mailbox/tool/src/test/java/org/apache/james/mailbox/indexer/ReIndexerImplTest.java
@@ -1,0 +1,123 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.indexer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.mailbox.MailboxListener;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.mock.MockMailboxSession;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
+import org.apache.james.mailbox.store.MessageBuilder;
+import org.apache.james.mailbox.store.TestId;
+import org.apache.james.mailbox.store.mail.MailboxMapper;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.model.Mailbox;
+import org.apache.james.mailbox.store.mail.model.Message;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+
+import java.util.Iterator;
+
+public class ReIndexerImplTest {
+
+    public static final MailboxPath INBOX = new MailboxPath("#private", "benwa@apache.org", "INBOX");
+    public static final int LIMIT = 0;
+    private MailboxManager mailboxManager;
+    private MailboxSessionMapperFactory<TestId> mailboxSessionMapperFactory;
+    private ListeningMessageSearchIndex<TestId> messageSearchIndex;
+
+    private ReIndexer reIndexer;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() {
+        mailboxManager = mock(MailboxManager.class);
+        mailboxSessionMapperFactory = mock(MailboxSessionMapperFactory.class);
+        messageSearchIndex = mock(ListeningMessageSearchIndex.class);
+        reIndexer = new ReIndexerImpl<TestId>(mailboxManager, messageSearchIndex, mailboxSessionMapperFactory);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test() throws Exception {
+        final MockMailboxSession mockMailboxSession = new MockMailboxSession("re-indexing");
+        when(mailboxManager.createSystemSession(any(String.class), any(Logger.class))).thenAnswer(new Answer<MailboxSession>() {
+            @Override
+            public MailboxSession answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return mockMailboxSession;
+            }
+        });
+        final MessageMapper<TestId> messageMapper = mock(MessageMapper.class);
+        final MailboxMapper<TestId> mailboxMapper = mock(MailboxMapper.class);
+        when(mailboxSessionMapperFactory.getMessageMapper(any(MailboxSession.class))).thenAnswer(new Answer<MessageMapper<TestId>>() {
+            @Override
+            public MessageMapper<TestId> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return messageMapper;
+            }
+        });
+        when(mailboxSessionMapperFactory.getMailboxMapper(any(MailboxSession.class))).thenAnswer(new Answer<MailboxMapper<TestId>>() {
+            @Override
+            public MailboxMapper<TestId> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return mailboxMapper;
+            }
+        });
+        final Message<TestId> message = new MessageBuilder().build();
+        final SimpleMailbox<TestId> mailbox = new SimpleMailbox<TestId>(INBOX, 42);
+        mailbox.setMailboxId(message.getMailboxId());
+        when(mailboxMapper.findMailboxByPath(INBOX)).thenAnswer(new Answer<Mailbox<TestId>>() {
+            @Override
+            public Mailbox<TestId> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return mailbox;
+            }
+        });
+        when(messageMapper.findInMailbox(mailbox, MessageRange.all(), MessageMapper.FetchType.Full, LIMIT)).thenAnswer(new Answer<Iterator<Message<TestId>>>() {
+            @Override
+            public Iterator<Message<TestId>> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return Lists.newArrayList(message).iterator();
+            }
+        });
+        reIndexer.reIndex(INBOX);
+        verify(mailboxManager).createSystemSession(any(String.class), any(Logger.class));
+        verify(mailboxSessionMapperFactory).getMailboxMapper(mockMailboxSession);
+        verify(mailboxSessionMapperFactory).getMessageMapper(mockMailboxSession);
+        verify(mailboxMapper).findMailboxByPath(INBOX);
+        verify(messageMapper).findInMailbox(mailbox, MessageRange.all(), MessageMapper.FetchType.Full, LIMIT);
+        verify(mailboxManager).addListener(eq(INBOX), any(MailboxListener.class), any(MailboxSession.class));
+        verify(mailboxManager).removeListener(eq(INBOX), any(MailboxListener.class), any(MailboxSession.class));
+        verify(messageSearchIndex).add(any(MailboxSession.class), eq(mailbox), eq(message));
+        verify(messageSearchIndex).delete(any(MailboxSession.class), eq(mailbox), eq(MessageRange.all()));
+        verifyNoMoreInteractions(mailboxMapper, mailboxSessionMapperFactory, messageSearchIndex, messageMapper, mailboxMapper);
+    }
+}

--- a/server/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
+++ b/server/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
@@ -256,6 +256,12 @@ public class ServerCmd {
         case GETDEFAULTMAXMESSAGECOUNTQUOTA:
             System.out.println("Default Maximum message count Quota : " + formatMessageValue(probe.getDefaultMaxMessageCount()));
             break;
+        case REINDEXMAILBOX:
+            probe.reIndexMailbox(arguments[1], arguments[2], arguments[3]);
+            break;
+        case REINDEXALL:
+            probe.reIndexAll();
+            break;
         default:
             throw new UnrecognizedCommandException(cmdType.getCommand());
         }

--- a/server/container/cli/src/main/java/org/apache/james/cli/probe/ServerProbe.java
+++ b/server/container/cli/src/main/java/org/apache/james/cli/probe/ServerProbe.java
@@ -244,4 +244,8 @@ public interface ServerProbe extends Closeable {
     void setDefaultMaxMessageCount(long maxDefaultMessageCount) throws MailboxException;
 
     void setDefaultMaxStorage(long maxDefaultSize) throws MailboxException;
+
+    void reIndexMailbox(String namespace, String user, String name) throws Exception;
+
+    void reIndexAll() throws Exception;
 }

--- a/server/container/cli/src/main/java/org/apache/james/cli/probe/impl/JmxServerProbe.java
+++ b/server/container/cli/src/main/java/org/apache/james/cli/probe/impl/JmxServerProbe.java
@@ -33,6 +33,7 @@ import javax.management.remote.JMXServiceURL;
 import org.apache.james.adapter.mailbox.MailboxCopierManagementMBean;
 import org.apache.james.adapter.mailbox.MailboxManagerManagementMBean;
 import org.apache.james.adapter.mailbox.QuotaManagementMBean;
+import org.apache.james.adapter.mailbox.ReIndexerManagementMBean;
 import org.apache.james.adapter.mailbox.SerializableQuota;
 import org.apache.james.cli.probe.ServerProbe;
 import org.apache.james.domainlist.api.DomainListManagementMBean;
@@ -49,6 +50,7 @@ public class JmxServerProbe implements ServerProbe {
     private final static String MAILBOXCOPIER_OBJECT_NAME = "org.apache.james:type=component,name=mailboxcopier";
     private final static String MAILBOXMANAGER_OBJECT_NAME = "org.apache.james:type=component,name=mailboxmanagerbean";
     private final static String QUOTAMANAGER_OBJECT_NAME = "org.apache.james:type=component,name=quotamanagerbean";
+    private final static String REINDEXER_OBJECT_NAME = "org.apache.james:type=component,name=reindexerbean";
 
     private JMXConnector jmxc;
     
@@ -58,6 +60,7 @@ public class JmxServerProbe implements ServerProbe {
     private MailboxCopierManagementMBean mailboxCopierManagement;
     private MailboxManagerManagementMBean mailboxManagerManagement;
     private QuotaManagementMBean quotaManagement;
+    private ReIndexerManagementMBean reIndexerManagement;
 
     private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
     private static final int defaultPort = 9999;
@@ -118,6 +121,9 @@ public class JmxServerProbe implements ServerProbe {
             name = new ObjectName(QUOTAMANAGER_OBJECT_NAME);
             quotaManagement = MBeanServerInvocationHandler.newProxyInstance(
                     mbeanServerConn, name, QuotaManagementMBean.class, true);
+            name = new ObjectName(REINDEXER_OBJECT_NAME);
+            reIndexerManagement = MBeanServerInvocationHandler.newProxyInstance(
+                mbeanServerConn, name, ReIndexerManagementMBean.class, true);
         } catch (MalformedObjectNameException e) {
             throw new RuntimeException("Invalid ObjectName? Please report this as a bug.", e);
         }
@@ -276,5 +282,15 @@ public class JmxServerProbe implements ServerProbe {
     @Override
     public void setDefaultMaxStorage(long maxDefaultSize) throws MailboxException {
         quotaManagement.setDefaultMaxStorage(maxDefaultSize);
+    }
+
+    @Override
+    public void reIndexMailbox(String namespace, String user, String name) throws Exception {
+        reIndexerManagement.reIndex(namespace, user, name);
+    }
+
+    @Override
+    public void reIndexAll() throws Exception {
+        reIndexerManagement.reIndex();
     }
 }

--- a/server/container/cli/src/main/java/org/apache/james/cli/type/CmdType.java
+++ b/server/container/cli/src/main/java/org/apache/james/cli/type/CmdType.java
@@ -51,7 +51,9 @@ public enum CmdType {
     SETDEFAULTMAXSTORAGEQUOTA("setdefaultmaxstoragequota", "max_storage"),
     SETDEFAULTMAXMESSAGECOUNTQUOTA("setdefaultmaxmessagecountquota", "max_message_count"),
     GETDEFAULTMAXSTORAGEQUOTA("getdefaultmaxstoragequota"),
-    GETDEFAULTMAXMESSAGECOUNTQUOTA("getdefaultmaxmessagecountquota");
+    GETDEFAULTMAXMESSAGECOUNTQUOTA("getdefaultmaxmessagecountquota"),
+    REINDEXMAILBOX("reindexmailbox", "namespace", "user", "name"),
+    REINDEXALL("reindexall");
 
     private final String command;
     private final String[] arguments;

--- a/server/container/cli/src/test/java/org/apache/james/cli/ServerCmdTest.java
+++ b/server/container/cli/src/test/java/org/apache/james/cli/ServerCmdTest.java
@@ -479,6 +479,35 @@ public class ServerCmdTest {
         control.verify();
     }
 
+    @Test
+    public void reIndexAllQuotaCommandShouldWork() throws Exception {
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.REINDEXALL.getCommand()};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        serverProbe.reIndexAll();
+        expectLastCall();
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void reIndexMailboxCommandShouldWork() throws Exception {
+        String namespace = "#private";
+        String user = "btellier@apache.org";
+        String name = "INBOX";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.REINDEXMAILBOX.getCommand(), namespace, user, name};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        serverProbe.reIndexMailbox(namespace, user, name);
+        expectLastCall();
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
     @Test(expected = InvalidArgumentNumberException.class)
     public void addDomainCommandShouldThrowOnMissingArguments() throws Exception {
         String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.ADDDOMAIN.getCommand()};
@@ -972,6 +1001,35 @@ public class ServerCmdTest {
     public void listUserMailboxesMappingsCommandShouldThrowOnAdditionalArguments() throws Exception {
         String user = "user@domain";
         String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.LISTUSERMAILBOXES.getCommand(), user, ADDITIONAL_ARGUMENT };
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        control.replay();
+        try {
+            testee.executeCommandLine(commandLine);
+        } finally {
+            control.verify();
+        }
+    }
+
+    @Test(expected = InvalidArgumentNumberException.class)
+    public void reIndexAllCommandShouldThrowOnAdditionalArguments() throws Exception {
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.REINDEXALL.getCommand(), ADDITIONAL_ARGUMENT };
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        control.replay();
+        try {
+            testee.executeCommandLine(commandLine);
+        } finally {
+            control.verify();
+        }
+    }
+
+    @Test(expected = InvalidArgumentNumberException.class)
+    public void reIndexMailboxCommandShouldThrowOnAdditionalArguments() throws Exception {
+        String user = "user@domain";
+        String namespace = "#private";
+        String name = "INBOX.test";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.REINDEXMAILBOX.getCommand(), namespace, user, name, ADDITIONAL_ARGUMENT };
         CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
 
         control.replay();

--- a/server/container/cli/src/test/java/org/apache/james/cli/type/CmdTypeTest.java
+++ b/server/container/cli/src/test/java/org/apache/james/cli/type/CmdTypeTest.java
@@ -189,8 +189,13 @@ public class CmdTypeTest {
     }
 
     @Test
-    public void lookupGetQuotaRootShouldReturnEnumValue() {
-        assertThat(CmdType.lookup("getquotaroot")).isEqualTo(CmdType.GETQUOTAROOT);
+    public void lookupReIndexMailboxShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("reindexall")).isEqualTo(CmdType.REINDEXALL);
+    }
+
+    @Test
+    public void lookupReIndexAllShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("reindexmailbox")).isEqualTo(CmdType.REINDEXMAILBOX);
     }
 
     @Test 

--- a/server/container/mailbox-adapter/pom.xml
+++ b/server/container/mailbox-adapter/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>apache-james-mailbox-maildir</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-james-mailbox-tool</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/server/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/ReIndexerManagement.java
+++ b/server/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/ReIndexerManagement.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.adapter.mailbox;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.indexer.ReIndexer;
+import org.apache.james.mailbox.model.MailboxPath;
+
+public class ReIndexerManagement implements ReIndexerManagementMBean {
+
+    private final ReIndexer reIndexer;
+
+    public ReIndexerManagement(ReIndexer reIndexer) {
+        this.reIndexer = reIndexer;
+    }
+
+    @Override
+    public void reIndex(String namespace, String user, String name) throws MailboxException {
+        reIndexer.reIndex(new MailboxPath(namespace, user, name));
+    }
+
+    @Override
+    public void reIndex() throws MailboxException {
+        reIndexer.reIndex();
+    }
+}

--- a/server/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/ReIndexerManagementMBean.java
+++ b/server/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/ReIndexerManagementMBean.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.adapter.mailbox;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.indexer.ReIndexer;
+import org.apache.james.mailbox.model.MailboxPath;
+
+public interface ReIndexerManagementMBean  {
+
+    void reIndex(String namespace, String user, String name) throws MailboxException;
+
+    void reIndex() throws MailboxException;
+
+}

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/IndexerConfigurationBeanFactoryPostProcessor.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/IndexerConfigurationBeanFactoryPostProcessor.java
@@ -49,15 +49,19 @@ public class IndexerConfigurationBeanFactoryPostProcessor implements BeanFactory
 
             BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
             String indexer = null;
+            String reIndexer = null;
             if (provider.equalsIgnoreCase("lazyIndex")) {
                 indexer = "lazyIndex";
+                reIndexer = "fake-reindexer";
             } else if (provider.equalsIgnoreCase("elasticsearch")) {
                 indexer = "elasticsearch-listener";
+                reIndexer = "reindexer-impl";
             }
 
             if (indexer == null)
                 throw new ConfigurationException("Indexer provider " + provider + " not supported!");
             registry.registerAlias(indexer, "indexer");
+            registry.registerAlias(reIndexer, "reindexer");
 
         } catch (ConfigurationException e) {
             throw new FatalBeanException("Unable to config the indexer", e);

--- a/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -234,12 +234,13 @@
                 -->
                 <entry key="org.apache.james:type=container,name=logprovider" value-ref="logprovider"/>
                 <entry key="org.apache.james:type=component,name=quotamanagerbean" value-ref="quotamanagermanagement"/>
+                <entry key="org.apache.james:type=component,name=reindexerbean" value-ref="reindexermanagement"/>
             </map>
         </property>
         <property name="assembler">
             <bean class="org.springframework.jmx.export.assembler.InterfaceBasedMBeanInfoAssembler">
                 <property name="managedInterfaces"
-                          value="org.apache.james.fetchmail.FetchSchedulerMBean,org.apache.james.domainlist.api.DomainListManagementMBean,org.apache.james.dnsservice.api.DNSServiceMBean,org.apache.james.rrt.api.RecipientRewriteTableManagementMBean,org.apache.james.user.api.UsersRepositoryManagementMBean,org.apache.james.adapter.mailbox.MailboxManagerManagementMBean,org.apache.james.adapter.mailbox.MailboxCopierManagementMBean,org.apache.james.mailetcontainer.api.jmx.MailSpoolerMBean,org.apache.james.container.spring.lifecycle.LogProviderManagementMBean,org.apache.james.adapter.mailbox.QuotaManagementMBean"/>
+                          value="org.apache.james.fetchmail.FetchSchedulerMBean,org.apache.james.domainlist.api.DomainListManagementMBean,org.apache.james.dnsservice.api.DNSServiceMBean,org.apache.james.rrt.api.RecipientRewriteTableManagementMBean,org.apache.james.user.api.UsersRepositoryManagementMBean,org.apache.james.adapter.mailbox.MailboxManagerManagementMBean,org.apache.james.adapter.mailbox.MailboxCopierManagementMBean,org.apache.james.mailetcontainer.api.jmx.MailSpoolerMBean,org.apache.james.container.spring.lifecycle.LogProviderManagementMBean,org.apache.james.adapter.mailbox.QuotaManagementMBean,org.apache.james.adapter.mailbox.ReIndexerManagementMBean"/>
             </bean>
         </property>
     </bean>
@@ -253,6 +254,9 @@
         <property name="maxQuotaManager" ref="maxQuotaManager"/>
         <property name="quotaRootResolver" ref="quotaRootResolver"/>
         <property name="quotaManager" ref="quotaManager"/>
+    </bean>
+    <bean id="reindexermanagement" class="org.apache.james.adapter.mailbox.ReIndexerManagement">
+        <constructor-arg index="0" ref="reindexer"/>
     </bean>
     <!--
         <bean id="james23importermanagement" class="org.apache.james.container.spring.tool.James23ImporterManagement" />

--- a/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -245,6 +245,8 @@
         </property>
     </bean>
 
+    <import resource="classpath:META-INF/spring/mailbox-tools.xml"/>
+
     <bean id="usersrepositorymanagement" class="org.apache.james.user.lib.UsersRepositoryManagement"/>
     <bean id="recipientrewritetablemanagement" class="org.apache.james.rrt.lib.RecipientRewriteTableManagement"/>
     <bean id="domainlistmanagement" class="org.apache.james.domainlist.lib.DomainListManagement"/>


### PR DESCRIPTION


This tool can be used if you change the technology you used as an indexer.

It an also be used to correct index inconsistency.

These inconsistencies can arrise from re ordering of non CRDT operations (example deletes), on server stops, on index information loss.

The idea with this tool is to drop all documents from the idex, read the whole mailbox, and reindex these documents.

Note that this tool is designed to be used against a running, client exposed James server. The idea is to listen on events and correct not yet indexed values (eg flags, or deletes). We do not care about additions as they are well handled by the normal indexer.

I took this to the next level : reindex the whole mailboxmanager. The idea is to get the snapshot of all mailboxes at time T. Then we reindex mailboxes one by one using the process described above. Of course the following process is event corrected (upon Mailbox deletion). We o not care about mailbox additions as they are well handled by the normal indexer.
