### PR TITLE
JAMES-1619 Unit tests for LocalDelivery mailet

### DIFF
--- a/server/mailet/mailets/pom.xml
+++ b/server/mailet/mailets/pom.xml
@@ -164,6 +164,18 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+            <version>${mailbox.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/LocalDeliveryTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/LocalDeliveryTest.java
@@ -1,0 +1,151 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets.delivery;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.transport.mailets.LocalDelivery;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.mailet.Mail;
+import org.apache.mailet.MailAddress;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMailetConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+
+import javax.activation.DataHandler;
+import javax.mail.Flags;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.Properties;
+
+public class LocalDeliveryTest {
+
+    private UsersRepository usersRepository;
+    private FileSystem fileSystem;
+    private RecipientRewriteTable recipientRewriteTable;
+    private MailboxManager mailboxManager;
+    private DomainList domainList;
+    private LocalDelivery localDelivery;
+
+    @Before
+    public void setUp() throws Exception {
+        usersRepository = mock(UsersRepository.class);
+        fileSystem = mock(FileSystem.class);
+        recipientRewriteTable = mock(RecipientRewriteTable.class);
+        mailboxManager = mock(MailboxManager.class);
+        domainList = mock(DomainList.class);
+
+        localDelivery = new LocalDelivery();
+        localDelivery.setDomainList(domainList);
+        localDelivery.setFileSystem(fileSystem);
+        localDelivery.setMailboxManager(mailboxManager);
+        localDelivery.setRrt(recipientRewriteTable);
+        localDelivery.setUsersRepository(usersRepository);
+    }
+
+    @Test
+    public void mailShouldBeWellDeliveredByDefaultToUserWhenvirtualHostingIsTurnedOn() throws Exception {
+        when(usersRepository.supportVirtualHosting()).thenReturn(true);
+        when(fileSystem.getFile(any(String.class))).thenThrow(FileNotFoundException.class);
+        MailboxPath inbox = new MailboxPath("#private", "receiver@domain.com", "INBOX");
+        final MessageManager messageManager = mock(MessageManager.class);
+        when(mailboxManager.getMailbox(eq(inbox), any(MailboxSession.class))).thenReturn(messageManager);
+        final MailboxSession session = mock(MailboxSession.class);
+        when(session.getPathDelimiter()).thenReturn('.');
+        when(mailboxManager.createSystemSession(any(String.class), any(Logger.class))).thenReturn(session);
+
+        Mail mail = createMail();
+
+        localDelivery.init(new FakeMailetConfig());
+        localDelivery.service(mail);
+
+        verify(messageManager).appendMessage(any(InputStream.class), any(Date.class), any(MailboxSession.class), eq(true), any(Flags.class));
+    }
+
+    @Test
+    public void mailShouldBeWellDeliveredByDefaultToUserWhenvirtualHostingIsTurnedOff() throws Exception {
+        when(usersRepository.supportVirtualHosting()).thenReturn(false);
+        when(fileSystem.getFile(any(String.class))).thenThrow(FileNotFoundException.class);
+        MailboxPath inbox = new MailboxPath("#private", "receiver", "INBOX");
+        final MessageManager messageManager = mock(MessageManager.class);
+        when(mailboxManager.getMailbox(eq(inbox), any(MailboxSession.class))).thenReturn(messageManager);
+        final MailboxSession session = mock(MailboxSession.class);
+        when(session.getPathDelimiter()).thenReturn('.');
+        when(mailboxManager.createSystemSession(any(String.class), any(Logger.class))).thenReturn(session);
+
+        Mail mail = createMail();
+
+        localDelivery.init(new FakeMailetConfig());
+        localDelivery.service(mail);
+
+        verify(messageManager).appendMessage(any(InputStream.class), any(Date.class), any(MailboxSession.class), eq(true), any(Flags.class));
+    }
+
+    private Mail createMail() throws MessagingException, IOException {
+        MimeMessage message = new MimeMessage(Session.getDefaultInstance(new Properties()));
+        message.setSubject("Subject");
+        message.setSender(new InternetAddress("sender@any.com"));
+        message.setRecipient(MimeMessage.RecipientType.TO, new InternetAddress("receiver@domain.com"));
+        MimeMultipart multipart = new MimeMultipart();
+        MimeBodyPart scriptPart = new MimeBodyPart();
+        scriptPart.setDataHandler(
+            new DataHandler(
+                new ByteArrayDataSource(
+                    "toto",
+                    "application/sieve; charset=UTF-8")
+            ));
+        scriptPart.setDisposition(MimeBodyPart.ATTACHMENT);
+        scriptPart.setHeader("Content-Type", "application/sieve; charset=UTF-8");
+        scriptPart.setFileName("file.txt");
+        multipart.addBodyPart(scriptPart);
+        message.setContent(multipart);
+        message.saveChanges();
+        Mail mail = new FakeMail(message);
+        mail.setState(Mail.DEFAULT);
+        mail.setRecipients(Lists.newArrayList(new MailAddress("receiver@domain.com")));
+        return mail;
+    }
+
+}


### PR DESCRIPTION
In this PR I present unit tests for LocalDelivery mailet. This mailet is used to deliver mail received from the SMTPServer to the appropriate user mailbox.

It is tested with :

-   with no SieveScript
-   with and without virtual hosting

This (crucial) functionality was not tested before.

This is a preliminary from JAMES-1620 : Proove JSIEVE integration in JAMES works
