### PR TITLE
James 1717 Handle HTML in vacation responses

### DIFF
--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationDAO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationDAO.java
@@ -62,7 +62,8 @@ public class CassandraVacationDAO {
             .value(CassandraVacationTable.FROM_DATE, bindMarker(CassandraVacationTable.FROM_DATE))
             .value(CassandraVacationTable.TO_DATE, bindMarker(CassandraVacationTable.TO_DATE))
             .value(CassandraVacationTable.TEXT, bindMarker(CassandraVacationTable.TEXT))
-            .value(CassandraVacationTable.SUBJECT, bindMarker(CassandraVacationTable.SUBJECT)));
+            .value(CassandraVacationTable.SUBJECT, bindMarker(CassandraVacationTable.SUBJECT))
+            .value(CassandraVacationTable.HTML, bindMarker(CassandraVacationTable.HTML)));
 
         this.readStatement = session.prepare(select()
             .from(CassandraVacationTable.TABLE_NAME)
@@ -77,8 +78,9 @@ public class CassandraVacationDAO {
                 .setBool(CassandraVacationTable.IS_ENABLED, vacation.isEnabled())
                 .setUDTValue(CassandraVacationTable.FROM_DATE, convertToUDTValue(vacation.getFromDate()))
                 .setUDTValue(CassandraVacationTable.TO_DATE, convertToUDTValue(vacation.getToDate()))
-                .setString(CassandraVacationTable.TEXT, vacation.getTextBody())
-                .setString(CassandraVacationTable.SUBJECT, vacation.getSubject().orElse(null)));
+                .setString(CassandraVacationTable.TEXT, vacation.getTextBody().orElse(null))
+                .setString(CassandraVacationTable.SUBJECT, vacation.getSubject().orElse(null))
+                .setString(CassandraVacationTable.HTML, vacation.getHtmlBody().orElse(null)));
     }
 
     public CompletableFuture<Optional<Vacation>> retrieveVacation(AccountId accountId) {
@@ -88,8 +90,9 @@ public class CassandraVacationDAO {
                 .enabled(row.getBool(CassandraVacationTable.IS_ENABLED))
                 .fromDate(retrieveDate(row, CassandraVacationTable.FROM_DATE))
                 .toDate(retrieveDate(row, CassandraVacationTable.TO_DATE))
-                .textBody(row.getString(CassandraVacationTable.TEXT))
                 .subject(Optional.ofNullable(row.getString(CassandraVacationTable.SUBJECT)))
+                .textBody(Optional.ofNullable(row.getString(CassandraVacationTable.TEXT)))
+                .htmlBody(Optional.ofNullable(row.getString(CassandraVacationTable.HTML)))
                 .build()));
     }
 

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationModule.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationModule.java
@@ -50,7 +50,8 @@ public class CassandraVacationModule implements CassandraModule {
                     .addUDTColumn(CassandraVacationTable.FROM_DATE, SchemaBuilder.frozen(CassandraZonedDateTimeModule.ZONED_DATE_TIME))
                     .addUDTColumn(CassandraVacationTable.TO_DATE, SchemaBuilder.frozen(CassandraZonedDateTimeModule.ZONED_DATE_TIME))
                     .addColumn(CassandraVacationTable.TEXT, text())
-                    .addColumn(CassandraVacationTable.SUBJECT, text())));
+                    .addColumn(CassandraVacationTable.SUBJECT, text())
+                    .addColumn(CassandraVacationTable.HTML, text())));
         index = ImmutableList.of();
         types = ImmutableList.of();
     }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/tables/CassandraVacationTable.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/tables/CassandraVacationTable.java
@@ -28,5 +28,6 @@ public interface CassandraVacationTable {
     String IS_ENABLED = "is_enabled";
     String TEXT = "text";
     String SUBJECT = "subject";
+    String HTML = "html";
 
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/vacation/Vacation.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/vacation/Vacation.java
@@ -38,8 +38,9 @@ public class Vacation {
         private Optional<Boolean> isEnabled = Optional.empty();
         private Optional<ZonedDateTime> fromDate = Optional.empty();
         private Optional<ZonedDateTime> toDate = Optional.empty();
+        private Optional<String> textBody = Optional.empty();
         private Optional<String> subject = Optional.empty();
-        private String textBody = "";
+        private Optional<String> htmlBody = Optional.empty();
 
         public Builder enabled(boolean enabled) {
             isEnabled = Optional.of(enabled);
@@ -58,13 +59,18 @@ public class Vacation {
             return this;
         }
 
-        public Builder textBody(String textBody) {
+        public Builder textBody(Optional<String> textBody) {
             this.textBody = textBody;
             return this;
         }
 
         public Builder subject(Optional<String> subject) {
             this.subject = subject;
+            return this;
+        }
+
+        public Builder htmlBody(Optional<String> htmlBody) {
+            this.htmlBody = htmlBody;
             return this;
         }
 
@@ -78,8 +84,8 @@ public class Vacation {
         }
 
         public Vacation build() {
-            Preconditions.checkNotNull(textBody);
-            return new Vacation(isEnabled.orElse(DEFAULT_DISABLED), fromDate, toDate, textBody, subject);
+            Preconditions.checkState(textBody.isPresent() || htmlBody.isPresent() || !isEnabled.orElse(DEFAULT_DISABLED), "textBody or htmlBody property of vacationResponse object should not be null when enabled");
+            return new Vacation(isEnabled.orElse(DEFAULT_DISABLED), fromDate, toDate, textBody, subject, htmlBody);
         }
     }
 
@@ -87,14 +93,17 @@ public class Vacation {
     private final Optional<ZonedDateTime> fromDate;
     private final Optional<ZonedDateTime> toDate;
     private final Optional<String> subject;
-    private final String textBody;
+    private final Optional<String> textBody;
+    private final Optional<String> htmlBody;
 
-    private Vacation(boolean isEnabled, Optional<ZonedDateTime> fromDate, Optional<ZonedDateTime> toDate, String textBody, Optional<String> subject) {
+    private Vacation(boolean isEnabled, Optional<ZonedDateTime> fromDate, Optional<ZonedDateTime> toDate,
+                     Optional<String> textBody, Optional<String> subject, Optional<String> htmlBody) {
         this.isEnabled = isEnabled;
         this.fromDate = fromDate;
         this.toDate = toDate;
         this.textBody = textBody;
         this.subject = subject;
+        this.htmlBody = htmlBody;
     }
 
 
@@ -110,12 +119,16 @@ public class Vacation {
         return toDate;
     }
 
-    public String getTextBody() {
+    public Optional<String> getTextBody() {
         return textBody;
     }
 
     public Optional<String> getSubject() {
         return subject;
+    }
+
+    public Optional<String> getHtmlBody() {
+        return htmlBody;
     }
 
     public boolean isActiveAtDate(ZonedDateTime instant) {
@@ -144,12 +157,13 @@ public class Vacation {
             Objects.equals(this.fromDate, vacation.fromDate) &&
             Objects.equals(this.toDate, vacation.toDate) &&
             Objects.equals(this.textBody, vacation.textBody) &&
-            Objects.equals(this.subject, vacation.subject);
+            Objects.equals(this.subject, vacation.subject) &&
+            Objects.equals(this.htmlBody, vacation.htmlBody);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isEnabled, fromDate, toDate, textBody, subject);
+        return Objects.hash(isEnabled, fromDate, toDate, textBody, subject, htmlBody);
     }
 
 }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/AbstractVacationRepositoryTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/AbstractVacationRepositoryTest.java
@@ -38,6 +38,8 @@ public abstract class AbstractVacationRepositoryTest {
         .fromDate(Optional.of(ZONED_DATE_TIME))
         .enabled(true)
         .subject(Optional.of("subject"))
+        .textBody(Optional.of("anyMessage"))
+        .htmlBody(Optional.of("html Message"))
         .build();
 
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/VacationTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/VacationTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.api.vacation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -32,6 +33,8 @@ public class VacationTest {
     public static final ZonedDateTime DATE_TIME_2017 = ZonedDateTime.parse("2017-10-09T08:07:06+07:00[Asia/Vientiane]");
     public static final ZonedDateTime DATE_TIME_2017_1MS = ZonedDateTime.parse("2017-10-09T08:07:06.001+07:00[Asia/Vientiane]");
     public static final ZonedDateTime DATE_TIME_2018 = ZonedDateTime.parse("2018-10-09T08:07:06+07:00[Asia/Vientiane]");
+    public static final Optional<String> TEXT_BODY = Optional.of("text is required when enabled");
+    public static final Optional<String> HTML_BODY = Optional.of("<b>HTML body</b>");
 
     @Test
     public void disabledVacationsAreNotActive() {
@@ -48,6 +51,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
             .isTrue();
@@ -58,6 +62,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -69,6 +74,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2016))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -80,6 +86,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .toDate(Optional.of(DATE_TIME_2018))
                 .build()
@@ -92,6 +99,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
@@ -104,6 +112,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2017))
                 .toDate(Optional.of(DATE_TIME_2018))
                 .build()
@@ -115,6 +124,7 @@ public class VacationTest {
     public void isActiveAtDateShouldThrowOnNullValue() {
         Vacation.builder()
             .enabled(true)
+            .textBody(TEXT_BODY)
             .fromDate(Optional.of(DATE_TIME_2016))
             .toDate(Optional.of(DATE_TIME_2016))
             .build()
@@ -126,6 +136,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .build()
                 .isActiveAtDate(DATE_TIME_2017))
@@ -137,6 +148,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -148,6 +160,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2018))
@@ -159,6 +172,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -170,10 +184,52 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2017_1MS))
             .isFalse();
+    }
+
+    @Test
+    public void activeVacationShouldHaveHtmlBodyOrTextBody() {
+        assertThatThrownBy(
+            () -> Vacation.builder()
+                .enabled(true)
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void textBodyShouldBeEnoughToBuildAnActivatedVacation() {
+        assertThat(
+            Vacation.builder()
+                .enabled(true)
+                .textBody(TEXT_BODY)
+                .build()
+                .getTextBody())
+            .contains(TEXT_BODY.get());
+    }
+
+    @Test
+    public void htmlBodyShouldBeEnoughToBuildAnActivatedVacation() {
+        assertThat(
+            Vacation.builder()
+                .enabled(true)
+                .htmlBody(HTML_BODY)
+                .build()
+                .getTextBody())
+            .contains(HTML_BODY.get());
+    }
+
+    @Test
+    public void textOrHtmlBodyShouldNotBeRequiredOnUnactivatedVacation() {
+        assertThat(
+            Vacation.builder()
+                .enabled(false)
+                .build()
+                .isEnabled())
+            .isTrue();
     }
 
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
@@ -99,8 +99,9 @@ public abstract class GetVacationResponseTest {
             .body(ARGUMENTS + ".list[0].fromDate", nullValue())
             .body(ARGUMENTS + ".list[0].toDate", nullValue())
             .body(ARGUMENTS + ".list[0].isEnabled", equalTo(false))
-            .body(ARGUMENTS + ".list[0].textBody", equalTo(""))
-            .body(ARGUMENTS + ".list[0].subject", nullValue());
+            .body(ARGUMENTS + ".list[0].subject", nullValue())
+            .body(ARGUMENTS + ".list[0].textBody", nullValue())
+            .body(ARGUMENTS + ".list[0].htmlBody", nullValue());
     }
 
     @Test
@@ -110,8 +111,9 @@ public abstract class GetVacationResponseTest {
                 .enabled(true)
                 .fromDate(Optional.of(ZonedDateTime.parse("2014-09-30T14:10:00Z")))
                 .toDate(Optional.of(ZonedDateTime.parse("2014-10-30T14:10:00Z")))
-                .textBody("Test explaining my vacations")
                 .subject(Optional.of(SUBJECT))
+                .textBody(Optional.of("Test explaining my vacations"))
+                .htmlBody(Optional.of("<p>Test explaining my vacations</p>"))
                 .build());
 
         given()
@@ -135,7 +137,8 @@ public abstract class GetVacationResponseTest {
             .body(ARGUMENTS + ".list[0].toDate", equalTo("2014-10-30T14:10:00Z"))
             .body(ARGUMENTS + ".list[0].isEnabled", equalTo(true))
             .body(ARGUMENTS + ".list[0].textBody", equalTo("Test explaining my vacations"))
-            .body(ARGUMENTS + ".list[0].subject", equalTo(SUBJECT));
+            .body(ARGUMENTS + ".list[0].subject", equalTo(SUBJECT))
+            .body(ARGUMENTS + ".list[0].htmlBody", equalTo("<p>Test explaining my vacations</p>"));
     }
 
     @Test
@@ -145,7 +148,7 @@ public abstract class GetVacationResponseTest {
                 .enabled(true)
                 .fromDate(Optional.of(ZonedDateTime.parse("2014-09-30T14:10:00+02:00")))
                 .toDate(Optional.of(ZonedDateTime.parse("2016-04-15T11:56:32.224+07:00[Asia/Vientiane]")))
-                .textBody("Test explaining my vacations")
+                .textBody(Optional.of("Test explaining my vacations"))
                 .build());
 
         given()
@@ -178,7 +181,7 @@ public abstract class GetVacationResponseTest {
                 .enabled(true)
                 .fromDate(Optional.of(ZonedDateTime.parse("2014-09-30T14:10:00+02:00")))
                 .toDate(Optional.of(ZonedDateTime.parse("2014-10-30T14:10:00+02:00")))
-                .textBody("Test explaining my vacations")
+                .textBody(Optional.of("Test explaining my vacations"))
                 .build());
 
         given()

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
@@ -146,6 +146,7 @@ public abstract class SetVacationResponseTest {
                         "\"id\": \"singleton\"," +
                         "\"isEnabled\": \"true\"," +
                         "\"textBody\": \"Message explaining my wonderful vacations\"," +
+                        "\"htmlBody\": \"<p>Here is the HTML version</p>\"," +
                         "\"fromDate\":\"2014-09-30T14:10:00Z[GMT]\"," +
                         "\"toDate\":\"2014-10-30T14:10:00Z[GMT]\"," +
                         "\"subject\":\"" + SUBJECT + "\"" +
@@ -168,7 +169,8 @@ public abstract class SetVacationResponseTest {
             .body(ARGUMENTS + ".updated[0]", equalTo("singleton"));
 
         Vacation vacation = jmapServer.serverProbe().retrieveVacation(AccountId.fromString(USER));
-        assertThat(vacation.getTextBody()).isEqualTo("Message explaining my wonderful vacations");
+        assertThat(vacation.getTextBody()).contains("Message explaining my wonderful vacations");
+        assertThat(vacation.getHtmlBody()).contains("<p>Here is the HTML version</p>");
         assertThat(vacation.isEnabled()).isTrue();
         assertThat(vacation.getFromDate()).contains(ZonedDateTime.parse("2014-09-30T14:10:00Z[GMT]"));
         assertThat(vacation.getToDate()).contains(ZonedDateTime.parse("2014-10-30T14:10:00Z[GMT]"));
@@ -206,7 +208,7 @@ public abstract class SetVacationResponseTest {
             .body(ARGUMENTS + ".updated[0]", equalTo("singleton"));
 
         Vacation vacation = jmapServer.serverProbe().retrieveVacation(AccountId.fromString(USER));
-        assertThat(vacation.getTextBody()).isEqualTo("Message explaining my wonderful vacations");
+        assertThat(vacation.getTextBody()).contains("Message explaining my wonderful vacations");
         assertThat(vacation.isEnabled()).isTrue();
         assertThat(vacation.getFromDate()).contains(ZonedDateTime.parse("2016-04-03T02:01+07:00[Asia/Vientiane]"));
         assertThat(vacation.getToDate()).contains(ZonedDateTime.parse("2016-04-07T02:01+07:00[Asia/Vientiane]"));
@@ -239,7 +241,7 @@ public abstract class SetVacationResponseTest {
             .statusCode(200)
             .body(NAME, equalTo("error"))
             .body(ARGUMENTS + ".type", equalTo("invalidArguments"))
-            .body(ARGUMENTS + ".description", containsString("textBody property of vacationResponse object should not be null"));
+            .body(ARGUMENTS + ".description", containsString("textBody or htmlBody property of vacationResponse object should not be null when enabled"));
     }
 
     @Test
@@ -268,7 +270,7 @@ public abstract class SetVacationResponseTest {
             .statusCode(200)
             .body(NAME, equalTo("error"))
             .body(ARGUMENTS + ".type", equalTo("invalidArguments"))
-            .body(ARGUMENTS + ".description", containsString("textBody property of vacationResponse object should not be null"));
+            .body(ARGUMENTS + ".description", containsString("textBody or htmlBody property of vacationResponse object should not be null when enabled"));
     }
 
     @Test

--- a/server/protocols/jmap/pom.xml
+++ b/server/protocols/jmap/pom.xml
@@ -274,6 +274,11 @@
                     <artifactId>bcpkix-jdk15on</artifactId>
                 </dependency>
                 <dependency>
+                    <groupId>org.jsoup</groupId>
+                    <artifactId>jsoup</artifactId>
+                    <version>1.9.2</version>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.james</groupId>
                     <artifactId>apache-james-mailbox-store</artifactId>
                     <scope>test</scope>

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
@@ -94,7 +94,7 @@ public class VacationMailet extends GenericMailet {
         try {
             VacationReply vacationReply = VacationReply.builder(processedMail)
                 .receivedMailRecipient(recipient)
-                .reason(vacation.getTextBody())
+                .vacation(vacation)
                 .build();
             sendNotification(vacationReply);
             notificationRegistry.register(AccountId.fromString(recipient.toString()),

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
@@ -19,12 +19,19 @@
 
 package org.apache.james.jmap.mailet;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import javax.activation.DataHandler;
 import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
 
+import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 
@@ -43,8 +50,7 @@ public class VacationReply {
         public static final boolean NOT_REPLY_TO_ALL = false;
         private final Mail originalMail;
         private MailAddress mailRecipient;
-        private String reason;
-        private Optional<String> subject = Optional.empty();
+        private Vacation vacation;
 
         private Builder(Mail originalMail) {
             Preconditions.checkNotNull(originalMail, "Origin mail shall not be null");
@@ -57,14 +63,8 @@ public class VacationReply {
             return this;
         }
 
-        public Builder reason(String reason) {
-            Preconditions.checkNotNull(reason);
-            this.reason = reason;
-            return this;
-        }
-
-        public Builder subject(Optional<String> subject) {
-            this.subject = subject;
+        public Builder vacation(Vacation vacation) {
+            this.vacation = vacation;
             return this;
         }
 
@@ -72,17 +72,66 @@ public class VacationReply {
             Preconditions.checkState(mailRecipient != null, "Original recipient address should not be null");
             Preconditions.checkState(originalMail.getSender() != null, "Original sender address should not be null");
 
+            MimeMessage reply = (MimeMessage) originalMail.getMessage().reply(false);
+            reply.setContent(generateMultipart());
+
             return new VacationReply(mailRecipient, ImmutableList.of(originalMail.getSender()), generateMimeMessage());
         }
 
         private MimeMessage generateMimeMessage() throws MessagingException {
             MimeMessage reply = (MimeMessage) originalMail.getMessage().reply(NOT_REPLY_TO_ALL);
-            subject.ifPresent(Throwing.consumer(subjectString -> reply.setHeader("subject", subjectString)));
-            reply.setText(reason);
+            vacation.getSubject().ifPresent(Throwing.consumer(subjectString -> reply.setHeader("subject", subjectString)));
             reply.setHeader("from", mailRecipient.toString());
             reply.setHeader("to", originalMail.getSender().toString());
             reply.setHeader("Auto-Submitted", "auto-replied");
+
+            return addBody(reply);
+        }
+
+        private MimeMessage addBody(MimeMessage reply) throws MessagingException {
+            if (! vacation.getHtmlBody().isPresent()) {
+                reply.setText(vacation.getTextBody().get());
+            } else {
+                reply.setContent(generateMultipart());
+            }
             return reply;
+        }
+
+
+        private Multipart generateMultipart() throws MessagingException {
+            try {
+                Multipart multipart = new MimeMultipart("mixed");
+                addPlainPart(multipart, vacation.getTextBody());
+                addHtmlPart(multipart, vacation.getHtmlBody());
+                return multipart;
+            } catch (IOException e) {
+                throw new MessagingException("Cannot read specified content", e);
+            }
+        }
+
+        private Multipart addPlainPart(Multipart multipart, Optional<String> textOptional) throws MessagingException, IOException {
+            if (textOptional.isPresent()) {
+                return addTextPart(multipart, textOptional.get(), "text/plain");
+            }
+            return multipart;
+        }
+
+        private Multipart addHtmlPart(Multipart multipart, Optional<String> htmlOptional) throws MessagingException, IOException {
+            if (htmlOptional.isPresent()) {
+                return addTextPart(multipart, htmlOptional.get(), "text/html");
+            }
+            return multipart;
+        }
+
+        private Multipart addTextPart(Multipart multipart, String text, String contentType) throws MessagingException, IOException {
+            MimeBodyPart textReasonPart = new MimeBodyPart();
+            textReasonPart.setDataHandler(
+                new DataHandler(
+                    new ByteArrayDataSource(
+                        text,
+                        contentType + "; charset=UTF-8")));
+            multipart.addBodyPart(textReasonPart);
+            return multipart;
         }
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetVacationResponseMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetVacationResponseMethod.java
@@ -123,6 +123,7 @@ public class SetVacationResponseMethod implements Method {
             .toDate(vacationResponse.getToDate())
             .textBody(vacationResponse.getTextBody())
             .subject(vacationResponse.getSubject())
+            .htmlBody(vacationResponse.getHtmlBody())
             .build();
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/VacationResponse.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/VacationResponse.java
@@ -44,11 +44,12 @@ public class VacationResponse {
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private String id;
-        private boolean isEnabled;
+        private boolean isEnabled = false;
         private Optional<ZonedDateTime> fromDate = Optional.empty();
         private Optional<ZonedDateTime> toDate = Optional.empty();
         private Optional<String> subject = Optional.empty();
-        private String textBody;
+        private Optional<String> textBody = Optional.empty();
+        private Optional<String> htmlBody = Optional.empty();
 
         public Builder id(String id) {
             this.id = id;
@@ -73,13 +74,18 @@ public class VacationResponse {
             return this;
         }
 
-        public Builder textBody(String textBody) {
+        public Builder textBody(Optional<String> textBody) {
             this.textBody = textBody;
             return this;
         }
 
         public Builder subject(Optional<String> subject) {
             this.subject = subject;
+            return this;
+        }
+
+        public Builder htmlBody(Optional<String> htmlBody) {
+            this.htmlBody = htmlBody;
             return this;
         }
 
@@ -90,12 +96,13 @@ public class VacationResponse {
             this.toDate = vacation.getToDate();
             this.textBody = vacation.getTextBody();
             this.subject = vacation.getSubject();
+            this.htmlBody = vacation.getHtmlBody();
             return this;
         }
 
         public VacationResponse build() {
-            Preconditions.checkState(textBody != null, "textBody property of vacationResponse object should not be null");
-            return new VacationResponse(id, isEnabled, fromDate, toDate, textBody, subject);
+            Preconditions.checkState(textBody.isPresent() || htmlBody.isPresent() || !isEnabled, "textBody or htmlBody property of vacationResponse object should not be null when enabled");
+            return new VacationResponse(id, isEnabled, fromDate, toDate, textBody, subject, htmlBody);
         }
     }
 
@@ -104,16 +111,18 @@ public class VacationResponse {
     private final Optional<ZonedDateTime> fromDate;
     private final Optional<ZonedDateTime> toDate;
     private final Optional<String> subject;
-    private final String textBody;
+    private final Optional<String> textBody;
+    private final Optional<String> htmlBody;
 
     private VacationResponse(String id, boolean isEnabled, Optional<ZonedDateTime> fromDate, Optional<ZonedDateTime> toDate,
-                             String textBody, Optional<String> subject) {
+                             Optional<String> textBody, Optional<String> subject, Optional<String> htmlBody) {
         this.id = id;
         this.isEnabled = isEnabled;
         this.fromDate = fromDate;
         this.toDate = toDate;
         this.textBody = textBody;
         this.subject = subject;
+        this.htmlBody = htmlBody;
     }
 
     public String getId() {
@@ -135,12 +144,16 @@ public class VacationResponse {
         return toDate;
     }
 
-    public String getTextBody() {
+    public Optional<String> getTextBody() {
         return textBody;
     }
 
     public Optional<String> getSubject() {
         return subject;
+    }
+
+    public Optional<String> getHtmlBody() {
+        return htmlBody;
     }
 
     @JsonIgnore
@@ -161,11 +174,12 @@ public class VacationResponse {
             && Objects.equals(this.fromDate, that.fromDate)
             && Objects.equals(this.toDate, that.toDate)
             && Objects.equals(this.textBody, that.textBody)
-            && Objects.equals(this.subject, that.subject);
+            && Objects.equals(this.subject, that.subject)
+            && Objects.equals(this.htmlBody, that.htmlBody);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, isEnabled, fromDate, toDate, textBody, subject);
+        return Objects.hash(id, isEnabled, fromDate, toDate, textBody, subject, htmlBody);
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
@@ -60,7 +60,7 @@ public class VacationMailetTest {
         .enabled(true)
         .fromDate(Optional.of(DATE_TIME_2016))
         .toDate(Optional.of(DATE_TIME_2018))
-        .textBody("Explaining my vacation")
+        .textBody(Optional.of("Explaining my vacation"))
         .build();
 
     private VacationMailet testee;

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
@@ -28,6 +28,7 @@ import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.Before;
@@ -36,7 +37,9 @@ import org.junit.Test;
 public class VacationReplyTest {
 
     public static final String REASON = "I am in vacation dudes !";
-    public static final Optional<String> SUBJECT = Optional.of("Vacation subject specified by the user!");
+    public static final String HTML_REASON = "<p>I am in vacation dudes !</p>";
+    public static final String SUBJECT = "subject";
+
     private MailAddress originalSender;
     private MailAddress originalRecipient;
     private FakeMail mail;
@@ -55,19 +58,42 @@ public class VacationReplyTest {
     public void vacationReplyShouldGenerateASuitableAnswer() throws Exception {
 
         VacationReply vacationReply = VacationReply.builder(mail)
-            .reason(REASON)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(Optional.of(REASON))
+                .htmlBody(Optional.of(HTML_REASON))
+                .build())
             .receivedMailRecipient(originalRecipient)
             .build();
 
         assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
         assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
         assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(REASON);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_REASON);
+    }
+
+    @Test
+    public void vacationReplyShouldNotBeMultipartWhenVacationHaveNoHTML() throws Exception {
+        VacationReply vacationReply = VacationReply.builder(mail)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(Optional.of(REASON))
+                .build())
+            .receivedMailRecipient(originalRecipient)
+            .build();
+
+        assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
+        assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).isEqualTo(REASON);
     }
 
     @Test
     public void vacationReplyShouldAddReSuffixToSubjectByDefault() throws Exception {
         VacationReply vacationReply = VacationReply.builder(mail)
-            .reason(REASON)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(Optional.of(REASON))
+                .build())
             .receivedMailRecipient(originalRecipient)
             .build();
 
@@ -77,12 +103,15 @@ public class VacationReplyTest {
     @Test
     public void aUserShouldBeAbleToSetTheSubjectOfTheGeneratedMimeMessage() throws Exception {
         VacationReply vacationReply = VacationReply.builder(mail)
-            .reason(REASON)
-            .subject(SUBJECT)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(Optional.of(REASON))
+                .subject(Optional.of(SUBJECT))
+                .build())
             .receivedMailRecipient(originalRecipient)
             .build();
 
-        assertThat(vacationReply.getMimeMessage().getHeader("subject")).containsExactly(SUBJECT.get());
+        assertThat(vacationReply.getMimeMessage().getHeader("subject")).containsExactly(SUBJECT);
     }
 
     @Test(expected = NullPointerException.class)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
@@ -36,8 +36,9 @@ import org.junit.Test;
 
 public class VacationReplyTest {
 
-    public static final String REASON = "I am in vacation dudes !";
-    public static final String HTML_REASON = "<p>I am in vacation dudes !</p>";
+    public static final String REASON = "I am in vacation dudes ! (plain text)";
+    public static final String HTML_REASON = "<b>I am in vacation dudes !</b> (html text)";
+    public static final String HTML_EXTRACTED_REASON = "I am in vacation dudes ! (html text)";
     public static final String SUBJECT = "subject";
 
     private MailAddress originalSender;
@@ -69,6 +70,22 @@ public class VacationReplyTest {
         assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
         assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
         assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(REASON);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_REASON);
+    }
+
+    @Test
+    public void vacationReplyShouldExtractPlainTextContentWhenOnlyHtmlBody() throws Exception {
+        VacationReply vacationReply = VacationReply.builder(mail)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .htmlBody(Optional.of(HTML_REASON))
+                .build())
+            .receivedMailRecipient(originalRecipient)
+            .build();
+
+        assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
+        assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_EXTRACTED_REASON);
         assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_REASON);
     }
 

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetVacationResponseMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetVacationResponseMethodTest.java
@@ -81,7 +81,7 @@ public class GetVacationResponseMethodTest {
         ClientId clientId = mock(ClientId.class);
         Vacation vacation = Vacation.builder()
             .enabled(true)
-            .textBody("I am in vacation")
+            .textBody(Optional.of("I am in vacation"))
             .subject(Optional.of("subject"))
             .build();
         when(vacationRepository.retrieveVacation(AccountId.fromString(USERNAME))).thenReturn(CompletableFuture.completedFuture(vacation));

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetVacationResponseMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetVacationResponseMethodTest.java
@@ -131,7 +131,7 @@ public class SetVacationResponseMethodTest {
             .update(ImmutableMap.of(WRONG_ID, VacationResponse.builder()
                 .id(Vacation.ID)
                 .enabled(false)
-                .textBody(TEXT_BODY)
+                .textBody(Optional.of(TEXT_BODY))
                 .build()))
             .build();
 
@@ -154,12 +154,12 @@ public class SetVacationResponseMethodTest {
             .update(ImmutableMap.of(Vacation.ID, VacationResponse.builder()
                     .id(Vacation.ID)
                     .enabled(false)
-                    .textBody(TEXT_BODY)
+                    .textBody(Optional.of(TEXT_BODY))
                     .build(),
                 WRONG_ID, VacationResponse.builder()
                     .id(Vacation.ID)
                     .enabled(false)
-                    .textBody(TEXT_BODY)
+                    .textBody(Optional.of(TEXT_BODY))
                     .build()))
             .build();
 
@@ -182,13 +182,13 @@ public class SetVacationResponseMethodTest {
             .update(ImmutableMap.of(Vacation.ID, VacationResponse.builder()
                     .id(Vacation.ID)
                     .enabled(false)
-                    .textBody(TEXT_BODY)
+                    .textBody(Optional.of(TEXT_BODY))
                     .subject(Optional.of(SUBJECT))
                     .build()))
             .build();
         Vacation vacation = Vacation.builder()
             .enabled(false)
-            .textBody(TEXT_BODY)
+            .textBody(Optional.of(TEXT_BODY))
             .subject(Optional.of(SUBJECT))
             .build();
         AccountId accountId = AccountId.fromString(USERNAME);
@@ -217,7 +217,7 @@ public class SetVacationResponseMethodTest {
         SetVacationRequest setVacationRequest = SetVacationRequest.builder()
             .update(ImmutableMap.of(Vacation.ID, VacationResponse.builder()
                 .id(WRONG_ID)
-                .textBody(TEXT_BODY)
+                .textBody(Optional.of(TEXT_BODY))
                 .enabled(false)
                 .build()))
             .build();

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/GetVacationResponseTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/GetVacationResponseTest.java
@@ -20,6 +20,8 @@ package org.apache.james.jmap.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+
 import org.junit.Test;
 
 public class GetVacationResponseTest {
@@ -29,7 +31,7 @@ public class GetVacationResponseTest {
     @Test
     public void getVacationResponseShouldBeConstructedWithTheRightInformation() {
         VacationResponse vacationResponse = VacationResponse.builder()
-            .textBody("Any text")
+            .textBody(Optional.of("Any text"))
             .id("singleton")
             .build();
         GetVacationResponse getVacationResponse = GetVacationResponse.builder()

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/SetVacationRequestTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/SetVacationRequestTest.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.AbstractMap;
+import java.util.Optional;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.junit.Test;
@@ -33,7 +34,7 @@ public class SetVacationRequestTest {
 
     @Test
     public void setVacationRequestShouldBeConstructedWithTheRightInformation() {
-        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody("any message").build();
+        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody(Optional.of("any message")).build();
         SetVacationRequest setVacationRequest = SetVacationRequest.builder()
             .update(ImmutableMap.of(VACATION_ID, vacationResponse))
             .build();
@@ -43,7 +44,7 @@ public class SetVacationRequestTest {
 
     @Test(expected = NotImplementedException.class)
     public void accountIdIsNotImplemented() {
-        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody("any message").build();
+        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody(Optional.of("any message")).build();
         SetVacationRequest.builder()
             .accountId("any")
             .update(ImmutableMap.of(VACATION_ID, vacationResponse))

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/VacationResponseTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/VacationResponseTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -30,6 +31,7 @@ public class VacationResponseTest {
 
     public static final String IDENTIFIER = "identifier";
     public static final String MESSAGE = "A message explaining I am in vacation";
+    public static final String HTML_MESSAGE = "<p>A message explaining I am in vacation</p>";
     public static final ZonedDateTime FROM_DATE = ZonedDateTime.parse("2016-04-15T11:56:32.224+07:00[Asia/Vientiane]");
     public static final ZonedDateTime TO_DATE = ZonedDateTime.parse("2016-04-16T11:56:32.224+07:00[Asia/Vientiane]");
     public static final String SUBJECT = "subject";
@@ -41,24 +43,69 @@ public class VacationResponseTest {
             .enabled(true)
             .fromDate(Optional.of(FROM_DATE))
             .toDate(Optional.of(TO_DATE))
-            .textBody(MESSAGE)
             .subject(Optional.of(SUBJECT))
+            .textBody(Optional.of(MESSAGE))
+            .htmlBody(Optional.of(HTML_MESSAGE))
             .build();
 
         assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
         assertThat(vacationResponse.isEnabled()).isEqualTo(true);
-        assertThat(vacationResponse.getTextBody()).isEqualTo(MESSAGE);
+        assertThat(vacationResponse.getTextBody()).contains(MESSAGE);
+        assertThat(vacationResponse.getHtmlBody()).contains(HTML_MESSAGE);
         assertThat(vacationResponse.getFromDate()).contains(FROM_DATE);
         assertThat(vacationResponse.getToDate()).contains(TO_DATE);
         assertThat(vacationResponse.getSubject()).contains(SUBJECT);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void vacationResponseBuilderRequiresABodyText() {
-        VacationResponse.builder()
+    @Test
+    public void vacationResponseBuilderRequiresABodyTextOrHtmlWhenEnabled() {
+        assertThatThrownBy(() ->
+            VacationResponse.builder()
+                .id(IDENTIFIER)
+                .enabled(true)
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void vacationResponseBuilderShouldNotRequiresABodyTextOrHtmlWhenDisabled() {
+        VacationResponse vacationResponse = VacationResponse.builder()
+            .id(IDENTIFIER)
+            .enabled(false)
+            .build();
+
+        assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
+        assertThat(vacationResponse.isEnabled()).isEqualTo(false);
+        assertThat(vacationResponse.getTextBody()).isEmpty();
+        assertThat(vacationResponse.getHtmlBody()).isEmpty();
+    }
+
+    @Test
+    public void bodyTextShouldBeEnoughWhenEnabled() {
+        VacationResponse vacationResponse = VacationResponse.builder()
             .id(IDENTIFIER)
             .enabled(true)
+            .textBody(Optional.of(MESSAGE))
             .build();
+
+        assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
+        assertThat(vacationResponse.isEnabled()).isEqualTo(true);
+        assertThat(vacationResponse.getTextBody()).contains(MESSAGE);
+        assertThat(vacationResponse.getHtmlBody()).isEmpty();
+    }
+
+    @Test
+    public void htmlTextShouldBeEnoughWhenEnabled() {
+        VacationResponse vacationResponse = VacationResponse.builder()
+            .id(IDENTIFIER)
+            .enabled(true)
+            .htmlBody(Optional.of(MESSAGE))
+            .build();
+
+        assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
+        assertThat(vacationResponse.isEnabled()).isEqualTo(true);
+        assertThat(vacationResponse.getTextBody()).isEmpty();
+        assertThat(vacationResponse.getHtmlBody()).contains(MESSAGE);
     }
 
 }


### PR DESCRIPTION
 - Store the htmlBody for vacation
 - Use it to right emails
 - Sent emails should have a plain text version extracted from HTML when no plain text is provided.