### PR TITLE
JAMES-1806 Unable to run windows service on 64bit platform (Windows 10)

### DIFF
--- a/server/app/pom.xml
+++ b/server/app/pom.xml
@@ -812,6 +812,7 @@
                                                 <include>solaris-sparc-64</include>
                                                 <include>solaris-x86-32</include>
                                                 <include>windows-x86-32</include>
+                                                <include>windows-x86-64</include>
                                             </includes>
 
                                             <configuration>

--- a/server/app/src/main/licensing/app/licensing.xml
+++ b/server/app/src/main/licensing/app/licensing.xml
@@ -1132,6 +1132,7 @@ The Apache Software Foundation (http://www.apache.org/).
                 <resource name='wrapper-solaris-sparc-64'/>
                 <resource name='wrapper-solaris-x86-32'/>
                 <resource name='wrapper-windows-x86-32.exe'/>
+                <resource name='wrapper-windows-x86-64.exe'/>
             </by-organisation>
         </with-license>
         <with-license id='ApacheLicenseVersion2'>


### PR DESCRIPTION
Deploy 64bit windows wrapper, by adding window-x86-64 to pom.xml and licensing xml.

Add "<include>windows-x86-64</include>" to "<generator>jsw</generator>" in pom.xml.
Add "<resource name='wrapper-windows-x86-64.exe'/> to "<by-organisation id='TanukiSoftware'>" in licensing.xml.
