### PR TITLE
Mailet 107 Rework HasHeader

### DIFF
--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasAttachment.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasAttachment.java
@@ -31,6 +31,8 @@ import javax.mail.Part;
 import javax.mail.internet.MimeMessage;
 import java.util.Collection;
 
+import com.google.common.base.Objects;
+
 /**
  * Checks whether this message has an attachment
  *
@@ -64,8 +66,7 @@ public class HasAttachment extends GenericMatcher {
                 for (int i = 0; i < multipart.getCount(); i++) {
                     try {
                         Part part = multipart.getBodyPart(i);
-                        String fileName = part.getFileName();
-                        if (fileName != null) {
+                        if (isAttachment(part)) {
                             return mail.getRecipients(); // file found
                         }
                     } catch (MessagingException e) {
@@ -73,8 +74,7 @@ public class HasAttachment extends GenericMatcher {
                     } // ignore any messaging exception and process next bodypart
                 }
             } else {
-                String fileName = message.getFileName();
-                if (fileName != null) {
+                if (isAttachment(message)) {
                     return mail.getRecipients(); // file found
                 }
             }
@@ -88,5 +88,9 @@ public class HasAttachment extends GenericMatcher {
         }
         
         return null; // no attachment found
+    }
+
+    private boolean isAttachment(Part part) throws MessagingException {
+        return Objects.equal(part.getDisposition(), MimeMessage.ATTACHMENT);
     }
 }

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/HasAttachmentTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/HasAttachmentTest.java
@@ -1,0 +1,108 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.matchers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import javax.mail.Session;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.MailAddress;
+import org.apache.mailet.base.test.FakeMail;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class HasAttachmentTest {
+
+    private HasAttachment testee;
+    private MimeMessage mimeMessage;
+    private Mail mail;
+
+    @Before
+    public void setUp() throws Exception {
+        testee = new HasAttachment();
+
+        mimeMessage = new MimeMessage(Session.getDefaultInstance(new Properties()));
+        mail = new FakeMail();
+        mail.setRecipients(ImmutableList.of(new MailAddress("me@james.apache.org")));
+        mail.setMessage(mimeMessage);
+    }
+
+    @Test
+    public void textMailsShouldNotBeMatched() throws Exception {
+        mimeMessage.setText("A simple text message");
+
+        assertThat(testee.match(mail)).isNull();
+    }
+
+    @Test
+    public void emptyMultipartShouldNotBeMatched() throws Exception {
+        mimeMessage.setContent(new MimeMultipart());
+
+        assertThat(testee.match(mail)).isNull();
+    }
+
+    @Test
+    public void inlinedOnlyMultipartShouldNotBeMatched() throws Exception {
+        MimeMultipart mimeMultipart = new MimeMultipart();
+        MimeBodyPart part = new MimeBodyPart();
+        part.setDisposition(MimeMessage.INLINE);
+        part.setFileName("bahamas.png");
+        mimeMultipart.addBodyPart(part);
+        mimeMessage.setContent(mimeMultipart);
+
+        assertThat(testee.match(mail)).isNull();
+    }
+
+    @Test
+    public void multipartWithOneAttachmentShouldBeMatched() throws Exception {
+        MimeMultipart mimeMultipart = new MimeMultipart();
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setDisposition(MimeMessage.INLINE);
+        mimeMultipart.addBodyPart(textPart);
+        MimeBodyPart attachmentPart = new MimeBodyPart();
+        attachmentPart.setDisposition(MimeMessage.ATTACHMENT);
+        mimeMultipart.addBodyPart(attachmentPart);
+        mimeMessage.setContent(mimeMultipart);
+
+        assertThat(testee.match(mail)).containsAll(mail.getRecipients());
+    }
+
+    @Test
+    public void attachmentMailsShouldBeMatched() throws Exception {
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(mimeMessage.getContent()).thenReturn(new Object());
+        when(mimeMessage.getDisposition()).thenReturn(MimeMessage.ATTACHMENT);
+        when(mimeMessage.getContentType()).thenReturn("application/json");
+        mail.setMessage(mimeMessage);
+
+        assertThat(testee.match(mail)).containsAll(mail.getRecipients());
+    }
+
+}

--- a/server/src/site/xdoc/dev-provided-matchers.xml
+++ b/server/src/site/xdoc/dev-provided-matchers.xml
@@ -102,7 +102,8 @@
             </subsection>
 
             <subsection name="HasAttachment">
-                <p>Description: Matches those messages with a MIME type of "multipart/mixed".  All recipients are returned.</p>
+                <p>Description: Matches those messages with at list a body part with an attachment. Content disposition
+                    is used to detect attachment, as specified by RFC-2183. All recipients are returned.</p>
                 <p>Configuration string: None.</p>
             </subsection>
 


### PR DESCRIPTION
 - Provide tests
 - Enforce attachment detection based on Content Disposition, according to RFC 2183