### PR TITLE
JAMES-1823 quotaUpdater is invoked more than one time for a message addition or deletion

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListener.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListener.java
@@ -20,6 +20,9 @@
 package org.apache.james.mailbox.store.event;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxSession;
@@ -36,6 +39,7 @@ public class DefaultDelegatingMailboxListener implements DelegatingMailboxListen
 
     private final MailboxListenerRegistry registry;
     private final EventDelivery eventDelivery;
+    Set<MailboxListener> addedListenerSet = Collections.newSetFromMap(new ConcurrentHashMap<MailboxListener, Boolean>());
 
     @Override
     public ListenerType getType() {
@@ -69,7 +73,11 @@ public class DefaultDelegatingMailboxListener implements DelegatingMailboxListen
         if (listener.getType() != ListenerType.EACH_NODE && listener.getType() != ListenerType.ONCE) {
             throw new MailboxException(listener.getClass().getCanonicalName() + " registered on global event dispatching while its listener type was " + listener.getType());
         }
-        registry.addGlobalListener(listener);
+
+        if (!addedListenerSet.contains(listener)) {
+            registry.addGlobalListener(listener);
+            addedListenerSet.add(listener);
+        }
     }
 
     @Override


### PR DESCRIPTION
I'm not sure if my solution is appropriate and on the right direction from the perspective of the system and its architecture because I don't fully understand it. My purpose in the patch is not to register the same listener duplicately in an instance of DefaultDelegatingMailboxListener. For this, I've added some code and data structure for checking duplication. If my solution isn't suitable for the whole system, you don't have to use it.
