### PR TITLE
Fix gateway port handling for remote delivery configuration

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remoteDelivery/RemoteDeliveryConfiguration.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remoteDelivery/RemoteDeliveryConfiguration.java
@@ -200,7 +200,7 @@ public class RemoteDeliveryConfiguration {
 
     private String parsePart(String gatewayPort, String gatewayPart) {
         String address = gatewayPart.trim();
-        if (address.contains(ADDRESS_PORT_SEPARATOR) && gatewayPort != null) {
+        if (!address.contains(ADDRESS_PORT_SEPARATOR) && gatewayPort != null) {
             return address + ADDRESS_PORT_SEPARATOR + gatewayPort;
         }
         return address;

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remoteDelivery/RemoteDeliveryConfigurationTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remoteDelivery/RemoteDeliveryConfigurationTest.java
@@ -639,6 +639,35 @@ public class RemoteDeliveryConfigurationTest {
     }
 
     @Test
+    public void getGatewayServerShouldReturnGatewayWithGatewayPort() {
+        String server = "127.0.0.1";
+        String port = "2525";
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
+            .setProperty(RemoteDeliveryConfiguration.GATEWAY, server)
+            .setProperty(RemoteDeliveryConfiguration.GATEWAY_PORT, port)
+            .build();
+
+        assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getGatewayServer())
+            .containsOnly(server + ':' + port);
+    }
+
+    @Test
+    public void getGatewayServerShouldOnlyOverridePortsNotInitiallySet() {
+        String server1 = "127.0.0.1:23432";
+        String server2 = "domain";
+        String port = "2525";
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
+            .setProperty(RemoteDeliveryConfiguration.GATEWAY, server1 + ',' + server2)
+            .setProperty(RemoteDeliveryConfiguration.GATEWAY_PORT, port)
+            .build();
+
+        assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getGatewayServer())
+            .containsOnly(server1, server2 + ':' + port);
+    }
+
+    @Test
     public void getAuthUserShouldBeNullByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
             .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")


### PR DESCRIPTION
The refactoring in https://github.com/apache/james-project/commit/6fa52984020803b4d4c7de43d42e6dad3bfad6a6 introduced a small bug regarding the handling of gateway ports as configured for the remote delivery mailet.

`server.indexOf(':') < 0` was replaced with `address.contains(ADDRESS_PORT_SEPARATOR)` instead of `!address.contains(ADDRESS_PORT_SEPARATOR)`.