### PR TITLE
JAMES-2270 Replace uses of considered-deprecated constants

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
@@ -24,15 +24,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
-
 public class AttachmentTest {
 
-    private static Charset CHARSET = Charsets.UTF_8;
+    private static Charset CHARSET = StandardCharsets.UTF_8;
 
     @Test
     public void streamShouldBeConsumedOneTime() throws Exception {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.cassandra;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import javax.mail.Flags;
@@ -46,12 +47,11 @@ import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.apache.james.mailbox.store.quota.ListeningCurrentQuotaUpdater;
 import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManager;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 
 public class CassandraMessageIdManagerTestSystem extends MessageIdManagerTestSystem {
 
-    private static final byte[] MESSAGE_CONTENT = "subject: any\n\nbody".getBytes(Charsets.UTF_8);
+    private static final byte[] MESSAGE_CONTENT = "subject: any\n\nbody".getBytes(StandardCharsets.UTF_8);
 
     public static MessageIdManagerTestSystem createTestingData(CassandraCluster cassandra, QuotaManager quotaManager, MailboxEventDispatcher dispatcher) throws Exception {
         CassandraMailboxSessionMapperFactory mapperFactory = CassandraTestSystemFixture.createMapperFactory(cassandra);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/ids/BlobIdTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/ids/BlobIdTest.java
@@ -21,12 +21,12 @@ package org.apache.james.mailbox.cassandra.ids;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import com.google.common.base.Charsets;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -77,7 +77,7 @@ public class BlobIdTest {
 
     @Test
     public void forPayloadShouldHashArray() {
-        BlobId blobId = BlobId.forPayload("content".getBytes(Charsets.UTF_8));
+        BlobId blobId = BlobId.forPayload("content".getBytes(StandardCharsets.UTF_8));
 
         assertThat(blobId.getId()).isEqualTo("ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73");
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraBlobsDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraBlobsDAOTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
@@ -34,7 +35,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 
 public class CassandraBlobsDAOTest {
@@ -74,21 +74,21 @@ public class CassandraBlobsDAOTest {
 
         byte[] bytes = testee.read(blobId).join();
 
-        assertThat(new String(bytes, Charsets.UTF_8)).isEmpty();
+        assertThat(new String(bytes, StandardCharsets.UTF_8)).isEmpty();
     }
 
     @Test
     public void saveShouldSaveBlankData() throws Exception {
-        BlobId blobId = testee.save("".getBytes(Charsets.UTF_8)).join();
+        BlobId blobId = testee.save("".getBytes(StandardCharsets.UTF_8)).join();
 
         byte[] bytes = testee.read(blobId).join();
 
-        assertThat(new String(bytes, Charsets.UTF_8)).isEmpty();
+        assertThat(new String(bytes, StandardCharsets.UTF_8)).isEmpty();
     }
 
     @Test
     public void saveShouldReturnBlobId() throws Exception {
-        BlobId blobId = testee.save("toto".getBytes(Charsets.UTF_8)).join();
+        BlobId blobId = testee.save("toto".getBytes(StandardCharsets.UTF_8)).join();
 
         assertThat(blobId).isEqualTo(BlobId.from("31f7a65e315586ac198bd798b6629ce4903d0899476d5741a9f32e2e521b6a66"));
     }
@@ -102,31 +102,31 @@ public class CassandraBlobsDAOTest {
 
     @Test
     public void readShouldReturnSavedData() throws IOException {
-        BlobId blobId = testee.save("toto".getBytes(Charsets.UTF_8)).join();
+        BlobId blobId = testee.save("toto".getBytes(StandardCharsets.UTF_8)).join();
 
         byte[] bytes = testee.read(blobId).join();
 
-        assertThat(new String(bytes, Charsets.UTF_8)).isEqualTo("toto");
+        assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo("toto");
     }
 
     @Test
     public void readShouldReturnLongSavedData() throws IOException {
         String longString = Strings.repeat("0123456789\n", 1000);
-        BlobId blobId = testee.save(longString.getBytes(Charsets.UTF_8)).join();
+        BlobId blobId = testee.save(longString.getBytes(StandardCharsets.UTF_8)).join();
 
         byte[] bytes = testee.read(blobId).join();
 
-        assertThat(new String(bytes, Charsets.UTF_8)).isEqualTo(longString);
+        assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo(longString);
     }
 
     @Test
     public void readShouldReturnSplitSavedDataByChunk() throws IOException {
         String longString = Strings.repeat("0123456789\n", MULTIPLE_CHUNK_SIZE);
-        BlobId blobId = testee.save(longString.getBytes(Charsets.UTF_8)).join();
+        BlobId blobId = testee.save(longString.getBytes(StandardCharsets.UTF_8)).join();
 
         byte[] bytes = testee.read(blobId).join();
 
-        assertThat(new String(bytes, Charsets.UTF_8)).isEqualTo(longString);
+        assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo(longString);
     }
 
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
@@ -58,7 +58,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Bytes;
@@ -140,7 +139,7 @@ public class CassandraMessageDAOTest {
         MessageWithoutAttachment attachmentRepresentation =
             toMessage(testee.retrieveMessages(messageIds, MessageMapper.FetchType.Full, Limit.unlimited()));
 
-        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), Charsets.UTF_8))
+        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), StandardCharsets.UTF_8))
             .isEqualTo(CONTENT);
     }
 
@@ -155,9 +154,9 @@ public class CassandraMessageDAOTest {
 
         byte[] expected = Bytes.concat(
             new byte[BODY_START],
-            CONTENT.substring(BODY_START).getBytes(Charsets.UTF_8));
-        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), Charsets.UTF_8))
-            .isEqualTo(IOUtils.toString(new ByteArrayInputStream(expected), Charsets.UTF_8));
+            CONTENT.substring(BODY_START).getBytes(StandardCharsets.UTF_8));
+        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), StandardCharsets.UTF_8))
+            .isEqualTo(IOUtils.toString(new ByteArrayInputStream(expected), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -169,7 +168,7 @@ public class CassandraMessageDAOTest {
         MessageWithoutAttachment attachmentRepresentation =
             toMessage(testee.retrieveMessages(messageIds, MessageMapper.FetchType.Headers, Limit.unlimited()));
 
-        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), Charsets.UTF_8))
+        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), StandardCharsets.UTF_8))
             .isEqualTo(CONTENT.substring(0, BODY_START));
     }
 
@@ -181,7 +180,7 @@ public class CassandraMessageDAOTest {
             .internalDate(new Date())
             .bodyStartOctet(bodyStart)
             .size(content.length())
-            .content(new SharedByteArrayInputStream(content.getBytes(Charsets.UTF_8)))
+            .content(new SharedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
             .flags(new Flags())
             .propertyBuilder(propertyBuilder)
             .addAttachments(attachments)

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreationTest.java
@@ -57,7 +57,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -179,7 +178,7 @@ public class AttachmentMessageIdCreationTest {
             .internalDate(new Date())
             .bodyStartOctet(BODY_START)
             .size(content.length())
-            .content(new SharedByteArrayInputStream(content.getBytes(Charsets.UTF_8)))
+            .content(new SharedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
             .flags(new Flags())
             .propertyBuilder(new PropertyBuilder())
             .addAttachments(attachments)

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/DataChunkerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/DataChunkerTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.cassandra.mail.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -30,7 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
 
@@ -81,7 +81,7 @@ public class DataChunkerTest {
 
     @Test
     public void chunkShouldReturnOneArrayWhenInputLessThanChunkSize() {
-        byte[] data = "12345".getBytes(Charsets.UTF_8);
+        byte[] data = "12345".getBytes(StandardCharsets.UTF_8);
 
         Stream<Pair<Integer, ByteBuffer>> chunks = testee.chunk(data, CHUNK_SIZE);
 
@@ -91,7 +91,7 @@ public class DataChunkerTest {
 
     @Test
     public void chunkShouldReturnOneArrayWhenInputEqualsChunkSize() {
-        byte[] data = "1234567890".getBytes(Charsets.UTF_8);
+        byte[] data = "1234567890".getBytes(StandardCharsets.UTF_8);
         assertThat(data.length).isEqualTo(CHUNK_SIZE);
 
         Stream<Pair<Integer, ByteBuffer>> chunks = testee.chunk(data, CHUNK_SIZE);
@@ -102,8 +102,8 @@ public class DataChunkerTest {
 
     @Test
     public void chunkShouldReturnSeveralArrayWhenInputBiggerThanChunkSize() {
-        byte[] part1 = "1234567890".getBytes(Charsets.UTF_8);
-        byte[] part2 = "12345".getBytes(Charsets.UTF_8);
+        byte[] part1 = "1234567890".getBytes(StandardCharsets.UTF_8);
+        byte[] part2 = "12345".getBytes(StandardCharsets.UTF_8);
         byte[] data = Bytes.concat(part1, part2);
 
         Stream<Pair<Integer, ByteBuffer>> chunks = testee.chunk(data, CHUNK_SIZE);

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.elasticsearch;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.concurrent.Executors;
@@ -60,7 +61,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 
 public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
@@ -147,7 +147,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
         String recipient = "benwa@linagora.com";
         ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
             "\n" +
-            Strings.repeat("0à2345678é", 3200)).getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+            Strings.repeat("0à2345678é", 3200)).getBytes(StandardCharsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
 
         embeddedElasticSearch.awaitForElasticSearch();
 
@@ -164,7 +164,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
         String recipient = "benwa@linagora.com";
         ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
             "\n" +
-            Strings.repeat("0123456789", 3300)).getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+            Strings.repeat("0123456789", 3300)).getBytes(StandardCharsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
 
         embeddedElasticSearch.awaitForElasticSearch();
 
@@ -181,7 +181,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
         String recipient = "benwa@linagora.com";
         ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
             "\n" +
-            Strings.repeat("0123456789 ", 5000)).getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+            Strings.repeat("0123456789 ", 5000)).getBytes(StandardCharsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
 
         embeddedElasticSearch.awaitForElasticSearch();
 
@@ -198,7 +198,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
         String recipient = "benwa@linagora.com";
         ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
             "\n" +
-            Strings.repeat("0123456789", 5000) + " matchMe").getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+            Strings.repeat("0123456789", 5000) + " matchMe").getBytes(StandardCharsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
 
         embeddedElasticSearch.awaitForElasticSearch();
 
@@ -216,7 +216,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
         String reasonableLongTerm = "dichlorodiphényltrichloroéthane";
         ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
             "\n" +
-            reasonableLongTerm).getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+            reasonableLongTerm).getBytes(StandardCharsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
 
         embeddedElasticSearch.awaitForElasticSearch();
 

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.Date;
 
@@ -54,7 +55,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
@@ -66,7 +66,7 @@ public class MessageToElasticSearchJsonTest {
     public static final MessageId MESSAGE_ID = TestMessageId.of(184L);
     public static final long MOD_SEQ = 42L;
     public static final MessageUid UID = MessageUid.of(25);
-    public static final Charset CHARSET = Charsets.UTF_8;
+    public static final Charset CHARSET = StandardCharsets.UTF_8;
 
     private TextExtractor textExtractor;
 
@@ -101,7 +101,7 @@ public class MessageToElasticSearchJsonTest {
                 date,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream("message".getBytes(Charsets.UTF_8)),
+                new SharedByteArrayInputStream("message".getBytes(StandardCharsets.UTF_8)),
                 new Flags(),
                 propertyBuilder,
                 MAILBOX_ID);

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/JsoupTextExtractor.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/JsoupTextExtractor.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.inmemory;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +28,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
 
-import com.google.common.base.Charsets;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
@@ -42,10 +42,10 @@ public class JsoupTextExtractor implements TextExtractor {
         Map<String, List<String>> emptyMetadata = Maps.newHashMap();
         if (contentType != null) {
            if (contentType.equals("text/plain")) {
-            return new ParsedContent(IOUtils.toString(inputStream, Charsets.UTF_8), emptyMetadata);
+            return new ParsedContent(IOUtils.toString(inputStream, StandardCharsets.UTF_8), emptyMetadata);
            }
            if (contentType.equals("text/html")) {
-               Document doc = Jsoup.parse(IOUtils.toString(inputStream, Charsets.UTF_8));
+               Document doc = Jsoup.parse(IOUtils.toString(inputStream, StandardCharsets.UTF_8));
                doc.select(TITLE_HTML_TAG).remove();
                return new ParsedContent(doc.text(), emptyMetadata);
            }

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMessageIdManagerTestSystem.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMessageIdManagerTestSystem.java
@@ -19,6 +19,7 @@
 package org.apache.james.mailbox.inmemory;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Optional;
 
@@ -43,7 +44,6 @@ import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 
 public class InMemoryMessageIdManagerTestSystem extends MessageIdManagerTestSystem {
@@ -59,7 +59,7 @@ public class InMemoryMessageIdManagerTestSystem extends MessageIdManagerTestSyst
     private static final MessageId FIRST_MESSAGE_ID = InMemoryMessageId.of(1);
     private static final long ONE_HUNDRED = 100;
     private static final int UID_VALIDITY = 1024;
-    public static final byte[] CONTENT = "Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8);
+    public static final byte[] CONTENT = "Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8);
 
     private final MailboxManager mailboxManager;
     private Optional<MessageId> lastMessageIdUsed;

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMessageManagerTestSystem.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMessageManagerTestSystem.java
@@ -19,6 +19,7 @@
 package org.apache.james.mailbox.inmemory;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Optional;
 
@@ -39,7 +40,6 @@ import org.apache.james.mailbox.store.MessageManagerTestSystem;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 
 public class InMemoryMessageManagerTestSystem extends MessageManagerTestSystem {
@@ -47,7 +47,7 @@ public class InMemoryMessageManagerTestSystem extends MessageManagerTestSystem {
     private static final MessageId FIRST_MESSAGE_ID = InMemoryMessageId.of(1);
     private static final long ONE_HUNDRED = 100;
     private static final int UID_VALIDITY = 1024;
-    public static final byte[] CONTENT = "Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8);
+    public static final byte[] CONTENT = "Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8);
 
     private final MailboxManager mailboxManager;
     private Optional<MessageId> lastMessageIdUsed;

--- a/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/PDFTextExtractor.java
+++ b/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/PDFTextExtractor.java
@@ -20,6 +20,7 @@ package org.apache.james.mailbox.store.search;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
@@ -27,7 +28,6 @@ import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
@@ -43,7 +43,7 @@ public class PDFTextExtractor implements TextExtractor {
         if (isPDF(contentType)) {
             return extractTextFromPDF(inputStream);
         }
-        return new ParsedContent(IOUtils.toString(inputStream, Charsets.UTF_8), ImmutableMap.of());
+        return new ParsedContent(IOUtils.toString(inputStream, StandardCharsets.UTF_8), ImmutableMap.of());
     }
 
     private boolean isPDF(String contentType) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
@@ -20,13 +20,12 @@
 package org.apache.james.mailbox.store.extractor;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
-
-import com.google.common.base.Charsets;
 
 /**
  * A default text extractor that is directly based on the input file provided.
@@ -38,7 +37,7 @@ public class DefaultTextExtractor implements TextExtractor {
     @Override
     public ParsedContent extractContent(InputStream inputStream, String contentType) throws Exception {
         if(contentType != null && contentType.startsWith("text/") ) {
-            return new ParsedContent(IOUtils.toString(inputStream, Charsets.UTF_8), new HashMap<>());
+            return new ParsedContent(IOUtils.toString(inputStream, StandardCharsets.UTF_8), new HashMap<>());
         } else {
             return new ParsedContent(null, new HashMap<>());
         }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/PartContentBuilderComplexMultipartTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/PartContentBuilderComplexMultipartTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -33,8 +34,6 @@ import org.apache.james.mailbox.store.streaming.PartContentBuilder;
 import org.apache.james.mailbox.store.streaming.PartContentBuilder.PartNotFoundException;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.base.Charsets;
 
 public class PartContentBuilderComplexMultipartTest {
 
@@ -193,12 +192,12 @@ public class PartContentBuilderComplexMultipartTest {
 
     private String fullContent(int[] position) throws Exception {
         to(position);
-        return IOUtils.toString(builder.getFullContent().getInputStream(), Charsets.UTF_8);
+        return IOUtils.toString(builder.getFullContent().getInputStream(), StandardCharsets.UTF_8);
     }
 
     private String bodyContent(int[] position) throws Exception {
         to(position);
-        return IOUtils.toString(builder.getMimeBodyContent().getInputStream(), Charsets.UTF_8);
+        return IOUtils.toString(builder.getMimeBodyContent().getInputStream(), StandardCharsets.UTF_8);
     }
 
     private void checkContentType(String contentType, int[] position)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/PartContentBuilderMultipartAlternativeTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/PartContentBuilderMultipartAlternativeTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -31,8 +32,6 @@ import org.apache.james.mailbox.model.MessageResult.Header;
 import org.apache.james.mailbox.store.streaming.PartContentBuilder;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.base.Charsets;
 
 public class PartContentBuilderMultipartAlternativeTest {
 
@@ -106,7 +105,7 @@ public class PartContentBuilderMultipartAlternativeTest {
                 .encode(mail).array());
         builder.parse(in);
         builder.to(position);
-        return IOUtils.toString(builder.getFullContent().getInputStream(), Charsets.UTF_8);
+        return IOUtils.toString(builder.getFullContent().getInputStream(), StandardCharsets.UTF_8);
     }
 
     private String bodyContent(String mail, int position) throws Exception {
@@ -114,7 +113,7 @@ public class PartContentBuilderMultipartAlternativeTest {
                 .encode(mail).array());
         builder.parse(in);
         builder.to(position);
-        return IOUtils.toString(builder.getMimeBodyContent().getInputStream(), Charsets.UTF_8);
+        return IOUtils.toString(builder.getMimeBodyContent().getInputStream(), StandardCharsets.UTF_8);
     }
 
     private void checkContentType(String contentType, String mail, int position)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.store.mail.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 
@@ -35,11 +36,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 
 public abstract class AttachmentMapperTest {
-    private static final AttachmentId UNKNOWN_ATTACHMENT_ID = AttachmentId.forPayloadAndType("unknown".getBytes(Charsets.UTF_8), "type");
+    private static final AttachmentId UNKNOWN_ATTACHMENT_ID = AttachmentId.forPayloadAndType("unknown".getBytes(StandardCharsets.UTF_8), "type");
     public static final Username OWNER = Username.fromRawValue("owner");
     public static final Username ADDITIONAL_OWNER = Username.fromRawValue("additionalOwner");
 
@@ -74,7 +74,7 @@ public abstract class AttachmentMapperTest {
     public void getAttachmentShouldReturnTheAttachmentWhenReferenced() throws Exception {
         //Given
         Attachment expected = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = expected.getAttachmentId();
@@ -89,11 +89,11 @@ public abstract class AttachmentMapperTest {
     public void getAttachmentShouldReturnTheAttachmentsWhenMultipleStored() throws Exception {
         //Given
         Attachment expected1 = Attachment.builder()
-                .bytes("payload1".getBytes(Charsets.UTF_8))
+                .bytes("payload1".getBytes(StandardCharsets.UTF_8))
                 .type("content1")
                 .build();
         Attachment expected2 = Attachment.builder()
-                .bytes("payload2".getBytes(Charsets.UTF_8))
+                .bytes("payload2".getBytes(StandardCharsets.UTF_8))
                 .type("content2")
                 .build();
         AttachmentId attachmentId1 = expected1.getAttachmentId();
@@ -124,14 +124,14 @@ public abstract class AttachmentMapperTest {
     public void getAttachmentsShouldReturnTheAttachmentsWhenSome() throws Exception {
         //Given
         Attachment expected = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = expected.getAttachmentId();
         attachmentMapper.storeAttachmentForOwner(expected, OWNER);
 
         Attachment expected2 = Attachment.builder()
-                .bytes("payload2".getBytes(Charsets.UTF_8))
+                .bytes("payload2".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId2 = expected2.getAttachmentId();
@@ -154,7 +154,7 @@ public abstract class AttachmentMapperTest {
     public void getOwnerMessageIdsShouldReturnEmptyWhenStoredWithoutMessageId() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = attachment.getAttachmentId();
@@ -170,7 +170,7 @@ public abstract class AttachmentMapperTest {
     public void getOwnerMessageIdsShouldReturnMessageIdWhenStoredWithMessageId() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = attachment.getAttachmentId();
@@ -187,7 +187,7 @@ public abstract class AttachmentMapperTest {
     public void getOwnerMessageIdsShouldReturnTwoMessageIdsWhenStoredTwice() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = attachment.getAttachmentId();
@@ -206,11 +206,11 @@ public abstract class AttachmentMapperTest {
     public void getOwnerMessageIdsShouldReturnOnlyMatchingMessageId() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         Attachment otherAttachment = Attachment.builder()
-                .bytes("something different".getBytes(Charsets.UTF_8))
+                .bytes("something different".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = attachment.getAttachmentId();
@@ -229,7 +229,7 @@ public abstract class AttachmentMapperTest {
     public void getOwnerMessageIdsShouldReturnOnlyOneMessageIdWhenStoredTwice() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = attachment.getAttachmentId();
@@ -247,11 +247,11 @@ public abstract class AttachmentMapperTest {
     public void getOwnerMessageIdsShouldReturnMessageIdForTwoAttachmentsWhenBothStoredAtTheSameTime() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-                .bytes("payload".getBytes(Charsets.UTF_8))
+                .bytes("payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         Attachment attachment2 = Attachment.builder()
-                .bytes("other payload".getBytes(Charsets.UTF_8))
+                .bytes("other payload".getBytes(StandardCharsets.UTF_8))
                 .type("content")
                 .build();
         AttachmentId attachmentId = attachment.getAttachmentId();
@@ -270,7 +270,7 @@ public abstract class AttachmentMapperTest {
     public void getOwnersShouldBeRetrievedWhenExplicitlySpecified() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-            .bytes("payload".getBytes(Charsets.UTF_8))
+            .bytes("payload".getBytes(StandardCharsets.UTF_8))
             .type("content")
             .build();
 
@@ -288,7 +288,7 @@ public abstract class AttachmentMapperTest {
     public void getOwnersShouldReturnEmptyWhenMessageIdReferenced() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-            .bytes("payload".getBytes(Charsets.UTF_8))
+            .bytes("payload".getBytes(StandardCharsets.UTF_8))
             .type("content")
             .build();
 
@@ -305,7 +305,7 @@ public abstract class AttachmentMapperTest {
     public void getOwnersShouldReturnAllOwners() throws Exception {
         //Given
         Attachment attachment = Attachment.builder()
-            .bytes("payload".getBytes(Charsets.UTF_8))
+            .bytes("payload".getBytes(StandardCharsets.UTF_8))
             .type("content")
             .build();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageAssert.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageAssert.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.store.mail.model;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.mail.Flags;
 
@@ -28,7 +29,6 @@ import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.assertj.core.api.AbstractAssert;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Objects;
 
 public class MessageAssert extends AbstractAssert<MessageAssert, MailboxMessage> {
@@ -88,18 +88,18 @@ public class MessageAssert extends AbstractAssert<MessageAssert, MailboxMessage>
             if (!Objects.equal(actual.getFullContentOctets(), expected.getFullContentOctets())) {
                 failWithMessage("Expected MailboxMessage size to be <%s> but was <%s>", expected.getFullContentOctets(), actual.getFullContentOctets());
             }
-            if (!Objects.equal(IOUtils.toString(actual.getFullContent(), Charsets.UTF_8), IOUtils.toString(expected.getFullContent(), Charsets.UTF_8))) {
-                failWithMessage("Expected Full content to be <%s> but was <%s>", IOUtils.toString(expected.getFullContent(), Charsets.UTF_8), IOUtils.toString(actual.getFullContent(), Charsets.UTF_8));
+            if (!Objects.equal(IOUtils.toString(actual.getFullContent(), StandardCharsets.UTF_8), IOUtils.toString(expected.getFullContent(), StandardCharsets.UTF_8))) {
+                failWithMessage("Expected Full content to be <%s> but was <%s>", IOUtils.toString(expected.getFullContent(), StandardCharsets.UTF_8), IOUtils.toString(actual.getFullContent(), StandardCharsets.UTF_8));
             }
         }
         if (usedFetchType == MessageMapper.FetchType.Full || usedFetchType == MessageMapper.FetchType.Headers) {
-            if (!Objects.equal(IOUtils.toString(actual.getHeaderContent(), Charsets.UTF_8), IOUtils.toString(expected.getHeaderContent(), Charsets.UTF_8))) {
-                failWithMessage("Expected Header content to be <%s> but was <%s>", IOUtils.toString(expected.getHeaderContent(), Charsets.UTF_8), IOUtils.toString(actual.getHeaderContent(), Charsets.UTF_8));
+            if (!Objects.equal(IOUtils.toString(actual.getHeaderContent(), StandardCharsets.UTF_8), IOUtils.toString(expected.getHeaderContent(), StandardCharsets.UTF_8))) {
+                failWithMessage("Expected Header content to be <%s> but was <%s>", IOUtils.toString(expected.getHeaderContent(), StandardCharsets.UTF_8), IOUtils.toString(actual.getHeaderContent(), StandardCharsets.UTF_8));
             }
         }
         if (usedFetchType == MessageMapper.FetchType.Full || usedFetchType == MessageMapper.FetchType.Body) {
-            if (!Objects.equal(IOUtils.toString(actual.getBodyContent(), Charsets.UTF_8), IOUtils.toString(expected.getBodyContent(), Charsets.UTF_8))) {
-                failWithMessage("Expected Body content to be <%s> but was <%s>", IOUtils.toString(expected.getBodyContent(), Charsets.UTF_8), IOUtils.toString(actual.getBodyContent(), Charsets.UTF_8));
+            if (!Objects.equal(IOUtils.toString(actual.getBodyContent(), StandardCharsets.UTF_8), IOUtils.toString(expected.getBodyContent(), StandardCharsets.UTF_8))) {
+                failWithMessage("Expected Body content to be <%s> but was <%s>", IOUtils.toString(expected.getBodyContent(), StandardCharsets.UTF_8), IOUtils.toString(actual.getBodyContent(), StandardCharsets.UTF_8));
             }
         }
         return this;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -44,11 +45,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 
 public class SimpleMailboxMessageTest {
-    private static final Charset MESSAGE_CHARSET = Charsets.UTF_8;
+    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
     private static final String MESSAGE_CONTENT = "Simple message content without special characters";
     public static final SharedByteArrayInputStream CONTENT_STREAM = new SharedByteArrayInputStream(MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET));
     private static final String MESSAGE_CONTENT_SPECIAL_CHAR = "Simple message content with special characters: \"'(§è!çà$*`";
@@ -127,8 +127,8 @@ public class SimpleMailboxMessageTest {
         assertThat(copy.getMessage())
             .isEqualToIgnoringGivenFields(original.getMessage(), "content")
             .isNotSameAs(original.getMessage());
-        assertThat(IOUtils.toString(copy.getMessage().getFullContent(), Charsets.UTF_8))
-            .isEqualTo(IOUtils.toString(original.getMessage().getFullContent(), Charsets.UTF_8));
+        assertThat(IOUtils.toString(copy.getMessage().getFullContent(), StandardCharsets.UTF_8))
+            .isEqualTo(IOUtils.toString(original.getMessage().getFullContent(), StandardCharsets.UTF_8));
         assertThat(SimpleMailboxMessage.copy(TEST_ID, original).getTextualLineCount()).isEqualTo(textualLineCount);
         assertThat(SimpleMailboxMessage.copy(TEST_ID, original).getMediaType()).isEqualTo(text);
         assertThat(SimpleMailboxMessage.copy(TEST_ID, original).getSubType()).isEqualTo(plain);
@@ -192,7 +192,7 @@ public class SimpleMailboxMessageTest {
         MessageUid uid = MessageUid.of(45);
         MessageAttachment messageAttachment = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("".getBytes(Charsets.UTF_8))
+                .bytes("".getBytes(StandardCharsets.UTF_8))
                 .type("type")
                 .build())
             .name("name")
@@ -217,7 +217,7 @@ public class SimpleMailboxMessageTest {
         soft.assertThat(message.getInternalDate()).isEqualTo(internalDate);
         soft.assertThat(message.getHeaderOctets()).isEqualTo(BODY_START_OCTET);
         soft.assertThat(message.getFullContentOctets()).isEqualTo(SIZE);
-        soft.assertThat(IOUtils.toString(message.getFullContent(), Charsets.UTF_8)).isEqualTo(MESSAGE_CONTENT);
+        soft.assertThat(IOUtils.toString(message.getFullContent(), StandardCharsets.UTF_8)).isEqualTo(MESSAGE_CONTENT);
         soft.assertThat(message.createFlags()).isEqualTo(flags);
         soft.assertThat(message.getProperties()).isEqualTo(propertyBuilder.toProperties());
         soft.assertThat(message.getUid()).isEqualTo(uid);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -59,7 +60,6 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 
 public abstract class AbstractMessageSearchIndexTest {
@@ -1185,7 +1185,7 @@ public abstract class AbstractMessageSearchIndexTest {
                 .setBody(attachmentContent, "application/pdf")
                 .setContentDisposition("attachment")
                 .build();
-        BodyPart textPart = BodyPartBuilder.create().setBody("The message has a PDF attachment.", "plain", Charsets.UTF_8).build();
+        BodyPart textPart = BodyPartBuilder.create().setBody("The message has a PDF attachment.", "plain", StandardCharsets.UTF_8).build();
         Multipart multipart = MultipartBuilder.create("mixed")
                 .addBodyPart(attachment)
                 .addBodyPart(textPart)

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -39,7 +40,6 @@ import org.junit.rules.ExpectedException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 
 public class TikaTextExtractorTest {
@@ -63,7 +63,7 @@ public class TikaTextExtractorTest {
 
     @Test
     public void textualContentShouldReturnNullWhenInputStreamIsEmpty() throws Exception {
-        assertThat(textExtractor.extractContent(IOUtils.toInputStream("", Charsets.UTF_8), "text/plain").getTextualContent())
+        assertThat(textExtractor.extractContent(IOUtils.toInputStream("", StandardCharsets.UTF_8), "text/plain").getTextualContent())
             .isEmpty();
     }
 
@@ -157,7 +157,7 @@ public class TikaTextExtractorTest {
     public void deserializerShouldNotThrowWhenMoreThanOneNode() throws Exception {
         TikaTextExtractor textExtractor = new TikaTextExtractor(
             (inputStream, contentType) -> new ByteArrayInputStream(("[{\"X-TIKA:content\": \"This is an awesome LibreOffice document !\"}, " +
-                "{\"Chroma BlackIsZero\": \"true\"}]").getBytes(Charsets.UTF_8)));
+                "{\"Chroma BlackIsZero\": \"true\"}]").getBytes(StandardCharsets.UTF_8)));
 
         InputStream inputStream = null;
         textExtractor.extractContent(inputStream, "text/plain");
@@ -168,7 +168,7 @@ public class TikaTextExtractorTest {
         String expectedExtractedContent = "content A";
         TikaTextExtractor textExtractor = new TikaTextExtractor(
             (inputStream, contentType) -> new ByteArrayInputStream(("[{\"X-TIKA:content\": \"" + expectedExtractedContent + "\"}, " +
-                "{\"X-TIKA:content\": \"content B\"}]").getBytes(Charsets.UTF_8)));
+                "{\"X-TIKA:content\": \"content B\"}]").getBytes(StandardCharsets.UTF_8)));
 
         InputStream inputStream = null;
         ParsedContent parsedContent = textExtractor.extractContent(inputStream, "text/plain");
@@ -182,7 +182,7 @@ public class TikaTextExtractorTest {
         expectedException.expectMessage("The element should be a Json object");
 
         TikaTextExtractor textExtractor = new TikaTextExtractor(
-            (inputStream, contentType) -> new ByteArrayInputStream("[\"value1\"]".getBytes(Charsets.UTF_8)));
+            (inputStream, contentType) -> new ByteArrayInputStream("[\"value1\"]".getBytes(StandardCharsets.UTF_8)));
 
         InputStream inputStream = null;
         textExtractor.extractContent(inputStream, "text/plain");

--- a/mailet/base/src/test/java/org/apache/mailet/base/test/MimeMessageBuilder.java
+++ b/mailet/base/src/test/java/org/apache/mailet/base/test/MimeMessageBuilder.java
@@ -22,6 +22,7 @@ package org.apache.mailet.base.test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -45,7 +46,6 @@ import javax.mail.util.ByteArrayDataSource;
 import org.apache.commons.io.IOUtils;
 
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -321,7 +321,7 @@ public class MimeMessageBuilder {
     public MimeMessageBuilder setMultipartWithSubMessage(MimeMessage mimeMessage) throws MessagingException, IOException {
         return setMultipartWithBodyParts(
             new MimeBodyPart(
-                new InternetHeaders(new ByteArrayInputStream("Content-Type: multipart/mixed".getBytes(Charsets.US_ASCII))),
+                new InternetHeaders(new ByteArrayInputStream("Content-Type: multipart/mixed".getBytes(StandardCharsets.US_ASCII))),
                 IOUtils.toByteArray(mimeMessage.getInputStream())));
     }
 

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMEDecrypt.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMEDecrypt.java
@@ -49,8 +49,6 @@ import org.bouncycastle.mail.smime.SMIMEUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Charsets;
-
 /**
  * This mailet decrypts a s/mime encrypted message. It takes as input an
  * encrypted message and it tries to dechiper it using the key specified in its
@@ -165,7 +163,7 @@ public class SMIMEDecrypt extends GenericMailet {
             // I start the message stripping.
             try {
                 MimeMessage newMessage = new MimeMessage(message);
-                newMessage.setText(text(strippedMessage), Charsets.UTF_8.name());
+                newMessage.setText(text(strippedMessage), StandardCharsets.UTF_8.name());
                 if (!strippedMessage.isMimeType("multipart/*")) {
                     newMessage.setDisposition(null);
                 }

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -44,7 +45,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 
 import net.fortuna.ical4j.model.Calendar;
@@ -174,7 +174,7 @@ public class ICALToJsonAttribute extends GenericMailet {
             .stream()
             .flatMap(recipient -> toICAL(entry, rawCalendars, recipient, sender))
             .flatMap(ical -> toJson(ical, mail.getName()))
-            .map(json -> Pair.of(UUID.randomUUID().toString(), json.getBytes(Charsets.UTF_8)));
+            .map(json -> Pair.of(UUID.randomUUID().toString(), json.getBytes(StandardCharsets.UTF_8)));
     }
 
     private Stream<String> toJson(ICAL ical, String mailName) {

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/model/ICAL.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/model/ICAL.java
@@ -19,13 +19,13 @@
 
 package org.apache.james.transport.mailets.model;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
 import net.fortuna.ical4j.model.Calendar;
@@ -47,7 +47,7 @@ public class ICAL {
         private Optional<String> recurrenceId = Optional.empty();
 
         public Builder from(Calendar calendar, byte[] originalEvent) {
-            this.ical = new String(originalEvent, Charsets.UTF_8);
+            this.ical = new String(originalEvent, StandardCharsets.UTF_8);
             VEvent vevent = (VEvent) calendar.getComponent("VEVENT");
             this.uid = optionalOf(vevent.getUid());
             this.method = optionalOf(calendar.getMethod());

--- a/mailet/icalendar/src/test/java/org/apache/james/transport/mailets/ICALToJsonAttributeTest.java
+++ b/mailet/icalendar/src/test/java/org/apache/james/transport/mailets/ICALToJsonAttributeTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -42,7 +43,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 
@@ -251,7 +251,7 @@ public class ICALToJsonAttributeTest {
 
         Map<String, byte[]> jsons = (Map<String, byte[]>) mail.getAttribute(ICALToJsonAttribute.DEFAULT_DESTINATION_ATTRIBUTE_NAME);
         assertThat(jsons).hasSize(1);
-        assertThatJson(new String(jsons.values().iterator().next(), Charsets.UTF_8))
+        assertThatJson(new String(jsons.values().iterator().next(), StandardCharsets.UTF_8))
             .isEqualTo("{" +
                 "\"ical\": \"" + toJsonValue(ics) +"\"," +
                 "\"sender\": \"" + SENDER.asString() + "\"," +
@@ -265,7 +265,7 @@ public class ICALToJsonAttributeTest {
     }
 
     private String toJsonValue(byte[] ics) throws UnsupportedEncodingException {
-        return new String(JsonStringEncoder.getInstance().quoteAsUTF8(new String(ics, Charsets.UTF_8)), Charsets.UTF_8);
+        return new String(JsonStringEncoder.getInstance().quoteAsUTF8(new String(ics, StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
     }
 
     @SuppressWarnings("unchecked")
@@ -453,7 +453,7 @@ public class ICALToJsonAttributeTest {
 
         Map<String, byte[]> jsons = (Map<String, byte[]>) mail.getAttribute(ICALToJsonAttribute.DEFAULT_DESTINATION_ATTRIBUTE_NAME);
         assertThat(jsons).hasSize(1);
-        assertThatJson(new String(jsons.values().iterator().next(), Charsets.UTF_8))
+        assertThatJson(new String(jsons.values().iterator().next(), StandardCharsets.UTF_8))
             .isEqualTo("{" +
                 "\"ical\": \"" + toJsonValue(ics) +"\"," +
                 "\"sender\": \"" + from + "\"," +
@@ -488,7 +488,7 @@ public class ICALToJsonAttributeTest {
 
         Map<String, byte[]> jsons = (Map<String, byte[]>) mail.getAttribute(ICALToJsonAttribute.DEFAULT_DESTINATION_ATTRIBUTE_NAME);
         assertThat(jsons).hasSize(1);
-        assertThatJson(new String(jsons.values().iterator().next(), Charsets.UTF_8))
+        assertThatJson(new String(jsons.values().iterator().next(), StandardCharsets.UTF_8))
             .isEqualTo("{" +
                 "\"ical\": \"" + toJsonValue(ics) +"\"," +
                 "\"sender\": \"" + SENDER.asString() + "\"," +
@@ -524,7 +524,7 @@ public class ICALToJsonAttributeTest {
 
         Map<String, byte[]> jsons = (Map<String, byte[]>) mail.getAttribute(ICALToJsonAttribute.DEFAULT_DESTINATION_ATTRIBUTE_NAME);
         assertThat(jsons).hasSize(1);
-        assertThatJson(new String(jsons.values().iterator().next(), Charsets.UTF_8))
+        assertThatJson(new String(jsons.values().iterator().next(), StandardCharsets.UTF_8))
             .isEqualTo("{" +
                 "\"ical\": \"" + toJsonValue(ics) +"\"," +
                 "\"sender\": \"" + from + "\"," +
@@ -540,7 +540,7 @@ public class ICALToJsonAttributeTest {
     private List<String> toSortedValueList(Map<String, byte[]> jsons) {
         return jsons.values()
                 .stream()
-                .map(bytes -> new String(bytes, Charsets.UTF_8))
+                .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
                 .sorted()
                 .collect(Collectors.toList());
     }

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/LogMessage.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/LogMessage.java
@@ -23,6 +23,7 @@ package org.apache.james.transport.mailets;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 
@@ -35,7 +36,6 @@ import org.apache.mailet.base.GenericMailet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 
 /**
@@ -120,7 +120,7 @@ public class LogMessage extends GenericMailet {
     private void logBody(MimeMessage message) throws MessagingException, IOException {
         if (body && logger.isInfoEnabled()) {
             InputStream inputStream = ByteStreams.limit(message.getRawInputStream(), lengthToLog(message));
-            logger.info(IOUtils.toString(inputStream, Charsets.UTF_8));
+            logger.info(IOUtils.toString(inputStream, StandardCharsets.UTF_8));
         }
     }
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/utils/MimeMessageModifier.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/utils/MimeMessageModifier.java
@@ -19,11 +19,11 @@
 
 package org.apache.james.transport.mailets.utils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
-
-import com.google.common.base.Charsets;
 
 public class MimeMessageModifier {
 
@@ -36,7 +36,7 @@ public class MimeMessageModifier {
     public void replaceSubject(Optional<String> newSubject) throws MessagingException {
         if (newSubject.isPresent()) {
             message.setSubject(null);
-            message.setSubject(newSubject.get(), Charsets.UTF_8.displayName());
+            message.setSubject(newSubject.get(), StandardCharsets.UTF_8.displayName());
         }
     }
 }

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttributeTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttributeTest.java
@@ -44,7 +44,6 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.rabbitmq.client.AMQP;
@@ -59,7 +58,7 @@ public class AmqpForwardAttributeTest {
     private static final String EXCHANGE_NAME = "exchangeName";
     private static final String ROUTING_KEY = "routingKey";
     private static final String AMQP_URI = "amqp://host";
-    private static final byte[] ATTACHMENT_CONTENT = "Attachment content".getBytes(Charsets.UTF_8);
+    private static final byte[] ATTACHMENT_CONTENT = "Attachment content".getBytes(StandardCharsets.UTF_8);
     private static final ImmutableMap<String, byte[]> ATTRIBUTE_CONTENT = ImmutableMap.of("attachment1.txt", ATTACHMENT_CONTENT);
 
     @Rule

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/ContentReplacerTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/ContentReplacerTest.java
@@ -23,14 +23,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.regex.Pattern;
+
 import javax.mail.internet.MimeMessage;
 
 import org.apache.mailet.Mail;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 
 public class ContentReplacerTest {
@@ -86,7 +88,7 @@ public class ContentReplacerTest {
         ReplaceConfig replaceConfig = ReplaceConfig.builder()
                 .addAllBodyReplacingUnits(patterns)
                 .build();
-        testee.replaceMailContentAndSubject(mail, replaceConfig, Optional.of(Charsets.UTF_8));
+        testee.replaceMailContentAndSubject(mail, replaceConfig, Optional.of(StandardCharsets.UTF_8));
 
         verify(mimeMessage).setContent("TEST ee o", "text/plain; charset=UTF-8");
     }
@@ -110,9 +112,9 @@ public class ContentReplacerTest {
         ReplaceConfig replaceConfig = ReplaceConfig.builder()
                 .addAllSubjectReplacingUnits(patterns)
                 .build();
-        testee.replaceMailContentAndSubject(mail, replaceConfig, Optional.of(Charsets.UTF_8));
+        testee.replaceMailContentAndSubject(mail, replaceConfig, Optional.of(StandardCharsets.UTF_8));
 
-        verify(mimeMessage).setSubject("TEST ee o", Charsets.UTF_8.name());
+        verify(mimeMessage).setSubject("TEST ee o", StandardCharsets.UTF_8.name());
     }
 
     @Test
@@ -136,6 +138,6 @@ public class ContentReplacerTest {
                 .build();
         testee.replaceMailContentAndSubject(mail, replaceConfig, Optional.empty());
 
-        verify(mimeMessage).setSubject("TEST ee o", Charsets.UTF_8.name());
+        verify(mimeMessage).setSubject("TEST ee o", StandardCharsets.UTF_8.name());
     }
 }

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/LogMessageTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/LogMessageTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import javax.mail.MessagingException;
@@ -46,8 +47,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
-
-import com.google.common.base.Charsets;
 
 public class LogMessageTest {
 
@@ -258,7 +257,7 @@ public class LogMessageTest {
 
     private FakeMail createMail() throws MessagingException, AddressException {
         MimeMessage message = new MimeMessage(Session.getDefaultInstance(new Properties()),
-                new ByteArrayInputStream("Subject: subject\r\nContent-Type: text/plain\r\n\r\nThis is a fake mail".getBytes(Charsets.UTF_8)));
+                new ByteArrayInputStream("Subject: subject\r\nContent-Type: text/plain\r\n\r\nThis is a fake mail".getBytes(StandardCharsets.UTF_8)));
         return FakeMail.builder()
                 .mimeMessage(message)
                 .name("name")

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/MimeDecodingMailetTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/MimeDecodingMailetTest.java
@@ -21,6 +21,7 @@ package org.apache.james.transport.mailets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import javax.mail.MessagingException;
@@ -37,7 +38,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -143,9 +143,9 @@ public class MimeDecodingMailetTest {
                 + "Content-Type: application/octet-stream; charset=utf-8\r\n\r\n"
                 + text;
         String expectedKey = "mimePart1";
-        mail.setAttribute(MAIL_ATTRIBUTE, ImmutableMap.of(expectedKey, content.getBytes(Charsets.UTF_8)));
+        mail.setAttribute(MAIL_ATTRIBUTE, ImmutableMap.of(expectedKey, content.getBytes(StandardCharsets.UTF_8)));
 
-        byte[] expectedValue = text.getBytes(Charsets.UTF_8);
+        byte[] expectedValue = text.getBytes(StandardCharsets.UTF_8);
         testee.service(mail);
 
         Map<String, byte[]> processedAttribute = (Map<String, byte[]>) mail.getAttribute(MAIL_ATTRIBUTE);

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/ReplaceContentTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/ReplaceContentTest.java
@@ -22,6 +22,7 @@ package org.apache.james.transport.mailets;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import javax.mail.Session;
@@ -34,8 +35,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import com.google.common.base.Charsets;
 
 public class ReplaceContentTest {
 
@@ -216,7 +215,7 @@ public class ReplaceContentTest {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
                 .mailetName("Test")
                 .setProperty("subjectPattern", "/test/TEST/i/,/o/a//,/s/s/i/")
-                .setProperty("charset", Charsets.UTF_8.name())
+                .setProperty("charset", StandardCharsets.UTF_8.name())
                 .build();
         mailet.init(mailetConfig);
 

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
@@ -22,13 +22,16 @@ package org.apache.james.transport.mailets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import javax.mail.BodyPart;
 import javax.mail.MessagingException;
 import javax.mail.Part;
@@ -50,8 +53,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-
-import com.google.common.base.Charsets;
 
 public class StripAttachmentTest {
 
@@ -308,7 +309,7 @@ public class StripAttachmentTest {
         assertThat(saved).hasSize(1);
         assertThat(saved).containsKey(expectedKey);
         MimeBodyPart savedBodyPart = new MimeBodyPart(new ByteArrayInputStream(saved.get(expectedKey)));
-        String content = IOUtils.toString(savedBodyPart.getInputStream(), Charsets.UTF_8);
+        String content = IOUtils.toString(savedBodyPart.getInputStream(), StandardCharsets.UTF_8);
         assertThat(content).isEqualTo(EXPECTED_ATTACHMENT_CONTENT);
     }
 
@@ -344,7 +345,7 @@ public class StripAttachmentTest {
         assertThat(saved).hasSize(1);
         assertThat(saved).containsKey(expectedKey);
         MimeBodyPart savedBodyPart = new MimeBodyPart(new ByteArrayInputStream(saved.get(expectedKey)));
-        String content = IOUtils.toString(savedBodyPart.getInputStream(), Charsets.UTF_8);
+        String content = IOUtils.toString(savedBodyPart.getInputStream(), StandardCharsets.UTF_8);
         assertThat(content).isEqualTo(EXPECTED_ATTACHMENT_CONTENT);
     }
 

--- a/mdn/src/main/java/org/apache/james/mdn/MDN.java
+++ b/mdn/src/main/java/org/apache/james/mdn/MDN.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mdn;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -29,7 +30,6 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
 public class MDN {
@@ -100,7 +100,7 @@ public class MDN {
 
     public BodyPart computeHumanReadablePart() throws MessagingException {
         MimeBodyPart textPart = new MimeBodyPart();
-        textPart.setText(humanReadableText, Charsets.UTF_8.displayName());
+        textPart.setText(humanReadableText, StandardCharsets.UTF_8.displayName());
         textPart.setDisposition(MimeMessage.INLINE);
         return textPart;
     }

--- a/mdn/src/test/java/org/apache/james/mdn/MDNTest.java
+++ b/mdn/src/test/java/org/apache/james/mdn/MDNTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mdn;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.mail.internet.MimeMessage;
 
@@ -32,8 +33,6 @@ import org.apache.james.mdn.type.DispositionType;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import com.google.common.base.Charsets;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -67,7 +66,7 @@ public class MDNTest {
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         mimeMessage.writeTo(byteArrayOutputStream);
-        assertThat(new String(byteArrayOutputStream.toByteArray(), Charsets.UTF_8))
+        assertThat(new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8))
             .contains(
                 "Content-Type: text/plain; charset=UTF-8\r\n" +
                 "Content-Transfer-Encoding: 7bit\r\n" +
@@ -92,7 +91,7 @@ public class MDNTest {
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         mimeMessage.writeTo(byteArrayOutputStream);
-        assertThat(new String(byteArrayOutputStream.toByteArray(), Charsets.UTF_8))
+        assertThat(new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8))
             .contains(
                 "Content-Type: text/plain; charset=UTF-8\r\n" +
                     "Content-Transfer-Encoding: 7bit\r\n" +
@@ -155,7 +154,7 @@ public class MDNTest {
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         mimeMessage.writeTo(byteArrayOutputStream);
-        assertThat(new String(byteArrayOutputStream.toByteArray(), Charsets.UTF_8))
+        assertThat(new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8))
             .contains(
                 "Content-Type: text/plain; charset=UTF-8\r\n" +
                     "Content-Transfer-Encoding: 7bit\r\n" +

--- a/mpt/impl/smtp/core/src/main/java/org/apache/james/mpt/smtp/ForwardSmtpTest.java
+++ b/mpt/impl/smtp/core/src/main/java/org/apache/james/mpt/smtp/ForwardSmtpTest.java
@@ -24,6 +24,7 @@ import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.apache.james.mpt.script.SimpleScriptedTestProtocol;
@@ -36,7 +37,6 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.testcontainers.containers.wait.HostPortWaitStrategy;
 
-import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
@@ -82,7 +82,7 @@ public abstract class ForwardSmtpTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
         		.setContentType(ContentType.JSON)
         		.setAccept(ContentType.JSON)
-        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
         		.setPort(80)
         		.setBaseUri("http://" + containerIp.getHostAddress())
         		.build();

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/ImapRequestLineReaderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/ImapRequestLineReaderTest.java
@@ -21,13 +21,13 @@ package org.apache.james.imap.decode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.base.Charsets;
 import org.apache.james.protocols.imap.DecodingException;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 public class ImapRequestLineReaderTest {
 
@@ -37,7 +37,7 @@ public class ImapRequestLineReaderTest {
 
     @Test
     public void nextNonSpaceCharShouldReturnTheFirstCharacter() throws Exception {
-        inputStream = new ByteArrayInputStream(("anyString \n").getBytes(Charsets.US_ASCII));
+        inputStream = new ByteArrayInputStream(("anyString \n").getBytes(StandardCharsets.US_ASCII));
         lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         assertThat(lineReader.nextNonSpaceChar()).isEqualTo('a');
@@ -45,7 +45,7 @@ public class ImapRequestLineReaderTest {
 
     @Test
     public void nextNonSpaceCharShouldIgnoreTheSpaceAndReturnTheFirstNonSpaceCharacter() throws Exception {
-        inputStream = new ByteArrayInputStream(("    anyString \n").getBytes(Charsets.US_ASCII));
+        inputStream = new ByteArrayInputStream(("    anyString \n").getBytes(StandardCharsets.US_ASCII));
         lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         assertThat(lineReader.nextNonSpaceChar()).isEqualTo('a');
@@ -53,7 +53,7 @@ public class ImapRequestLineReaderTest {
 
     @Test(expected = DecodingException.class)
     public void nextNonSpaceCharShouldThrowExceptionWhenNotFound() throws Exception {
-        inputStream = new ByteArrayInputStream(("    ").getBytes(Charsets.US_ASCII));
+        inputStream = new ByteArrayInputStream(("    ").getBytes(StandardCharsets.US_ASCII));
         lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         lineReader.nextNonSpaceChar();

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/CreateCommandParserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/CreateCommandParserTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.james.imap.api.ImapCommand;
 import org.apache.james.imap.api.ImapSessionUtils;
@@ -38,8 +39,6 @@ import org.apache.james.mailbox.mock.MockMailboxSession;
 import org.apache.james.protocols.imap.DecodingException;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.base.Charsets;
 
 public class CreateCommandParserTest {
     private static final OutputStream outputStream = null;
@@ -62,7 +61,7 @@ public class CreateCommandParserTest {
 
     @Test
     public void decodeShouldThrowWhenCommandHasEmptyMailbox() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream(" \n".getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream(" \n".getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         assertThatThrownBy(() -> parser.decode(command, lineReader, TAG, mockImapSession))
@@ -71,7 +70,7 @@ public class CreateCommandParserTest {
 
     @Test
     public void decodeShouldThrowWhenCommandHasOnlySeparatorMailbox() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream("..\n".getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream("..\n".getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         assertThatThrownBy(() -> parser.decode(command, lineReader, TAG, mockImapSession))
@@ -80,7 +79,7 @@ public class CreateCommandParserTest {
 
     @Test
     public void decodeShouldReturnCreateRequestWhenValidMailboxName() throws Exception {
-        InputStream inputStream = new ByteArrayInputStream(".AnyMailbox.\n".getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream(".AnyMailbox.\n".getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         CreateRequest imapMessage = (CreateRequest)parser.decode(command, lineReader, TAG, mockImapSession);

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/GetAnnotationCommandParserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/GetAnnotationCommandParserTest.java
@@ -20,9 +20,11 @@
 package org.apache.james.imap.decode.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.james.imap.api.ImapCommand;
 import org.apache.james.imap.api.process.ImapSession;
@@ -32,7 +34,6 @@ import org.apache.james.imap.message.request.GetAnnotationRequest.Depth;
 import org.apache.james.mailbox.model.MailboxAnnotationKey;
 import org.apache.james.protocols.imap.DecodingException;
 
-import com.google.common.base.Charsets;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -55,7 +56,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowsExceptionWhenCommandHasNotMailbox() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream(" \n".getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream(" \n".getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -63,7 +64,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWhenCommandHasMailboxOnly() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + "    \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + "    \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest) parser.decode(command, lineReader, TAG, session);
@@ -78,7 +79,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasOneKeyButInWrongFormat() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " /private/comment extrastring \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " /private/comment extrastring \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -86,7 +87,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWhenCommandHasOnlyOneKey() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " /private/comment \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " /private/comment \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest) parser.decode(command, lineReader, TAG, session);
@@ -101,7 +102,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasOneInvalidKey() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + "/shared/comment private/comment \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + "/shared/comment private/comment \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -109,7 +110,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWhenCommandHasMultiKeys() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest) parser.decode(command, lineReader, TAG, session);
@@ -124,7 +125,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMultiKeysButInWrongFormat() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) (/another/key/group)\n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) (/another/key/group)\n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -132,7 +133,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMultiKeysAndSingleKey() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) /another/key \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) /another/key \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -140,7 +141,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMultiKeysButNotOpenQuote() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " /shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " /shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -148,7 +149,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMultiKeysButNotCloseQuote() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -156,7 +157,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMaxsizeOptButInWrongPlace() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) (MAXSIZE 1024) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) (MAXSIZE 1024) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -164,7 +165,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMaxsizeWithWrongValue() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE invalid) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE invalid) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -172,7 +173,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMaxsizeWithoutValue() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -180,7 +181,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMaxsizeDoesNotInParenthesis() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " MAXSIZE 1024 (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " MAXSIZE 1024 (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -188,7 +189,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasMaxsizeDoesNotInParenthesisAndNoValue() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " MAXSIZE (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " MAXSIZE (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -196,7 +197,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWhenCommandHasMaxsizeOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest) parser.decode(command, lineReader, TAG, session);
@@ -211,7 +212,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasWrongMaxsizeOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZErr 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZErr 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -219,7 +220,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasWrongMaxsizeValue() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 0) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 0) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -227,7 +228,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasWrongDepthOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH -1) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH -1) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -235,7 +236,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasWrongDepthOptionName() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTHerr 1) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTHerr 1) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -243,7 +244,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasDepthOptionButNoValue() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -251,7 +252,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasDepthOptionButInvalidValue() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH invalid) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH invalid) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -259,7 +260,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasDepthOptionButNotInParenthesis() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " DEPTH (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " DEPTH (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -267,7 +268,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldReturnRequestWhenCommandHasDepthOptionAndValueButNotInParenthesis() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " DEPTH 1 (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " DEPTH 1 (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -275,7 +276,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWithZeroDepthOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH 0) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH 0) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest)parser.decode(command, lineReader, TAG, null);
@@ -290,7 +291,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWithOneDepthOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH 1) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH 1) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest)parser.decode(command, lineReader, TAG, session);
@@ -305,7 +306,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWhenCommandHasOptionsInAnyOrder() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 1024) (DEPTH 1) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 1024) (DEPTH 1) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest)parser.decode(command, lineReader, TAG, session);
@@ -320,7 +321,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWithInfinityDepthOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH infinity) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH infinity) (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest)parser.decode(command, lineReader, TAG, session);
@@ -335,7 +336,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWithOnlyInfinityDepthOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH infinity) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH infinity) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest)parser.decode(command, lineReader, TAG, session);
@@ -350,7 +351,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test
     public void decodeMessageShouldReturnRequestWithDefaultDepthOptionWhenCommandHasDoesNotHaveDepthOption() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (MAXSIZE 1024) (/shared/comment /private/comment) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         GetAnnotationRequest request = (GetAnnotationRequest)parser.decode(command, lineReader, TAG, session);
@@ -365,7 +366,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasOneDepthButWithoutKey() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH 1) (MAXSIZE 1024) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH 1) (MAXSIZE 1024) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -373,7 +374,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasInfinityDepthButWithoutKey() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH infinity) (MAXSIZE 1024) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (DEPTH infinity) (MAXSIZE 1024) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);
@@ -381,7 +382,7 @@ public class GetAnnotationCommandParserTest {
 
     @Test(expected = DecodingException.class)
     public void decodeMessageShouldThrowExceptionWhenCommandHasDepthOptionInWrongPlace() throws DecodingException {
-        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) (DEPTH infinity) \n").getBytes(Charsets.US_ASCII));
+        InputStream inputStream = new ByteArrayInputStream((INBOX + " (/shared/comment /private/comment) (DEPTH infinity) \n").getBytes(StandardCharsets.US_ASCII));
         ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
 
         parser.decode(command, lineReader, TAG, session);

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/AllButStartTlsDelimiterChannelHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/AllButStartTlsDelimiterChannelHandler.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.protocols.smtp;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 
@@ -29,7 +30,6 @@ import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.handler.codec.frame.DelimiterBasedFrameDecoder;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 
 
@@ -57,7 +57,7 @@ public class AllButStartTlsDelimiterChannelHandler extends DelimiterBasedFrameDe
     }
 
     private String readAll(ChannelBuffer buffer) {
-        return buffer.toString(Charsets.US_ASCII);
+        return buffer.toString(StandardCharsets.US_ASCII);
     }
 
     private boolean hasCommandInjection(String trimedLowerCasedInput) {

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -55,7 +56,6 @@ import org.apache.james.protocols.smtp.utils.TestMessageHook;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 
 public abstract class AbstractSMTPServerTest {
@@ -102,7 +102,7 @@ public abstract class AbstractSMTPServerTest {
 
             final ProtocolServer finalServer = server;
             final InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
-            final String mailContent = CharStreams.toString(new InputStreamReader(ClassLoader.getSystemResourceAsStream("a50.eml"), Charsets.US_ASCII));
+            final String mailContent = CharStreams.toString(new InputStreamReader(ClassLoader.getSystemResourceAsStream("a50.eml"), StandardCharsets.US_ASCII));
             int threadCount = 4;
             int updateCount = 1;
             assertThat(new ConcurrentTestRunner(threadCount, updateCount,

--- a/server/container/cli-integration/src/test/java/org/apache/james/cli/util/OutputCapture.java
+++ b/server/container/cli-integration/src/test/java/org/apache/james/cli/util/OutputCapture.java
@@ -21,8 +21,7 @@ package org.apache.james.cli.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-
-import com.google.common.base.Charsets;
+import java.nio.charset.StandardCharsets;
 
 public class OutputCapture {
 
@@ -33,7 +32,7 @@ public class OutputCapture {
     }
 
     public String getContent() {
-        return new String(byteArrayOutputStream.toByteArray(), Charsets.UTF_8);
+        return new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
     }
 
 }

--- a/server/container/cli-integration/src/test/java/org/apache/james/cli/util/OutputCaptureTest.java
+++ b/server/container/cli-integration/src/test/java/org/apache/james/cli/util/OutputCaptureTest.java
@@ -21,9 +21,9 @@ package org.apache.james.cli.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import java.nio.charset.StandardCharsets;
 
-import com.google.common.base.Charsets;
+import org.junit.Test;
 
 public class OutputCaptureTest {
 
@@ -37,7 +37,7 @@ public class OutputCaptureTest {
         OutputCapture outputCapture = new OutputCapture();
 
         String message = "Hello world!\n";
-        outputCapture.getPrintStream().write(message.getBytes(Charsets.UTF_8));
+        outputCapture.getPrintStream().write(message.getBytes(StandardCharsets.UTF_8));
 
         assertThat(outputCapture.getContent()).isEqualTo(message);
     }
@@ -47,11 +47,11 @@ public class OutputCaptureTest {
     public void mixingReadsAndWritesShouldWork() throws Exception {
         OutputCapture outputCapture = new OutputCapture();
         String message = "Hello world!\n";
-        outputCapture.getPrintStream().write(message.getBytes(Charsets.UTF_8));
+        outputCapture.getPrintStream().write(message.getBytes(StandardCharsets.UTF_8));
         outputCapture.getContent();
 
         String additionalMessage = "Additional message!\n";
-        outputCapture.getPrintStream().write(additionalMessage.getBytes(Charsets.UTF_8));
+        outputCapture.getPrintStream().write(additionalMessage.getBytes(StandardCharsets.UTF_8));
 
         assertThat(outputCapture.getContent()).isEqualTo(message + additionalMessage);
     }

--- a/server/container/filesystem-api/src/test/java/org/apache/james/filesystem/api/AbstractFileSystemTest.java
+++ b/server/container/filesystem-api/src/test/java/org/apache/james/filesystem/api/AbstractFileSystemTest.java
@@ -25,8 +25,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
@@ -76,7 +76,7 @@ public abstract class AbstractFileSystemTest {
     private void createSubFolderWithAFileIn(String folderName, String fileName, String fileContent) throws IOException {
         File folder = tmpFolder.newFolder(folderName);
         File file = new File(folder.getAbsolutePath() + "/" + fileName);
-        FileUtils.writeStringToFile(file, fileContent, Charsets.UTF_8);
+        FileUtils.writeStringToFile(file, fileContent, StandardCharsets.UTF_8);
     }
 
     @After
@@ -239,7 +239,7 @@ public abstract class AbstractFileSystemTest {
         InputStream inputStream = null;
         try {
             inputStream = fileSystem.getResource("file:" + temp.getAbsolutePath());
-            assertThat(IOUtils.toString(inputStream, Charsets.UTF_8)).isEqualTo("content");
+            assertThat(IOUtils.toString(inputStream, StandardCharsets.UTF_8)).isEqualTo("content");
         } finally {
             IOUtils.closeQuietly(inputStream);
             temp.delete();
@@ -254,7 +254,7 @@ public abstract class AbstractFileSystemTest {
         InputStream inputStream = null;
         try {
             inputStream = fileSystem.getResource("file://" + temp.getAbsolutePath());
-            assertThat(IOUtils.toString(inputStream, Charsets.UTF_8)).isEqualTo("content");
+            assertThat(IOUtils.toString(inputStream, StandardCharsets.UTF_8)).isEqualTo("content");
         } finally {
             IOUtils.closeQuietly(inputStream);
             temp.delete();
@@ -264,7 +264,7 @@ public abstract class AbstractFileSystemTest {
     @SuppressWarnings("deprecation")
     private File createTempFile(String name, String extension) throws IOException {
         File temp = File.createTempFile(name, extension);
-        FileUtils.write(temp, "content", Charsets.UTF_8);
+        FileUtils.write(temp, "content", StandardCharsets.UTF_8);
         return temp;
     }
 

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/ESReporterTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/ESReporterTest.java
@@ -24,6 +24,7 @@ import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
 import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -45,7 +46,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Charsets;
 import com.jayway.awaitility.Duration;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
@@ -84,7 +84,7 @@ public class ESReporterTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setAccept(ContentType.JSON)
-                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
                 .setPort(server.getProbe(JmapGuiceProbe.class).getJmapPort())
                 .build();
         accessToken = HttpJmapAuthentication.authenticateJamesUser(baseUri(), USERNAME, PASSWORD);
@@ -97,7 +97,7 @@ public class ESReporterTest {
             .setScheme("http")
             .setHost("localhost")
             .setPort(server.getProbe(JmapGuiceProbe.class).getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPModule.java
@@ -20,6 +20,7 @@ package org.apache.james.jmap;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -52,7 +53,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -128,7 +128,7 @@ public class JMAPModule extends AbstractModule {
     }
 
     private Optional<String> loadPublicKey(FileSystem fileSystem, Optional<String> jwtPublickeyPemUrl) {
-        return jwtPublickeyPemUrl.map(Throwing.function(url -> FileUtils.readFileToString(fileSystem.getFile(url), Charsets.US_ASCII)));
+        return jwtPublickeyPemUrl.map(Throwing.function(url -> FileUtils.readFileToString(fileSystem.getFile(url), StandardCharsets.US_ASCII)));
     }
 
     @Singleton

--- a/server/container/guice/protocols/jmap/src/test/java/org/apache/james/AbstractJmapJamesServerTest.java
+++ b/server/container/guice/protocols/jmap/src/test/java/org/apache/james/AbstractJmapJamesServerTest.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.JmapGuiceProbe;
@@ -36,7 +37,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -63,7 +63,7 @@ public abstract class AbstractJmapJamesServerTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             .setAccept(ContentType.JSON)
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(server.getProbe(JmapGuiceProbe.class).getJmapPort())
             .build();
     }

--- a/server/container/mailbox-adapter/src/test/java/org/apache/james/adapter/mailbox/MailboxManagementTest.java
+++ b/server/container/mailbox-adapter/src/test/java/org/apache/james/adapter/mailbox/MailboxManagementTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 import org.apache.commons.io.IOUtils;
@@ -42,8 +43,6 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.base.Charsets;
 
 public class MailboxManagementTest {
 
@@ -257,8 +256,8 @@ public class MailboxManagementTest {
                 MessageRange.all(), MessageMapper.FetchType.Full, LIMIT);
         MailboxMessage mailboxMessage = iterator.next();
 
-        assertThat(IOUtils.toString(new FileInputStream(new File(emlpath)), Charsets.UTF_8))
-                .isEqualTo(IOUtils.toString(mailboxMessage.getFullContent(), Charsets.UTF_8));
+        assertThat(IOUtils.toString(new FileInputStream(new File(emlpath)), StandardCharsets.UTF_8))
+                .isEqualTo(IOUtils.toString(mailboxMessage.getFullContent(), StandardCharsets.UTF_8));
     }
 
     @Test

--- a/server/container/util-java8/src/test/java/org/apache/james/util/mime/MessageContentExtractorTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/mime/MessageContentExtractorTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import javax.mail.internet.MimeMessage;
@@ -39,8 +40,6 @@ import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.util.mime.MessageContentExtractor.MessageContent;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.base.Charsets;
 
 public class MessageContentExtractorTest {
     private static final String BINARY_CONTENT = "binary";
@@ -78,14 +77,14 @@ public class MessageContentExtractorTest {
     @Before
     public void setup() throws IOException {
         testee = new MessageContentExtractor();
-        textPart = BodyPartBuilder.create().setBody(TEXT_CONTENT, "plain", Charsets.UTF_8).build();
-        htmlPart = BodyPartBuilder.create().setBody(HTML_CONTENT, "html", Charsets.UTF_8).build();
+        textPart = BodyPartBuilder.create().setBody(TEXT_CONTENT, "plain", StandardCharsets.UTF_8).build();
+        htmlPart = BodyPartBuilder.create().setBody(HTML_CONTENT, "html", StandardCharsets.UTF_8).build();
         textAttachment = BodyPartBuilder.create()
-                .setBody(ATTACHMENT_CONTENT, "plain", Charsets.UTF_8)
+                .setBody(ATTACHMENT_CONTENT, "plain", StandardCharsets.UTF_8)
                 .setContentDisposition("attachment")
                 .build();
         inlineText = BodyPartBuilder.create()
-                .setBody(ATTACHMENT_CONTENT, "plain", Charsets.UTF_8)
+                .setBody(ATTACHMENT_CONTENT, "plain", StandardCharsets.UTF_8)
                 .setContentDisposition("inline")
                 .build();
         inlineImage = BodyPartBuilder.create()
@@ -97,7 +96,7 @@ public class MessageContentExtractorTest {
     @Test
     public void extractShouldReturnEmptyWhenBinaryContentOnly() throws IOException {
         Message message = Message.Builder.of()
-                .setBody(BasicBodyFactory.INSTANCE.binaryBody(BINARY_CONTENT, Charsets.UTF_8))
+                .setBody(BasicBodyFactory.INSTANCE.binaryBody(BINARY_CONTENT, StandardCharsets.UTF_8))
                 .build();
         MessageContent actual = testee.extract(message);
         assertThat(actual.getTextBody()).isEmpty();
@@ -107,7 +106,7 @@ public class MessageContentExtractorTest {
     @Test
     public void extractShouldReturnTextOnlyWhenTextOnlyBody() throws IOException {
         Message message = Message.Builder.of()
-                .setBody(TEXT_CONTENT, Charsets.UTF_8)
+                .setBody(TEXT_CONTENT, StandardCharsets.UTF_8)
                 .build();
         MessageContent actual = testee.extract(message);
         assertThat(actual.getTextBody()).contains(TEXT_CONTENT);
@@ -117,7 +116,7 @@ public class MessageContentExtractorTest {
     @Test
     public void extractShouldReturnHtmlOnlyWhenHtmlOnlyBody() throws IOException {
         Message message = Message.Builder.of()
-                .setBody(HTML_CONTENT, "html", Charsets.UTF_8)
+                .setBody(HTML_CONTENT, "html", StandardCharsets.UTF_8)
                 .build();
         MessageContent actual = testee.extract(message);
         assertThat(actual.getTextBody()).isEmpty();
@@ -184,11 +183,11 @@ public class MessageContentExtractorTest {
         String textBody = "body 1";
         Multipart multipart = MultipartBuilder.create("report")
             .addBodyPart(BodyPartBuilder.create()
-                .setBody(textBody, "plain", Charsets.UTF_8)
+                .setBody(textBody, "plain", StandardCharsets.UTF_8)
                 .setContentDisposition("inline")
                 .build())
             .addBodyPart(BodyPartBuilder.create()
-                .setBody("body 2", "rfc822-headers", Charsets.UTF_8)
+                .setBody("body 2", "rfc822-headers", StandardCharsets.UTF_8)
                 .setContentDisposition("inline")
                 .build())
             .build();
@@ -281,7 +280,7 @@ public class MessageContentExtractorTest {
     public void extractShouldRetrieveHtmlBodyWithOneInlinedHTMLAttachmentWithoutCid() throws IOException {
         //Given
         BodyPart inlinedHTMLPart = BodyPartBuilder.create()
-            .setBody(HTML_CONTENT, "html", Charsets.UTF_8)
+            .setBody(HTML_CONTENT, "html", StandardCharsets.UTF_8)
             .build();
         HeaderImpl inlinedHeader = new HeaderImpl();
         inlinedHeader.addField(Fields.contentDisposition(MimeMessage.INLINE));
@@ -305,7 +304,7 @@ public class MessageContentExtractorTest {
     public void extractShouldNotRetrieveHtmlBodyWithOneInlinedHTMLAttachmentWithCid() throws IOException {
         //Given
         BodyPart inlinedHTMLPart = BodyPartBuilder.create()
-            .setBody(HTML_CONTENT, "html", Charsets.UTF_8)
+            .setBody(HTML_CONTENT, "html", StandardCharsets.UTF_8)
             .build();
         HeaderImpl inlinedHeader = new HeaderImpl();
         inlinedHeader.addField(Fields.contentDisposition(MimeMessage.INLINE));
@@ -331,7 +330,7 @@ public class MessageContentExtractorTest {
     public void extractShouldRetrieveTextBodyWithOneInlinedTextAttachmentWithoutCid() throws IOException {
         //Given
         BodyPart inlinedTextPart = BodyPartBuilder.create()
-            .setBody(TEXT_CONTENT, "text", Charsets.UTF_8)
+            .setBody(TEXT_CONTENT, "text", StandardCharsets.UTF_8)
             .build();
         HeaderImpl inlinedHeader = new HeaderImpl();
         inlinedHeader.addField(Fields.contentDisposition(MimeMessage.INLINE));
@@ -355,7 +354,7 @@ public class MessageContentExtractorTest {
     public void extractShouldNotRetrieveTextBodyWithOneInlinedTextAttachmentWithCid() throws IOException {
         //Given
         BodyPart inlinedTextPart = BodyPartBuilder.create()
-            .setBody(TEXT_CONTENT, "text", Charsets.UTF_8)
+            .setBody(TEXT_CONTENT, "text", StandardCharsets.UTF_8)
             .build();
         HeaderImpl inlinedHeader = new HeaderImpl();
         inlinedHeader.addField(Fields.contentDisposition(MimeMessage.INLINE));
@@ -502,7 +501,7 @@ public class MessageContentExtractorTest {
     public void extractShouldRespectCharsetWhenUTF8() throws IOException {
         String text = "éééé\r\nèèèè\r\nàààà";
         Message message = Message.Builder.of()
-                .setBody(text, Charsets.UTF_8)
+                .setBody(text, StandardCharsets.UTF_8)
                 .build();
         MessageContent actual = testee.extract(message);
         assertThat(actual.getTextBody()).contains(text);

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/model/Script.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/model/Script.java
@@ -2,12 +2,12 @@
 
 package org.apache.james.sieve.cassandra.model;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.james.sieverepository.api.ScriptSummary;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
 public class Script {
@@ -58,7 +58,7 @@ public class Script {
             return new Script(name,
                 content,
                 isActive.get(),
-                size.orElse((long) content.getBytes(Charsets.UTF_8).length));
+                size.orElse((long) content.getBytes(StandardCharsets.UTF_8).length));
         }
 
     }

--- a/server/data/data-cassandra/src/test/java/org/apache/james/sieve/cassandra/model/ScriptTest.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/sieve/cassandra/model/ScriptTest.java
@@ -21,12 +21,12 @@ package org.apache.james.sieve.cassandra.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.james.sieverepository.api.ScriptSummary;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import com.google.common.base.Charsets;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -130,7 +130,7 @@ public class ScriptTest {
                 .isActive(true)
                 .build()
                 .getSize())
-            .isEqualTo(content.getBytes(Charsets.UTF_8).length);
+            .isEqualTo(content.getBytes(StandardCharsets.UTF_8).length);
     }
 
     @Test

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.james.dnsservice.api.DNSService;
@@ -60,7 +61,6 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.testcontainers.containers.wait.HostPortWaitStrategy;
 
-import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
@@ -111,7 +111,7 @@ public class GatewayRemoteDeliveryIntegrationTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             .setAccept(ContentType.JSON)
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(80)
             .setBaseUri("http://" + fakeSmtp.getContainerIp())
             .build();

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpAuthorizedAddressesTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpAuthorizedAddressesTest.java
@@ -25,6 +25,8 @@ import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.mailets.TemporaryJamesServer;
 import org.apache.james.mailets.configuration.CommonProcessors;
@@ -52,7 +54,6 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.testcontainers.containers.wait.HostPortWaitStrategy;
 
-import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
@@ -100,7 +101,7 @@ public class SmtpAuthorizedAddressesTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             .setAccept(ContentType.JSON)
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(80)
             .setBaseUri("http://" + fakeSmtp.getContainerIp())
             .build();

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
@@ -21,6 +21,8 @@ package org.apache.james.transport.mailets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
@@ -51,7 +53,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
@@ -72,7 +73,7 @@ public class AmqpForwardAttachmentTest {
     private static final String EXCHANGE_NAME = "myExchange";
     private static final String ROUTING_KEY = "myRoutingKey";
     
-    private static final byte[] TEST_ATTACHMENT_CONTENT = "Test attachment content".getBytes(Charsets.UTF_8);
+    private static final byte[] TEST_ATTACHMENT_CONTENT = "Test attachment content".getBytes(StandardCharsets.UTF_8);
 
     public SwarmGenericContainer rabbitMqContainer = new SwarmGenericContainer(Images.RABBITMQ)
             .withAffinityToContainer();

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ICSAttachmentWorkflowTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ICSAttachmentWorkflowTest.java
@@ -21,6 +21,7 @@ package org.apache.james.transport.mailets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import javax.mail.internet.MimeMessage;
@@ -54,7 +55,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
@@ -547,7 +547,7 @@ public class ICSAttachmentWorkflowTest {
                     .data("simple text")
                     .build(),
                 MimeMessageBuilder.bodyPartBuilder()
-                    .data(ICS_1.getBytes(Charsets.UTF_8))
+                    .data(ICS_1.getBytes(StandardCharsets.UTF_8))
                     .filename("meeting.ics")
                     .disposition("attachment")
                     .build())
@@ -559,7 +559,7 @@ public class ICSAttachmentWorkflowTest {
                 MimeMessageBuilder.bodyPartBuilder()
                     .data("simple text")
                     .build(),
-                MimeMessageBuilder.bodyPartFromBytes(ICS_BASE64.getBytes(Charsets.UTF_8)))
+                MimeMessageBuilder.bodyPartFromBytes(ICS_BASE64.getBytes(StandardCharsets.UTF_8)))
             .setSubject("test")
             .build();
 
@@ -571,17 +571,17 @@ public class ICSAttachmentWorkflowTest {
                     .data("simple text")
                     .build(),
                 MimeMessageBuilder.bodyPartBuilder()
-                    .data(ICS_1.getBytes(Charsets.UTF_8))
+                    .data(ICS_1.getBytes(StandardCharsets.UTF_8))
                     .filename("test1.txt")
                     .disposition("attachment")
                     .build(),
                 MimeMessageBuilder.bodyPartBuilder()
-                    .data(ICS_2.getBytes(Charsets.UTF_8))
+                    .data(ICS_2.getBytes(StandardCharsets.UTF_8))
                     .filename("test2.txt")
                     .disposition("attachment")
                     .build(),
                 MimeMessageBuilder.bodyPartBuilder()
-                    .data(ICS_3.getBytes(Charsets.UTF_8))
+                    .data(ICS_3.getBytes(StandardCharsets.UTF_8))
                     .filename("test3.txt")
                     .disposition("attachment")
                     .build())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/amqp/AmqpRule.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/amqp/AmqpRule.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets.amqp;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -27,7 +28,6 @@ import java.util.concurrent.TimeoutException;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.junit.rules.ExternalResource;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.jayway.awaitility.Awaitility;
 import com.rabbitmq.client.BuiltinExchangeType;
@@ -71,7 +71,7 @@ public class AmqpRule extends ExternalResource {
 
     public Optional<String> readContent() throws IOException {
         return readContentAsBytes()
-            .map(value -> new String(value, Charsets.UTF_8));
+            .map(value -> new String(value, StandardCharsets.UTF_8));
     }
 
     public Optional<byte[]> readContentAsBytes() throws IOException {

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailDispatcherTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailDispatcherTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 
@@ -45,7 +46,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ArrayListMultimap;
 
 public class MailDispatcherTest {
@@ -155,7 +155,7 @@ public class MailDispatcherTest {
             .fromMailet()
             .state(Mail.ERROR).build();
         assertThat(actual).containsOnly(expected);
-        assertThat(IOUtils.toString(actual.get(0).getMsg().getInputStream(), Charsets.UTF_8))
+        assertThat(IOUtils.toString(actual.get(0).getMsg().getInputStream(), StandardCharsets.UTF_8))
             .contains("toto");
     }
 

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/managesieve/ManageSieveMailetTestCase.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/managesieve/ManageSieveMailetTestCase.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
@@ -51,7 +52,6 @@ import org.apache.mailet.base.test.MimeMessageBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 
 public class ManageSieveMailetTestCase {
@@ -518,7 +518,7 @@ public class ManageSieveMailetTestCase {
             if (multipart.getBodyPart(i).getContent() instanceof String) {
                 assertThat(((String) multipart.getBodyPart(i).getContent()).trim()).isEqualTo(contents[i]);
             } else {
-                assertThat(IOUtils.toString((ByteArrayInputStream) multipart.getBodyPart(i).getContent(), Charsets.UTF_8).trim()).isEqualTo(contents[i]);
+                assertThat(IOUtils.toString((ByteArrayInputStream) multipart.getBodyPart(i).getContent(), StandardCharsets.UTF_8).trim()).isEqualTo(contents[i]);
             }
         }
     }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/JMAPAuthenticationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/JMAPAuthenticationTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
@@ -40,7 +41,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -64,7 +64,7 @@ public abstract class JMAPAuthenticationTest {
         jmapServer = createJmapServer(zonedDateTimeProvider);
         jmapServer.start();
         RestAssured.requestSpecification = new RequestSpecBuilder()
-        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
         		.setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
         		.build();
         

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/UserProvisionningConcurrencyTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/UserProvisionningConcurrencyTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.client.utils.URIBuilder;
@@ -39,7 +40,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 
@@ -58,7 +58,7 @@ public abstract class UserProvisionningConcurrencyTest {
         jmapServer = createJmapServer();
         jmapServer.start();
         RestAssured.requestSpecification = new RequestSpecBuilder()
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
             .build();
 
@@ -104,6 +104,6 @@ public abstract class UserProvisionningConcurrencyTest {
             .setScheme("http")
             .setHost("localhost")
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationIntegrationTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -46,7 +47,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
@@ -98,7 +98,7 @@ public abstract class VacationIntegrationTest {
             .setAccept(ContentType.JSON)
             .setConfig(newConfig()
                 .encoderConfig(
-                    encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                    encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(jmapGuiceProbe
                 .getJmapPort())
             .build();
@@ -117,7 +117,7 @@ public abstract class VacationIntegrationTest {
             .setHost("localhost")
             .setPort(guiceJamesServer.getProbe(JmapGuiceProbe.class)
                 .getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
@@ -25,6 +25,7 @@ import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.net.smtp.SMTPClient;
@@ -46,7 +47,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.wait.HostPortWaitStrategy;
 
-import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
@@ -105,7 +105,7 @@ public abstract class VacationRelayIntegrationTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             .setAccept(ContentType.JSON)
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(80)
             .setBaseUri("http://" + containerIp.getHostAddress())
             .build();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMailboxesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMailboxesMethodTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -65,7 +66,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.RestAssured;
@@ -102,7 +102,7 @@ public abstract class GetMailboxesMethodTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setAccept(ContentType.JSON)
-                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
                 .setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
                 .build();
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
@@ -125,7 +125,7 @@ public abstract class GetMailboxesMethodTest {
             .setHost("localhost")
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class)
                 .getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMessageListMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMessageListMethodTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.not;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
@@ -68,7 +69,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -104,7 +104,7 @@ public abstract class GetMessageListMethodTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setAccept(ContentType.JSON)
-                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
                 .setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
                 .build();
 
@@ -128,7 +128,7 @@ public abstract class GetMessageListMethodTest {
             .setHost("localhost")
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class)
                 .getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After
@@ -1012,7 +1012,7 @@ public abstract class GetMessageListMethodTest {
                 .setBody(attachmentContent, "application/pdf")
                 .setContentDisposition("attachment")
                 .build();
-        BodyPart textPart = BodyPartBuilder.create().setBody("The message has a PDF attachment.", "plain", Charsets.UTF_8).build();
+        BodyPart textPart = BodyPartBuilder.create().setBody("The message has a PDF attachment.", "plain", StandardCharsets.UTF_8).build();
         Multipart multipart = MultipartBuilder.create("mixed")
                 .addBodyPart(attachment)
                 .addBodyPart(textPart)
@@ -1045,7 +1045,7 @@ public abstract class GetMessageListMethodTest {
                 .setBody(attachmentContent, "application/pdf")
                 .setContentDisposition("attachment")
                 .build();
-        BodyPart textPart = BodyPartBuilder.create().setBody("The message has a PDF attachment.", "plain", Charsets.UTF_8).build();
+        BodyPart textPart = BodyPartBuilder.create().setBody("The message has a PDF attachment.", "plain", StandardCharsets.UTF_8).build();
         Multipart multipart = MultipartBuilder.create("mixed")
                 .addBodyPart(attachment)
                 .addBodyPart(textPart)

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsNull.nullValue;
 
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 
 import org.apache.http.client.utils.URIBuilder;
@@ -43,7 +44,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -81,7 +81,7 @@ public abstract class GetVacationResponseTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setAccept(ContentType.JSON)
-                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
                 .setPort(jmapGuiceProbe.getJmapPort())
                 .build();
 
@@ -99,7 +99,7 @@ public abstract class GetVacationResponseTest {
             .setHost("localhost")
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class)
                 .getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMailboxesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMailboxesMethodTest.java
@@ -38,6 +38,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.james.GuiceJamesServer;
@@ -61,7 +63,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.RestAssured;
@@ -101,7 +102,7 @@ public abstract class SetMailboxesMethodTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setAccept(ContentType.JSON)
-                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
                 .setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
                 .build();
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
@@ -122,7 +123,7 @@ public abstract class SetMailboxesMethodTest {
             .setHost("localhost")
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class)
                 .getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
@@ -93,7 +94,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
@@ -153,7 +153,7 @@ public abstract class SetMessagesMethodTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setAccept(ContentType.JSON)
-                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
                 .setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
                 .build();
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
@@ -182,7 +182,7 @@ public abstract class SetMessagesMethodTest {
             .setHost("localhost")
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class)
                 .getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After
@@ -293,7 +293,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         given()
@@ -316,7 +316,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         // When
@@ -347,13 +347,13 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message1 = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
 
         mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test2\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test2\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
 
         ComposedMessageId message3 = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test3\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test3\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String missingMessageId = randomMessageId().serialize();
@@ -384,13 +384,13 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message1 = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
 
         ComposedMessageId message2 = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test2\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test2\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
 
         ComposedMessageId message3 = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test3\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test3\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         // When
@@ -424,7 +424,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -446,7 +446,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String messageId = message.getMessageId().serialize();
@@ -469,7 +469,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -501,7 +501,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -537,7 +537,7 @@ public abstract class SetMessagesMethodTest {
                 .add(FORWARDED)
                 .build();
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, flags);
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, flags);
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -568,7 +568,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.ANSWERED));
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.ANSWERED));
         await();
 
         String messageId = message.getMessageId().serialize();
@@ -591,7 +591,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.ANSWERED));
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.ANSWERED));
         await();
 
         String messageId = message.getMessageId().serialize();
@@ -614,7 +614,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.DELETED));
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.DELETED));
         await();
 
         String messageId = message.getMessageId().serialize();
@@ -647,7 +647,7 @@ public abstract class SetMessagesMethodTest {
             .add(Flag.DELETED, Flag.RECENT)
             .build();
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, flags);
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, flags);
         await();
 
         String messageId = message.getMessageId().serialize();
@@ -682,7 +682,7 @@ public abstract class SetMessagesMethodTest {
                 .add(Flag.DRAFT, Flag.ANSWERED)
                 .build();
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, currentFlags);
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, currentFlags);
         await();
 
         String messageId = message.getMessageId().serialize();
@@ -726,7 +726,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -755,7 +755,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.SEEN));
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.SEEN));
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -777,7 +777,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.SEEN));
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.SEEN));
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -806,7 +806,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -828,7 +828,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -854,7 +854,7 @@ public abstract class SetMessagesMethodTest {
     public void setMessagesShouldRejectUpdateWhenPropertyHasWrongType() throws MailboxException {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
         mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
 
         await();
 
@@ -882,7 +882,7 @@ public abstract class SetMessagesMethodTest {
     public void setMessagesShouldRejectUpdateWhenPropertiesHaveWrongTypes() throws MailboxException {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
         mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
 
         await();
 
@@ -911,7 +911,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -933,7 +933,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -961,7 +961,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -981,7 +981,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String serializedMessageId = message.getMessageId().serialize();
@@ -1873,7 +1873,7 @@ public abstract class SetMessagesMethodTest {
         String messageCreationId = "creationId1337";
         String fromAddress = USERNAME;
         Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(Charsets.UTF_8))
+            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment);
@@ -1916,7 +1916,7 @@ public abstract class SetMessagesMethodTest {
     public void setMessagesShouldNotAllowDraftCreationInSomeoneElseMailbox() throws Exception {
         String messageCreationId = "creationId1337";
         Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(Charsets.UTF_8))
+            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment);
@@ -1954,7 +1954,7 @@ public abstract class SetMessagesMethodTest {
     public void setMessagesShouldNotAllowDraftCreationInADelegatedMailbox() throws Exception {
         String messageCreationId = "creationId1337";
         Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(Charsets.UTF_8))
+            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment);
@@ -2107,7 +2107,7 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void setMessagesShouldRejectMovingMessageToOutboxWhenNotInDraft() throws MailboxException {
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String messageId = message.getMessageId().serialize();
@@ -3065,7 +3065,7 @@ public abstract class SetMessagesMethodTest {
     public void mailboxIdsShouldReturnUpdatedWhenNoChange() throws Exception {
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String mailboxId = message.getMailboxId().serialize();
@@ -3098,7 +3098,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String requestBody = "[" +
@@ -3142,7 +3142,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String requestBody = "[" +
@@ -3184,7 +3184,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String inboxId = message.getMailboxId().serialize();
@@ -3227,7 +3227,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String inboxId = message.getMailboxId().serialize();
@@ -3267,7 +3267,7 @@ public abstract class SetMessagesMethodTest {
     public void mailboxIdsShouldBeInOriginalMailboxWhenNoChange() throws Exception {
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String mailboxId = message.getMailboxId().serialize();
@@ -3307,7 +3307,7 @@ public abstract class SetMessagesMethodTest {
     public void mailboxIdsShouldReturnErrorWhenMovingToADeletedMailbox() throws Exception {
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "any");
         String mailboxId = mailboxProbe.getMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "any")
@@ -3346,7 +3346,7 @@ public abstract class SetMessagesMethodTest {
     public void mailboxIdsShouldReturnErrorWhenSetToEmpty() throws Exception {
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String requestBody = "[" +
@@ -3384,7 +3384,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String requestBody = "[" +
@@ -3417,7 +3417,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String requestBody = "[" +
@@ -3460,7 +3460,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String requestBody = "[" +
@@ -3496,7 +3496,7 @@ public abstract class SetMessagesMethodTest {
 
         ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, MailboxPath.forUser(USERNAME, MailboxConstants.INBOX),
-            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
+            new ByteArrayInputStream("Subject: my test subject\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), Date.from(dateTime.toInstant()), false, new Flags());
 
         String messageToMoveId = message.getMessageId().serialize();
         String mailboxId = message.getMailboxId().serialize();
@@ -3577,12 +3577,12 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void setMessagesShouldReturnAttachmentsWhenMessageHasAttachment() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(Charsets.UTF_8))
+            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment);
         Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(Charsets.UTF_8))
+            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment2);
@@ -3646,17 +3646,17 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void setMessagesShouldReturnAttachmentsWithNonASCIINames() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(Charsets.UTF_8))
+            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment);
         Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(Charsets.UTF_8))
+            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment2);
         Attachment attachment3 = Attachment.builder()
-            .bytes("attachment3".getBytes(Charsets.UTF_8))
+            .bytes("attachment3".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment3);
@@ -3732,19 +3732,19 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void filenamesAttachmentsWithNonASCIICharactersShouldBeRetrievedWhenChainingSetMessagesAndGetMessages() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(Charsets.UTF_8))
+            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment);
 
         Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(Charsets.UTF_8))
+            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment2);
 
         Attachment attachment3 = Attachment.builder()
-            .bytes("attachment3".getBytes(Charsets.UTF_8))
+            .bytes("attachment3".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment3);
@@ -3847,7 +3847,7 @@ public abstract class SetMessagesMethodTest {
         with()
             .header("Authorization", accessToken.serialize())
             .contentType(attachment.getType())
-            .content(new String(IOUtils.toByteArray(attachment.getStream()), Charsets.UTF_8))
+            .content(new String(IOUtils.toByteArray(attachment.getStream()), StandardCharsets.UTF_8))
             .post("/upload");
     }
 
@@ -4025,7 +4025,7 @@ public abstract class SetMessagesMethodTest {
         Attachment attachment = Attachment.builder()
             .bytes(("<html>\n" +
                     "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
-                    "</html>").getBytes(Charsets.UTF_8))
+                    "</html>").getBytes(StandardCharsets.UTF_8))
             .type("text/html; charset=UTF-8")
             .build();
         uploadTextAttachment(attachment);
@@ -4099,7 +4099,7 @@ public abstract class SetMessagesMethodTest {
         Attachment attachment = Attachment.builder()
             .bytes(("<html>\n" +
                     "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
-                    "</html>").getBytes(Charsets.UTF_8))
+                    "</html>").getBytes(StandardCharsets.UTF_8))
             .type("text/html; charset=UTF-8")
             .build();
         uploadTextAttachment(attachment);
@@ -4169,7 +4169,7 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void attachmentAndEmptyBodyShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesWithTextAttachmentWithoutMailBody() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes(("some text").getBytes(Charsets.UTF_8))
+            .bytes(("some text").getBytes(StandardCharsets.UTF_8))
             .type("text/plain; charset=UTF-8")
             .build();
         uploadTextAttachment(attachment);
@@ -4756,12 +4756,12 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void setMessagesShouldReturnAttachmentsWhenMessageHasInlinedAttachmentButNoCid() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(Charsets.UTF_8))
+            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment);
         Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(Charsets.UTF_8))
+            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
         uploadAttachment(attachment2);
@@ -4826,7 +4826,7 @@ public abstract class SetMessagesMethodTest {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
 
         ComposedMessageId message = mailboxProbe.appendMessage(USERNAME, USER_MAILBOX,
-                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8)), new Date(), false, new Flags());
+                new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
         await();
 
         String messageId = message.getMessageId().serialize();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
@@ -25,6 +25,7 @@ import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -42,7 +43,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -72,7 +72,7 @@ public abstract class SetVacationResponseTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setAccept(ContentType.JSON)
-                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
                 .setPort(jmapGuiceProbe
                     .getJmapPort())
                 .build();
@@ -90,7 +90,7 @@ public abstract class SetVacationResponseTest {
             .setHost("localhost")
             .setPort(jmapServer.getProbe(JmapGuiceProbe.class)
                 .getJmapPort())
-            .setCharset(Charsets.UTF_8);
+            .setCharset(StandardCharsets.UTF_8);
     }
 
     @After

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/DownloadStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/DownloadStepdefs.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +48,6 @@ import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mime4j.codec.DecoderUtil;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Charsets;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ArrayListMultimap;
@@ -395,7 +395,7 @@ public class DownloadStepdefs {
     @Then("^(?:he|she|the user) can read that blob")
     public void httpOkStatusAndExpectedContent() throws IOException {
         assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-        assertThat(IOUtils.toString(response.getEntity().getContent(), Charsets.UTF_8)).isNotEmpty();
+        assertThat(IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8)).isNotEmpty();
     }
 
     @Then("^the user should receive a not found response$")
@@ -412,7 +412,7 @@ public class DownloadStepdefs {
     public void accessTokenResponse() throws Throwable {
         assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
         assertThat(response.getHeaders("Content-Type")).extracting(Header::toString).containsExactly("Content-Type: text/plain");
-        assertThat(IOUtils.toString(response.getEntity().getContent(), Charsets.UTF_8)).isNotEmpty();
+        assertThat(IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8)).isNotEmpty();
     }
 
     @Then("^\"([^\"]*)\" should receive an attachment access token$")
@@ -448,6 +448,6 @@ public class DownloadStepdefs {
     }
 
     private String decode(String name) {
-        return DecoderUtil.decodeEncodedWords(name, Charsets.UTF_8);
+        return DecoderUtil.decodeEncodedWords(name, StandardCharsets.UTF_8);
     }
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/GetMessagesMethodStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/GetMessagesMethodStepdefs.java
@@ -22,6 +22,7 @@ package org.apache.james.jmap.methods.integration.cucumber;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
@@ -47,7 +48,6 @@ import org.javatuples.Pair;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -172,7 +172,7 @@ public class GetMessagesMethodStepdefs {
         try {
             return mainStepdefs.mailboxProbe.appendMessage(userStepdefs.getConnectedUser(),
                 MailboxPath.forUser(userStepdefs.getConnectedUser(), mailbox),
-                new ByteArrayInputStream(message(contentType, subject, content, headers).getBytes(Charsets.UTF_8)),
+                new ByteArrayInputStream(message(contentType, subject, content, headers).getBytes(StandardCharsets.UTF_8)),
                 Date.from(dateTime.toInstant()), false, new Flags()).getMessageId();
         } finally {
             mainStepdefs.awaitMethod.run();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/MainStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/MainStepdefs.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.jmap.methods.integration.cucumber;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
@@ -38,7 +39,6 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.apache.james.utils.MessageIdProbe;
 
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
@@ -69,7 +69,7 @@ public class MainStepdefs {
                 .setScheme("http")
                 .setHost("localhost")
                 .setPort(jmapServer.getProbe(JmapGuiceProbe.class).getJmapPort())
-                .setCharset(Charsets.UTF_8);
+                .setCharset(StandardCharsets.UTF_8);
     }
     
     public void tearDown() {

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UploadStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UploadStepdefs.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.BufferedInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -42,7 +43,6 @@ import org.apache.james.util.CountDownConsumeInputStream;
 import org.apache.james.util.ZeroedInputStream;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Charsets;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 
@@ -123,7 +123,7 @@ public class UploadStepdefs {
     public void userUploadContentWithoutContentType(String username) throws Throwable {
         AccessToken accessToken = userStepdefs.authenticate(username);
         Request request = Request.Post(uploadUri)
-                .bodyByteArray("some text".getBytes(Charsets.UTF_8));
+                .bodyByteArray("some text".getBytes(StandardCharsets.UTF_8));
         if (accessToken != null) {
             request.addHeader("Authorization", accessToken.serialize());
         }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UserStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UserStepdefs.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.jmap.methods.integration.cucumber;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +34,6 @@ import org.apache.james.jmap.api.access.AccessToken;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.runnable.ThrowingRunnable;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
 
@@ -128,6 +128,6 @@ public class UserStepdefs {
     }
 
     private String generatePassword(String username) {
-        return Hashing.murmur3_128().hashString(username, Charsets.UTF_8).toString();
+        return Hashing.murmur3_128().hashString(username, StandardCharsets.UTF_8).toString();
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/JMAPServletTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/JMAPServletTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import org.apache.james.http.jetty.Configuration;
@@ -43,7 +44,6 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -70,7 +70,7 @@ public class JMAPServletTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
         		.setContentType(ContentType.JSON)
         		.setAccept(ContentType.JSON)
-        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
         		.setPort(server.getPort())
         		.build();
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetMessagesMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetMessagesMethodTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -73,7 +74,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -176,11 +176,11 @@ public class GetMessagesMethodTest {
     public void processShouldFetchMessages() throws MailboxException {
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
-        ByteArrayInputStream message2Content = new ByteArrayInputStream("Subject: message 2 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message2Content = new ByteArrayInputStream("Subject: message 2 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message2 = inbox.appendMessage(message2Content, now, session, false, null);
-        ByteArrayInputStream message3Content = new ByteArrayInputStream("Great-Header: message 3 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message3Content = new ByteArrayInputStream("Great-Header: message 3 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message3 = inbox.appendMessage(message3Content, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -210,7 +210,7 @@ public class GetMessagesMethodTest {
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("Content-Type: text/html\r\n"
                 + "Subject: message 1 subject\r\n"
                 + "\r\n"
-                + "my <b>HTML</b> message").getBytes(Charsets.UTF_8));
+                + "my <b>HTML</b> message").getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message = inbox.appendMessage(messageContent, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -232,7 +232,7 @@ public class GetMessagesMethodTest {
     public void processShouldReturnOnlyMandatoryPropertiesOnEmptyPropertyList() throws MailboxException {
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -251,7 +251,7 @@ public class GetMessagesMethodTest {
     public void processShouldReturnAllPropertiesWhenNoPropertyGiven() throws MailboxException {
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -268,7 +268,7 @@ public class GetMessagesMethodTest {
     public void processShouldAddMandatoryPropertiesWhenNotInPropertyList() throws MailboxException {
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -288,7 +288,7 @@ public class GetMessagesMethodTest {
     public void processShouldReturnTextBodyWhenBodyInPropertyListAndEmptyHtmlBody() throws MailboxException {
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -312,7 +312,7 @@ public class GetMessagesMethodTest {
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("Content-Type: text/html\r\n"
             + "Subject: message 1 subject\r\n"
             + "\r\n"
-            + "my <b>HTML</b> message").getBytes(Charsets.UTF_8));
+            + "my <b>HTML</b> message").getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message = inbox.appendMessage(messageContent, now, session, false, null);
 
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -336,7 +336,7 @@ public class GetMessagesMethodTest {
         Date now = new Date();
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("Content-Type: text/html\r\n"
             + "Subject: message 1 subject\r\n"
-            + "\r\n").getBytes(Charsets.UTF_8));
+            + "\r\n").getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message = inbox.appendMessage(messageContent, now, session, false, null);
 
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -373,7 +373,7 @@ public class GetMessagesMethodTest {
             + "Content-Transfer-Encoding: 7bit\n"
             + "\n"
             + "<a>The </a> <strong>HTML</strong> message"
-        ).getBytes(Charsets.UTF_8));
+        ).getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message = inbox.appendMessage(messageContent, now, session, false, null);
 
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -398,7 +398,7 @@ public class GetMessagesMethodTest {
         ByteArrayInputStream message1Content = new ByteArrayInputStream(("From: user@domain.tld\r\n"
                 + "header1: Header1Content\r\n"
                 + "HEADer2: Header2Content\r\n"
-                + "Subject: message 1 subject\r\n\r\nmy message").getBytes(Charsets.UTF_8));
+                + "Subject: message 1 subject\r\n\r\nmy message").getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -422,7 +422,7 @@ public class GetMessagesMethodTest {
         ByteArrayInputStream message1Content = new ByteArrayInputStream(("From: user@domain.tld\r\n"
                 + "header1: Header1Content\r\n"
                 + "HEADer2: Header2Content\r\n"
-                + "Subject: message 1 subject\r\n\r\nmy message").getBytes(Charsets.UTF_8));
+                + "Subject: message 1 subject\r\n\r\nmy message").getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
         
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -450,7 +450,7 @@ public class GetMessagesMethodTest {
         ByteArrayInputStream message1Content = new ByteArrayInputStream(("From: user@domain.tld\r\n"
             + "header1: Header1Content\r\n"
             + "HEADer2: Header2Content\r\n"
-            + "Subject: message 1 subject\r\n\r\nmy message").getBytes(Charsets.UTF_8));
+            + "Subject: message 1 subject\r\n\r\nmy message").getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, null);
 
         MailboxId customMailboxId = mailboxManager.getMailbox(customMailboxPath, session).getId();
@@ -482,7 +482,7 @@ public class GetMessagesMethodTest {
         ByteArrayInputStream message1Content = new ByteArrayInputStream(("From: user@domain.tld\r\n"
             + "header1: Header1Content\r\n"
             + "HEADer2: Header2Content\r\n"
-            + "Subject: message 1 subject\r\n\r\nmy message").getBytes(Charsets.UTF_8));
+            + "Subject: message 1 subject\r\n\r\nmy message").getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, NOT_RECENT, FLAGS);
         ComposedMessageId message2 = inbox.appendMessage(message1Content, now, session, NOT_RECENT, FLAGS);
         when(messageFactory.fromMetaDataWithContent(any()))
@@ -510,11 +510,11 @@ public class GetMessagesMethodTest {
             .build();
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, flags);
-        ByteArrayInputStream message2Content = new ByteArrayInputStream("Subject: message 2 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message2Content = new ByteArrayInputStream("Subject: message 2 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message2 = inbox.appendMessage(message2Content, now, session, false, flags);
-        ByteArrayInputStream message3Content = new ByteArrayInputStream("Great-Header: message 3 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message3Content = new ByteArrayInputStream("Great-Header: message 3 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message3 = inbox.appendMessage(message3Content, now, session, false, flags);
 
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -559,11 +559,11 @@ public class GetMessagesMethodTest {
             .build();
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, flags1);
-        ByteArrayInputStream message2Content = new ByteArrayInputStream("Subject: message 2 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message2Content = new ByteArrayInputStream("Subject: message 2 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message2 = inbox.appendMessage(message2Content, now, session, false, flags2);
-        ByteArrayInputStream message3Content = new ByteArrayInputStream("Great-Header: message 3 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message3Content = new ByteArrayInputStream("Great-Header: message 3 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message3 = inbox.appendMessage(message3Content, now, session, false, flags3);
 
         GetMessagesRequest request = GetMessagesRequest.builder()
@@ -602,7 +602,7 @@ public class GetMessagesMethodTest {
             .build();
         MessageManager inbox = mailboxManager.getMailbox(inboxPath, session);
         Date now = new Date();
-        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(Charsets.UTF_8));
+        ByteArrayInputStream message1Content = new ByteArrayInputStream("Subject: message 1 subject\r\n\r\nmy message".getBytes(StandardCharsets.UTF_8));
         ComposedMessageId message1 = inbox.appendMessage(message1Content, now, session, false, flags);
 
         GetMessagesRequest request = GetMessagesRequest.builder()

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MessageFactoryTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MessageFactoryTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -44,7 +45,6 @@ import org.apache.james.util.mime.MessageContentExtractor;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -74,7 +74,7 @@ public class MessageFactoryTest {
                 .keywords(Keywords.factory().from(Keyword.SEEN))
                 .size(0)
                 .internalDate(INTERNAL_DATE)
-                .content(new ByteArrayInputStream("".getBytes(Charsets.UTF_8)))
+                .content(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)))
                 .attachments(ImmutableList.of())
                 .mailboxId(MAILBOX_ID)
                 .messageId(TestMessageId.of(2))
@@ -93,7 +93,7 @@ public class MessageFactoryTest {
                 .keywords(Keywords.factory().from(Keyword.ANSWERED, Keyword.FLAGGED, Keyword.DRAFT, Keyword.FORWARDED))
                 .size(0)
                 .internalDate(INTERNAL_DATE)
-                .content(new ByteArrayInputStream("".getBytes(Charsets.UTF_8)))
+                .content(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)))
                 .attachments(ImmutableList.of())
                 .mailboxId(MAILBOX_ID)
                 .messageId(TestMessageId.of(2))
@@ -121,7 +121,7 @@ public class MessageFactoryTest {
                 .keywords(keywords)
                 .size(headers.length())
                 .internalDate(INTERNAL_DATE)
-                .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+                .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
                 .attachments(ImmutableList.of())
                 .mailboxId(MAILBOX_ID)
                 .messageId(TestMessageId.of(2))
@@ -183,7 +183,7 @@ public class MessageFactoryTest {
             .keywords(keywords)
             .size(headers.length())
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(TestMessageId.of(2))
@@ -235,7 +235,7 @@ public class MessageFactoryTest {
             .keywords(keywords)
             .size(headers.length())
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(TestMessageId.of(2))
@@ -282,7 +282,7 @@ public class MessageFactoryTest {
                 .keywords(keywords)
                 .size(mail.length())
                 .internalDate(INTERNAL_DATE)
-                .content(new ByteArrayInputStream(mail.getBytes(Charsets.UTF_8)))
+                .content(new ByteArrayInputStream(mail.getBytes(StandardCharsets.UTF_8)))
                 .attachments(ImmutableList.of())
                 .mailboxId(MAILBOX_ID)
                 .messageId(TestMessageId.of(2))
@@ -308,7 +308,7 @@ public class MessageFactoryTest {
             + "Content-Transfer-Encoding: 7bit\n"
             + "\n"
             + "<a>The </a> <strong>HTML</strong> message"
-        ).getBytes(Charsets.UTF_8));
+        ).getBytes(StandardCharsets.UTF_8));
 
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
@@ -344,7 +344,7 @@ public class MessageFactoryTest {
             .keywords(Keywords.factory().from(Keyword.SEEN))
                 .size(mail.length())
                 .internalDate(INTERNAL_DATE)
-                .content(new ByteArrayInputStream(mail.getBytes(Charsets.UTF_8)))
+                .content(new ByteArrayInputStream(mail.getBytes(StandardCharsets.UTF_8)))
                 .attachments(ImmutableList.of())
                 .mailboxId(MAILBOX_ID)
                 .messageId(TestMessageId.of(2))
@@ -418,7 +418,7 @@ public class MessageFactoryTest {
             .keywords(Keywords.factory().from(Keyword.SEEN))
             .size(headers.length())
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(new TestMessageId.Factory().generate())
@@ -447,7 +447,7 @@ public class MessageFactoryTest {
             .keywords(Keywords.factory().from(Keyword.SEEN))
             .size(headers.length())
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(new TestMessageId.Factory().generate())
@@ -472,7 +472,7 @@ public class MessageFactoryTest {
             .keywords(Keywords.factory().from(Keyword.SEEN))
             .size(headers.length())
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(new TestMessageId.Factory().generate())
@@ -498,7 +498,7 @@ public class MessageFactoryTest {
             .keywords(Keywords.factory().from(Keyword.SEEN))
             .size(headers.length())
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(new TestMessageId.Factory().generate())
@@ -523,7 +523,7 @@ public class MessageFactoryTest {
             .keywords(Keywords.factory().from(Keyword.SEEN))
             .size(headers.length())
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream(headers.getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(new TestMessageId.Factory().generate())
@@ -541,7 +541,7 @@ public class MessageFactoryTest {
             .keywords(Keywords.factory().from(Keyword.SEEN))
                 .size(1010)
                 .internalDate(INTERNAL_DATE)
-                .content(new ByteArrayInputStream((StringUtils.repeat("0123456789", 101).getBytes(Charsets.UTF_8))))
+                .content(new ByteArrayInputStream((StringUtils.repeat("0123456789", 101).getBytes(StandardCharsets.UTF_8))))
                 .attachments(ImmutableList.of())
                 .mailboxId(MAILBOX_ID)
                 .messageId(TestMessageId.of(2))
@@ -558,7 +558,7 @@ public class MessageFactoryTest {
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("CContent-Type: text/html\r\n"
             + "Subject: message 1 subject\r\n"
             + "\r\n"
-            + "my <b>HTML</b> message").getBytes(Charsets.UTF_8));
+            + "my <b>HTML</b> message").getBytes(StandardCharsets.UTF_8));
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
             .keywords(Keywords.factory().from(Keyword.SEEN))
@@ -579,7 +579,7 @@ public class MessageFactoryTest {
     @Test
     public void textBodyShouldBeEmptyInCaseOfEmptyHtmlBodyAndEmptyTextBody() throws Exception {
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("CContent-Type: text/html\r\n"
-            + "Subject: message 1 subject\r\n").getBytes(Charsets.UTF_8));
+            + "Subject: message 1 subject\r\n").getBytes(StandardCharsets.UTF_8));
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
             .keywords(Keywords.factory().from(Keyword.SEEN))
@@ -610,7 +610,7 @@ public class MessageFactoryTest {
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("CContent-Type: text/html\r\n"
             + "Subject: message 1 subject\r\n"
             + "\r\n"
-            + body).getBytes(Charsets.UTF_8));
+            + body).getBytes(StandardCharsets.UTF_8));
 
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
@@ -632,7 +632,7 @@ public class MessageFactoryTest {
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("CContent-Type: text/plain\r\n"
             + "Subject: message 1 subject\r\n"
             + "\r\n"
-            + "My plain text").getBytes(Charsets.UTF_8));
+            + "My plain text").getBytes(StandardCharsets.UTF_8));
 
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
@@ -651,7 +651,7 @@ public class MessageFactoryTest {
 
     @Test
     public void previewBodyShouldReturnStringEmptyWhenNoHtmlBodyAndNoTextBody() throws Exception {
-        ByteArrayInputStream messageContent = new ByteArrayInputStream(("Subject: message 1 subject\r\n").getBytes(Charsets.UTF_8));
+        ByteArrayInputStream messageContent = new ByteArrayInputStream(("Subject: message 1 subject\r\n").getBytes(StandardCharsets.UTF_8));
 
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
@@ -675,7 +675,7 @@ public class MessageFactoryTest {
         ByteArrayInputStream messageContent = new ByteArrayInputStream(("CContent-Type: text/html\r\n"
             + "Subject: message 1 subject\r\n"
             + "\r\n"
-            + "<html><body></body></html>").getBytes(Charsets.UTF_8));
+            + "<html><body></body></html>").getBytes(StandardCharsets.UTF_8));
 
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
@@ -711,7 +711,7 @@ public class MessageFactoryTest {
             + "Content-Transfer-Encoding: 7bit\n"
             + "\n"
             + "<html></html>"
-        ).getBytes(Charsets.UTF_8));
+        ).getBytes(StandardCharsets.UTF_8));
 
         MetaDataWithContent testMail = MetaDataWithContent.builder()
             .uid(MessageUid.of(2))
@@ -739,7 +739,7 @@ public class MessageFactoryTest {
             .keywords(keywords)
             .size(0)
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream("".getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(TestMessageId.of(2))
@@ -757,7 +757,7 @@ public class MessageFactoryTest {
             .keywords(keywords)
             .size(0)
             .internalDate(INTERNAL_DATE)
-            .content(new ByteArrayInputStream("".getBytes(Charsets.UTF_8)))
+            .content(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)))
             .attachments(ImmutableList.of())
             .mailboxId(MAILBOX_ID)
             .messageId(TestMessageId.of(2))

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/send/MailFactoryTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/send/MailFactoryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collection;
 
@@ -49,7 +50,6 @@ import org.apache.mailet.Mail;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -76,7 +76,7 @@ public class MailFactoryTest {
                 .keywords(Keywords.factory().from(Keyword.SEEN))
                 .size(content.length())
                 .internalDate(Instant.now())
-                .sharedContent(new SharedByteArrayInputStream(content.getBytes(Charsets.UTF_8)))
+                .sharedContent(new SharedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
                 .attachments(ImmutableList.of())
                 .mailboxId(InMemoryId.of(3))
                 .messageId(TestMessageId.of(2))

--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ChannelManageSieveResponseWriter.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ChannelManageSieveResponseWriter.java
@@ -22,11 +22,10 @@ package org.apache.james.managesieveserver.netty;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.stream.ChunkedStream;
-
-import com.google.common.base.Charsets;
 
 public class ChannelManageSieveResponseWriter {
     private final Channel channel;
@@ -37,7 +36,7 @@ public class ChannelManageSieveResponseWriter {
 
     public void write(String response) throws IOException {
         if (channel.isConnected()) {
-            InputStream in = new ByteArrayInputStream(response.getBytes(Charsets.UTF_8));
+            InputStream in = new ByteArrayInputStream(response.getBytes(StandardCharsets.UTF_8));
             channel.write(new ChunkedStream(in));
         }
     }

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/JwtFilterIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/JwtFilterIntegrationTest.java
@@ -25,6 +25,7 @@ import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static org.apache.james.webadmin.Constants.SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
@@ -44,7 +45,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -79,7 +79,7 @@ public class JwtFilterIntegrationTest {
     public void setUp() throws Exception {
         JwtConfiguration jwtConfiguration = new JwtConfiguration(
             Optional.of(
-                IOUtils.toString(ClassLoader.getSystemResourceAsStream("jwt_publickey"), Charsets.UTF_8)));
+                IOUtils.toString(ClassLoader.getSystemResourceAsStream("jwt_publickey"), StandardCharsets.UTF_8)));
 
         guiceJamesServer = cassandraJmapTestRule.jmapServer(cassandra.getModule())
             .overrideWith(new WebAdminConfigurationModule(),
@@ -92,7 +92,7 @@ public class JwtFilterIntegrationTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             .setAccept(ContentType.JSON)
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .build();
     }
 

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.james.CassandraJmapTestRule;
@@ -49,7 +50,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -88,7 +88,7 @@ public class WebAdminServerIntegrationTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
         		.setContentType(ContentType.JSON)
         		.setAccept(ContentType.JSON)
-        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+        		.setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
         		.build();
     }
 

--- a/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/routes/CassandraMigrationRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/routes/CassandraMigrationRoutesTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -49,7 +50,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
@@ -86,7 +86,7 @@ public class CassandraMigrationRoutesTest {
             .setAccept(ContentType.JSON)
             .setBasePath(CassandraMigrationRoutes.VERSION_BASE)
             .setPort(webAdminServer.getPort().get().getValue())
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/GlobalQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/GlobalQuotaRoutesTest.java
@@ -25,6 +25,7 @@ import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static org.apache.james.webadmin.WebAdminServer.NO_CONFIGURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.james.mailbox.inmemory.quota.InMemoryPerUserMaxQuotaManager;
@@ -38,7 +39,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -61,7 +61,7 @@ public class GlobalQuotaRoutesTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             .setAccept(ContentType.JSON)
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(webAdminServer.getPort().get().getValue())
             .build();
     }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +62,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.RestAssured;
@@ -93,7 +93,7 @@ public class UserMailboxesRoutesTest {
             .setAccept(ContentType.JSON)
             .setBasePath(USERS_BASE + SEPARATOR + USERNAME + SEPARATOR + UserMailboxesRoutes.MAILBOXES)
             .setPort(webAdminServer.getPort().get().getValue())
-            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .build();
     }
 

--- a/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
+++ b/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
@@ -22,6 +22,7 @@ package org.apache.james.utils;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -35,7 +36,6 @@ import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
 
 import com.github.fge.lambdas.Throwing;
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 
 public class SMTPMessageSender implements Closeable {
@@ -122,7 +122,7 @@ public class SMTPMessageSender implements Closeable {
     private String asString(Message message) throws IOException, MessagingException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         message.writeTo(outputStream);
-        return new String(outputStream.toByteArray(), Charsets.UTF_8);
+        return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
     }
 
     public boolean messageHasBeenSent() throws IOException {


### PR DESCRIPTION
In Java 7+ projects, constants within `com.google.common.base.Charsets` are considered deprecated, and the corresponding constants from `StandardCharsets` are preferred.

These changes were suggested by the Extra Hints plugin for NetBeans:
http://plugins.netbeans.org/plugin/73447/