### PR TITLE
JAMES-2310 Use LineBasedFrameDecoder instead of DelimiterBasedFrameDecoder

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/LineDelimiterBasedChannelHandlerFactory.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/LineDelimiterBasedChannelHandlerFactory.java
@@ -20,10 +20,10 @@ package org.apache.james.protocols.netty;
 
 import org.jboss.netty.channel.ChannelHandler;
 import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.handler.codec.frame.DelimiterBasedFrameDecoder;
-import org.jboss.netty.handler.codec.frame.Delimiters;
+import org.jboss.netty.handler.codec.frame.LineBasedFrameDecoder;
 
 public class LineDelimiterBasedChannelHandlerFactory implements ChannelHandlerFactory {
+    private static final Boolean FAIL_FAST = true;
     private final int maxLineLength;
 
     public LineDelimiterBasedChannelHandlerFactory(int maxLineLength) {
@@ -32,7 +32,7 @@ public class LineDelimiterBasedChannelHandlerFactory implements ChannelHandlerFa
 
     @Override
     public ChannelHandler create(ChannelPipeline pipeline) {
-        return new DelimiterBasedFrameDecoder(maxLineLength, false, Delimiters.lineDelimiter());
+        return new LineBasedFrameDecoder(maxLineLength, false, !FAIL_FAST);
     }
 
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/AllButStartTlsLineBasedChannelHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/AllButStartTlsLineBasedChannelHandler.java
@@ -27,19 +27,20 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.handler.codec.frame.DelimiterBasedFrameDecoder;
+import org.jboss.netty.handler.codec.frame.LineBasedFrameDecoder;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 
 
-public class AllButStartTlsDelimiterChannelHandler extends DelimiterBasedFrameDecoder {
+public class AllButStartTlsLineBasedChannelHandler extends LineBasedFrameDecoder {
 
     private static final String STARTTLS = "starttls";
+    private static final Boolean FAIL_FAST = true;
     private final ChannelPipeline pipeline;
 
-    public AllButStartTlsDelimiterChannelHandler(ChannelPipeline pipeline, int maxFrameLength, boolean stripDelimiter, ChannelBuffer[] delimiters) {
-        super(maxFrameLength, stripDelimiter, delimiters);
+    public AllButStartTlsLineBasedChannelHandler(ChannelPipeline pipeline, int maxFrameLength, boolean stripDelimiter) {
+        super(maxFrameLength, stripDelimiter, !FAIL_FAST);
         this.pipeline = pipeline;
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/AllButStartTlsLineChannelHandlerFactory.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/AllButStartTlsLineChannelHandlerFactory.java
@@ -16,23 +16,22 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
-package org.apache.james.imapserver.netty;
+package org.apache.james.protocols.smtp;
 
 import org.apache.james.protocols.netty.ChannelHandlerFactory;
 import org.jboss.netty.channel.ChannelHandler;
 import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.handler.codec.frame.Delimiters;
 
-public class SwitchableLineDelimiterBasedFrameDecoderFactory implements ChannelHandlerFactory {
+public class AllButStartTlsLineChannelHandlerFactory implements ChannelHandlerFactory {
 
-    private int maxLineLength;
+    private int maxFrameLength;
 
-    public SwitchableLineDelimiterBasedFrameDecoderFactory(int maxLineLength) {
-        this.maxLineLength = maxLineLength;
+    public AllButStartTlsLineChannelHandlerFactory(int maxFrameLength) {
+        this.maxFrameLength = maxFrameLength;
     }
 
     @Override
     public ChannelHandler create(ChannelPipeline pipeline) {
-        return new SwitchableDelimiterBasedFrameDecoder(maxLineLength, false, Delimiters.lineDelimiter());
+        return new AllButStartTlsLineBasedChannelHandler(pipeline, maxFrameLength, false);
     }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/netty/NettyStartTlsSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/netty/NettyStartTlsSMTPServerTest.java
@@ -46,7 +46,7 @@ import org.apache.james.protocols.api.utils.BogusTrustManagerFactory;
 import org.apache.james.protocols.api.utils.ProtocolServerUtils;
 import org.apache.james.protocols.netty.AbstractChannelPipelineFactory;
 import org.apache.james.protocols.netty.NettyServer;
-import org.apache.james.protocols.smtp.AllButStartTlsLineDelimiterChannelHandlerFactory;
+import org.apache.james.protocols.smtp.AllButStartTlsLineChannelHandlerFactory;
 import org.apache.james.protocols.smtp.SMTPConfigurationImpl;
 import org.apache.james.protocols.smtp.SMTPProtocol;
 import org.apache.james.protocols.smtp.SMTPProtocolHandlerChain;
@@ -80,7 +80,7 @@ public class NettyStartTlsSMTPServerTest {
         NettyServer server = NettyServer.builder()
                 .protocol(protocol)
                 .secure(enc)
-                .frameHandlerFactory(new AllButStartTlsLineDelimiterChannelHandlerFactory(AbstractChannelPipelineFactory.MAX_LINE_LENGTH))
+                .frameHandlerFactory(new AllButStartTlsLineChannelHandlerFactory(AbstractChannelPipelineFactory.MAX_LINE_LENGTH))
                 .build();
         server.setListenAddresses(new InetSocketAddress(LOCALHOST_IP, RANDOM_PORT));
         return server;

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -225,7 +225,7 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
 
     @Override
     protected ChannelHandlerFactory createFrameHandlerFactory() {
-        return new SwitchableLineDelimiterBasedFrameDecoderFactory(maxLineLength);
+        return new SwitchableLineBasedFrameDecoderFactory(maxLineLength);
     }
 
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -180,7 +180,7 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
                 //    channel.getPipeline().addFirst(FRAMER, handler);
                 //}
                 
-                ((SwitchableDelimiterBasedFrameDecoder) channel.getPipeline().get(FRAMER)).enableFraming();
+                ((SwitchableLineBasedFrameDecoder) channel.getPipeline().get(FRAMER)).enableFraming();
                 
                 attachment.clear();
                 return message;
@@ -200,7 +200,7 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
                 //attachment.put(FRAMER, handler);
 
                 // SwitchableDelimiterBasedFrameDecoder added further to JAMES-1436.
-                final SwitchableDelimiterBasedFrameDecoder framer = (SwitchableDelimiterBasedFrameDecoder) pipeline.get(FRAMER);
+                final SwitchableLineBasedFrameDecoder framer = (SwitchableLineBasedFrameDecoder) pipeline.get(FRAMER);
                 framer.disableFraming(framerContext);
                 
                 buffer.resetReaderIndex();

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
@@ -23,14 +23,15 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.Channels;
 import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.handler.codec.frame.DelimiterBasedFrameDecoder;
+import org.jboss.netty.handler.codec.frame.LineBasedFrameDecoder;
 
-public class SwitchableDelimiterBasedFrameDecoder extends DelimiterBasedFrameDecoder {
+public class SwitchableLineBasedFrameDecoder extends LineBasedFrameDecoder {
 
+    private static final Boolean FAIL_FAST = true;
     private volatile boolean framingEnabled = true;
 
-    public SwitchableDelimiterBasedFrameDecoder(int maxFrameLength, boolean stripDelimiter, ChannelBuffer... delimiters) {
-        super(maxFrameLength, stripDelimiter, delimiters);
+    public SwitchableLineBasedFrameDecoder(int maxFrameLength, boolean stripDelimiter) {
+        super(maxFrameLength, stripDelimiter, !FAIL_FAST);
     }
 
     @Override

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoderFactory.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoderFactory.java
@@ -16,23 +16,22 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
-package org.apache.james.protocols.smtp;
+package org.apache.james.imapserver.netty;
 
 import org.apache.james.protocols.netty.ChannelHandlerFactory;
 import org.jboss.netty.channel.ChannelHandler;
 import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.handler.codec.frame.Delimiters;
 
-public class AllButStartTlsLineDelimiterChannelHandlerFactory implements ChannelHandlerFactory {
+public class SwitchableLineBasedFrameDecoderFactory implements ChannelHandlerFactory {
 
-    private int maxFrameLength;
+    private int maxLineLength;
 
-    public AllButStartTlsLineDelimiterChannelHandlerFactory(int maxFrameLength) {
-        this.maxFrameLength = maxFrameLength;
+    public SwitchableLineBasedFrameDecoderFactory(int maxLineLength) {
+        this.maxLineLength = maxLineLength;
     }
 
     @Override
     public ChannelHandler create(ChannelPipeline pipeline) {
-        return new AllButStartTlsDelimiterChannelHandler(pipeline, maxFrameLength, false, Delimiters.lineDelimiter());
+        return new SwitchableLineBasedFrameDecoder(maxLineLength, false);
     }
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -32,7 +32,7 @@ import org.apache.james.protocols.lib.handler.HandlersPackage;
 import org.apache.james.protocols.lib.netty.AbstractProtocolAsyncServer;
 import org.apache.james.protocols.netty.AbstractChannelPipelineFactory;
 import org.apache.james.protocols.netty.ChannelHandlerFactory;
-import org.apache.james.protocols.smtp.AllButStartTlsLineDelimiterChannelHandlerFactory;
+import org.apache.james.protocols.smtp.AllButStartTlsLineChannelHandlerFactory;
 import org.apache.james.protocols.smtp.SMTPConfiguration;
 import org.apache.james.protocols.smtp.SMTPProtocol;
 import org.apache.james.smtpserver.CoreCmdHandlerLoader;
@@ -371,7 +371,7 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
 
     @Override
     protected ChannelHandlerFactory createFrameHandlerFactory() {
-        return new AllButStartTlsLineDelimiterChannelHandlerFactory(AbstractChannelPipelineFactory.MAX_LINE_LENGTH);
+        return new AllButStartTlsLineChannelHandlerFactory(AbstractChannelPipelineFactory.MAX_LINE_LENGTH);
     }
 
 }


### PR DESCRIPTION

The resulting decoder should be the same as before commit b4f1ed6 except starttls handling. This is because delimiter decoder will try to use line decoder *if* the delimiter is CRLF and LF AND the decoder is not subclass of delimiter decoder. Therefore, before b4f1ed6 the underlying decoder is actually line decoder, after that commit the decoder became generic delimiter decoder which cause huge performance drop (in my simple benchmark, using line decoder only take 60% time of delimiter decoder to complete the same SMTP transcations).