### PR TITLE
commented index creation for MAILBOX_ID, MAIL_UID

### DIFF
--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAProperty.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAProperty.java
@@ -38,7 +38,7 @@ public class JPAProperty implements Property {
     @Column(name = "PROPERTY_ID", nullable = true)
     // TODO The columnNames are not interpreted, see OPENJPA-223 to fix
     // MAILBOX-186
-    @Index(name = "INDEX_PROPERTY_MSG_ID", columnNames = { "MAILBOX_ID", "MAIL_UID" })
+    //@Index(name = "INDEX_PROPERTY_MSG_ID", columnNames = { "MAILBOX_ID", "MAIL_UID" })
     private long id;
 
     /** Order within the list of properties */


### PR DESCRIPTION
I commented index creation annotation for MAILBOX_ID and MAIL_UID because it generate this SQL command:
"CREATE INDEX INDEX_PROPERTY_MSG_ID ON JAMES_MAIL_PROPERTY (PROPERTY_ID)"
instead of :
"CREATE INDEX INDEX_PROPERTY_MSG_ID ON JAMES_MAIL_PROPERTY (MAILBOX_ID,MAIL_UID)"
and because of PROPERTY_ID is primary key and indexed automatically then index creation generates error in Oracle database.
I think this index creation annotation must move to table scope, not field scope.