### PR TITLE
JAMES-2355 setenv vs setenv.sh

### DIFF
--- a/server/app/pom.xml
+++ b/server/app/pom.xml
@@ -829,6 +829,7 @@
                                 <!-- this is needed because appassembler is not really smart on some settings -->
                                 <replace file="${project.build.directory}/appassembler/jsw/james/conf/wrapper.conf" token="lib/wrapper.jar" value="%REPO_DIR%/wrapper.jar" />
                                 <replace file="${project.build.directory}/appassembler/jsw/james/bin/james" token="logs" value="var" />
+                                <replace file="${project.build.directory}/appassembler/jsw/james/bin/james" token="setenv" value="setenv.sh" />
 
                                 <!-- copy the linux wrapper-linux-x86-32 to wrapper, so use it as default if no matching wrapper was found -->
                                 <copy file="${project.build.directory}/appassembler/jsw/james/bin/wrapper-linux-x86-32" tofile="${project.build.directory}/appassembler/jsw/james/bin/wrapper" />

--- a/server/app/src/main/app/bin/setenv.bat
+++ b/server/app/src/main/app/bin/setenv.bat
@@ -1,5 +1,5 @@
 @REM ----------------------------------------------------------------------------
-@REM Copyright 2001-2010 The Apache Software Foundation.
+@REM Copyright 2001-2018 The Apache Software Foundation.
 @REM
 @REM Licensed under the Apache License, Version 2.0 (the "License");
 @REM you may not use this file except in compliance with the License.
@@ -15,5 +15,17 @@
 @REM ----------------------------------------------------------------------------
 @REM
 
+@REM   This file is sourced (using 'CALL') by the various start scripts. 
+@REM   You can use it to add extra environment variables to the startup 
+@REM   procedure.
+@REM   
+@REM   NOTE:  Instead of changing this file it is better to create a new file
+@REM          named setenv.bat in the ../conf directory as the files in the
+@REM          bin directory should generally not be changed.
+
+
 @REM Add every needed extra jar to this 
-set CLASSPATH_PREFIX=../conf/lib/*
+set CLASSPATH_PREFIX=..\conf\lib\*
+
+
+if exist "%BASEDIR%\conf\setenv.bat" call "%BASEDIR%\conf\setenv.bat"

--- a/server/app/src/main/app/bin/setenv.sh
+++ b/server/app/src/main/app/bin/setenv.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ----------------------------------------------------------------------------
-# Copyright 2001-2010 The Apache Software Foundation.
+# Copyright 2001-2018 The Apache Software Foundation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,15 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 #
+# This file is sourced by the various start scripts. You can use it to
+# add extra environment variables to the startup procedure.
+#
+#   NOTE:  Instead of changing this file it is better to create a file
+#          named setenv.sh in the ../conf directory as the files in the
+#          bin directory should generally not be changed.
+
 # Add every needed extra jar to this
 CLASSPATH_PREFIX=../conf/lib/*
 export CLASSPATH_PREFIX
+
+[ -f "$BASEDIR"/conf/setenv.sh ] && . "$BASEDIR"/conf/setenv.sh


### PR DESCRIPTION
- ([JAMES-2355](https://issues.apache.org/jira/browse/JAMES-2355)). Fixes a discrepancy on *nix where two of the start scripts, `run.sh` and `james-cli.sh`, attempts to source `setenv.sh` while the script `james` will attempt to source `setenv`. This is fixed by the change to the pom.

- Adds extra feature to setenv script:  Can now optionally be put in conf dir instead of bin dir (configuration-like data do not really belong in bin dir)

- Added extra comments in the setenv files.

- Changed semi-bug in `setenv.bat`:  The `CLASSPATH_PREFIX` variable was using Unix syntax, not Windows syntax. This has been changed to Windows syntax. I'm not sure this has had any negative effect in the past as the Java classpath variable on Windows seems to be forgiving about use of Unix path separator. However, this is an undocumented feature of `java.exe` and Apache James should not rely on undocumented features.