### PR TITLE
JAMES-2382: Change the method name "hasAnnotatedProperty".

### DIFF
--- a/server/container/spring/src/main/java/org/apache/james/container/spring/lifecycle/osgi/AbstractOSGIAnnotationBeanPostProcessor.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/lifecycle/osgi/AbstractOSGIAnnotationBeanPostProcessor.java
@@ -178,7 +178,7 @@ public abstract class AbstractOSGIAnnotationBeanPostProcessor<A extends Annotati
 
         MutablePropertyValues newprops = new MutablePropertyValues(pvs);
         for (PropertyDescriptor pd : pds) {
-            A s = hasAnnotatedProperty(pd);
+            A s = findAnnotatedProperty(pd);
             if (s != null && !pvs.contains(pd.getName())) {
                 try {
                     logger.debug("Processing annotation [{}] for [{}.{}]", s, beanName, pd.getName());
@@ -267,7 +267,7 @@ public abstract class AbstractOSGIAnnotationBeanPostProcessor<A extends Annotati
     }
 
 
-    private A hasAnnotatedProperty(PropertyDescriptor propertyDescriptor) {
+    private A findAnnotatedProperty(PropertyDescriptor propertyDescriptor) {
         Method setter = propertyDescriptor.getWriteMethod();
         return setter != null ? AnnotationUtils.getAnnotation(setter, getAnnotation()) : null;
     }


### PR DESCRIPTION
The method is named "hasAnnotatedProperty" that is a query of asking whether the propertyDescriptor has the AnnotatedProperty or not.
Actually, the method returns an AnnotatedProperty found by the propertyDescriptor.
Thus, the method name "findAnnotatedProperty" should be intuitive than "hasAnnotatedProperty".