### PR TITLE
JAMES-2386 Datasource validation is configurable

### DIFF
--- a/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/JPAConstants.java
+++ b/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/JPAConstants.java
@@ -1,0 +1,26 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.jpa;
+
+public class JPAConstants {
+
+    public static final int VALIDATION_NO_TIMEOUT = -1;
+
+}

--- a/dockerfiles/run/guice/jpa/destination/conf/james-database.properties
+++ b/dockerfiles/run/guice/jpa/destination/conf/james-database.properties
@@ -38,3 +38,9 @@ vendorAdapter.database=DERBY
 # http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html  #7.11.  LOB Streaming 
 # 
 openjpa.streaming=false
+
+# Validate the data source before using it
+# datasource.testOnBorrow=true
+# datasource.validationQueryTimeoutSec=2
+# This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
+# datasource.validationQuery=select 1

--- a/dockerfiles/run/spring/destination/conf/james-database.properties
+++ b/dockerfiles/run/spring/destination/conf/james-database.properties
@@ -38,3 +38,9 @@ vendorAdapter.database=DERBY
 # http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html  #7.11.  LOB Streaming 
 # 
 openjpa.streaming=false
+
+# Validate the data source before using it
+# datasource.testOnBorrow=true
+# datasource.validationQueryTimeoutSec=2
+# This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
+# datasource.validationQuery=select 1

--- a/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
+++ b/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
@@ -78,6 +78,9 @@
         <property name="url" value="${database.url}" />
         <property name="username" value="${database.username}" />
         <property name="password" value="${database.password}" />
+        <property name="testOnBorrow" value="${datasource.testOnBorrow:false}" />
+        <property name="validationQueryTimeout" value="${datasource.validationQueryTimeoutSec:-1}" />
+        <property name="validationQuery" value="${datasource.validationQuery:#{null}}" />
     </bean>
     <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
         <property name="dataSource" ref="datasource"/>

--- a/mailbox/jpa/src/main/resources/james-database.properties
+++ b/mailbox/jpa/src/main/resources/james-database.properties
@@ -14,13 +14,33 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#
+
+#  This template file can be used as example for James Server configuration
+#  DO NOT USE IT AS SUCH AND ADAPT IT TO YOUR NEEDS
 
 # See http://james.apache.org/server/3/config.html for usage
 
+# Use derby as default
 database.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
 database.url=jdbc:derby:../var/store/derby;create=true
 database.username=app
 database.password=app
+
+# Supported adapters are:
+# DB2, DERBY, H2, HSQL, INFORMIX, MYSQL, ORACLE, POSTGRESQL, SQL_SERVER, SYBASE 
 vendorAdapter.database=DERBY
+
+# Use streaming for Blobs
+# This is only supported on a limited set of databases atm. You should check if its supported by your DB before enable
+# it. 
+# 
+# See:
+# http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html  #7.11.  LOB Streaming 
+# 
 openjpa.streaming=false
+
+# Validate the data source before using it
+# datasource.testOnBorrow=true
+# datasource.validationQueryTimeoutSec=2
+# This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
+# datasource.validationQuery=select 1

--- a/server/app/src/main/resources/james-database.properties
+++ b/server/app/src/main/resources/james-database.properties
@@ -38,3 +38,9 @@ vendorAdapter.database=DERBY
 # http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html  #7.11.  LOB Streaming 
 # 
 openjpa.streaming=false
+
+# Validate the data source before using it
+# datasource.testOnBorrow=true
+# datasource.validationQueryTimeoutSec=2
+# This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
+# datasource.validationQuery=select 1

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAConfiguration.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAConfiguration.java
@@ -18,10 +18,13 @@
  ****************************************************************/
 package org.apache.james;
 
+import org.apache.james.backends.jpa.JPAConstants;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class JPAConfiguration {
+
     public static Builder builder() {
         return new Builder();
     }
@@ -29,6 +32,10 @@ public class JPAConfiguration {
     public static class Builder {
         private String driverName;
         private String driverURL;
+        private boolean testOnBorrow;
+        private int validationQueryTimeoutSec = JPAConstants.VALIDATION_NO_TIMEOUT;
+        private String validationQuery;
+
 
         public Builder driverName(String driverName) {
             this.driverName = driverName;
@@ -40,19 +47,41 @@ public class JPAConfiguration {
             return this;
         }
 
+        public Builder testOnBorrow(boolean testOnBorrow) {
+            this.testOnBorrow = testOnBorrow;
+            return this;
+        }
+
+        public Builder validationQueryTimeoutSec(int validationQueryTimeoutSec) {
+            this.validationQueryTimeoutSec = validationQueryTimeoutSec;
+            return this;
+        }
+
+        public Builder validationQuery(String validationQuery) {
+            this.validationQuery = validationQuery;
+            return this;
+        }
+
         public JPAConfiguration build() {
             Preconditions.checkNotNull(driverName);
             Preconditions.checkNotNull(driverURL);
-            return new JPAConfiguration(driverName, driverURL);
+            return new JPAConfiguration(driverName, driverURL, testOnBorrow, validationQueryTimeoutSec, validationQuery);
         }
     }
 
     private final String driverName;
     private final String driverURL;
+    private final boolean testOnBorrow;
+    private final int validationQueryTimeoutSec;
+    private final String validationQuery;
 
-    @VisibleForTesting JPAConfiguration(String driverName, String driverURL) {
+    @VisibleForTesting
+    JPAConfiguration(String driverName, String driverURL, boolean testOnBorrow, int validationQueryTimeoutSec, String validationQuery) {
         this.driverName = driverName;
         this.driverURL = driverURL;
+        this.testOnBorrow = testOnBorrow;
+        this.validationQueryTimeoutSec = validationQueryTimeoutSec;
+        this.validationQuery = validationQuery;
     }
 
     public String getDriverName() {
@@ -61,6 +90,18 @@ public class JPAConfiguration {
 
     public String getDriverURL() {
         return driverURL;
+    }
+
+    public boolean isTestOnBorrow() {
+        return testOnBorrow;
+    }
+
+    public int getValidationQueryTimeoutSec() {
+        return validationQueryTimeoutSec;
+    }
+
+    public String getValidationQuery() {
+        return validationQuery;
     }
 
 }

--- a/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerWithSqlValidationTest.java
+++ b/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerWithSqlValidationTest.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.apache.james.modules.TestFilesystemModule;
+
+public class JPAJamesServerWithSqlValidationTest extends JPAJamesServerTest {
+
+    @Override
+    protected GuiceJamesServer createJamesServer() {
+        return new GuiceJamesServer()
+            .combineWith(JPAJamesServerMain.JPA_SERVER_MODULE, JPAJamesServerMain.PROTOCOLS)
+            .overrideWith(new TestFilesystemModule(temporaryFolder),
+                        new TestJPAConfigurationModuleWithSqlValidation());
+    }
+
+}

--- a/server/container/guice/jpa-guice/src/test/java/org/apache/james/TestJPAConfigurationModuleWithSqlValidation.java
+++ b/server/container/guice/jpa-guice/src/test/java/org/apache/james/TestJPAConfigurationModuleWithSqlValidation.java
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.io.FileNotFoundException;
+
+import javax.inject.Singleton;
+
+import org.apache.commons.configuration.ConfigurationException;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+public class TestJPAConfigurationModuleWithSqlValidation extends AbstractModule {
+
+    private static final String JDBC_EMBEDDED_URL = "jdbc:derby:memory:mailboxintegration;create=true";
+    private static final String JDBC_EMBEDDED_DRIVER = org.apache.derby.jdbc.EmbeddedDriver.class.getName();
+    private static final String VALIDATION_SQL_QUERY = "VALUES 1";
+
+    @Override
+    protected void configure() {
+    }
+
+    @Provides
+    @Singleton
+    JPAConfiguration provideConfiguration() throws FileNotFoundException, ConfigurationException {
+        return JPAConfiguration.builder()
+                .driverName(JDBC_EMBEDDED_DRIVER)
+                .driverURL(JDBC_EMBEDDED_URL)
+                .testOnBorrow(true)
+                .validationQueryTimeoutSec(2)
+                .validationQuery(VALIDATION_SQL_QUERY)
+                .build();
+    }
+}

--- a/server/container/guice/jpa-smtp/sample-configuration/james-database.properties
+++ b/server/container/guice/jpa-smtp/sample-configuration/james-database.properties
@@ -38,3 +38,9 @@ vendorAdapter.database=DERBY
 # http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html  #7.11.  LOB Streaming 
 # 
 openjpa.streaming=false
+
+# Validate the data source before using it
+# datasource.testOnBorrow=true
+# datasource.validationQueryTimeoutSec=2
+# This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
+# datasource.validationQuery=select 1

--- a/server/container/guice/jpa-smtp/src/main/java/org/apache/james/JPAConfiguration.java
+++ b/server/container/guice/jpa-smtp/src/main/java/org/apache/james/JPAConfiguration.java
@@ -18,10 +18,13 @@
  ****************************************************************/
 package org.apache.james;
 
+import org.apache.james.backends.jpa.JPAConstants;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class JPAConfiguration {
+
     public static Builder builder() {
         return new Builder();
     }
@@ -29,6 +32,10 @@ public class JPAConfiguration {
     public static class Builder {
         private String driverName;
         private String driverURL;
+        private boolean testOnBorrow;
+        private int validationQueryTimeoutSec = JPAConstants.VALIDATION_NO_TIMEOUT;
+        private String validationQuery;
+
 
         public Builder driverName(String driverName) {
             this.driverName = driverName;
@@ -40,19 +47,41 @@ public class JPAConfiguration {
             return this;
         }
 
+        public Builder testOnBorrow(boolean testOnBorrow) {
+            this.testOnBorrow = testOnBorrow;
+            return this;
+        }
+
+        public Builder validationQueryTimeoutSec(int validationQueryTimeoutSec) {
+            this.validationQueryTimeoutSec = validationQueryTimeoutSec;
+            return this;
+        }
+
+        public Builder validationQuery(String validationQuery) {
+            this.validationQuery = validationQuery;
+            return this;
+        }
+
         public JPAConfiguration build() {
             Preconditions.checkNotNull(driverName);
             Preconditions.checkNotNull(driverURL);
-            return new JPAConfiguration(driverName, driverURL);
+            return new JPAConfiguration(driverName, driverURL, testOnBorrow, validationQueryTimeoutSec, validationQuery);
         }
     }
 
     private final String driverName;
     private final String driverURL;
+    private final boolean testOnBorrow;
+    private final int validationQueryTimeoutSec;
+    private final String validationQuery;
 
-    @VisibleForTesting JPAConfiguration(String driverName, String driverURL) {
+    @VisibleForTesting
+    JPAConfiguration(String driverName, String driverURL, boolean testOnBorrow, int validationQueryTimeoutSec, String validationQuery) {
         this.driverName = driverName;
         this.driverURL = driverURL;
+        this.testOnBorrow = testOnBorrow;
+        this.validationQueryTimeoutSec = validationQueryTimeoutSec;
+        this.validationQuery = validationQuery;
     }
 
     public String getDriverName() {
@@ -61,6 +90,18 @@ public class JPAConfiguration {
 
     public String getDriverURL() {
         return driverURL;
+    }
+
+    public boolean isTestOnBorrow() {
+        return testOnBorrow;
+    }
+
+    public int getValidationQueryTimeoutSec() {
+        return validationQueryTimeoutSec;
+    }
+
+    public String getValidationQuery() {
+        return validationQuery;
     }
 
 }

--- a/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -181,6 +181,9 @@
         <property name="url" value="${database.url}"/>
         <property name="username" value="${database.username}"/>
         <property name="password" value="${database.password}"/>
+        <property name="testOnBorrow" value="${datasource.testOnBorrow:false}" />
+        <property name="validationQueryTimeout" value="${datasource.validationQueryTimeoutSec:-1}" />
+        <property name="validationQuery" value="${datasource.validationQuery:#{null}}" />
         <!--The value for maxActive should always be larger than the number of spooler threads. The-->
         <!--reason is that a spooler thread normally requires 1 connection to process a mail, however-->
         <!--sometimes OpenJPA requires 1 connection to finish the processing on top of that. If-->

--- a/server/data/data-jdbc/src/main/resources/OSGI-INF/blueprint/jdbc.xml
+++ b/server/data/data-jdbc/src/main/resources/OSGI-INF/blueprint/jdbc.xml
@@ -36,6 +36,9 @@
     <property name="url" value="${jdbc.url}" />
     <property name="username" value="${jdbc.username}" />
     <property name="password" value="${jdbc.password}" />
+    <property name="testOnBorrow" value="${datasource.testOnBorrow:false}" />
+    <property name="validationQueryTimeout" value="${datasource.validationQueryTimeoutSec:-1}" />
+    <property name="validationQuery" value="${datasource.validationQuery:#{null}}" />
   </bean>
   <service id="datasource" ref="dataSourceJames" interface="javax.sql.DataSource">
     <service-properties>


### PR DESCRIPTION
My fix includes:

- instructions in comments in file `james-database.properties`
- default values when not set are the current ones: no validation
- can set the 3 variables