### PR TITLE
JAMES-2389 fix bug: when sending email with different case, making new inbox for destination user.

### DIFF
--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepository.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepository.java
@@ -770,7 +770,7 @@ public class ReadOnlyUsersLDAPRepository implements UsersRepository, Configurabl
         if (supportVirtualHosting()) {
             return mailAddress.asString();
         } else {
-            return mailAddress.getLocalPart();
+            return mailAddress.getLocalPart().toLowerCase();
         }
     }
 

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/AbstractUsersRepository.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/AbstractUsersRepository.java
@@ -124,7 +124,7 @@ public abstract class AbstractUsersRepository implements UsersRepository, Config
         if (supportVirtualHosting()) {
             return mailAddress.asString();
         } else {
-            return mailAddress.getLocalPart();
+            return mailAddress.getLocalPart().toLowerCase();
         }
     }
 


### PR DESCRIPTION
[JAMES-2389](https://issues.apache.org/jira/browse/JAMES-2389)
the bug:
When sending an email to a user with no lower case user name, a new Inbox is created for that user.
For example assume:
I have a user with "test1@t.t1" name for example. When I send mail to "Test1@t.t1", James accepts it but creates a new mail box with "Test1@t.t1" name in database(JAMES_MAILBOX table in USER_NAME field) and "test1@t.t1" user can't see the email.
It seems user existence check is case insensitive but mailbox creation is case sensitive.
James should not create a new inbox in this situation.

fix: In all implementation of `getUser ` method of `org.apache.james.user.api.UsersRepository` interface, I converted the result to lower case to avoid generating new inbox.