### PR TITLE
PROTOCOLS-118 Continuation Response can't handle Login

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/AuthenticateResponseEncoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/AuthenticateResponseEncoder.java
@@ -38,7 +38,8 @@ public class AuthenticateResponseEncoder  extends AbstractChainedImapEncoder {
 
     @Override
     protected void doEncode(ImapMessage acceptableMessage, ImapResponseComposer composer, ImapSession session) throws IOException {
-        composer.continuationResponse("");
+        // Some clients dont recognise the continuation, unless it is followed by text
+        composer.continuationResponse("Ok");
     }
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/AuthenticateResponseEncoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/AuthenticateResponseEncoder.java
@@ -38,7 +38,7 @@ public class AuthenticateResponseEncoder  extends AbstractChainedImapEncoder {
 
     @Override
     protected void doEncode(ImapMessage acceptableMessage, ImapResponseComposer composer, ImapSession session) throws IOException {
-        // Some clients dont recognise the continuation, unless it is followed by text
+        // Some clients dont recognise the continuation, unless it is followed by text - PROTOCOLS-118
         composer.continuationResponse("Ok");
     }
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/AbstractNettyImapRequestLineReader.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/AbstractNettyImapRequestLineReader.java
@@ -26,7 +26,7 @@ import org.jboss.netty.channel.Channel;
 
 public abstract class AbstractNettyImapRequestLineReader extends ImapRequestLineReader {
     private final Channel channel;
-    // Some clients dont recognise the continuation, unless it is followed by text
+    // Some clients dont recognise the continuation, unless it is followed by text - PROTOCOLS-118
     private final ChannelBuffer cRequest = ChannelBuffers.wrappedBuffer("+ Ok\r\n".getBytes());
     private final boolean retry;
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/AbstractNettyImapRequestLineReader.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/AbstractNettyImapRequestLineReader.java
@@ -26,7 +26,8 @@ import org.jboss.netty.channel.Channel;
 
 public abstract class AbstractNettyImapRequestLineReader extends ImapRequestLineReader {
     private final Channel channel;
-    private final ChannelBuffer cRequest = ChannelBuffers.wrappedBuffer("+\r\n".getBytes());
+    // Some clients dont recognise the continuation, unless it is followed by text
+    private final ChannelBuffer cRequest = ChannelBuffers.wrappedBuffer("+ Ok\r\n".getBytes());
     private final boolean retry;
 
     public AbstractNettyImapRequestLineReader(Channel channel, boolean retry) {


### PR DESCRIPTION
It seems James does not handle the repeated continuation request correctly.

This is the first part of the fix.
NGINX for example is expecting some text after the initial continuation Tag ("+").
Changed it so an "+ Ok" is send.
It seems to be specified by the RFC 3501, though it is a very vague description.