### PR TITLE
JAMES-2431 Fix Dockerfile for build the website

### DIFF
--- a/dockerfiles/site/homepage/Dockerfile
+++ b/dockerfiles/site/homepage/Dockerfile
@@ -1,6 +1,7 @@
-FROM ruby:2.1
+FROM ruby:2.2
 
-RUN apt-get update \
+RUN apt-key update \
+  && apt-get update \
   && apt-get install -y \
     node \
     python-pygments \


### PR DESCRIPTION
The actual build command ```docker build -t james/homepage dockerfiles/site/homepage``` is based on ruby:2.1 and fail with:

```
Sending build context to Docker daemon  3.584kB
Step 1/6 : FROM ruby:2.1
 ---> 223d1eaa9523
Step 2/6 : RUN apt-get update   && apt-get install -y     node     python-pygments   && apt-get clean   && rm -rf /var/lib/apt/lists/
 ---> Using cache
 ---> e0a6ea40e651
Step 3/6 : RUN gem install   github-pages   jekyll   jekyll-redirect-from   kramdown   rdiscount   rouge
 ---> Running in 1a7e4b06740a
Successfully installed public_suffix-2.0.5
Successfully installed addressable-2.5.2
Successfully installed colorator-1.1.0
Building native extensions.  This could take a while...
Successfully installed http_parser.rb-0.6.0
Building native extensions.  This could take a while...
Successfully installed eventmachine-1.2.7
Successfully installed em-websocket-0.5.1
Successfully installed concurrent-ruby-1.0.5
Successfully installed i18n-0.9.5
Successfully installed rb-fsevent-0.10.3
Building native extensions.  This could take a while...
ERROR:  Error installing github-pages:
	ruby_dep requires Ruby version >= 2.2.5, ~> 2.2.
ERROR:  Error installing jekyll:
	ruby_dep requires Ruby version >= 2.2.5, ~> 2.2.
ERROR:  Error installing jekyll-redirect-from:
	ruby_dep requires Ruby version >= 2.2.5, ~> 2.2.
Successfully installed ffi-1.9.25
Successfully installed rb-inotify-0.9.10
Successfully installed sass-listen-4.0.0
Successfully installed sass-3.5.6
Successfully installed jekyll-sass-converter-1.5.2
Successfully installed kramdown-1.17.0
Building native extensions.  This could take a while...
Successfully installed rdiscount-2.2.0.1
Successfully installed rouge-3.1.1
3 gems installed
The command '/bin/sh -c gem install   github-pages   jekyll   jekyll-redirect-from   kramdown   rdiscount   rouge' returned a non-zero code: 1
```
