### PR TITLE
JAMES-2301 JMS mail queue do not preserve per-recipient headers.

### DIFF
--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
@@ -102,13 +102,6 @@ public class ActiveMQMailQueueBlobTest implements DelayedManageableMailQueueCont
 
     @Test
     @Override
-    @Disabled("JAMES-2301 Per recipients headers are not attached to the message.")
-    public void queueShouldPreservePerRecipientHeaders() {
-
-    }
-
-    @Test
-    @Override
     @Disabled("JAMES-2296 Not handled by JMS mailqueue. Only single recipient per-recipient removal works")
     public void removeByRecipientShouldRemoveSpecificEmailWhenMultipleRecipients() {
 

--- a/server/queue/queue-jms/pom.xml
+++ b/server/queue/queue-jms/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
         </dependency>

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -52,7 +52,6 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.collections.iterators.EnumerationIterator;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.james.core.MailAddress;

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSSupport.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSSupport.java
@@ -41,6 +41,9 @@ public interface JMSSupport {
     /** JMS Property which holds the mail name as String */
     String JAMES_MAIL_NAME = "JAMES_MAIL_NAME";
 
+    /** JMS Property which holds the association between recipients and specific headers*/
+    String JAMES_MAIL_PER_RECIPIENT_HEADERS = "JAMES_MAIL_PER_RECIPIENT_HEADERS";
+
     /**
      * Separator which is used for separate an array of String values in the JMS
      * Property value


### PR DESCRIPTION
Now we serialize per-recipient headers as a message property and
deserialize it when dequeue.