### PR TITLE
JAMES-2296 JMS remove by recipient is not remove message from queue.

### DIFF
--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
@@ -109,13 +109,6 @@ public class ActiveMQMailQueueBlobTest implements DelayedManageableMailQueueCont
 
     @Test
     @Override
-    @Disabled("JAMES-2296 Not handled by JMS mailqueue. Only single recipient per-recipient removal works")
-    public void removeByRecipientShouldRemoveSpecificEmailWhenMultipleRecipients() {
-
-    }
-
-    @Test
-    @Override
     @Disabled("JAMES-2308 Flushing JMS mail queue randomly re-order them" +
         "Random test failing around 1% of the time")
     public void flushShouldPreserveBrowseOrder() {

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -462,7 +462,6 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
     /**
      * Create a {@link org.apache.james.queue.api.MailQueue.MailQueueItem} for the given parameters
      *
-     * @param connection
      * @param session
      * @param consumer
      * @param message
@@ -624,7 +623,9 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
             case Sender:
                 return count(removeWithSelector(JAMES_MAIL_SENDER + " = '" + value + "'"));
             case Recipient:
-                return count(removeWithSelector(JAMES_MAIL_RECIPIENTS + " = '" + value + "' or " + JAMES_MAIL_RECIPIENTS + " = '%," + value + "' or " + JAMES_MAIL_RECIPIENTS + " = '%," + value + "%'"));
+                return count(removeWithSelector(JAMES_MAIL_RECIPIENTS + " = '" + value + "' or " + JAMES_MAIL_RECIPIENTS
+                        + " LIKE '%" + JAMES_MAIL_SEPARATOR + value + "' or " + JAMES_MAIL_RECIPIENTS + " LIKE '%"
+                        + JAMES_MAIL_SEPARATOR + value + "%'"));
             default:
                 break;
         }


### PR DESCRIPTION
Using proper separator and LIKE operator instead of equals operator to match single recipient
from serialized string.