### PR TITLE
Correct the names for the action on the MDC

### DIFF
--- a/server/container/cli/src/main/java/org/apache/james/cli/probe/impl/JmxDataProbe.java
+++ b/server/container/cli/src/main/java/org/apache/james/cli/probe/impl/JmxDataProbe.java
@@ -265,7 +265,7 @@ public class JmxDataProbe implements DataProbe, JmxProbe {
         try (Closeable closeable =
                  MDCBuilder.create()
                      .addContext(MDCBuilder.PROTOCOL, JMX)
-                     .addContext(MDCBuilder.ACTION, "removeForwardMapping")
+                     .addContext(MDCBuilder.ACTION, "addGroupMapping")
                      .build()) {
             virtualUserTableProxy.addGroupMapping(toUser, toDomain, fromAddress);
         }
@@ -276,7 +276,7 @@ public class JmxDataProbe implements DataProbe, JmxProbe {
         try (Closeable closeable =
                  MDCBuilder.create()
                      .addContext(MDCBuilder.PROTOCOL, JMX)
-                     .addContext(MDCBuilder.ACTION, "removeForwardMapping")
+                     .addContext(MDCBuilder.ACTION, "removeGroupMapping")
                      .build()) {
             virtualUserTableProxy.removeGroupMapping(toUser, toDomain, fromAddress);
         }


### PR DESCRIPTION
The names on the action on the MDC context were wrong. Just a little fix.