### PR TITLE
JAMES-2570 Upgrade spark java from 2.6.0 to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1846,7 +1846,7 @@
             <dependency>
                 <groupId>com.sparkjava</groupId>
                 <artifactId>spark-core</artifactId>
-                <version>2.6.0</version>
+                <version>2.8.0</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
[CVE-2018-9159](https://nvd.nist.gov/vuln/detail/CVE-2018-9159)
moderate severity
Vulnerable versions: < 2.7.2
Patched version: 2.7.2
In Spark before 2.7.2, a remote attacker can read unintended static files via various representations of absolute or relative pathnames, as demonstrated by file: URLs and directory traversal sequences. NOTE: this product is unrelated to Ignite Realtime Spark.