### PR TITLE
JAMES-2657: SSLEngine and SslHandler unaware of remote ip and port

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/AbstractSSLAwareChannelPipelineFactory.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/AbstractSSLAwareChannelPipelineFactory.java
@@ -18,8 +18,6 @@
  ****************************************************************/
 package org.apache.james.protocols.netty;
 
-import java.net.InetSocketAddress;
-
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
@@ -68,13 +66,7 @@ public abstract class AbstractSSLAwareChannelPipelineFactory extends AbstractCha
         if (isSSLSocket()) {
             // We need to set clientMode to false.
             // See https://issues.apache.org/jira/browse/JAMES-1025
-            SSLEngine engine;
-            if (pipeline.getChannel().isConnected()){
-                InetSocketAddress remoteAddress = (InetSocketAddress) pipeline.getChannel().getRemoteAddress();
-                engine = getSSLContext().createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort());
-            } else {
-                engine = getSSLContext().createSSLEngine();
-            }
+            SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(pipeline.getChannel(), getSSLContext());
             engine.setUseClientMode(false);
             if (enabledCipherSuites != null && enabledCipherSuites.length > 0) {
                 engine.setEnabledCipherSuites(enabledCipherSuites);

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelUpstreamHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelUpstreamHandler.java
@@ -19,7 +19,6 @@
 package org.apache.james.protocols.netty;
 
 import java.io.Closeable;
-import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.LinkedList;
 import java.util.List;
@@ -205,12 +204,7 @@ public class BasicChannelUpstreamHandler extends SimpleChannelUpstreamHandler {
     protected ProtocolSession createSession(ChannelHandlerContext ctx) throws Exception {
         SSLEngine engine = null;
         if (secure != null) {
-            if (ctx.getChannel().isConnected()){
-                InetSocketAddress remoteAddress = (InetSocketAddress) ctx.getChannel().getRemoteAddress();
-                engine = secure.getContext().createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort());
-            } else {
-                engine = secure.getContext().createSSLEngine();
-            }
+            engine = SslEngineUtil.INSTANCE.generateSslEngine(ctx.getChannel(), secure.getContext());
             String[] enabledCipherSuites = secure.getEnabledCipherSuites();
             if (enabledCipherSuites != null && enabledCipherSuites.length > 0) {
                 engine.setEnabledCipherSuites(enabledCipherSuites);

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelUpstreamHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelUpstreamHandler.java
@@ -19,6 +19,7 @@
 package org.apache.james.protocols.netty;
 
 import java.io.Closeable;
+import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.LinkedList;
 import java.util.List;
@@ -204,7 +205,12 @@ public class BasicChannelUpstreamHandler extends SimpleChannelUpstreamHandler {
     protected ProtocolSession createSession(ChannelHandlerContext ctx) throws Exception {
         SSLEngine engine = null;
         if (secure != null) {
-            engine = secure.getContext().createSSLEngine();
+            if (ctx.getChannel().isConnected()){
+                InetSocketAddress remoteAddress = (InetSocketAddress) ctx.getChannel().getRemoteAddress();
+                engine = secure.getContext().createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort());
+            } else {
+                engine = secure.getContext().createSSLEngine();
+            }
             String[] enabledCipherSuites = secure.getEnabledCipherSuites();
             if (enabledCipherSuites != null && enabledCipherSuites.length > 0) {
                 engine.setEnabledCipherSuites(enabledCipherSuites);

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/SslEngineUtil.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/SslEngineUtil.java
@@ -1,0 +1,103 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.netty;
+
+import org.jboss.netty.channel.Channel;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import java.net.InetSocketAddress;
+
+public enum SslEngineUtil {
+    INSTANCE;
+
+    public enum SslEngineUtilMode {
+        NONE,
+        REMOTE_ONLY,
+        LOCAL_ONLY,
+        REMOTE_LOCAL,
+        LOCAL_REMOTE
+    }
+
+    //default is NONE, so behavior is same as it was if users do nothing
+    private SslEngineUtilMode sslEngineUtilMode = SslEngineUtilMode.NONE;
+
+    public void setSslEngineUtilMode(final SslEngineUtilMode sslEngineUtilMode) {
+        if (sslEngineUtilMode != null) {
+            this.sslEngineUtilMode = sslEngineUtilMode;
+        }
+    }
+
+    public SSLEngine generateSslEngine(final Channel channel, final SSLContext sslContext) {
+        if (channel == null) {
+            return sslContext.createSSLEngine();
+        }
+        SSLEngine engine;
+        switch (sslEngineUtilMode != null ? sslEngineUtilMode : SslEngineUtilMode.NONE) {
+            case NONE:
+                engine = sslContext.createSSLEngine();
+                break;
+            case REMOTE_ONLY:
+                if (channel.isConnected() && channel.getRemoteAddress() != null) {
+                    engine = createSslEngineFromAddress(sslContext, (InetSocketAddress) channel.getRemoteAddress());
+                } else {
+                    engine = sslContext.createSSLEngine();
+                }
+                break;
+            case LOCAL_ONLY:
+                if (channel.isBound() && channel.getLocalAddress() != null) {
+                    engine = createSslEngineFromAddress(sslContext, (InetSocketAddress) channel.getLocalAddress());
+                } else {
+                    engine = sslContext.createSSLEngine();
+                }
+                break;
+            case REMOTE_LOCAL:
+                if (channel.isConnected() && channel.getRemoteAddress() != null) {
+                    engine = createSslEngineFromAddress(sslContext, (InetSocketAddress) channel.getRemoteAddress());
+                } else if (channel.isBound() && channel.getLocalAddress() != null) {
+                    engine = createSslEngineFromAddress(sslContext, (InetSocketAddress) channel.getLocalAddress());
+                } else {
+                    engine = sslContext.createSSLEngine();
+                }
+                break;
+            case LOCAL_REMOTE:
+                if (channel.isBound() && channel.getLocalAddress() != null) {
+                    engine = createSslEngineFromAddress(sslContext, (InetSocketAddress) channel.getLocalAddress());
+                } else if (channel.isConnected() && channel.getRemoteAddress() != null) {
+                    engine = createSslEngineFromAddress(sslContext, (InetSocketAddress) channel.getRemoteAddress());
+                } else {
+                    engine = sslContext.createSSLEngine();
+                }
+                break;
+            default:
+                engine = sslContext.createSSLEngine();
+                break;
+        }
+        return engine;
+    }
+
+    private SSLEngine createSslEngineFromAddress(final SSLContext sslContext, final InetSocketAddress address) {
+        if (address != null && address.getAddress() != null) {
+            return sslContext.createSSLEngine(address.getAddress().getHostAddress(), address.getPort());
+        } else {
+            return sslContext.createSSLEngine();
+        }
+    }
+}

--- a/protocols/netty/src/test/java/org/apache/james/protocols/netty/SslEngineUtilTest.java
+++ b/protocols/netty/src/test/java/org/apache/james/protocols/netty/SslEngineUtilTest.java
@@ -1,0 +1,213 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.netty;
+
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.jboss.netty.channel.Channel;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import java.net.InetSocketAddress;
+
+public class SslEngineUtilTest {
+
+    //remote connection fields
+    private String remoteAddress = "1.1.1.1";
+    private int remotePort = 1;
+    //local connection fields
+    private String localAddress = "2.2.2.2";
+    private int localPort = 2;
+
+
+    @Test
+    public void testDefaultSslEngineUtilMode()  throws Exception {
+        //since channel is null, will use the default implementation
+        SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(null, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        Channel channel = mock(Channel.class);
+
+        //since SslEngineUtil.INSTANCE will use Mode NONE by default, will use the default implementation
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+    }
+
+    @Test
+    public void testSslEngineUtilMode_null()  throws Exception {
+        SslEngineUtil.INSTANCE.setSslEngineUtilMode(null);
+        //since channel is null, will use the default implementation
+        SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(null, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        Channel channel = mock(Channel.class);
+
+        //since SslEngineUtil.INSTANCE will use Mode NONE by default, will use the default implementation
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+    }
+
+    @Test
+    public void testSslEngineUtilMode_NONE()  throws Exception {
+        SslEngineUtil.INSTANCE.setSslEngineUtilMode(SslEngineUtil.SslEngineUtilMode.NONE);
+        //since channel is null, will use the default implementation
+        SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(null, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        Channel channel = mock(Channel.class);
+        //since SslEngineUtil.INSTANCE will use Mode NONE by default, will use the default implementation
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+    }
+
+    @Test
+    public void testSslEngineUtilMode_REMOTE_ONLY()  throws Exception {
+        SslEngineUtil.INSTANCE.setSslEngineUtilMode(SslEngineUtil.SslEngineUtilMode.REMOTE_ONLY);
+        //channel is null, should return default values
+        SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(null, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //channel is empty, should return default values
+        Channel channel = mock(Channel.class);
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //set up with local, should return default values
+        when(channel.isBound()).thenReturn(true);
+        when(channel.getLocalAddress()).thenReturn(new InetSocketAddress(localAddress, localPort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //set up with remote, should return remote values
+        when(channel.isConnected()).thenReturn(true);
+        when(channel.getRemoteAddress()).thenReturn(new InetSocketAddress(remoteAddress, remotePort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost().equals(remoteAddress));
+        Assert.assertTrue(engine.getPeerPort() == remotePort);
+    }
+
+    @Test
+    public void testSslEngineUtilMode_LOCAL_ONLY()  throws Exception {
+        SslEngineUtil.INSTANCE.setSslEngineUtilMode(SslEngineUtil.SslEngineUtilMode.LOCAL_ONLY);
+        //channel is null, should return default values
+        SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(null, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //channel is empty, should return default values
+        Channel channel = mock(Channel.class);
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //set up with remote, should return default values
+        when(channel.isConnected()).thenReturn(true);
+        when(channel.getRemoteAddress()).thenReturn(new InetSocketAddress(remoteAddress, remotePort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //set up with local, should return local values
+        when(channel.isBound()).thenReturn(true);
+        when(channel.getLocalAddress()).thenReturn(new InetSocketAddress(localAddress, localPort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost().equals(localAddress));
+        Assert.assertTrue(engine.getPeerPort() == localPort);
+    }
+
+    @Test
+    public void testSslEngineUtilMode_LOCAL_REMOTE()  throws Exception {
+        SslEngineUtil.INSTANCE.setSslEngineUtilMode(SslEngineUtil.SslEngineUtilMode.LOCAL_REMOTE);
+        //channel is null, should return default values
+        SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(null, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //channel is empty, should return default values
+        Channel channel = mock(Channel.class);
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //set up with remote, should return remote values
+        when(channel.isConnected()).thenReturn(true);
+        when(channel.getRemoteAddress()).thenReturn(new InetSocketAddress(remoteAddress, remotePort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost().equals(remoteAddress));
+        Assert.assertTrue(engine.getPeerPort() == remotePort);
+
+        //set up with local, should return local values
+        when(channel.isBound()).thenReturn(true);
+        when(channel.getLocalAddress()).thenReturn(new InetSocketAddress(localAddress, localPort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost().equals(localAddress));
+        Assert.assertTrue(engine.getPeerPort() == localPort);
+    }
+
+    @Test
+    public void testSslEngineUtilMode_REMOTE_LOCAL()  throws Exception {
+        SslEngineUtil.INSTANCE.setSslEngineUtilMode(SslEngineUtil.SslEngineUtilMode.REMOTE_LOCAL);
+        //channel is null, should return default values
+        SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(null, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //channel is empty, should return default values
+        Channel channel = mock(Channel.class);
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost() == null);
+        Assert.assertTrue(engine.getPeerPort() == -1);
+
+        //set up with local, should return local values
+        when(channel.isBound()).thenReturn(true);
+        when(channel.getLocalAddress()).thenReturn(new InetSocketAddress(localAddress, localPort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost().equals(localAddress));
+        Assert.assertTrue(engine.getPeerPort() == localPort);
+
+        //set up with remote, should return remote values
+        when(channel.isConnected()).thenReturn(true);
+        when(channel.getRemoteAddress()).thenReturn(new InetSocketAddress(remoteAddress, remotePort));
+        //since channel is connected and has remote address, build SslEngine with those as peer
+        engine = SslEngineUtil.INSTANCE.generateSslEngine(channel, SSLContext.getDefault());
+        Assert.assertTrue(engine.getPeerHost().equals(remoteAddress));
+        Assert.assertTrue(engine.getPeerPort() == remotePort);
+    }
+}

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -20,6 +20,7 @@ package org.apache.james.imapserver.netty;
 
 import static org.jboss.netty.channel.Channels.pipeline;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLEngine;
@@ -172,7 +173,13 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
                 if (secure != null && !secure.isStartTLS()) {
                     // We need to set clientMode to false.
                     // See https://issues.apache.org/jira/browse/JAMES-1025
-                    SSLEngine engine = secure.getContext().createSSLEngine();
+                    SSLEngine engine;
+                    if (pipeline.getChannel().isConnected()){
+                        InetSocketAddress remoteAddress = (InetSocketAddress) pipeline.getChannel().getRemoteAddress();
+                        engine = secure.getContext().createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort());
+                    } else {
+                        engine = secure.getContext().createSSLEngine();
+                    }
                     engine.setUseClientMode(false);
                     pipeline.addFirst(SSL_HANDLER, new SslHandler(engine));
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -20,7 +20,6 @@ package org.apache.james.imapserver.netty;
 
 import static org.jboss.netty.channel.Channels.pipeline;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLEngine;
@@ -38,6 +37,7 @@ import org.apache.james.protocols.netty.ChannelGroupHandler;
 import org.apache.james.protocols.netty.ChannelHandlerFactory;
 import org.apache.james.protocols.netty.ConnectionLimitUpstreamHandler;
 import org.apache.james.protocols.netty.ConnectionPerIpLimitUpstreamHandler;
+import org.apache.james.protocols.netty.SslEngineUtil;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.ChannelUpstreamHandler;
@@ -173,13 +173,7 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
                 if (secure != null && !secure.isStartTLS()) {
                     // We need to set clientMode to false.
                     // See https://issues.apache.org/jira/browse/JAMES-1025
-                    SSLEngine engine;
-                    if (pipeline.getChannel().isConnected()){
-                        InetSocketAddress remoteAddress = (InetSocketAddress) pipeline.getChannel().getRemoteAddress();
-                        engine = secure.getContext().createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort());
-                    } else {
-                        engine = secure.getContext().createSSLEngine();
-                    }
+                    SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(pipeline.getChannel(), secure.getContext());
                     engine.setUseClientMode(false);
                     pipeline.addFirst(SSL_HANDLER, new SslHandler(engine));
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.imapserver.netty;
 
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -124,7 +125,13 @@ public class NettyImapSession implements ImapSession, NettyConstants {
         }
         channel.setReadable(false);
 
-        SslHandler filter = new SslHandler(sslContext.createSSLEngine(), false);
+        SslHandler filter;
+        if (channel.isConnected()){
+            InetSocketAddress remoteAddress = (InetSocketAddress) channel.getRemoteAddress();
+            filter = new SslHandler(sslContext.createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort()), false);
+        } else {
+            filter = new SslHandler(sslContext.createSSLEngine(), false);
+        }
         filter.getEngine().setUseClientMode(false);
         if (enabledCipherSuites != null && enabledCipherSuites.length > 0) {
             filter.getEngine().setEnabledCipherSuites(enabledCipherSuites);

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -18,7 +18,6 @@
  ****************************************************************/
 package org.apache.james.imapserver.netty;
 
-import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,6 +27,7 @@ import org.apache.james.imap.api.ImapSessionState;
 import org.apache.james.imap.api.process.ImapLineHandler;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.protocols.netty.SslEngineUtil;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.compression.ZlibDecoder;
 import org.jboss.netty.handler.codec.compression.ZlibEncoder;
@@ -125,13 +125,7 @@ public class NettyImapSession implements ImapSession, NettyConstants {
         }
         channel.setReadable(false);
 
-        SslHandler filter;
-        if (channel.isConnected()){
-            InetSocketAddress remoteAddress = (InetSocketAddress) channel.getRemoteAddress();
-            filter = new SslHandler(sslContext.createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort()), false);
-        } else {
-            filter = new SslHandler(sslContext.createSSLEngine(), false);
-        }
+        SslHandler filter = new SslHandler(SslEngineUtil.INSTANCE.generateSslEngine(channel, sslContext), false);
         filter.getEngine().setUseClientMode(false);
         if (enabledCipherSuites != null && enabledCipherSuites.length > 0) {
             filter.getEngine().setEnabledCipherSuites(enabledCipherSuites);

--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
@@ -133,7 +133,13 @@ public class ManageSieveChannelUpstreamHandler extends SimpleChannelUpstreamHand
     private void turnSSLon(Channel channel) {
         if (sslContext != null) {
             channel.setReadable(false);
-            SslHandler filter = new SslHandler(sslContext.createSSLEngine(), false);
+            SslHandler filter;
+            if (channel.isConnected()){
+                InetSocketAddress remoteAddress = (InetSocketAddress) channel.getRemoteAddress();
+                filter = new SslHandler(sslContext.createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort()), false);
+            } else {
+                filter = new SslHandler(sslContext.createSSLEngine(), false);
+            }
             filter.getEngine().setUseClientMode(false);
             if (enabledCipherSuites != null && enabledCipherSuites.length > 0) {
                 filter.getEngine().setEnabledCipherSuites(enabledCipherSuites);

--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
@@ -28,6 +28,7 @@ import org.apache.james.managesieve.api.Session;
 import org.apache.james.managesieve.api.SessionTerminatedException;
 import org.apache.james.managesieve.transcode.ManageSieveProcessor;
 import org.apache.james.managesieve.util.SettableSession;
+import org.apache.james.protocols.netty.SslEngineUtil;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFutureListener;
@@ -133,13 +134,7 @@ public class ManageSieveChannelUpstreamHandler extends SimpleChannelUpstreamHand
     private void turnSSLon(Channel channel) {
         if (sslContext != null) {
             channel.setReadable(false);
-            SslHandler filter;
-            if (channel.isConnected()){
-                InetSocketAddress remoteAddress = (InetSocketAddress) channel.getRemoteAddress();
-                filter = new SslHandler(sslContext.createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort()), false);
-            } else {
-                filter = new SslHandler(sslContext.createSSLEngine(), false);
-            }
+            SslHandler filter = new SslHandler(SslEngineUtil.INSTANCE.generateSslEngine(channel, sslContext), false);
             filter.getEngine().setUseClientMode(false);
             if (enabledCipherSuites != null && enabledCipherSuites.length > 0) {
                 filter.getEngine().setEnabledCipherSuites(enabledCipherSuites);

--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveServer.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveServer.java
@@ -21,6 +21,8 @@ package org.apache.james.managesieveserver.netty;
 
 import static org.jboss.netty.channel.Channels.pipeline;
 
+import java.net.InetSocketAddress;
+
 import javax.net.ssl.SSLEngine;
 
 import org.apache.james.managesieve.transcode.ManageSieveProcessor;
@@ -104,7 +106,13 @@ public class ManageSieveServer extends AbstractConfigurableAsyncServer implement
                 if (secure != null && !secure.isStartTLS()) {
                     // We need to set clientMode to false.
                     // See https://issues.apache.org/jira/browse/JAMES-1025
-                    SSLEngine engine = secure.getContext().createSSLEngine();
+                    SSLEngine engine;
+                    if (pipeline.getChannel().isConnected()){
+                        InetSocketAddress remoteAddress = (InetSocketAddress) pipeline.getChannel().getRemoteAddress();
+                        engine = secure.getContext().createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort());
+                    } else {
+                        engine = secure.getContext().createSSLEngine();
+                    }
                     engine.setUseClientMode(false);
                     pipeline.addFirst(SSL_HANDLER, new SslHandler(engine));
 

--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveServer.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveServer.java
@@ -33,6 +33,7 @@ import org.apache.james.protocols.netty.ChannelHandlerFactory;
 import org.apache.james.protocols.netty.ConnectionLimitUpstreamHandler;
 import org.apache.james.protocols.netty.ConnectionPerIpLimitUpstreamHandler;
 import org.apache.james.protocols.netty.LineDelimiterBasedChannelHandlerFactory;
+import org.apache.james.protocols.netty.SslEngineUtil;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.ChannelUpstreamHandler;
@@ -106,13 +107,7 @@ public class ManageSieveServer extends AbstractConfigurableAsyncServer implement
                 if (secure != null && !secure.isStartTLS()) {
                     // We need to set clientMode to false.
                     // See https://issues.apache.org/jira/browse/JAMES-1025
-                    SSLEngine engine;
-                    if (pipeline.getChannel().isConnected()){
-                        InetSocketAddress remoteAddress = (InetSocketAddress) pipeline.getChannel().getRemoteAddress();
-                        engine = secure.getContext().createSSLEngine(remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort());
-                    } else {
-                        engine = secure.getContext().createSSLEngine();
-                    }
+                    SSLEngine engine = SslEngineUtil.INSTANCE.generateSslEngine(pipeline.getChannel(), secure.getContext());
                     engine.setUseClientMode(false);
                     pipeline.addFirst(SSL_HANDLER, new SslHandler(engine));
 


### PR DESCRIPTION
add remoteaddress ip and port, if available, to SSLEngine and SslHandler

if the channel is connected, ie has a remote connection, I add it to the SSLEngine before passing it to the SslHandler.

We added this logic to our jamse SMTP server to be able to provide different certs based on ip.