### PR TITLE
JAMES-2884 Rename classes to more closely match the JMAP spec

### DIFF
--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServlet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServlet.java
@@ -36,7 +36,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.james.jmap.methods.RequestHandler;
 import org.apache.james.jmap.model.AuthenticatedRequest;
 import org.apache.james.jmap.model.InvocationRequest;
-import org.apache.james.jmap.model.ProtocolResponse;
+import org.apache.james.jmap.model.InvocationResponse;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.metrics.api.TimeMetric;
 import org.slf4j.Logger;
@@ -75,7 +75,7 @@ public class JMAPServlet extends HttpServlet {
                     .map(InvocationRequest::deserialize)
                     .map(x -> AuthenticatedRequest.decorate(x, req))
                     .flatMap(this::handle)
-                    .map(ProtocolResponse::asProtocolSpecification)
+                    .map(InvocationResponse::asProtocolSpecification)
                     .collect(Collectors.toList());
 
             resp.setContentType(JSON_CONTENT_TYPE);
@@ -100,7 +100,7 @@ public class JMAPServlet extends HttpServlet {
         }
     }
 
-    private Stream<? extends ProtocolResponse> handle(AuthenticatedRequest request) {
+    private Stream<? extends InvocationResponse> handle(AuthenticatedRequest request) {
         try {
             return requestHandler.handle(request);
         } catch (IOException e) {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServlet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServlet.java
@@ -34,7 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.james.jmap.methods.RequestHandler;
-import org.apache.james.jmap.model.AuthenticatedProtocolRequest;
+import org.apache.james.jmap.model.AuthenticatedRequest;
 import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.jmap.model.ProtocolResponse;
 import org.apache.james.metrics.api.MetricFactory;
@@ -73,7 +73,7 @@ public class JMAPServlet extends HttpServlet {
             List<Object[]> responses =
                 requestAsJsonStream(req)
                     .map(InvocationRequest::deserialize)
-                    .map(x -> AuthenticatedProtocolRequest.decorate(x, req))
+                    .map(x -> AuthenticatedRequest.decorate(x, req))
                     .flatMap(this::handle)
                     .map(ProtocolResponse::asProtocolSpecification)
                     .collect(Collectors.toList());
@@ -100,7 +100,7 @@ public class JMAPServlet extends HttpServlet {
         }
     }
 
-    private Stream<? extends ProtocolResponse> handle(AuthenticatedProtocolRequest request) {
+    private Stream<? extends ProtocolResponse> handle(AuthenticatedRequest request) {
         try {
             return requestHandler.handle(request);
         } catch (IOException e) {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServlet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServlet.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.james.jmap.methods.RequestHandler;
 import org.apache.james.jmap.model.AuthenticatedProtocolRequest;
-import org.apache.james.jmap.model.ProtocolRequest;
+import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.jmap.model.ProtocolResponse;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.metrics.api.TimeMetric;
@@ -72,7 +72,7 @@ public class JMAPServlet extends HttpServlet {
         try {
             List<Object[]> responses =
                 requestAsJsonStream(req)
-                    .map(ProtocolRequest::deserialize)
+                    .map(InvocationRequest::deserialize)
                     .map(x -> AuthenticatedProtocolRequest.decorate(x, req))
                     .flatMap(this::handle)
                     .map(ProtocolResponse::asProtocolSpecification)

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetMailboxesMethod.java
@@ -27,11 +27,11 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.apache.james.jmap.model.ClientId;
 import org.apache.james.jmap.model.GetMailboxesRequest;
 import org.apache.james.jmap.model.GetMailboxesResponse;
 import org.apache.james.jmap.model.MailboxFactory;
 import org.apache.james.jmap.model.MailboxProperty;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.mailbox.Mailbox;
 import org.apache.james.jmap.utils.quotas.QuotaLoader;
 import org.apache.james.jmap.utils.quotas.QuotaLoaderWithDefaultPreloaded;
@@ -88,7 +88,7 @@ public class GetMailboxesMethod implements Method {
     }
 
     @Override
-    public Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession) {
+    public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
         Preconditions.checkArgument(request instanceof GetMailboxesRequest);
         GetMailboxesRequest mailboxesRequest = (GetMailboxesRequest) request;
         return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
@@ -97,12 +97,12 @@ public class GetMailboxesMethod implements Method {
                 .addContext("accountId", mailboxesRequest.getAccountId())
                 .addContext("mailboxIds", mailboxesRequest.getIds())
                 .addContext("properties", mailboxesRequest.getProperties())
-                .wrapArround(() -> process(clientId, mailboxSession, mailboxesRequest)));
+                .wrapArround(() -> process(methodCallId, mailboxSession, mailboxesRequest)));
     }
 
-    private Stream<JmapResponse> process(ClientId clientId, MailboxSession mailboxSession, GetMailboxesRequest mailboxesRequest) {
+    private Stream<JmapResponse> process(MethodCallId methodCallId, MailboxSession mailboxSession, GetMailboxesRequest mailboxesRequest) {
         return Stream.of(
-            JmapResponse.builder().clientId(clientId)
+            JmapResponse.builder().methodCallId(methodCallId)
                 .response(getMailboxesResponse(mailboxesRequest, mailboxSession))
                 .properties(mailboxesRequest.getProperties().map(this::ensureContainsId))
                 .responseName(RESPONSE_NAME)

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetMessagesMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetMessagesMethod.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 
 import org.apache.james.jmap.JmapFieldNotSupportedException;
 import org.apache.james.jmap.json.FieldNamePropertyFilter;
-import org.apache.james.jmap.model.ClientId;
 import org.apache.james.jmap.model.GetMessagesRequest;
 import org.apache.james.jmap.model.GetMessagesResponse;
 import org.apache.james.jmap.model.Keywords;
@@ -38,6 +37,7 @@ import org.apache.james.jmap.model.MessageFactory;
 import org.apache.james.jmap.model.MessageFactory.MetaDataWithContent;
 import org.apache.james.jmap.model.MessageProperties;
 import org.apache.james.jmap.model.MessageProperties.HeaderProperty;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.utils.KeywordsCombiner;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
@@ -92,7 +92,7 @@ public class GetMessagesMethod implements Method {
     }
     
     @Override
-    public Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession) {
+    public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
         Preconditions.checkNotNull(request);
         Preconditions.checkNotNull(mailboxSession);
         Preconditions.checkArgument(request instanceof GetMessagesRequest);
@@ -107,7 +107,7 @@ public class GetMessagesMethod implements Method {
                 .addContext("ids", getMessagesRequest.getIds())
                 .addContext("properties", getMessagesRequest.getProperties())
                 .wrapArround(
-                    () -> Stream.of(JmapResponse.builder().clientId(clientId)
+                    () -> Stream.of(JmapResponse.builder().methodCallId(methodCallId)
                         .response(getMessagesResponse(mailboxSession, getMessagesRequest))
                         .responseName(RESPONSE_NAME)
                         .properties(outputProperties.getOptionalMessageProperties())

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetVacationResponseMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetVacationResponseMethod.java
@@ -26,9 +26,9 @@ import javax.inject.Inject;
 import org.apache.james.jmap.api.vacation.AccountId;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationRepository;
-import org.apache.james.jmap.model.ClientId;
 import org.apache.james.jmap.model.GetVacationRequest;
 import org.apache.james.jmap.model.GetVacationResponse;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.VacationResponse;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.metrics.api.MetricFactory;
@@ -64,9 +64,9 @@ public class GetVacationResponseMethod implements Method {
     }
 
     @Override
-    public Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession) {
+    public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
         Preconditions.checkNotNull(request);
-        Preconditions.checkNotNull(clientId);
+        Preconditions.checkNotNull(methodCallId);
         Preconditions.checkNotNull(mailboxSession);
         Preconditions.checkArgument(request instanceof GetVacationRequest);
 
@@ -75,7 +75,7 @@ public class GetVacationResponseMethod implements Method {
                 .addContext(MDCBuilder.ACTION, "VACATION")
                 .wrapArround(
                     () -> Stream.of(JmapResponse.builder()
-                        .clientId(clientId)
+                        .methodCallId(methodCallId)
                         .responseName(RESPONSE_NAME)
                         .response(process(mailboxSession))
                         .build())));

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapRequestParser.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapRequestParser.java
@@ -21,13 +21,13 @@ package org.apache.james.jmap.methods;
 
 import java.io.IOException;
 
-import org.apache.james.jmap.model.ProtocolRequest;
+import org.apache.james.jmap.model.InvocationRequest;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 public interface JmapRequestParser {
 
-    <T extends JmapRequest> T extractJmapRequest(ProtocolRequest request, Class<T> requestClass) 
+    <T extends JmapRequest> T extractJmapRequest(InvocationRequest request, Class<T> requestClass)
             throws IOException, JsonParseException, JsonMappingException;
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapRequestParserImpl.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapRequestParserImpl.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 
 import org.apache.james.jmap.json.ObjectMapperFactory;
-import org.apache.james.jmap.model.ProtocolRequest;
+import org.apache.james.jmap.model.InvocationRequest;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -40,7 +40,7 @@ public class JmapRequestParserImpl implements JmapRequestParser {
     }
 
     @Override
-    public <T extends JmapRequest> T extractJmapRequest(ProtocolRequest request, Class<T> requestClass) 
+    public <T extends JmapRequest> T extractJmapRequest(InvocationRequest request, Class<T> requestClass)
             throws IOException, JsonParseException, JsonMappingException {
         return objectMapper.readValue(request.getParameters().toString(), requestClass);
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponse.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponse.java
@@ -22,7 +22,7 @@ package org.apache.james.jmap.methods;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.Property;
 
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
@@ -39,7 +39,7 @@ public class JmapResponse {
     public static class Builder {
         
         private Method.Response.Name responseName;
-        private ClientId id;
+        private MethodCallId methodCallId;
         private Method.Response response;
         private Optional<? extends Set<? extends Property>> properties = Optional.empty();
         private Optional<SimpleFilterProvider> filterProvider = Optional.empty();
@@ -52,8 +52,8 @@ public class JmapResponse {
             return this;
         }
         
-        public Builder clientId(ClientId id) {
-            this.id = id;
+        public Builder methodCallId(MethodCallId methodCallId) {
+            this.methodCallId = methodCallId;
             return this;
         }
         
@@ -96,19 +96,19 @@ public class JmapResponse {
 
         
         public JmapResponse build() {
-            return new JmapResponse(responseName, id, response, properties, filterProvider);
+            return new JmapResponse(responseName, methodCallId, response, properties, filterProvider);
         }
     }
 
     private final Method.Response.Name method;
-    private final ClientId clientId;
+    private final MethodCallId methodCallId;
     private final Method.Response response;
     private final Optional<? extends Set<? extends Property>> properties;
     private final Optional<SimpleFilterProvider> filterProvider;
     
-    private JmapResponse(Method.Response.Name method, ClientId clientId, Method.Response response, Optional<? extends Set<? extends Property>> properties, Optional<SimpleFilterProvider> filterProvider) {
+    private JmapResponse(Method.Response.Name method, MethodCallId methodCallId, Method.Response response, Optional<? extends Set<? extends Property>> properties, Optional<SimpleFilterProvider> filterProvider) {
         this.method = method;
-        this.clientId = clientId;
+        this.methodCallId = methodCallId;
         this.response = response;
         this.properties = properties;
         this.filterProvider = filterProvider;
@@ -122,8 +122,8 @@ public class JmapResponse {
         return response;
     }
     
-    public ClientId getClientId() {
-        return clientId;
+    public MethodCallId getMethodCallId() {
+        return methodCallId;
     }
 
     public Optional<? extends Set<? extends Property>> getProperties() {
@@ -136,7 +136,7 @@ public class JmapResponse {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(method, clientId, response, properties, filterProvider);
+        return Objects.hashCode(method, methodCallId, response, properties, filterProvider);
     }
 
     @Override
@@ -144,7 +144,7 @@ public class JmapResponse {
         if (object instanceof JmapResponse) {
             JmapResponse that = (JmapResponse) object;
             return Objects.equal(this.method, that.method)
-                    && Objects.equal(this.clientId, that.clientId)
+                    && Objects.equal(this.methodCallId, that.methodCallId)
                     && Objects.equal(this.response, that.response)
                     && Objects.equal(this.properties, that.properties)
                     && Objects.equal(this.filterProvider, that.filterProvider);
@@ -157,7 +157,7 @@ public class JmapResponse {
         return MoreObjects.toStringHelper(getClass())
                 .add("method", method)
                 .add("response", response)
-                .add("clientId", clientId)
+                .add("methodCallId", methodCallId)
                 .add("properties", properties)
                 .add("filterProvider", filterProvider)
                 .toString();

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponseWriter.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponseWriter.java
@@ -21,10 +21,10 @@ package org.apache.james.jmap.methods;
 
 import java.util.stream.Stream;
 
-import org.apache.james.jmap.model.ProtocolResponse;
+import org.apache.james.jmap.model.InvocationResponse;
 
 public interface JmapResponseWriter {
 
-    Stream<ProtocolResponse> formatMethodResponse(Stream<JmapResponse> jmapResponse);
+    Stream<InvocationResponse> formatMethodResponse(Stream<JmapResponse> jmapResponse);
 
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponseWriterImpl.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponseWriterImpl.java
@@ -26,8 +26,8 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 
 import org.apache.james.jmap.json.ObjectMapperFactory;
-import org.apache.james.jmap.model.Property;
 import org.apache.james.jmap.model.InvocationResponse;
+import org.apache.james.jmap.model.Property;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -54,7 +54,7 @@ public class JmapResponseWriterImpl implements JmapResponseWriter {
             return new InvocationResponse(
                     jmapResponse.getResponseName(),
                     objectMapper.valueToTree(jmapResponse.getResponse()),
-                    jmapResponse.getClientId());
+                    jmapResponse.getMethodCallId());
         });
     }
     

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponseWriterImpl.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/JmapResponseWriterImpl.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 
 import org.apache.james.jmap.json.ObjectMapperFactory;
 import org.apache.james.jmap.model.Property;
-import org.apache.james.jmap.model.ProtocolResponse;
+import org.apache.james.jmap.model.InvocationResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -47,11 +47,11 @@ public class JmapResponseWriterImpl implements JmapResponseWriter {
     }
 
     @Override
-    public Stream<ProtocolResponse> formatMethodResponse(Stream<JmapResponse> jmapResponses) {
+    public Stream<InvocationResponse> formatMethodResponse(Stream<JmapResponse> jmapResponses) {
         return jmapResponses.map(jmapResponse -> {
             ObjectMapper objectMapper = newConfiguredObjectMapper(jmapResponse);
 
-            return new ProtocolResponse(
+            return new InvocationResponse(
                     jmapResponse.getResponseName(),
                     objectMapper.valueToTree(jmapResponse.getResponse()),
                     jmapResponse.getClientId());

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/Method.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/Method.java
@@ -24,7 +24,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.mailbox.MailboxSession;
 
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -124,6 +124,6 @@ public interface Method {
 
     Class<? extends JmapRequest> requestType();
     
-    Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession);
+    Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession);
 
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/RequestHandler.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/RequestHandler.java
@@ -33,7 +33,7 @@ import javax.inject.Inject;
 import org.apache.james.core.User;
 import org.apache.james.jmap.JmapFieldNotSupportedException;
 import org.apache.james.jmap.model.AuthenticatedRequest;
-import org.apache.james.jmap.model.ProtocolResponse;
+import org.apache.james.jmap.model.InvocationResponse;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.util.MDCBuilder;
 import org.slf4j.Logger;
@@ -55,7 +55,7 @@ public class RequestHandler {
                 .collect(Collectors.toMap(Method::requestHandled, Function.identity()));
     }
 
-    public Stream<ProtocolResponse> handle(AuthenticatedRequest request) throws IOException {
+    public Stream<InvocationResponse> handle(AuthenticatedRequest request) throws IOException {
         Optional<MailboxSession> mailboxSession = Optional.ofNullable(request.getMailboxSession());
         try (Closeable closeable =
                  MDCBuilder.create()

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/RequestHandler.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/RequestHandler.java
@@ -32,7 +32,7 @@ import javax.inject.Inject;
 
 import org.apache.james.core.User;
 import org.apache.james.jmap.JmapFieldNotSupportedException;
-import org.apache.james.jmap.model.AuthenticatedProtocolRequest;
+import org.apache.james.jmap.model.AuthenticatedRequest;
 import org.apache.james.jmap.model.ProtocolResponse;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.util.MDCBuilder;
@@ -55,7 +55,7 @@ public class RequestHandler {
                 .collect(Collectors.toMap(Method::requestHandled, Function.identity()));
     }
 
-    public Stream<ProtocolResponse> handle(AuthenticatedProtocolRequest request) throws IOException {
+    public Stream<ProtocolResponse> handle(AuthenticatedRequest request) throws IOException {
         Optional<MailboxSession> mailboxSession = Optional.ofNullable(request.getMailboxSession());
         try (Closeable closeable =
                  MDCBuilder.create()
@@ -70,7 +70,7 @@ public class RequestHandler {
         }
     }
     
-    private Function<Method, Stream<JmapResponse>> extractAndProcess(AuthenticatedProtocolRequest request) {
+    private Function<Method, Stream<JmapResponse>> extractAndProcess(AuthenticatedRequest request) {
         MailboxSession mailboxSession = request.getMailboxSession();
         return (Method method) -> {
                     try {
@@ -95,7 +95,7 @@ public class RequestHandler {
             .build();
     }
 
-    private Stream<JmapResponse> errorNotImplemented(JmapFieldNotSupportedException error, AuthenticatedProtocolRequest request) {
+    private Stream<JmapResponse> errorNotImplemented(JmapFieldNotSupportedException error, AuthenticatedRequest request) {
         return Stream.of(
                 JmapResponse.builder()
                     .clientId(request.getClientId())
@@ -103,7 +103,7 @@ public class RequestHandler {
                     .build());
     }
 
-    private Stream<JmapResponse> error(AuthenticatedProtocolRequest request, ErrorResponse error) {
+    private Stream<JmapResponse> error(AuthenticatedRequest request, ErrorResponse error) {
         return Stream.of(
                 JmapResponse.builder()
                     .clientId(request.getClientId())

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/RequestHandler.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/RequestHandler.java
@@ -75,7 +75,7 @@ public class RequestHandler {
         return (Method method) -> {
                     try {
                         JmapRequest jmapRequest = jmapRequestParser.extractJmapRequest(request, method.requestType());
-                        return method.process(jmapRequest, request.getClientId(), mailboxSession);
+                        return method.process(jmapRequest, request.getMethodCallId(), mailboxSession);
                     } catch (IOException e) {
                         LOGGER.error("Error occured while parsing the request.", e);
                         if (e.getCause() instanceof JmapFieldNotSupportedException) {
@@ -98,7 +98,7 @@ public class RequestHandler {
     private Stream<JmapResponse> errorNotImplemented(JmapFieldNotSupportedException error, AuthenticatedRequest request) {
         return Stream.of(
                 JmapResponse.builder()
-                    .clientId(request.getClientId())
+                    .methodCallId(request.getMethodCallId())
                     .error(generateInvalidArgumentError("The field '" + error.getField() + "' of '" + error.getIssuer() + "' is not supported"))
                     .build());
     }
@@ -106,7 +106,7 @@ public class RequestHandler {
     private Stream<JmapResponse> error(AuthenticatedRequest request, ErrorResponse error) {
         return Stream.of(
                 JmapResponse.builder()
-                    .clientId(request.getClientId())
+                    .methodCallId(request.getMethodCallId())
                     .error(error)
                     .build());
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesMethod.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.SetMailboxesRequest;
 import org.apache.james.jmap.model.SetMailboxesResponse;
 import org.apache.james.mailbox.MailboxSession;
@@ -59,9 +59,9 @@ public class SetMailboxesMethod implements Method {
     }
 
     @Override
-    public Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession) {
+    public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
         Preconditions.checkNotNull(request);
-        Preconditions.checkNotNull(clientId);
+        Preconditions.checkNotNull(methodCallId);
         Preconditions.checkNotNull(mailboxSession);
         Preconditions.checkArgument(request instanceof SetMailboxesRequest);
 
@@ -75,7 +75,7 @@ public class SetMailboxesMethod implements Method {
                 .addContext("destroy", setMailboxesRequest.getDestroy())
                 .wrapArround(
                     () -> Stream.of(
-                        JmapResponse.builder().clientId(clientId)
+                        JmapResponse.builder().methodCallId(methodCallId)
                             .response(setMailboxesResponse(setMailboxesRequest, mailboxSession))
                             .responseName(RESPONSE_NAME)
                             .build())));

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesMethod.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.SetMessagesRequest;
 import org.apache.james.jmap.model.SetMessagesResponse;
 import org.apache.james.mailbox.MailboxSession;
@@ -59,7 +59,7 @@ public class SetMessagesMethod implements Method {
     }
 
     @Override
-    public Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession) {
+    public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
         Preconditions.checkArgument(request instanceof SetMessagesRequest);
         SetMessagesRequest setMessagesRequest = (SetMessagesRequest) request;
 
@@ -72,7 +72,7 @@ public class SetMessagesMethod implements Method {
                 .addContext("ifInState", setMessagesRequest.getIfInState())
                 .wrapArround(
                     () ->  Stream.of(
-                        JmapResponse.builder().clientId(clientId)
+                        JmapResponse.builder().methodCallId(methodCallId)
                             .response(setMessagesResponse(setMessagesRequest, mailboxSession))
                             .responseName(RESPONSE_NAME)
                             .build())));

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AuthenticatedProtocolRequest.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AuthenticatedProtocolRequest.java
@@ -23,15 +23,15 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.james.jmap.AuthenticationFilter;
 import org.apache.james.mailbox.MailboxSession;
 
-public class AuthenticatedProtocolRequest extends ProtocolRequest {
+public class AuthenticatedProtocolRequest extends InvocationRequest {
     
-    public static AuthenticatedProtocolRequest decorate(ProtocolRequest request, HttpServletRequest httpServletRequest) {
+    public static AuthenticatedProtocolRequest decorate(InvocationRequest request, HttpServletRequest httpServletRequest) {
         return new AuthenticatedProtocolRequest(request, httpServletRequest);
     }
 
     private final HttpServletRequest httpServletRequest;
 
-    private AuthenticatedProtocolRequest(ProtocolRequest request, HttpServletRequest httpServletRequest) {
+    private AuthenticatedProtocolRequest(InvocationRequest request, HttpServletRequest httpServletRequest) {
         super(request.getMethodName(), request.getParameters(), request.getClientId());
         this.httpServletRequest = httpServletRequest;
         

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AuthenticatedRequest.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AuthenticatedRequest.java
@@ -23,15 +23,15 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.james.jmap.AuthenticationFilter;
 import org.apache.james.mailbox.MailboxSession;
 
-public class AuthenticatedProtocolRequest extends InvocationRequest {
+public class AuthenticatedRequest extends InvocationRequest {
     
-    public static AuthenticatedProtocolRequest decorate(InvocationRequest request, HttpServletRequest httpServletRequest) {
-        return new AuthenticatedProtocolRequest(request, httpServletRequest);
+    public static AuthenticatedRequest decorate(InvocationRequest request, HttpServletRequest httpServletRequest) {
+        return new AuthenticatedRequest(request, httpServletRequest);
     }
 
     private final HttpServletRequest httpServletRequest;
 
-    private AuthenticatedProtocolRequest(InvocationRequest request, HttpServletRequest httpServletRequest) {
+    private AuthenticatedRequest(InvocationRequest request, HttpServletRequest httpServletRequest) {
         super(request.getMethodName(), request.getParameters(), request.getClientId());
         this.httpServletRequest = httpServletRequest;
         

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AuthenticatedRequest.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AuthenticatedRequest.java
@@ -32,7 +32,7 @@ public class AuthenticatedRequest extends InvocationRequest {
     private final HttpServletRequest httpServletRequest;
 
     private AuthenticatedRequest(InvocationRequest request, HttpServletRequest httpServletRequest) {
-        super(request.getMethodName(), request.getParameters(), request.getClientId());
+        super(request.getMethodName(), request.getParameters(), request.getMethodCallId());
         this.httpServletRequest = httpServletRequest;
         
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationRequest.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationRequest.java
@@ -31,17 +31,17 @@ public class InvocationRequest {
         Preconditions.checkState(json[0].isTextual(), "first element should be a String");
         Preconditions.checkState(json[1].isObject(), "second element should be a Json");
         Preconditions.checkState(json[2].isTextual(), "third element should be a String");
-        return new InvocationRequest(Method.Request.name(json[0].textValue()), (ObjectNode) json[1], ClientId.of(json[2].textValue()));
+        return new InvocationRequest(Method.Request.name(json[0].textValue()), (ObjectNode) json[1], MethodCallId.of(json[2].textValue()));
     }
 
     private final Method.Request.Name method;
     private final ObjectNode parameters;
-    private final ClientId clientId;
+    private final MethodCallId methodCallId;
 
-    protected InvocationRequest(Method.Request.Name method, ObjectNode parameters, ClientId clientId) {
+    protected InvocationRequest(Method.Request.Name method, ObjectNode parameters, MethodCallId methodCallId) {
         this.method = method;
         this.parameters = parameters;
-        this.clientId = clientId;
+        this.methodCallId = methodCallId;
     }
 
     public Method.Request.Name getMethodName() {
@@ -52,7 +52,7 @@ public class InvocationRequest {
         return parameters;
     }
 
-    public ClientId getClientId() {
-        return clientId;
+    public MethodCallId getMethodCallId() {
+        return methodCallId;
     }
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationRequest.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationRequest.java
@@ -24,21 +24,21 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 
-public class ProtocolRequest {
+public class InvocationRequest {
 
-    public static ProtocolRequest deserialize(JsonNode[] json) {
+    public static InvocationRequest deserialize(JsonNode[] json) {
         Preconditions.checkState(json.length == 3, "should have three elements");
         Preconditions.checkState(json[0].isTextual(), "first element should be a String");
         Preconditions.checkState(json[1].isObject(), "second element should be a Json");
         Preconditions.checkState(json[2].isTextual(), "third element should be a String");
-        return new ProtocolRequest(Method.Request.name(json[0].textValue()), (ObjectNode) json[1], ClientId.of(json[2].textValue()));
+        return new InvocationRequest(Method.Request.name(json[0].textValue()), (ObjectNode) json[1], ClientId.of(json[2].textValue()));
     }
 
     private final Method.Request.Name method;
     private final ObjectNode parameters;
     private final ClientId clientId;
 
-    protected ProtocolRequest(Method.Request.Name method, ObjectNode parameters, ClientId clientId) {
+    protected InvocationRequest(Method.Request.Name method, ObjectNode parameters, ClientId clientId) {
         this.method = method;
         this.parameters = parameters;
         this.clientId = clientId;

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationResponse.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationResponse.java
@@ -23,13 +23,13 @@ import org.apache.james.jmap.methods.Method;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 
-public class ProtocolResponse {
+public class InvocationResponse {
 
     private final Method.Response.Name name;
     private final ObjectNode results;
     private final ClientId clientId;
 
-    public ProtocolResponse(Method.Response.Name name, ObjectNode results, ClientId clientId) {
+    public InvocationResponse(Method.Response.Name name, ObjectNode results, ClientId clientId) {
         Preconditions.checkNotNull(name, "method is mandatory");
         Preconditions.checkNotNull(results, "results is mandatory");
         Preconditions.checkNotNull(clientId,  "clientId is mandatory");

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationResponse.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/InvocationResponse.java
@@ -27,15 +27,15 @@ public class InvocationResponse {
 
     private final Method.Response.Name name;
     private final ObjectNode results;
-    private final ClientId clientId;
+    private final MethodCallId methodCallId;
 
-    public InvocationResponse(Method.Response.Name name, ObjectNode results, ClientId clientId) {
+    public InvocationResponse(Method.Response.Name name, ObjectNode results, MethodCallId methodCallId) {
         Preconditions.checkNotNull(name, "method is mandatory");
         Preconditions.checkNotNull(results, "results is mandatory");
-        Preconditions.checkNotNull(clientId,  "clientId is mandatory");
+        Preconditions.checkNotNull(methodCallId,  "methodCallId is mandatory");
         this.name = name;
         this.results = results;
-        this.clientId = clientId;
+        this.methodCallId = methodCallId;
     }
 
     public Method.Response.Name getResponseName() {
@@ -46,11 +46,11 @@ public class InvocationResponse {
         return results;
     }
 
-    public ClientId getClientId() {
-        return clientId;
+    public MethodCallId getMethodCallId() {
+        return methodCallId;
     }
 
     public Object[] asProtocolSpecification() {
-        return new Object[] { getResponseName(), getResults(), getClientId() };
+        return new Object[] { getResponseName(), getResults(), getMethodCallId() };
     }
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MethodCallId.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MethodCallId.java
@@ -23,15 +23,15 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
 
-public class ClientId {
+public class MethodCallId {
 
-    public static ClientId of(String clientId) {
-        return new ClientId(clientId);
+    public static MethodCallId of(String methodCallId) {
+        return new MethodCallId(methodCallId);
     }
     
     private final String id;
 
-    private ClientId(String id) {
+    private MethodCallId(String id) {
         Preconditions.checkNotNull(id);
         Preconditions.checkArgument(!id.isEmpty());
         this.id = id;
@@ -44,8 +44,8 @@ public class ClientId {
     
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof ClientId) {
-            ClientId other = (ClientId) obj;
+        if (obj instanceof MethodCallId) {
+            MethodCallId other = (MethodCallId) obj;
             return Objects.equals(this.id, other.id);
         }
         return false;

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/JMAPServletTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/JMAPServletTest.java
@@ -35,7 +35,7 @@ import org.apache.james.jmap.methods.ErrorResponse;
 import org.apache.james.jmap.methods.Method;
 import org.apache.james.jmap.methods.RequestHandler;
 import org.apache.james.jmap.model.ClientId;
-import org.apache.james.jmap.model.ProtocolResponse;
+import org.apache.james.jmap.model.InvocationResponse;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -99,7 +99,7 @@ public class JMAPServletTest {
         json.put("type", "invalidArgument");
 
         when(requestHandler.handle(any()))
-            .thenReturn(Stream.of(new ProtocolResponse(ErrorResponse.ERROR_METHOD, json, ClientId.of("#0"))));
+            .thenReturn(Stream.of(new InvocationResponse(ErrorResponse.ERROR_METHOD, json, ClientId.of("#0"))));
 
         given()
             .body("[[\"getAccounts\", {\"state\":false}, \"#0\"]]")
@@ -121,7 +121,7 @@ public class JMAPServletTest {
         arrayNode.add(list);
 
         when(requestHandler.handle(any()))
-            .thenReturn(Stream.of(new ProtocolResponse(Method.Response.name("accounts"), json, ClientId.of("#0"))));
+            .thenReturn(Stream.of(new InvocationResponse(Method.Response.name("accounts"), json, ClientId.of("#0"))));
 
         given()
             .body("[[\"getAccounts\", {}, \"#0\"]]")

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/JMAPServletTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/JMAPServletTest.java
@@ -34,7 +34,7 @@ import org.apache.james.http.jetty.JettyHttpServer;
 import org.apache.james.jmap.methods.ErrorResponse;
 import org.apache.james.jmap.methods.Method;
 import org.apache.james.jmap.methods.RequestHandler;
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.InvocationResponse;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.After;
@@ -99,7 +99,7 @@ public class JMAPServletTest {
         json.put("type", "invalidArgument");
 
         when(requestHandler.handle(any()))
-            .thenReturn(Stream.of(new InvocationResponse(ErrorResponse.ERROR_METHOD, json, ClientId.of("#0"))));
+            .thenReturn(Stream.of(new InvocationResponse(ErrorResponse.ERROR_METHOD, json, MethodCallId.of("#0"))));
 
         given()
             .body("[[\"getAccounts\", {\"state\":false}, \"#0\"]]")
@@ -121,7 +121,7 @@ public class JMAPServletTest {
         arrayNode.add(list);
 
         when(requestHandler.handle(any()))
-            .thenReturn(Stream.of(new InvocationResponse(Method.Response.name("accounts"), json, ClientId.of("#0"))));
+            .thenReturn(Stream.of(new InvocationResponse(Method.Response.name("accounts"), json, MethodCallId.of("#0"))));
 
         given()
             .body("[[\"getAccounts\", {}, \"#0\"]]")

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetMailboxesMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetMailboxesMethodTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 
 import javax.mail.Flags;
 
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.GetMailboxesRequest;
 import org.apache.james.jmap.model.GetMailboxesResponse;
 import org.apache.james.jmap.model.MailboxFactory;
@@ -63,7 +63,7 @@ public class GetMailboxesMethodTest {
 
     private StoreMailboxManager mailboxManager;
     private GetMailboxesMethod getMailboxesMethod;
-    private ClientId clientId;
+    private MethodCallId methodCallId;
     private MailboxFactory mailboxFactory;
 
     private QuotaRootResolver quotaRootResolver;
@@ -71,7 +71,7 @@ public class GetMailboxesMethodTest {
 
     @Before
     public void setup() throws Exception {
-        clientId = ClientId.of("#0");
+        methodCallId = MethodCallId.of("#0");
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
         quotaRootResolver = mailboxManager.getQuotaComponents().getQuotaRootResolver();
         quotaManager = mailboxManager.getQuotaComponents().getQuotaManager();
@@ -87,7 +87,7 @@ public class GetMailboxesMethodTest {
 
         MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -111,7 +111,7 @@ public class GetMailboxesMethodTest {
                 .build();
         MailboxSession session = MailboxSessionUtil.create(USERNAME);
 
-        List<JmapResponse> getMailboxesResponse = testee.process(getMailboxesRequest, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = testee.process(getMailboxesRequest, methodCallId, session).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -141,7 +141,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -166,7 +166,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, userSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, userSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -187,7 +187,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -208,7 +208,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -229,7 +229,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -257,7 +257,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -287,7 +287,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -317,7 +317,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -356,7 +356,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)
@@ -386,7 +386,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, clientId, mailboxSession).collect(Collectors.toList());
+        List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
         assertThat(getMailboxesResponse)
                 .hasSize(1)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetMessagesMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetMessagesMethodTest.java
@@ -36,7 +36,7 @@ import javax.mail.Flags.Flag;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.core.User;
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.GetMessagesRequest;
 import org.apache.james.jmap.model.GetMessagesResponse;
 import org.apache.james.jmap.model.Message;
@@ -93,11 +93,11 @@ public class GetMessagesMethodTest {
     private MailboxSession session;
     private MailboxPath inboxPath;
     private MailboxPath customMailboxPath;
-    private ClientId clientId;
+    private MethodCallId methodCallId;
     
     @Before
     public void setup() throws Exception {
-        clientId = ClientId.of("#0");
+        methodCallId = MethodCallId.of("#0");
         HtmlTextExtractor htmlTextExtractor = new JsoupHtmlTextExtractor();
         MessagePreviewGenerator messagePreview = new MessagePreviewGenerator();
         MessageContentExtractor messageContentExtractor = new MessageContentExtractor();
@@ -134,25 +134,25 @@ public class GetMessagesMethodTest {
     @Test
     public void processShouldThrowWhenNullRequest() {
         GetMessagesRequest request = null;
-        assertThatThrownBy(() -> testee.process(request, mock(ClientId.class), mock(MailboxSession.class))).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> testee.process(request, mock(MethodCallId.class), mock(MailboxSession.class))).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     public void processShouldThrowWhenNullSession() {
         MailboxSession mailboxSession = null;
-        assertThatThrownBy(() -> testee.process(mock(GetMessagesRequest.class), mock(ClientId.class), mailboxSession)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> testee.process(mock(GetMessagesRequest.class), mock(MethodCallId.class), mailboxSession)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void processShouldThrowWhenNullClientId() {
-        ClientId clientId = null;
-        assertThatThrownBy(() -> testee.process(mock(GetMessagesRequest.class), clientId, mock(MailboxSession.class))).isInstanceOf(NullPointerException.class);
+    public void processShouldThrowWhenNullMethodCallId() {
+        MethodCallId methodCallId = null;
+        assertThatThrownBy(() -> testee.process(mock(GetMessagesRequest.class), methodCallId, mock(MailboxSession.class))).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     public void processShouldThrowWhenRequestHasAccountId() {
         assertThatThrownBy(() -> testee.process(
-                GetMessagesRequest.builder().accountId("abc").build(), mock(ClientId.class), mock(MailboxSession.class))).isInstanceOf(NotImplementedException.class);
+                GetMessagesRequest.builder().accountId("abc").build(), mock(MethodCallId.class), mock(MailboxSession.class))).isInstanceOf(NotImplementedException.class);
     }
     
     @Test
@@ -169,7 +169,7 @@ public class GetMessagesMethodTest {
                         message3.getMessageId()))
                 .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
         
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)
@@ -198,7 +198,7 @@ public class GetMessagesMethodTest {
                 .ids(ImmutableList.of(message.getMessageId()))
                 .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
         
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)
@@ -219,7 +219,7 @@ public class GetMessagesMethodTest {
                 .properties(ImmutableList.of())
                 .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getProperties())
@@ -236,7 +236,7 @@ public class GetMessagesMethodTest {
                 .ids(ImmutableList.of(message1.getMessageId()))
                 .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getProperties())
             .isEqualTo(Optional.of(MessageProperty.allOutputProperties()));
@@ -255,7 +255,7 @@ public class GetMessagesMethodTest {
 
         Set<MessageProperty> expected = Sets.newHashSet(MessageProperty.id, MessageProperty.subject);
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getProperties())
             .isEqualTo(Optional.of(expected));
@@ -274,7 +274,7 @@ public class GetMessagesMethodTest {
 
         Set<MessageProperty> expected = Sets.newHashSet(MessageProperty.id, MessageProperty.textBody);
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getProperties())
@@ -297,7 +297,7 @@ public class GetMessagesMethodTest {
             .ids(ImmutableList.of(message.getMessageId()))
             .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)
@@ -323,7 +323,7 @@ public class GetMessagesMethodTest {
             .ids(ImmutableList.of(message.getMessageId()))
             .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)
@@ -355,7 +355,7 @@ public class GetMessagesMethodTest {
             .ids(ImmutableList.of(message.getMessageId()))
             .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)
@@ -387,7 +387,7 @@ public class GetMessagesMethodTest {
 
         Set<MessageProperty> expected = Sets.newHashSet(MessageProperty.id, MessageProperty.headers);
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getProperties())
@@ -413,7 +413,7 @@ public class GetMessagesMethodTest {
                 .properties(ImmutableList.of("headers.from", "headers.heADER2"))
                 .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result)
             .hasSize(1)
@@ -450,7 +450,7 @@ public class GetMessagesMethodTest {
             .properties(ImmutableList.of("mailboxIds"))
             .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1);
         Method.Response response = result.get(0).getResponse();
@@ -485,7 +485,7 @@ public class GetMessagesMethodTest {
             .properties(ImmutableList.of("mailboxIds"))
             .build();
 
-        List<JmapResponse> responses = testee.process(request, clientId, session).collect(Guavate.toImmutableList());
+        List<JmapResponse> responses = testee.process(request, methodCallId, session).collect(Guavate.toImmutableList());
 
         assertThat(responses).hasSize(1);
         Method.Response response = responses.get(0).getResponse();
@@ -522,7 +522,7 @@ public class GetMessagesMethodTest {
                 message3.getMessageId()))
             .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)
@@ -579,7 +579,7 @@ public class GetMessagesMethodTest {
                 message3.getMessageId()))
             .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)
@@ -619,7 +619,7 @@ public class GetMessagesMethodTest {
             .ids(ImmutableList.of(message1.getMessageId()))
             .build();
 
-        List<JmapResponse> result = testee.process(request, clientId, session).collect(Collectors.toList());
+        List<JmapResponse> result = testee.process(request, methodCallId, session).collect(Collectors.toList());
 
         assertThat(result).hasSize(1)
             .extracting(JmapResponse::getResponse)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetVacationResponseMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/GetVacationResponseMethodTest.java
@@ -31,7 +31,7 @@ import org.apache.james.core.User;
 import org.apache.james.jmap.api.vacation.AccountId;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationRepository;
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.GetMailboxesRequest;
 import org.apache.james.jmap.model.GetVacationRequest;
 import org.apache.james.jmap.model.GetVacationResponse;
@@ -71,27 +71,27 @@ public class GetVacationResponseMethodTest {
 
     @Test(expected = NullPointerException.class)
     public void processShouldThrowOnNullRequest() {
-        testee.process(null, mock(ClientId.class), mock(MailboxSession.class));
+        testee.process(null, mock(MethodCallId.class), mock(MailboxSession.class));
     }
 
     @Test(expected = NullPointerException.class)
-    public void processShouldThrowOnNullClientId() {
+    public void processShouldThrowOnNullMethodCallId() {
         testee.process(mock(GetMailboxesRequest.class), null, mock(MailboxSession.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void processShouldThrowOnNullMailboxSession() {
-        testee.process(mock(GetMailboxesRequest.class), mock(ClientId.class), null);
+        testee.process(mock(GetMailboxesRequest.class), mock(MethodCallId.class), null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void processShouldThrowOnWrongRequestType() {
-        testee.process(mock(SetMailboxesRequest.class), mock(ClientId.class), mock(MailboxSession.class));
+        testee.process(mock(SetMailboxesRequest.class), mock(MethodCallId.class), mock(MailboxSession.class));
     }
 
     @Test
     public void processShouldReturnTheAppropriateVacationResponse() {
-        ClientId clientId = mock(ClientId.class);
+        MethodCallId methodCallId = mock(MethodCallId.class);
         Vacation vacation = Vacation.builder()
             .enabled(true)
             .textBody("I am in vacation")
@@ -105,10 +105,10 @@ public class GetVacationResponseMethodTest {
 
         GetVacationRequest getVacationRequest = GetVacationRequest.builder().build();
 
-        Stream<JmapResponse> result = testee.process(getVacationRequest, clientId, mailboxSession);
+        Stream<JmapResponse> result = testee.process(getVacationRequest, methodCallId, mailboxSession);
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .responseName(GetVacationResponseMethod.RESPONSE_NAME)
             .response(GetVacationResponse.builder()
                 .accountId(USERNAME)
@@ -123,7 +123,7 @@ public class GetVacationResponseMethodTest {
 
     @Test
     public void processShouldReturnUnActivatedVacationResponseWhenBeforeDate() {
-        ClientId clientId = mock(ClientId.class);
+        MethodCallId methodCallId = mock(MethodCallId.class);
         Vacation vacation = Vacation.builder()
             .enabled(true)
             .textBody("I am in vacation")
@@ -137,10 +137,10 @@ public class GetVacationResponseMethodTest {
 
         GetVacationRequest getVacationRequest = GetVacationRequest.builder().build();
 
-        Stream<JmapResponse> result = testee.process(getVacationRequest, clientId, mailboxSession);
+        Stream<JmapResponse> result = testee.process(getVacationRequest, methodCallId, mailboxSession);
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .responseName(GetVacationResponseMethod.RESPONSE_NAME)
             .response(GetVacationResponse.builder()
                 .accountId(USERNAME)
@@ -157,7 +157,7 @@ public class GetVacationResponseMethodTest {
 
     @Test
     public void processShouldReturnUnActivatedVacationResponseWhenAfterDate() {
-        ClientId clientId = mock(ClientId.class);
+        MethodCallId methodCallId = mock(MethodCallId.class);
         Vacation vacation = Vacation.builder()
             .enabled(true)
             .textBody("I am in vacation")
@@ -171,10 +171,10 @@ public class GetVacationResponseMethodTest {
 
         GetVacationRequest getVacationRequest = GetVacationRequest.builder().build();
 
-        Stream<JmapResponse> result = testee.process(getVacationRequest, clientId, mailboxSession);
+        Stream<JmapResponse> result = testee.process(getVacationRequest, methodCallId, mailboxSession);
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .responseName(GetVacationResponseMethod.RESPONSE_NAME)
             .response(GetVacationResponse.builder()
                 .accountId(USERNAME)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapRequestParserImplTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapRequestParserImplTest.java
@@ -20,7 +20,7 @@
 package org.apache.james.jmap.methods;
 
 import org.apache.james.jmap.json.ObjectMapperFactory;
-import org.apache.james.jmap.model.ProtocolRequest;
+import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.junit.Before;
@@ -44,7 +44,7 @@ public class JmapRequestParserImplTest {
                 new ObjectNode(new JsonNodeFactory(false)).putObject("{\"id\": \"id\"}"),
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        testee.extractJmapRequest(ProtocolRequest.deserialize(nodes), null);
+        testee.extractJmapRequest(InvocationRequest.deserialize(nodes), null);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class JmapRequestParserImplTest {
                 parameters,
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        testee.extractJmapRequest(ProtocolRequest.deserialize(nodes), RequestClass.class);
+        testee.extractJmapRequest(InvocationRequest.deserialize(nodes), RequestClass.class);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class JmapRequestParserImplTest {
                 parameters,
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        testee.extractJmapRequest(ProtocolRequest.deserialize(nodes), RequestClass.class);
+        testee.extractJmapRequest(InvocationRequest.deserialize(nodes), RequestClass.class);
     }
 
     private static class RequestClass implements JmapRequest {

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapResponseWriterImplTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapResponseWriterImplTest.java
@@ -31,7 +31,7 @@ import org.apache.james.jmap.json.ObjectMapperFactory;
 import org.apache.james.jmap.model.ClientId;
 import org.apache.james.jmap.model.Property;
 import org.apache.james.jmap.model.InvocationRequest;
-import org.apache.james.jmap.model.ProtocolResponse;
+import org.apache.james.jmap.model.InvocationResponse;
 import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.junit.Before;
@@ -61,15 +61,15 @@ public class JmapResponseWriterImplTest {
         String expectedClientId = "#1";
         String expectedId = "myId";
 
-        Stream<ProtocolResponse> response = testee.formatMethodResponse(Stream.of(JmapResponse
+        Stream<InvocationResponse> response = testee.formatMethodResponse(Stream.of(JmapResponse
                 .builder()
                 .clientId(ClientId.of(expectedClientId))
                 .response(null)
                 .build()));
 
-        List<ProtocolResponse> responseList = response.collect(Collectors.toList());
+        List<InvocationResponse> responseList = response.collect(Collectors.toList());
         assertThat(responseList).hasSize(1)
-                .extracting(ProtocolResponse::getResponseName, x -> x.getResults().get("id").asText(), ProtocolResponse::getClientId)
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("id").asText(), InvocationResponse::getClientId)
                 .containsExactly(tuple(expectedMethod, expectedId, expectedClientId));
     }
 
@@ -81,7 +81,7 @@ public class JmapResponseWriterImplTest {
         ResponseClass responseClass = new ResponseClass();
         responseClass.id = expectedId;
 
-        List<ProtocolResponse> response = testee.formatMethodResponse(
+        List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                 .builder()
                 .responseName(Method.Response.name("unknownMethod"))
@@ -91,7 +91,7 @@ public class JmapResponseWriterImplTest {
                 .collect(Collectors.toList());
 
         assertThat(response).hasSize(1)
-                .extracting(ProtocolResponse::getResponseName, x -> x.getResults().get("id").asText(), ProtocolResponse::getClientId)
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("id").asText(), InvocationResponse::getClientId)
                 .containsExactly(tuple(Method.Response.name("unknownMethod"), expectedId, ClientId.of(expectedClientId)));
     }
 
@@ -108,7 +108,7 @@ public class JmapResponseWriterImplTest {
         responseClass.list = ImmutableList.of(new ObjectResponseClass.Foo("id", "name"));
         Property property = () -> "id";
 
-        List<ProtocolResponse> response = testee.formatMethodResponse(
+        List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                 .builder()
                 .responseName(Method.Response.name("unknownMethod"))
@@ -133,7 +133,7 @@ public class JmapResponseWriterImplTest {
         Property property = () -> "id";
 
         @SuppressWarnings("unused")
-        Stream<ProtocolResponse> ignoredResponse = testee.formatMethodResponse(
+        Stream<InvocationResponse> ignoredResponse = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                         .builder()
                         .responseName(Method.Response.name("unknownMethod"))
@@ -142,7 +142,7 @@ public class JmapResponseWriterImplTest {
                         .response(responseClass)
                         .build()));
 
-        List<ProtocolResponse> response = testee.formatMethodResponse(
+        List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                 .builder()
                 .responseName(Method.Response.name("unknownMethod"))
@@ -165,7 +165,7 @@ public class JmapResponseWriterImplTest {
         Property idProperty = () -> "id";
         Property nameProperty = () -> "name";
 
-        List<ProtocolResponse> response = testee.formatMethodResponse(
+        List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                             .builder()
                             .responseName(Method.Response.name("unknownMethod"))
@@ -216,7 +216,7 @@ public class JmapResponseWriterImplTest {
                 parameters,
                 new ObjectNode(new JsonNodeFactory(false)).textNode(expectedClientId)};
 
-        List<ProtocolResponse> response = testee.formatMethodResponse(
+        List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                     .builder()
                     .clientId(InvocationRequest.deserialize(nodes).getClientId())
@@ -225,7 +225,7 @@ public class JmapResponseWriterImplTest {
                 .collect(Collectors.toList());
 
         assertThat(response).hasSize(1)
-                .extracting(ProtocolResponse::getResponseName, x -> x.getResults().get("type").asText(), ProtocolResponse::getClientId)
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("type").asText(), InvocationResponse::getClientId)
                 .containsExactly(tuple(ErrorResponse.ERROR_METHOD, ErrorResponse.DEFAULT_ERROR_MESSAGE, ClientId.of(expectedClientId)));
     }
 
@@ -239,7 +239,7 @@ public class JmapResponseWriterImplTest {
                 parameters,
                 new ObjectNode(new JsonNodeFactory(false)).textNode(expectedClientId)};
 
-        List<ProtocolResponse> response = testee.formatMethodResponse(
+        List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                     .builder()
                     .clientId(InvocationRequest.deserialize(nodes).getClientId())
@@ -252,7 +252,7 @@ public class JmapResponseWriterImplTest {
                 .collect(Collectors.toList());
 
         assertThat(response).hasSize(1)
-                .extracting(ProtocolResponse::getResponseName, x -> x.getResults().get("type").asText(), x -> x.getResults().get("description").asText(), ProtocolResponse::getClientId)
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("type").asText(), x -> x.getResults().get("description").asText(), InvocationResponse::getClientId)
                 .containsExactly(tuple(ErrorResponse.ERROR_METHOD, "errorType", "complete description", ClientId.of(expectedClientId)));
     }
 

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapResponseWriterImplTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapResponseWriterImplTest.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.james.jmap.json.ObjectMapperFactory;
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.Property;
 import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.jmap.model.InvocationResponse;
@@ -58,24 +58,24 @@ public class JmapResponseWriterImplTest {
     @Test(expected = IllegalStateException.class)
     public void formatMethodResponseShouldWorkWhenNullJmapResponse() {
         String expectedMethod = "nwonMethod";
-        String expectedClientId = "#1";
+        String expectedMethodCallId = "#1";
         String expectedId = "myId";
 
         Stream<InvocationResponse> response = testee.formatMethodResponse(Stream.of(JmapResponse
                 .builder()
-                .clientId(ClientId.of(expectedClientId))
+                .methodCallId(MethodCallId.of(expectedMethodCallId))
                 .response(null)
                 .build()));
 
         List<InvocationResponse> responseList = response.collect(Collectors.toList());
         assertThat(responseList).hasSize(1)
-                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("id").asText(), InvocationResponse::getClientId)
-                .containsExactly(tuple(expectedMethod, expectedId, expectedClientId));
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("id").asText(), InvocationResponse::getMethodCallId)
+                .containsExactly(tuple(expectedMethod, expectedId, expectedMethodCallId));
     }
 
     @Test
     public void formatMethodResponseShouldWork() {
-        String expectedClientId = "#1";
+        String expectedMethodCallId = "#1";
         String expectedId = "myId";
 
         ResponseClass responseClass = new ResponseClass();
@@ -85,14 +85,14 @@ public class JmapResponseWriterImplTest {
                 Stream.of(JmapResponse
                 .builder()
                 .responseName(Method.Response.name("unknownMethod"))
-                .clientId(ClientId.of(expectedClientId))
+                .methodCallId(MethodCallId.of(expectedMethodCallId))
                 .response(responseClass)
                 .build()))
                 .collect(Collectors.toList());
 
         assertThat(response).hasSize(1)
-                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("id").asText(), InvocationResponse::getClientId)
-                .containsExactly(tuple(Method.Response.name("unknownMethod"), expectedId, ClientId.of(expectedClientId)));
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("id").asText(), InvocationResponse::getMethodCallId)
+                .containsExactly(tuple(Method.Response.name("unknownMethod"), expectedId, MethodCallId.of(expectedMethodCallId)));
     }
 
     private static class ResponseClass implements Method.Response {
@@ -112,7 +112,7 @@ public class JmapResponseWriterImplTest {
                 Stream.of(JmapResponse
                 .builder()
                 .responseName(Method.Response.name("unknownMethod"))
-                .clientId(ClientId.of("#1"))
+                .methodCallId(MethodCallId.of("#1"))
                 .properties(ImmutableSet.of(property))
                 .response(responseClass)
                 .build()))
@@ -137,7 +137,7 @@ public class JmapResponseWriterImplTest {
                 Stream.of(JmapResponse
                         .builder()
                         .responseName(Method.Response.name("unknownMethod"))
-                        .clientId(ClientId.of("#1"))
+                        .methodCallId(MethodCallId.of("#1"))
                         .properties(ImmutableSet.of(property))
                         .response(responseClass)
                         .build()));
@@ -146,7 +146,7 @@ public class JmapResponseWriterImplTest {
                 Stream.of(JmapResponse
                 .builder()
                 .responseName(Method.Response.name("unknownMethod"))
-                .clientId(ClientId.of("#1"))
+                .methodCallId(MethodCallId.of("#1"))
                 .response(responseClass)
                 .build()))
                 .collect(Collectors.toList());
@@ -169,14 +169,14 @@ public class JmapResponseWriterImplTest {
                 Stream.of(JmapResponse
                             .builder()
                             .responseName(Method.Response.name("unknownMethod"))
-                            .clientId(ClientId.of("#1"))
+                            .methodCallId(MethodCallId.of("#1"))
                             .properties(ImmutableSet.of(idProperty, nameProperty))
                             .response(responseClass)
                             .build(),
                         JmapResponse
                             .builder()
                             .responseName(Method.Response.name("unknownMethod"))
-                            .clientId(ClientId.of("#1"))
+                            .methodCallId(MethodCallId.of("#1"))
                             .properties(ImmutableSet.of(idProperty))
                             .response(responseClass)
                             .build()))
@@ -208,41 +208,41 @@ public class JmapResponseWriterImplTest {
 
     @Test
     public void formatErrorResponseShouldWork() {
-        String expectedClientId = "#1";
+        String expectedMethodCallId = "#1";
 
         ObjectNode parameters = new ObjectNode(new JsonNodeFactory(false));
         parameters.put("id", "myId");
         JsonNode[] nodes = new JsonNode[] { new ObjectNode(new JsonNodeFactory(false)).textNode("unknwonMethod"),
                 parameters,
-                new ObjectNode(new JsonNodeFactory(false)).textNode(expectedClientId)};
+                new ObjectNode(new JsonNodeFactory(false)).textNode(expectedMethodCallId)};
 
         List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                     .builder()
-                    .clientId(InvocationRequest.deserialize(nodes).getClientId())
+                    .methodCallId(InvocationRequest.deserialize(nodes).getMethodCallId())
                     .error()
                     .build()))
                 .collect(Collectors.toList());
 
         assertThat(response).hasSize(1)
-                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("type").asText(), InvocationResponse::getClientId)
-                .containsExactly(tuple(ErrorResponse.ERROR_METHOD, ErrorResponse.DEFAULT_ERROR_MESSAGE, ClientId.of(expectedClientId)));
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("type").asText(), InvocationResponse::getMethodCallId)
+                .containsExactly(tuple(ErrorResponse.ERROR_METHOD, ErrorResponse.DEFAULT_ERROR_MESSAGE, MethodCallId.of(expectedMethodCallId)));
     }
 
     @Test
     public void formatErrorResponseShouldWorkWithTypeAndDescription() {
-        String expectedClientId = "#1";
+        String expectedMethodCallId = "#1";
 
         ObjectNode parameters = new ObjectNode(new JsonNodeFactory(false));
         parameters.put("id", "myId");
         JsonNode[] nodes = new JsonNode[] { new ObjectNode(new JsonNodeFactory(false)).textNode("unknwonMethod"),
                 parameters,
-                new ObjectNode(new JsonNodeFactory(false)).textNode(expectedClientId)};
+                new ObjectNode(new JsonNodeFactory(false)).textNode(expectedMethodCallId)};
 
         List<InvocationResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                     .builder()
-                    .clientId(InvocationRequest.deserialize(nodes).getClientId())
+                    .methodCallId(InvocationRequest.deserialize(nodes).getMethodCallId())
                     .error(ErrorResponse
                             .builder()
                             .type("errorType")
@@ -252,8 +252,8 @@ public class JmapResponseWriterImplTest {
                 .collect(Collectors.toList());
 
         assertThat(response).hasSize(1)
-                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("type").asText(), x -> x.getResults().get("description").asText(), InvocationResponse::getClientId)
-                .containsExactly(tuple(ErrorResponse.ERROR_METHOD, "errorType", "complete description", ClientId.of(expectedClientId)));
+                .extracting(InvocationResponse::getResponseName, x -> x.getResults().get("type").asText(), x -> x.getResults().get("description").asText(), InvocationResponse::getMethodCallId)
+                .containsExactly(tuple(ErrorResponse.ERROR_METHOD, "errorType", "complete description", MethodCallId.of(expectedMethodCallId)));
     }
 
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapResponseWriterImplTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/JmapResponseWriterImplTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import org.apache.james.jmap.json.ObjectMapperFactory;
 import org.apache.james.jmap.model.ClientId;
 import org.apache.james.jmap.model.Property;
-import org.apache.james.jmap.model.ProtocolRequest;
+import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.jmap.model.ProtocolResponse;
 import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
@@ -219,7 +219,7 @@ public class JmapResponseWriterImplTest {
         List<ProtocolResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                     .builder()
-                    .clientId(ProtocolRequest.deserialize(nodes).getClientId())
+                    .clientId(InvocationRequest.deserialize(nodes).getClientId())
                     .error()
                     .build()))
                 .collect(Collectors.toList());
@@ -242,7 +242,7 @@ public class JmapResponseWriterImplTest {
         List<ProtocolResponse> response = testee.formatMethodResponse(
                 Stream.of(JmapResponse
                     .builder()
-                    .clientId(ProtocolRequest.deserialize(nodes).getClientId())
+                    .clientId(InvocationRequest.deserialize(nodes).getClientId())
                     .error(ErrorResponse
                             .builder()
                             .type("errorType")

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.james.jmap.json.ObjectMapperFactory;
 import org.apache.james.jmap.model.AuthenticatedProtocolRequest;
 import org.apache.james.jmap.model.ClientId;
-import org.apache.james.jmap.model.ProtocolRequest;
+import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.jmap.model.ProtocolResponse;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.inmemory.InMemoryId;
@@ -140,7 +140,7 @@ public class RequestHandlerTest {
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
         RequestHandler requestHandler = new RequestHandler(ImmutableSet.of(), jmapRequestParser, jmapResponseWriter);
-        requestHandler.handle(AuthenticatedProtocolRequest.decorate(ProtocolRequest.deserialize(nodes), mockHttpServletRequest));
+        requestHandler.handle(AuthenticatedProtocolRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -208,7 +208,7 @@ public class RequestHandlerTest {
                 parameters,
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        List<ProtocolResponse> responses = testee.handle(AuthenticatedProtocolRequest.decorate(ProtocolRequest.deserialize(nodes), mockHttpServletRequest))
+        List<ProtocolResponse> responses = testee.handle(AuthenticatedProtocolRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest))
                 .collect(Collectors.toList());
 
         assertThat(responses).hasSize(1)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
@@ -34,7 +34,7 @@ import org.apache.james.jmap.json.ObjectMapperFactory;
 import org.apache.james.jmap.model.AuthenticatedRequest;
 import org.apache.james.jmap.model.ClientId;
 import org.apache.james.jmap.model.InvocationRequest;
-import org.apache.james.jmap.model.ProtocolResponse;
+import org.apache.james.jmap.model.InvocationResponse;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
@@ -208,7 +208,7 @@ public class RequestHandlerTest {
                 parameters,
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        List<ProtocolResponse> responses = testee.handle(AuthenticatedRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest))
+        List<InvocationResponse> responses = testee.handle(AuthenticatedRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest))
                 .collect(Collectors.toList());
 
         assertThat(responses).hasSize(1)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.james.jmap.json.ObjectMapperFactory;
 import org.apache.james.jmap.model.AuthenticatedRequest;
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.jmap.model.InvocationResponse;
 import org.apache.james.mailbox.MailboxSession;
@@ -106,14 +106,14 @@ public class RequestHandlerTest {
         }
 
         @Override
-        public Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession) {
+        public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
             Preconditions.checkArgument(request instanceof TestJmapRequest);
             TestJmapRequest typedRequest = (TestJmapRequest) request;
             return Stream.of(
                     JmapResponse.builder()
                             .response(new TestJmapResponse(typedRequest.getId(), typedRequest.getName(), "works"))
                             .responseName(Response.name("test"))
-                            .clientId(ClientId.of("#0"))
+                            .methodCallId(MethodCallId.of("#0"))
                             .build());
         }
     }
@@ -193,7 +193,7 @@ public class RequestHandlerTest {
         }
         
         @Override
-        public Stream<JmapResponse> process(JmapRequest request, ClientId clientId, MailboxSession mailboxSession) {
+        public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
             return null;
         }
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/RequestHandlerTest.java
@@ -31,7 +31,7 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.james.jmap.json.ObjectMapperFactory;
-import org.apache.james.jmap.model.AuthenticatedProtocolRequest;
+import org.apache.james.jmap.model.AuthenticatedRequest;
 import org.apache.james.jmap.model.ClientId;
 import org.apache.james.jmap.model.InvocationRequest;
 import org.apache.james.jmap.model.ProtocolResponse;
@@ -140,7 +140,7 @@ public class RequestHandlerTest {
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
         RequestHandler requestHandler = new RequestHandler(ImmutableSet.of(), jmapRequestParser, jmapResponseWriter);
-        requestHandler.handle(AuthenticatedProtocolRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest));
+        requestHandler.handle(AuthenticatedRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -208,7 +208,7 @@ public class RequestHandlerTest {
                 parameters,
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        List<ProtocolResponse> responses = testee.handle(AuthenticatedProtocolRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest))
+        List<ProtocolResponse> responses = testee.handle(AuthenticatedRequest.decorate(InvocationRequest.deserialize(nodes), mockHttpServletRequest))
                 .collect(Collectors.toList());
 
         assertThat(responses).hasSize(1)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMailboxesMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMailboxesMethodTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.stream.Stream;
 
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.GetMailboxesRequest;
 import org.apache.james.jmap.model.MailboxCreationId;
 import org.apache.james.jmap.model.SetMailboxesRequest;
@@ -61,16 +61,16 @@ public class SetMailboxesMethodTest {
     public void processShouldThrowWhenNullJmapRequest() {
         MailboxSession session = mock(MailboxSession.class);
         JmapRequest nullJmapRequest = null;
-        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(nullJmapRequest, ClientId.of("clientId"), session))
+        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(nullJmapRequest, MethodCallId.of("methodCallId"), session))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void processShouldThrowWhenNullClientId() {
+    public void processShouldThrowWhenNullMethodCallId() {
         MailboxSession session = mock(MailboxSession.class);
         JmapRequest jmapRequest = mock(JmapRequest.class);
-        ClientId nullClientId = null;
-        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(jmapRequest, nullClientId, session))
+        MethodCallId nullMethodCallId = null;
+        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(jmapRequest, nullMethodCallId, session))
             .isInstanceOf(NullPointerException.class);
     }
 
@@ -78,7 +78,7 @@ public class SetMailboxesMethodTest {
     public void processShouldThrowWhenNullMailboxSession() {
         MailboxSession nullMailboxSession = null;
         JmapRequest jmapRequest = mock(JmapRequest.class);
-        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(jmapRequest, ClientId.of("clientId"), nullMailboxSession))
+        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(jmapRequest, MethodCallId.of("methodCallId"), nullMailboxSession))
             .isInstanceOf(NullPointerException.class);
     }
 
@@ -86,7 +86,7 @@ public class SetMailboxesMethodTest {
     public void processShouldThrowWhenJmapRequestTypeMismatch() {
         MailboxSession session = mock(MailboxSession.class);
         JmapRequest getMailboxesRequest = GetMailboxesRequest.builder().build();
-        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(getMailboxesRequest, ClientId.of("clientId"), session))
+        assertThatThrownBy(() -> new SetMailboxesMethod(NO_PROCESSOR, TIME_METRIC_FACTORY).process(getMailboxesRequest, MethodCallId.of("methodCallId"), session))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -100,7 +100,7 @@ public class SetMailboxesMethodTest {
         SetMailboxesResponse creationResponse = SetMailboxesResponse.builder().created(creationId, createdfooFolder).build();
         JmapResponse jmapResponse = JmapResponse.builder()
             .response(creationResponse)
-            .clientId(ClientId.of("clientId"))
+            .methodCallId(MethodCallId.of("methodCallId"))
             .responseName(SetMailboxesMethod.RESPONSE_NAME)
             .build();
 
@@ -110,7 +110,7 @@ public class SetMailboxesMethodTest {
 
         Stream<JmapResponse> actual =
             new SetMailboxesMethod(ImmutableSet.of(creatorProcessor), TIME_METRIC_FACTORY)
-                    .process(creationRequest, ClientId.of("clientId"), session);
+                    .process(creationRequest, MethodCallId.of("methodCallId"), session);
 
         assertThat(actual).contains(jmapResponse);
     }
@@ -123,7 +123,7 @@ public class SetMailboxesMethodTest {
         SetMailboxesResponse destructionResponse = SetMailboxesResponse.builder().destroyed(deletions).build();
         JmapResponse jmapResponse = JmapResponse.builder()
             .response(destructionResponse)
-            .clientId(ClientId.of("clientId"))
+            .methodCallId(MethodCallId.of("methodCallId"))
             .responseName(SetMailboxesMethod.RESPONSE_NAME)
             .build();
 
@@ -133,7 +133,7 @@ public class SetMailboxesMethodTest {
 
         Stream<JmapResponse> actual =
             new SetMailboxesMethod(ImmutableSet.of(destructorProcessor), TIME_METRIC_FACTORY)
-                    .process(destructionRequest, ClientId.of("clientId"), session);
+                    .process(destructionRequest, MethodCallId.of("methodCallId"), session);
 
         assertThat(actual).contains(jmapResponse);
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetVacationResponseMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetVacationResponseMethodTest.java
@@ -35,7 +35,7 @@ import org.apache.james.jmap.api.vacation.AccountId;
 import org.apache.james.jmap.api.vacation.NotificationRegistry;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationRepository;
-import org.apache.james.jmap.model.ClientId;
+import org.apache.james.jmap.model.MethodCallId;
 import org.apache.james.jmap.model.GetMailboxesRequest;
 import org.apache.james.jmap.model.SetError;
 import org.apache.james.jmap.model.SetMailboxesRequest;
@@ -59,13 +59,13 @@ public class SetVacationResponseMethodTest {
 
     private SetVacationResponseMethod testee;
     private VacationRepository vacationRepository;
-    private ClientId clientId;
+    private MethodCallId methodCallId;
     private MailboxSession mailboxSession;
     private NotificationRegistry notificationRegistry;
 
     @Before
     public void setUp() {
-        clientId = mock(ClientId.class);
+        methodCallId = mock(MethodCallId.class);
         mailboxSession = mock(MailboxSession.class);
         vacationRepository = mock(VacationRepository.class);
         notificationRegistry = mock(NotificationRegistry.class);
@@ -74,22 +74,22 @@ public class SetVacationResponseMethodTest {
 
     @Test(expected = NullPointerException.class)
     public void processShouldThrowOnNullRequest() {
-        testee.process(null, mock(ClientId.class), mock(MailboxSession.class));
+        testee.process(null, mock(MethodCallId.class), mock(MailboxSession.class));
     }
 
     @Test(expected = NullPointerException.class)
-    public void processShouldThrowOnNullClientId() {
+    public void processShouldThrowOnNullMethodCallId() {
         testee.process(mock(SetMailboxesRequest.class), null, mock(MailboxSession.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void processShouldThrowOnNullMailboxSession() {
-        testee.process(mock(SetMailboxesRequest.class), mock(ClientId.class), null);
+        testee.process(mock(SetMailboxesRequest.class), mock(MethodCallId.class), null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void processShouldThrowOnWrongRequestType() {
-        testee.process(mock(GetMailboxesRequest.class), mock(ClientId.class), mock(MailboxSession.class));
+        testee.process(mock(GetMailboxesRequest.class), mock(MethodCallId.class), mock(MailboxSession.class));
     }
 
     @Test
@@ -98,10 +98,10 @@ public class SetVacationResponseMethodTest {
             .update(ImmutableMap.of())
             .build();
 
-        Stream<JmapResponse> result = testee.process(setVacationRequest, clientId, mock(MailboxSession.class));
+        Stream<JmapResponse> result = testee.process(setVacationRequest, methodCallId, mock(MailboxSession.class));
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .error(ErrorResponse.builder()
                 .type(SetVacationResponseMethod.INVALID_ARGUMENTS)
                 .description(SetVacationResponseMethod.INVALID_ARGUMENT_DESCRIPTION)
@@ -121,10 +121,10 @@ public class SetVacationResponseMethodTest {
                 .build()))
             .build();
 
-        Stream<JmapResponse> result = testee.process(setVacationRequest, clientId, mock(MailboxSession.class));
+        Stream<JmapResponse> result = testee.process(setVacationRequest, methodCallId, mock(MailboxSession.class));
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .error(ErrorResponse.builder()
                 .type(SetVacationResponseMethod.INVALID_ARGUMENTS)
                 .description(SetVacationResponseMethod.INVALID_ARGUMENT_DESCRIPTION)
@@ -149,10 +149,10 @@ public class SetVacationResponseMethodTest {
                     .build()))
             .build();
 
-        Stream<JmapResponse> result = testee.process(setVacationRequest, clientId, mock(MailboxSession.class));
+        Stream<JmapResponse> result = testee.process(setVacationRequest, methodCallId, mock(MailboxSession.class));
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .error(ErrorResponse.builder()
                 .type(SetVacationResponseMethod.INVALID_ARGUMENTS)
                 .description(SetVacationResponseMethod.INVALID_ARGUMENT_DESCRIPTION)
@@ -179,10 +179,10 @@ public class SetVacationResponseMethodTest {
         when(notificationRegistry.flush(any()))
             .thenReturn(Mono.empty());
 
-        Stream<JmapResponse> result = testee.process(setVacationRequest, clientId, mailboxSession);
+        Stream<JmapResponse> result = testee.process(setVacationRequest, methodCallId, mailboxSession);
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .responseName(SetVacationResponseMethod.RESPONSE_NAME)
             .response(SetVacationResponse.builder()
                 .updatedId(Vacation.ID)
@@ -206,10 +206,10 @@ public class SetVacationResponseMethodTest {
             .build();
         when(mailboxSession.getUser()).thenReturn(USER);
 
-        Stream<JmapResponse> result = testee.process(setVacationRequest, clientId, mailboxSession);
+        Stream<JmapResponse> result = testee.process(setVacationRequest, methodCallId, mailboxSession);
 
         JmapResponse expected = JmapResponse.builder()
-            .clientId(clientId)
+            .methodCallId(methodCallId)
             .responseName(SetVacationResponseMethod.RESPONSE_NAME)
             .response(SetVacationResponse.builder()
                 .notUpdated(Vacation.ID, SetError.builder()

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationRequestTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationRequestTest.java
@@ -32,14 +32,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-public class ProtocolRequestTest {
+public class InvocationRequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void deserializedRequestsShouldThrowWhenNotEnoughElements() throws Exception {
         JsonNode[] nodes = new JsonNode[] { new ObjectNode(new JsonNodeFactory(false)).textNode("getAccounts"),
                 new ObjectNode(new JsonNodeFactory(false)).putObject("{}")};
 
-        ProtocolRequest.deserialize(nodes);
+        InvocationRequest.deserialize(nodes);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -49,7 +49,7 @@ public class ProtocolRequestTest {
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#0"),
                 new ObjectNode(new JsonNodeFactory(false)).textNode("tooMuch")};
 
-        ProtocolRequest.deserialize(nodes);
+        InvocationRequest.deserialize(nodes);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -58,7 +58,7 @@ public class ProtocolRequestTest {
                 new ObjectNode(new JsonNodeFactory(false)).putObject("{}"),
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#0")};
 
-        ProtocolRequest.deserialize(nodes);
+        InvocationRequest.deserialize(nodes);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -67,7 +67,7 @@ public class ProtocolRequestTest {
                 new ObjectNode(new JsonNodeFactory(false)).textNode("true"),
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#0")};
 
-        ProtocolRequest.deserialize(nodes);
+        InvocationRequest.deserialize(nodes);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -76,7 +76,7 @@ public class ProtocolRequestTest {
                 new ObjectNode(new JsonNodeFactory(false)).putObject("{}"),
                 new ObjectNode(new JsonNodeFactory(false)).booleanNode(true)};
 
-        ProtocolRequest.deserialize(nodes);
+        InvocationRequest.deserialize(nodes);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class ProtocolRequestTest {
                 new ObjectNode(new JsonNodeFactory(false)).putObject("{\"id\": \"id\"}"),
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        ProtocolRequest request = ProtocolRequest.deserialize(nodes);
+        InvocationRequest request = InvocationRequest.deserialize(nodes);
 
         assertThat(request.getMethodName()).isEqualTo(Method.Request.name("getAccounts"));
         assertThat(request.getParameters()).isNotNull();

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationRequestTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationRequestTest.java
@@ -89,6 +89,6 @@ public class InvocationRequestTest {
 
         assertThat(request.getMethodName()).isEqualTo(Method.Request.name("getAccounts"));
         assertThat(request.getParameters()).isNotNull();
-        assertThat(request.getClientId()).isEqualTo(ClientId.of("#1"));
+        assertThat(request.getMethodCallId()).isEqualTo(MethodCallId.of("#1"));
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationResponseTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationResponseTest.java
@@ -31,27 +31,27 @@ public class InvocationResponseTest {
 
     @Test(expected = NullPointerException.class)
     public void newInstanceShouldThrowWhenMethodIsNull() {
-        new InvocationResponse(null, new ObjectNode(JsonNodeFactory.instance), ClientId.of("id"));
+        new InvocationResponse(null, new ObjectNode(JsonNodeFactory.instance), MethodCallId.of("id"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void newInstanceShouldThrowWhenMethodIsEmpty() {
-        new InvocationResponse(Method.Response.name(""), new ObjectNode(JsonNodeFactory.instance), ClientId.of("id"));
+        new InvocationResponse(Method.Response.name(""), new ObjectNode(JsonNodeFactory.instance), MethodCallId.of("id"));
     }
 
     @Test(expected = NullPointerException.class)
     public void newInstanceShouldThrowWhenResultsIsNull() {
-        new InvocationResponse(Method.Response.name("method"), null, ClientId.of("id"));
+        new InvocationResponse(Method.Response.name("method"), null, MethodCallId.of("id"));
     }
 
     @Test(expected = NullPointerException.class)
-    public void newInstanceShouldThrowWhenClientIdIsNull() {
+    public void newInstanceShouldThrowWhenMethodCallIdIsNull() {
         new InvocationResponse(Method.Response.name("method"), new ObjectNode(new JsonNodeFactory(false)).putObject("{}"), null);
     }
 
     @Test
     public void asProtocolSpecificationShouldReturnAnArrayWithThreeElements() {
-        Object[] asProtocolSpecification = new InvocationResponse(Method.Response.name("method"), new ObjectNode(new JsonNodeFactory(false)).putObject("{}"), ClientId.of("#1"))
+        Object[] asProtocolSpecification = new InvocationResponse(Method.Response.name("method"), new ObjectNode(new JsonNodeFactory(false)).putObject("{}"), MethodCallId.of("#1"))
                 .asProtocolSpecification();
 
         assertThat(asProtocolSpecification).hasSize(3);

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationResponseTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/InvocationResponseTest.java
@@ -27,31 +27,31 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-public class ProtocolResponseTest {
+public class InvocationResponseTest {
 
     @Test(expected = NullPointerException.class)
     public void newInstanceShouldThrowWhenMethodIsNull() {
-        new ProtocolResponse(null, new ObjectNode(JsonNodeFactory.instance), ClientId.of("id"));
+        new InvocationResponse(null, new ObjectNode(JsonNodeFactory.instance), ClientId.of("id"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void newInstanceShouldThrowWhenMethodIsEmpty() {
-        new ProtocolResponse(Method.Response.name(""), new ObjectNode(JsonNodeFactory.instance), ClientId.of("id"));
+        new InvocationResponse(Method.Response.name(""), new ObjectNode(JsonNodeFactory.instance), ClientId.of("id"));
     }
 
     @Test(expected = NullPointerException.class)
     public void newInstanceShouldThrowWhenResultsIsNull() {
-        new ProtocolResponse(Method.Response.name("method"), null, ClientId.of("id"));
+        new InvocationResponse(Method.Response.name("method"), null, ClientId.of("id"));
     }
 
     @Test(expected = NullPointerException.class)
     public void newInstanceShouldThrowWhenClientIdIsNull() {
-        new ProtocolResponse(Method.Response.name("method"), new ObjectNode(new JsonNodeFactory(false)).putObject("{}"), null);
+        new InvocationResponse(Method.Response.name("method"), new ObjectNode(new JsonNodeFactory(false)).putObject("{}"), null);
     }
 
     @Test
     public void asProtocolSpecificationShouldReturnAnArrayWithThreeElements() {
-        Object[] asProtocolSpecification = new ProtocolResponse(Method.Response.name("method"), new ObjectNode(new JsonNodeFactory(false)).putObject("{}"), ClientId.of("#1"))
+        Object[] asProtocolSpecification = new InvocationResponse(Method.Response.name("method"), new ObjectNode(new JsonNodeFactory(false)).putObject("{}"), ClientId.of("#1"))
                 .asProtocolSpecification();
 
         assertThat(asProtocolSpecification).hasSize(3);

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MethodCallIdTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MethodCallIdTest.java
@@ -23,22 +23,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-public class ClientIdTest {
+public class MethodCallIdTest {
 
     @Test
     public void nullInputShouldThrow() {
-        assertThatThrownBy(() -> ClientId.of(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> MethodCallId.of(null)).isInstanceOf(NullPointerException.class);
     }
     
     @Test
     public void emptyInputShouldThrow() {
-        assertThatThrownBy(() -> ClientId.of("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> MethodCallId.of("")).isInstanceOf(IllegalArgumentException.class);
     }
     
 
     @Test
-    public void validInputShouldCreateClientId() {
-        ClientId testee = ClientId.of("valid");
+    public void validInputShouldCreateMethodCallId() {
+        MethodCallId testee = MethodCallId.of("valid");
         assertThat(testee).isNotNull();
         assertThat(testee.getId()).isEqualTo("valid");
     }


### PR DESCRIPTION
This pull request renames the following classes:
* `ProtocolRequest` to `InvocationRequest` (it models the `Invocation` type from the specification)
* `AuthenticatedProtocolRequest` to `AuthenticatedRequest`
* `ProtocolResponse` to `InvocationResponse` (it models the `Invocation` type from the specification)
* `ClientId` to `MethodCallId` (the spec simply uses the type `String` for this; but the element is called "method call id")

This change should make it easier to map classes used in James to types from the specification. Another thing that motivated this change is that `ProtocolRequest` would be a good name to use for a class that holds the properties of a (current spec) request, namely, the `using` and `methodCalls` properties.

```json
{
  "using": [ "urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail" ],
  "methodCalls": [
    [ "method1", {
      "arg1": "arg1data",
      "arg2": "arg2data"
    }, "c1" ],
    [ "method2", {
      "arg1": "arg1data"
    }, "c2" ],
    [ "method3", {}, "c3" ]
  ]
}
```

This pull request only renames classes, fields, methods, parameters and local variables. None of the functionality has been changed.

https://issues.apache.org/jira/browse/JAMES-2884