### PR TITLE
Various ADR regarding JMAP and blobStore performance enhancements

### DIFF
--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -10,7 +10,7 @@ Accepted (lazy consensus)
 
 JMAP core RFC8620 requires that the server responds only properties requested by the client.
 
-James currently returns all of the properties regardless of their cost, and if it had been asked by the client.
+James currently computes all of the properties regardless of their cost, and if it had been asked by the client.
 
 Clearly we can save some latencies and resources by avoiding reading/computing expensive properties that had not been explicitly requested by the client.
 
@@ -18,11 +18,12 @@ This is furthermore an opportunity to conform to /get behavior of released RFC-8
 
 ## Decision
 
-Introduce two projections for JMAP messages:
+Introduce two new datastructures representing JMAP messages:
  - One with only metadata
  - One with metadata + headers
 
-Given the properties requested by the client, the most appropriate message projection will be returned.
+Given the properties requested by the client, the most appropriate message datastructure will be returned, on top of 
+existing message storage APIs that should remain unchanged.
 
 Some performance tests will be run in order to evaluate the improvements.
 

--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -1,0 +1,38 @@
+# 12. Projections for JMAP Messages
+
+Date: 2019-10-09
+
+## Status
+
+Accepted (lazy consensus)
+
+## Context
+
+JMAP core RFC8620 requires that the server responds only properties requested by the client.
+
+James currently returns all of the properties regardless of their cost, and if it had been asked by the client.
+
+Clearly we can save some latencies and resources by avoiding reading/computing expensive properties that had not been explicitly requested by the client.
+
+This is furthermore an opportunity to conform to /get behavior of released RFC-8620
+
+## Decision
+
+Introduce two projections for JMAP messages:
+ - One with only metadata
+ - One with metadata + headers
+
+Given the properties requested by the client, the most appropriate message projection will be returned.
+
+Some performance tests will be run in order to evaluate the improvements.
+
+## Consequences
+
+Fields that were previously returned in Messages might not be returned anymore if not explicitly asked by the client.
+
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+
+## References
+
+ - /get method: https://tools.ietf.org/html/rfc8620#section-5.1
+ - [JIRA](https://issues.apache.org/jira/browse/JAMES-2919)

--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -4,7 +4,9 @@ Date: 2019-10-09
 
 ## Status
 
-Accepted (lazy consensus)
+Proposed
+
+Adoption needs to be backed by some performance tests.
 
 ## Context
 
@@ -14,22 +16,21 @@ James currently computes all of the properties regardless of their cost, and if 
 
 Clearly we can save some latencies and resources by avoiding reading/computing expensive properties that had not been explicitly requested by the client.
 
-This is furthermore an opportunity to conform to /get behavior of released RFC-8620
-
 ## Decision
 
 Introduce two new datastructures representing JMAP messages:
  - One with only metadata
  - One with metadata + headers
 
-Given the properties requested by the client, the most appropriate message datastructure will be returned, on top of 
+Given the properties requested by the client, the most appropriate message datastructure will be computed, on top of 
 existing message storage APIs that should remain unchanged.
 
 Some performance tests will be run in order to evaluate the improvements.
 
 ## Consequences
 
-Fields that were previously returned in Messages might not be returned anymore if not explicitly asked by the client.
+GetMessages with a limited set of requested properties will no longer result necessarily in full database message read. We
+thus expect a significant improvement, for instance when only metadata are requested.
 
 In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 

--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -31,7 +31,7 @@ Some performance tests will be run in order to evaluate the improvements.
 
 Fields that were previously returned in Messages might not be returned anymore if not explicitly asked by the client.
 
-In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 
 ## References
 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -4,7 +4,9 @@ Date: 2019-10-09
 
 ## Status
 
-Accepted (lazy consensus)
+Proposed
+
+Adoption needs to be backed by some performance tests.
 
 ## Context
 
@@ -26,15 +28,14 @@ When the preview is precomputed then for these messages we can consider the "pre
 
 When the preview is not precomputed then we should compute the preview for these messages, and save the result for later.
 
-We should provide a webAdmin task allowing to rebuild the projection.
+We should provide a webAdmin task allowing to rebuild the projection. The computing and storing in MessagePreviewStore 
+is idempotent and that the task can be run in live without any concurrency problem.
 
 Some performance tests will be run in order to evaluate the improvements.
 
 ## Consequences
 
 We expect a huge performance enhancement for JMAP clients relying on preview for listing mails.
-
-Messages whose preview is not yet computed will still require live preview computation as a fallback mechanism.
 
 In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -36,7 +36,7 @@ We expect a huge performance enhancement for JMAP clients relying on preview for
 
 Messages whose preview is not yet computed will still require live preview computation as a fallback mechanism.
 
-In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 
 ## References
 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -12,7 +12,7 @@ JMAP messages have a handy preview property displaying the firsts 256 characters
 
 This property is often displayed for message listing in JMAP clients, thus it is queried a lot.
 
-Currently, to get the preview, James retrieves the full message body, parse it using MIME parsers, removes HTML and keep meaningful text. This process is expensive, especially for clients relying on polling.
+Currently, to get the preview, James retrieves the full message body, parse it using MIME parsers, removes HTML and keep meaningful text.
 
 ## Decision
 
@@ -23,6 +23,8 @@ A MailboxListener will compute the preview and store it in a MessagePreviewStore
 We should have a Cassandra and memory implementation.
 
 When the preview is precomputed then for these messages we can consider the "preview" property as a metadata.
+
+When the preview is not precomputed then we should compute the preview for these messages, and save the result for later.
 
 We should provide a webAdmin task allowing to rebuild the projection.
 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -29,7 +29,7 @@ When the preview is precomputed then for these messages we can consider the "pre
 When the preview is not precomputed then we should compute the preview for these messages, and save the result for later.
 
 We should provide a webAdmin task allowing to rebuild the projection. The computing and storing in MessagePreviewStore 
-is idempotent and that the task can be run in live without any concurrency problem.
+is idempotent and the task can be run in live without any concurrency problem.
 
 Some performance tests will be run in order to evaluate the improvements.
 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -1,0 +1,45 @@
+# 13. Precompute JMAP Email preview
+
+Date: 2019-10-09
+
+## Status
+
+Accepted (lazy consensus)
+
+## Context
+
+JMAP messages have a handy preview property displaying the firsts 256 characters of meaningful test of a message.
+
+This property is often displayed for message listing in JMAP clients, thus it is queried a lot.
+
+Currently, to get the preview, James retrieves the full message body, parse it using MIME persers, removes HTML and keep meaningful text. This process is expensive, especially for clients relying on polling.
+
+## Decision
+
+We should pre-compute message preview.
+
+A MailboxListener will compute the preview and store it in a MessagePreviewStore.
+
+We should have a Cassandra and memory implementation.
+
+When the preview is precomputed then for these messages we can consider the "preview" property as a metadata.
+
+We should provide a webAdmin task allowing to rebuild the projection.
+
+Some performance tests will be run in order to evaluate the improvements.
+
+## Consequences
+
+We expect a huge performance enhancement for JMAP clients relying on preview for listing mails.
+
+Messages whose preview is not yet computed will still require live preview computation as a fallback mechanism.
+
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+
+## References
+
+ - https://jmap.io/server.html#1-emails JMAP client guice states that preview needs to be quick to retrieve
+
+ - Similar decision had been taken at FastMail: https://fastmail.blog/2014/12/15/dec-15-putting-the-fast-in-fastmail-loading-your-mailbox-quickly/
+
+ - [JIRA](https://issues.apache.org/jira/browse/JAMES-2919)

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -12,7 +12,7 @@ JMAP messages have a handy preview property displaying the firsts 256 characters
 
 This property is often displayed for message listing in JMAP clients, thus it is queried a lot.
 
-Currently, to get the preview, James retrieves the full message body, parse it using MIME persers, removes HTML and keep meaningful text. This process is expensive, especially for clients relying on polling.
+Currently, to get the preview, James retrieves the full message body, parse it using MIME parsers, removes HTML and keep meaningful text. This process is expensive, especially for clients relying on polling.
 
 ## Decision
 

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -23,7 +23,7 @@ Also, the capabilities of the various implementations of BlobStore have differen
  - CassandraBlobStore is efficient for small blobs and offers low latency. However it is known to be expensive for big blobs. Cassandra storage is expensive.
  - Object Storage blob store is good at storing big blobs, but it induces higher latencies than Cassandra for small blobs for a cost gain that isn't worth it.
 
-Thus, significant performance could be unlocked by using the right blob store for the right blob.
+Thus, significant performance and cost ratio refinement could be unlocked by using the right blob store for the right blob.
 
 ## Decision
 
@@ -35,7 +35,7 @@ The proposed policies include:
  - LowCostStoragePolicy: The blob is expected to be saved in low cost storage. Access is expected to be unfrequent.
  - PerformantStoragePolicy: The blob is expected to be saved in performant storage. Access is expected to be frequent.
 
-An HybridBlobStore will be created to choose between Cassandra and ObjectStorage implementations depending on the policies.
+An HybridBlobStore will be replace current UnionBlobStore and will allow to choose between Cassandra and ObjectStorage implementations depending on the policies.
 
 DeletedMessageVault, BlobExport & MailRepository will rely on LowCostStoragePolicy. Other BlobStore users will rely on SizeBasedStoragePolicy.
 

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -21,7 +21,7 @@ As an example:
 Also, the capabilities of the various implementations of BlobStore have different strengths:
 
  - CassandraBlobStore is efficient for small blobs and offer low latency. However it is known to be expensive for big blobs. Cassandra storage is expensive.
- - Object Storage blob store is good at storing big blobs, but it induces higher latencies than Cassandra for small blobs for a cost gain that doesn't worth it.
+ - Object Storage blob store is good at storing big blobs, but it induces higher latencies than Cassandra for small blobs for a cost gain that isn't worth it.
 
 Thus, significant performance could be unlocked by using the right blob store for the right blob.
 
@@ -29,7 +29,7 @@ Thus, significant performance could be unlocked by using the right blob store fo
 
 Introduce StoragePolicies at the level of the BlobStore API.
 
-The proposed policies includes:
+The proposed policies include:
 
  - SizeBasedStoragePolicy: The blob underlying storage medium will be chosen depending of its size.
  - LowCostStoragePolicy: The blob is expected to be saved in low cost storage. Access is expected to be unfrequent.

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -35,7 +35,7 @@ The proposed policies include:
  - LowCostStoragePolicy: The blob is expected to be saved in low cost storage. Access is expected to be unfrequent.
  - PerformantStoragePolicy: The blob is expected to be saved in performant storage. Access is expected to be frequent.
 
-An HybridBlobStore will be replace current UnionBlobStore and will allow to choose between Cassandra and ObjectStorage implementations depending on the policies.
+An HybridBlobStore will replace current UnionBlobStore and will allow to choose between Cassandra and ObjectStorage implementations depending on the policies.
 
 DeletedMessageVault, BlobExport & MailRepository will rely on LowCostStoragePolicy. Other BlobStore users will rely on SizeBasedStoragePolicy.
 

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -6,7 +6,7 @@ Date: 2019-10-09
 
 Proposed
 
-Adoption needs to be backed by some performance tests.
+Adoption needs to be backed by some performance tests, as well as data repartition between Cassandra and object storage shifts.
 
 ## Context
 
@@ -47,7 +47,7 @@ We expect small frequently accessed blobs to be located in Cassandra, allowing O
 
 In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 
-We expect more data to be stored in Cassandra.
+We expect more data to be stored in Cassandra. We need to quantify this for adoption.
 
 As reads will be reading the two blobStores, no migration is required to use this composite blobstore on top an existing implementation,
 however we will benefits of the performance enhancements only for newly stored blobs.

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -47,6 +47,11 @@ We expect small frequently accessed blobs to be located in Cassandra, allowing O
 
 In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 
+We expect more data to be stored in Cassandra.
+
+As reads will be reading the two blobStores, no migration is required to use this composite blobstore on top an existing implementation,
+however we will benefits of the performance enhancements only for newly stored blobs.
+
 ## References
 
  - [JIRA](https://issues.apache.org/jira/browse/JAMES-2921)

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -1,0 +1,52 @@
+# 14. Add storage policies for BlobStore
+
+Date: 2019-10-09
+
+## Status
+
+Proposed
+
+Adoption needs to be backed by some performance tests.
+
+## Context
+
+James exposes a simple BlobStore API for storing raw data. However such raw data often vary in size and access patterns.
+
+As an example:
+
+ - Mailbox message headers are expected to be small and frequently accessed
+ - Mailbox message body are expected to have sizes ranging from small to big but are unfrequently accessed
+ - DeletedMessageVault message headers are expected to be small and unfrequently accessed
+
+Also, the capabilities of the various implementations of BlobStore have different strengths:
+
+ - CassandraBlobStore is efficient for small blobs and offer low latency. However it is known to be expensive for big blobs. Cassandra storage is expensive.
+ - Object Storage blob store is good at storing big blobs, but it induces higher latencies than Cassandra for small blobs for a cost gain that doesn't worth it.
+
+Thus, significant performance could be unlocked by using the right blob store for the right blob.
+
+## Decision
+
+Introduce StoragePolicies at the level of the BlobStore API.
+
+The proposed policies includes:
+
+ - SizeBasedStoragePolicy: The blob underlying storage medium will be chosen depending of its size.
+ - LowCostStoragePolicy: The blob is expected to be saved in low cost storage. Access is expected to be unfrequent.
+ - PerformantStoragePolicy: The blob is expected to be saved in performant storage. Access is expected to be unfrequent.
+
+An HybridBlobStore will be created to choose between Cassandra and ObjectStorage implementations depending on the policies.
+
+DeletedMessageVault, BlobExport & MailRepository will rely on LowCostStoragePolicy. Other BlobStore users will rely on SizeBasedStoragePolicy.
+
+Some performance tests will be run in order to evaluate the improvements.
+
+## Consequences
+
+We expect small frequently accessed blobs to be located in Cassandra, allowing ObjectStorage to be used mainly for large costly blobs.
+
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+
+## References
+
+ - [JIRA](https://issues.apache.org/jira/browse/JAMES-2921)

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -20,7 +20,7 @@ As an example:
 
 Also, the capabilities of the various implementations of BlobStore have different strengths:
 
- - CassandraBlobStore is efficient for small blobs and offer low latency. However it is known to be expensive for big blobs. Cassandra storage is expensive.
+ - CassandraBlobStore is efficient for small blobs and offers low latency. However it is known to be expensive for big blobs. Cassandra storage is expensive.
  - Object Storage blob store is good at storing big blobs, but it induces higher latencies than Cassandra for small blobs for a cost gain that isn't worth it.
 
 Thus, significant performance could be unlocked by using the right blob store for the right blob.
@@ -31,9 +31,9 @@ Introduce StoragePolicies at the level of the BlobStore API.
 
 The proposed policies include:
 
- - SizeBasedStoragePolicy: The blob underlying storage medium will be chosen depending of its size.
+ - SizeBasedStoragePolicy: The blob underlying storage medium will be chosen depending on its size.
  - LowCostStoragePolicy: The blob is expected to be saved in low cost storage. Access is expected to be unfrequent.
- - PerformantStoragePolicy: The blob is expected to be saved in performant storage. Access is expected to be unfrequent.
+ - PerformantStoragePolicy: The blob is expected to be saved in performant storage. Access is expected to be frequent.
 
 An HybridBlobStore will be created to choose between Cassandra and ObjectStorage implementations depending on the policies.
 

--- a/src/adr/0014-blobstore-storage-policies.md
+++ b/src/adr/0014-blobstore-storage-policies.md
@@ -45,7 +45,7 @@ Some performance tests will be run in order to evaluate the improvements.
 
 We expect small frequently accessed blobs to be located in Cassandra, allowing ObjectStorage to be used mainly for large costly blobs.
 
-In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 
 ## References
 

--- a/src/adr/0015-objectstorage-blobid-list.md
+++ b/src/adr/0015-objectstorage-blobid-list.md
@@ -22,14 +22,14 @@ However writing in Object storage:
 
 Thus choosing a right strategy to avoid writing blob twice is desirable.
 
-However, ObjectStorage (OpenStack Swift) exist method was not efficient enough to be a real cost and performance saver.
+However, ObjectStorage (OpenStack Swift) `exist` method was not efficient enough to be a real cost and performance saver.
 
 ## Decision
 
 Rely on a StoredBlobIdsList API to know which blob is persisted or not in object storage. Provide a Cassandra implementation of it. Located in blob-api for convenience, this it not a top level API. It is intended to be used by some blobStore implementations (here only ObjectStorage).
 
- - When saving a blob with precomputed blobId, we can check the existance of the blob in storage, avoiding possibly the expensive "save".
- - When saving a blob too big to precompute its blobId, once the blob had been stream using a temporary random blobId, copy operation can be avoided and the temporary blob could be directly removed.
+ - When saving a blob with precomputed blobId, we can check the existence of the blob in storage, avoiding possibly the expensive "save".
+ - When saving a blob too big to precompute its blobId, once the blob had been streamed using a temporary random blobId, copy operation can be avoided and the temporary blob could be directly removed.
 
 Cassandra is faster doing "write every time" rather than "read before write" so we should not use the stored blob projection for it
 

--- a/src/adr/0015-objectstorage-blobid-list.md
+++ b/src/adr/0015-objectstorage-blobid-list.md
@@ -1,0 +1,55 @@
+# 15. Persist BlobIds for avoiding persisting several time the same blobs within ObjectStorage
+
+Date: 2019-10-09
+
+## Status
+
+Proposed
+
+Adoption needs to be backed by some performance tests.
+
+## Context
+
+A given mail is often written to the blob store by different components. And mail traffic is heavily duplicated (several recipients receiving similar email, same attachments). This causes a given blob to often be persisted several times.
+
+Cassandra was the first implementation of the blobStore. Cassandra is a heavily write optimized NoSQL database. One can assume writes to be fast on top of Cassandra. Thus we assumed we could always overwrite blobs.
+
+This usage pattern was also adopted for BlobStore on top of ObjectStorage.
+
+However writing in Object storage:
+ - Takes time
+ - Is billed by most cloud providers
+
+Thus choosing a right strategy to avoid writing blob twice is desirable.
+
+However, ObjectStorage (OpenStack Swift) exist method was not efficient enough to be a real cost and performance saver.
+
+## Decision
+
+Rely on a StoredBlobIdsList API to know which blob is persisted or not in object storage. Provide a Cassandra implementation of it. Located in blob-api for convenience, this it not a top level API. It is intended to be used by some blobStore implementations (here only ObjectStorage).
+
+ - When saving a blob with precomputed blobId, we can check the existance of the blob in storage, avoiding possibly the expensive "save".
+ - When saving a blob too big to precompute its blobId, once the blob had been stream using a temporary random blobId, copy operation can be avoided and the temporary blob could be directly removed.
+
+Cassandra is faster doing "write every time" rather than "read before write" so we should not use the storedblob projection for it
+
+Some performance tests will be run in order to evaluate the improvements.
+
+## Consequences
+
+We expect to reduce the amount of writes to the object storage. This is expected to improve:
+ - operational costs on cloud providers
+ - performance improvment
+ - latency reduction under load
+
+Inconsistencies in StoredBlobIdsList will lead to duplicated saved blobs, which is the current behaviour.
+
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+
+## Reference
+
+Previous optimization proposal using blob existence checks before persist. This work was done using ObjectStorage exist method and was prooven not efficient enough.
+
+https://github.com/linagora/james-project/pull/2011 (V2)
+
+ - [JIRA](https://issues.apache.org/jira/browse/JAMES-2921)

--- a/src/adr/0015-objectstorage-blobid-list.md
+++ b/src/adr/0015-objectstorage-blobid-list.md
@@ -44,7 +44,7 @@ We expect to reduce the amount of writes to the object storage. This is expected
 
 Inconsistencies in StoredBlobIdsList will lead to duplicated saved blobs, which is the current behaviour.
 
-In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'accepted but inconclusive'.
+In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 
 ## Reference
 

--- a/src/adr/0015-objectstorage-blobid-list.md
+++ b/src/adr/0015-objectstorage-blobid-list.md
@@ -31,7 +31,7 @@ Rely on a StoredBlobIdsList API to know which blob is persisted or not in object
  - When saving a blob with precomputed blobId, we can check the existance of the blob in storage, avoiding possibly the expensive "save".
  - When saving a blob too big to precompute its blobId, once the blob had been stream using a temporary random blobId, copy operation can be avoided and the temporary blob could be directly removed.
 
-Cassandra is faster doing "write every time" rather than "read before write" so we should not use the storedblob projection for it
+Cassandra is faster doing "write every time" rather than "read before write" so we should not use the stored blob projection for it
 
 Some performance tests will be run in order to evaluate the improvements.
 
@@ -39,7 +39,7 @@ Some performance tests will be run in order to evaluate the improvements.
 
 We expect to reduce the amount of writes to the object storage. This is expected to improve:
  - operational costs on cloud providers
- - performance improvment
+ - performance improvement
  - latency reduction under load
 
 Inconsistencies in StoredBlobIdsList will lead to duplicated saved blobs, which is the current behaviour.

--- a/src/adr/0015-objectstorage-blobid-list.md
+++ b/src/adr/0015-objectstorage-blobid-list.md
@@ -26,12 +26,15 @@ However, ObjectStorage (OpenStack Swift) `exist` method was not efficient enough
 
 ## Decision
 
-Rely on a StoredBlobIdsList API to know which blob is persisted or not in object storage. Provide a Cassandra implementation of it. Located in blob-api for convenience, this it not a top level API. It is intended to be used by some blobStore implementations (here only ObjectStorage).
+Rely on a StoredBlobIdsList API to know which blob is persisted or not in object storage. Provide a Cassandra implementation of it. 
+Located in blob-api for convenience, this it not a top level API. It is intended to be used by some blobStore implementations
+(here only ObjectStorage). We will provide a CassandraStoredBlobIdsList in blob-cassandra project so that guice products combining
+object storage and Cassandra can define a binding to it. 
 
  - When saving a blob with precomputed blobId, we can check the existence of the blob in storage, avoiding possibly the expensive "save".
  - When saving a blob too big to precompute its blobId, once the blob had been streamed using a temporary random blobId, copy operation can be avoided and the temporary blob could be directly removed.
 
-Cassandra is faster doing "write every time" rather than "read before write" so we should not use the stored blob projection for it
+Cassandra is probably faster doing "write every time" rather than "read before write" so we should not use the stored blob projection for it
 
 Some performance tests will be run in order to evaluate the improvements.
 
@@ -42,7 +45,8 @@ We expect to reduce the amount of writes to the object storage. This is expected
  - performance improvement
  - latency reduction under load
 
-Inconsistencies in StoredBlobIdsList will lead to duplicated saved blobs, which is the current behaviour.
+As id persistence in StoredBlobIdsList will be done once the blob successfully saved, inconsistencies in StoredBlobIdsList
+will lead to duplicated saved blobs, which is the current behaviour.
 
 In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
 


### PR DESCRIPTION
The goal of these architecture decisions is to ensure a GetMessageList call does not end up calling the blob store.