### PR TITLE
JAMES-2929 JDBCMailRepository broken: SQL and JDBC code out of sync

### DIFF
--- a/dockerfiles/run/spring/destination/conf/sqlResources.xml
+++ b/dockerfiles/run/spring/destination/conf/sqlResources.xml
@@ -1,20 +1,20 @@
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one   
-  or more contributor license agreements.  See the NOTICE file 
-  distributed with this work for additional information        
-  regarding copyright ownership.  The ASF licenses this file   
-  to you under the Apache License, Version 2.0 (the            
-  "License"); you may not use this file except in compliance   
-  with the License.  You may obtain a copy of the License at   
-                                                               
-    http://www.apache.org/licenses/LICENSE-2.0                 
-                                                               
-  Unless required by applicable law or agreed to in writing,   
-  software distributed under the License is distributed on an  
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       
-  KIND, either express or implied.  See the License for the    
-  specific language governing permissions and limitations      
-  under the License.                                           
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
  -->
 
 <!--
@@ -497,7 +497,8 @@
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-            )    </sql>
+            )
+        </sql>
         <sql name="createWhiteListTable" db="hsqldb">
             CREATE CACHED TABLE ${table} (
             CREATE TABLE whitelist (
@@ -506,7 +507,8 @@
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-            )    </sql>
+            )
+        </sql>
         <sql name="createWhiteListTable" db="mysql">
             CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
@@ -596,14 +598,16 @@
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost)
-            )    </sql>
+            )
+        </sql>
         <sql name="createNetworkWhiteListTable" db="hsqldb">
             CREATE CACHED TABLE ${table} (
             CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-            )    </sql>
+            )
+        </sql>
         <sql name="createNetworkWhiteListTable" db="mysql">
             CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
@@ -693,8 +697,8 @@
             count int NOT NULL,
             create_time datetime NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-            )    </sql>
-
+            )
+        </sql>
         <sql name="createGreyListTable" db="hsqldb">
             CREATE CACHED TABLE ${table} (
             CREATE TABLE greylist (
@@ -704,7 +708,8 @@
             count int NOT NULL,
             create_time timestamo NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-            )    </sql>
+            )
+        </sql>
         <sql name="createGreyListTable" db="mysql">
             CREATE TABLE greylist (
             ipaddress varchar (20) NOT NULL,
@@ -788,4 +793,3 @@
     </sqlDefs>
 
 </sqlResources>
-

--- a/dockerfiles/run/spring/destination/conf/sqlResources.xml
+++ b/dockerfiles/run/spring/destination/conf/sqlResources.xml
@@ -17,8 +17,29 @@
   under the License.                                           
  -->
 
+<!--
+   This template file can be used as example for James Server configuration
+   DO NOT USE IT AS SUCH AND ADAPT IT TO YOUR NEEDS
+-->
+
+<!-- See http://james.apache.org/server/3/config.html for usage -->
+
 <sqlResources>
 
+<!--
+     This section provided configuration to determine the
+     database product which is being used for storage. Different database
+     products may require different SQL syntax.
+
+     The jdbc database connection is examined to see if it matches with the
+     regular expressions specified in any of the defined matchers. The matchers
+     are processed in the over provided here, with the first successful match
+     defining the "db" value for this connection.
+
+     This value is then used to choose between different definitions for various
+     named sql statements, defined below. If no match is found,
+     the default sql statements are used.
+-->
     <dbMatchers>
         <dbMatcher db="mssql" databaseProductName="microsoft sql server"/>
         <dbMatcher db="oracle" databaseProductName="oracle.*"/>
@@ -32,6 +53,32 @@
         <dbMatcher db="ingres" databaseProductName="ingres.*"/>
     </dbMatchers>
 
+<!--
+    With the following section it is possible to associate several name/value pairs
+        of options to a database product, identified by the "db" XML attribute name.
+
+    An element without a "db" attribute, if used for an option name, will become a default value for such option.
+    Each option may have a "default default", i.e. a default that applies if no element with an empty
+        "db" attribute (default element) exists as said above;
+        such default default must be documented for such option below.
+
+    The order of the XML elements is meaningless.
+
+    Here only "getBody" and "getAttributes" option names are set, but others could be used in the future.
+    Option names:
+        "getBody" - a string (case insensitive) telling which JDBC ResultSet method will be used to
+            get the message body field for a database product.
+            The default default value is "useBytes"..
+            Values (case insensitive):
+                "useBytes"  - use getBytes(int).
+                "useBlob"   - use getBlob(int).
+        "getAttributes" - a string (case insensitive) telling which JDBC ResultSet method will be used to
+            get the message attributes field for a database product.
+           The default default value is "useBytes"..
+            Values (case insensitive):
+                "useBytes"  - use getBytes(int).
+                "useBlob"   - use getBlob(int).
+-->
     <dbOptions>
         <dbOption name="getBody" value="useBytes"/>
         <dbOption name="getAttributes" value="useBytes"/>
@@ -57,6 +104,15 @@
         <dbOption db="ingres" name="getAttributes" value="useBytes"/>
     </dbOptions>
 
+<!-- SQL statements to use for various components. -->
+<!-- -->
+<!-- Parameter definitions ${param} are replaced with parameter values -->
+<!-- read from the configuration file. -->
+<!-- -->
+<!-- If a named statement has a definition defined for the current database product, -->
+<!-- then that statement is used. Otherwise the default statement is used. -->
+
+<!-- SQL statements for the JdbcMailRepository  -->
     <sqlDefs name="org.apache.james.mailrepository.jdbc.JDBCMailRepository">
 
         <!-- Statements used to check whether a particular message exists in this repository. -->
@@ -74,11 +130,11 @@
         <!-- Statements used to insert a message into this repository. -->
         <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
             repository_name, message_state, error_message, sender, recipients,
-            remote_host, remote_addr, last_updated, message_body,
-            message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
+    remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
+    message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
 
         <!-- Statements used to retrieve a message stored in this repository. -->
-        <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+    <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
         <!-- Statements used to retrieve the body of a message stored in this repository. -->
         <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
@@ -104,6 +160,9 @@
         <!-- Statements used to list all messages stored in this repository. -->
         <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
 
+    <!-- Statements used to count messages stored in this repository. -->
+    <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
+
         <!-- Statements used to create the table associated with this class. -->
         <sql name="createTable" db="mysql">
             CREATE TABLE ${table} (
@@ -115,9 +174,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers longblob NULL ,
+            last_updated datetime NOT NULL,
             message_body longblob NOT NULL ,
             message_attributes longblob NULL ,
-            last_updated datetime NOT NULL,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -131,9 +191,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers varchar NULL ,
+            last_updated timestamp NOT NULL,
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -147,9 +208,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers varchar NULL ,
+            last_updated timestamp NOT NULL,
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -163,9 +225,10 @@
             [recipients] [text] NOT NULL ,
             [remote_host] [varchar] (255) NOT NULL ,
             [remote_addr] [varchar] (20) NOT NULL ,
+            [per_recipient_headers] [image] NULL ,
+            [last_updated] [datetime] NOT NULL,
             [message_body] [image] NOT NULL ,
             [message_attributes] [image] NULL ,
-            [last_updated] [datetime] NOT NULL,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -179,9 +242,10 @@
             recipients varchar2(1000) NOT NULL ,
             remote_host varchar2(100) NOT NULL ,
             remote_addr varchar2(20) NOT NULL ,
+            per_recipient_headers blob NULL ,
+            last_updated date NOT NULL ,
             message_body blob NOT NULL ,
             message_attributes blob NULL ,
-            last_updated date NOT NULL ,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -195,9 +259,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers oid NULL ,
+            last_updated timestamp NOT NULL,
             message_body bytea NOT NULL ,
             message_attributes bytea NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -211,9 +276,10 @@
             recipients long NOT NULL ,
             remote_host varchar (100) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers long byte NULL ,
+            last_updated date NOT NULL,
             message_body long byte NOT NULL ,
             message_attributes long byte NULL ,
-            last_updated date NOT NULL,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -227,9 +293,10 @@
             recipients varchar(1000) NOT NULL ,
             remote_host varchar(100) NOT NULL ,
             remote_addr varchar(20) NOT NULL ,
+            per_recipient_headers blob ,
+            last_updated timestamp NOT NULL ,
             message_body blob NOT NULL ,
             message_attributes blob ,
-            last_updated timestamp NOT NULL ,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
@@ -243,9 +310,10 @@
             recipients LONG VARCHAR NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers LONG BYTE ,
+            last_updated DATE NOT NULL
             message_body LONG BYTE NOT NULL ,
             message_attributes LONG BYTE ,
-            last_updated DATE NOT NULL
             )
         </sql>
         <sql name="createTable" db="derby">
@@ -258,14 +326,18 @@
             recipients long varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers blob ,
+            last_updated timestamp NOT NULL,
             message_body blob NOT NULL ,
             message_attributes blob ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
             )
         </sql>
     </sqlDefs>
 
+
+<!-- SQL statements to support the BayesianAnalysis and the BayesianAnalysisFeeder mailets -->
+<!-- -->
     <sqlDefs name="org.apache.james.util.bayesian.JDBCBayesianAnalyzer">
 
         <sql name="hamTableName">bayesiananalysis_ham</sql>
@@ -399,6 +471,8 @@
         </sql>
     </sqlDefs>
 
+<!-- SQL statements to support the WhiteListManager mailet and the IsInWhiteList matcher -->
+<!-- -->
     <sqlDefs name="WhiteList">
 
         <sql name="whiteListTableName">whitelist</sql>
@@ -589,6 +663,8 @@
 
     </sqlDefs>
 
+<!-- SQL statements to support the GreyList Handler-->
+<!-- -->
     <sqlDefs name="GreyList">
 
         <sql name="greyListTableName">greylist</sql>

--- a/server/app/src/main/resources/sqlResources.xml
+++ b/server/app/src/main/resources/sqlResources.xml
@@ -1,27 +1,27 @@
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one   
-  or more contributor license agreements.  See the NOTICE file 
-  distributed with this work for additional information        
-  regarding copyright ownership.  The ASF licenses this file   
-  to you under the Apache License, Version 2.0 (the            
-  "License"); you may not use this file except in compliance   
-  with the License.  You may obtain a copy of the License at   
-                                                               
-    http://www.apache.org/licenses/LICENSE-2.0                 
-                                                               
-  Unless required by applicable law or agreed to in writing,   
-  software distributed under the License is distributed on an  
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       
-  KIND, either express or implied.  See the License for the    
-  specific language governing permissions and limitations      
-  under the License.                                           
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
  -->
 
 <!--
    This template file can be used as example for James Server configuration
    DO NOT USE IT AS SUCH AND ADAPT IT TO YOUR NEEDS
 -->
- 
+
 <!-- See http://james.apache.org/server/3/config.html for usage -->
 
 <sqlResources>
@@ -40,30 +40,30 @@
      named sql statements, defined below. If no match is found,
      the default sql statements are used.
 -->
-<dbMatchers>
-    <dbMatcher db="mssql" databaseProductName="microsoft sql server"/>
-    <dbMatcher db="oracle" databaseProductName="oracle.*"/>
-    <dbMatcher db="mysql" databaseProductName="my.*"/>
-    <dbMatcher db="derby" databaseProductName="derby.*"/>
-    <dbMatcher db="postgresql" databaseProductName="postgres.*"/>
-    <dbMatcher db="hsqldb" databaseProductName="hsql.*"/>
-    <dbMatcher db="sapdb" databaseProductName="sap.*"/>
-    <dbMatcher db="hypersonic" databaseProductName="HypersonicSQL"/>
-    <dbMatcher db="db2" databaseProductName="db2.*"/>
-    <dbMatcher db="ingres" databaseProductName="ingres.*"/>
-</dbMatchers>
+    <dbMatchers>
+        <dbMatcher db="mssql" databaseProductName="microsoft sql server"/>
+        <dbMatcher db="oracle" databaseProductName="oracle.*"/>
+        <dbMatcher db="mysql" databaseProductName="my.*"/>
+        <dbMatcher db="derby" databaseProductName="derby.*"/>
+        <dbMatcher db="postgresql" databaseProductName="postgres.*"/>
+        <dbMatcher db="hsqldb" databaseProductName="hsql.*"/>
+        <dbMatcher db="sapdb" databaseProductName="sap.*"/>
+        <dbMatcher db="hypersonic" databaseProductName="HypersonicSQL"/>
+        <dbMatcher db="db2" databaseProductName="db2.*"/>
+        <dbMatcher db="ingres" databaseProductName="ingres.*"/>
+    </dbMatchers>
 
 <!--
     With the following section it is possible to associate several name/value pairs
         of options to a database product, identified by the "db" XML attribute name.
-    
+
     An element without a "db" attribute, if used for an option name, will become a default value for such option.
     Each option may have a "default default", i.e. a default that applies if no element with an empty
         "db" attribute (default element) exists as said above;
         such default default must be documented for such option below.
-    
+
     The order of the XML elements is meaningless.
-    
+
     Here only "getBody" and "getAttributes" option names are set, but others could be used in the future.
     Option names:
         "getBody" - a string (case insensitive) telling which JDBC ResultSet method will be used to
@@ -79,30 +79,30 @@
                 "useBytes"  - use getBytes(int).
                 "useBlob"   - use getBlob(int).
 -->
-<dbOptions>
-    <dbOption name="getBody" value="useBytes"/>
-    <dbOption name="getAttributes" value="useBytes"/>
-    <dbOption db="mssql" name="getBody" value="useBytes"/>
-    <dbOption db="mssql" name="getAttributes" value="useBytes"/>
-    <dbOption db="oracle" name="getBody" value="useBlob"/>
-    <dbOption db="oracle" name="getAttributes" value="useBlob"/>
-    <dbOption db="mysql" name="getBody" value="useBytes"/>
-    <dbOption db="mysql" name="getAttributes" value="useBytes"/>
-    <dbOption db="derby" name="getBody" value="useBytes"/>
-    <dbOption db="derby" name="getAttributes" value="useBytes"/>
-    <dbOption db="postgresql" name="getBody" value="useBytes"/>
-    <dbOption db="postgresql" name="getAttributes" value="useBytes"/>
-    <dbOption db="sapdb" name="getBody" value="useBytes"/>
-    <dbOption db="sapdb" name="getAttributes" value="useBytes"/>
-    <dbOption db="hypersonic" name="getBody" value="useBytes"/>
-    <dbOption db="hypersonic" name="getAttributes" value="useBytes"/>
-    <dbOption db="hsqldb" name="getBody" value="useBytes"/>
-    <dbOption db="hsqldb" name="getAttributes" value="useBytes"/>
-    <dbOption db="db2" name="getBody" value="useBlob"/>
-    <dbOption db="db2" name="getAttributes" value="useBlob"/>
-    <dbOption db="ingres" name="getBody" value="useBytes"/>
-    <dbOption db="ingres" name="getAttributes" value="useBytes"/>
-</dbOptions>
+    <dbOptions>
+        <dbOption name="getBody" value="useBytes"/>
+        <dbOption name="getAttributes" value="useBytes"/>
+        <dbOption db="mssql" name="getBody" value="useBytes"/>
+        <dbOption db="mssql" name="getAttributes" value="useBytes"/>
+        <dbOption db="oracle" name="getBody" value="useBlob"/>
+        <dbOption db="oracle" name="getAttributes" value="useBlob"/>
+        <dbOption db="mysql" name="getBody" value="useBytes"/>
+        <dbOption db="mysql" name="getAttributes" value="useBytes"/>
+        <dbOption db="derby" name="getBody" value="useBytes"/>
+        <dbOption db="derby" name="getAttributes" value="useBytes"/>
+        <dbOption db="postgresql" name="getBody" value="useBytes"/>
+        <dbOption db="postgresql" name="getAttributes" value="useBytes"/>
+        <dbOption db="sapdb" name="getBody" value="useBytes"/>
+        <dbOption db="sapdb" name="getAttributes" value="useBytes"/>
+        <dbOption db="hypersonic" name="getBody" value="useBytes"/>
+        <dbOption db="hypersonic" name="getAttributes" value="useBytes"/>
+        <dbOption db="hsqldb" name="getBody" value="useBytes"/>
+        <dbOption db="hsqldb" name="getAttributes" value="useBytes"/>
+        <dbOption db="db2" name="getBody" value="useBlob"/>
+        <dbOption db="db2" name="getAttributes" value="useBlob"/>
+        <dbOption db="ingres" name="getBody" value="useBytes"/>
+        <dbOption db="ingres" name="getAttributes" value="useBytes"/>
+    </dbOptions>
 
 <!-- SQL statements to use for various components. -->
 <!-- -->
@@ -113,59 +113,59 @@
 <!-- then that statement is used. Otherwise the default statement is used. -->
 
 <!-- SQL statements for the JdbcMailRepository  -->
-<sqlDefs name="org.apache.james.mailrepository.jdbc.JDBCMailRepository">
+    <sqlDefs name="org.apache.james.mailrepository.jdbc.JDBCMailRepository">
 
-    <!-- Statements used to check whether a particular message exists in this repository. -->
-    <sql name="checkMessageExistsSQL">SELECT count(*) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to check whether a particular message exists in this repository. -->
+        <sql name="checkMessageExistsSQL">SELECT count(*) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update a message stored in this repository. -->
-    <sql name="updateMessageSQL">UPDATE ${table} SET message_state = ?, error_message = ?, sender = ?, recipients = ?, remote_host = ?, remote_addr = ?, last_updated = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update a message stored in this repository. -->
+        <sql name="updateMessageSQL">UPDATE ${table} SET message_state = ?, error_message = ?, sender = ?, recipients = ?, remote_host = ?, remote_addr = ?, last_updated = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update the body of a message stored in this repository. -->
-    <sql name="updateMessageBodySQL">UPDATE ${table} SET message_body = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update the body of a message stored in this repository. -->
+        <sql name="updateMessageBodySQL">UPDATE ${table} SET message_body = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update the attributes of a message stored in this repository. -->
-    <sql name="updateMessageAttributesSQL">UPDATE ${table} SET message_attributes = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update the attributes of a message stored in this repository. -->
+        <sql name="updateMessageAttributesSQL">UPDATE ${table} SET message_attributes = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to insert a message into this repository. -->
-    <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
-    repository_name, message_state, error_message, sender, recipients,
+        <!-- Statements used to insert a message into this repository. -->
+        <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
+            repository_name, message_state, error_message, sender, recipients,
     remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
     message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
 
-    <!-- Statements used to retrieve a message stored in this repository. -->
+        <!-- Statements used to retrieve a message stored in this repository. -->
     <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the body of a message stored in this repository. -->
-    <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the body of a message stored in this repository. -->
+        <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the attributes of a message stored in this repository. -->
-    <sql name="retrieveMessageAttributesSQL">SELECT message_attributes FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the attributes of a message stored in this repository. -->
+        <sql name="retrieveMessageAttributesSQL">SELECT message_attributes FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the size of the body of a message stored in this repository. -->
-    <!-- NOTE: This statement is optional and need not be implemented for a particular database to be supported. -->
-    <sql name="retrieveMessageBodySizeSQL" db="mssql">SELECT datalength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="mysql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="hypersonic">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="hsqldb">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="postgresql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="oracle">SELECT dbms_lob.getlength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="db2">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="ingres">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="derby">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the size of the body of a message stored in this repository. -->
+        <!-- NOTE: This statement is optional and need not be implemented for a particular database to be supported. -->
+        <sql name="retrieveMessageBodySizeSQL" db="mssql">SELECT datalength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="mysql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="hypersonic">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="hsqldb">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="postgresql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="oracle">SELECT dbms_lob.getlength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="db2">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="ingres">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="derby">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to delete a message stored in this repository. -->
-    <sql name="removeMessageSQL">DELETE FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to delete a message stored in this repository. -->
+        <sql name="removeMessageSQL">DELETE FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to list all messages stored in this repository. -->
-    <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
+        <!-- Statements used to list all messages stored in this repository. -->
+        <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
 
     <!-- Statements used to count messages stored in this repository. -->
     <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
 
-    <!-- Statements used to create the table associated with this class. -->
-    <sql name="createTable" db="mysql">
-        CREATE TABLE ${table} (
+        <!-- Statements used to create the table associated with this class. -->
+        <sql name="createTable" db="mysql">
+            CREATE TABLE ${table} (
             message_name varchar (200) NOT NULL,
             repository_name varchar (100) NOT NULL,
             message_state varchar (30) NOT NULL ,
@@ -179,10 +179,10 @@
             message_body longblob NOT NULL ,
             message_attributes longblob NULL ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="hypersonic">
-        CREATE CACHED TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="hypersonic">
+            CREATE CACHED TABLE ${table} (
             message_name varchar (200) NOT NULL,
             repository_name varchar (255) NOT NULL,
             message_state varchar (30) NOT NULL ,
@@ -196,10 +196,10 @@
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="hsqldb">
-        CREATE CACHED TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="hsqldb">
+            CREATE CACHED TABLE ${table} (
             message_name varchar (200) NOT NULL,
             repository_name varchar (255) NOT NULL,
             message_state varchar (30) NOT NULL ,
@@ -213,10 +213,10 @@
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="mssql">
-        CREATE TABLE [${table}] (
+            )
+        </sql>
+        <sql name="createTable" db="mssql">
+            CREATE TABLE [${table}] (
             [message_name] [varchar] (200) NOT NULL,
             [repository_name] [varchar] (255) NOT NULL,
             [message_state] [varchar] (30) NOT NULL ,
@@ -230,10 +230,10 @@
             [message_body] [image] NOT NULL ,
             [message_attributes] [image] NULL ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="oracle">
-        CREATE TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="oracle">
+            CREATE TABLE ${table} (
             message_name varchar2(200) NOT NULL ,
             repository_name varchar2(255) NOT NULL ,
             message_state varchar2(30) NOT NULL ,
@@ -247,10 +247,10 @@
             message_body blob NOT NULL ,
             message_attributes blob NULL ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="postgresql">
-        CREATE TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="postgresql">
+            CREATE TABLE ${table} (
             message_name varchar (200) NOT NULL,
             repository_name varchar (255) NOT NULL,
             message_state varchar (30) NOT NULL ,
@@ -264,10 +264,10 @@
             message_body bytea NOT NULL ,
             message_attributes bytea NULL ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="sapdb">
-        CREATE TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="sapdb">
+            CREATE TABLE ${table} (
             message_name varchar (200) NOT NULL,
             repository_name varchar (200) NOT NULL,
             message_state varchar (30) NOT NULL ,
@@ -281,10 +281,10 @@
             message_body long byte NOT NULL ,
             message_attributes long byte NULL ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="db2">
-        CREATE TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="db2">
+            CREATE TABLE ${table} (
             message_name varchar(200) NOT NULL ,
             repository_name varchar(255) NOT NULL ,
             message_state varchar(30) NOT NULL ,
@@ -298,10 +298,10 @@
             message_body blob NOT NULL ,
             message_attributes blob ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="ingres">
-        CREATE TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="ingres">
+            CREATE TABLE ${table} (
             message_name varchar (200) NOT NULL,
             repository_name varchar (255) NOT NULL,
             message_state varchar (30) NOT NULL ,
@@ -314,10 +314,10 @@
             last_updated DATE NOT NULL
             message_body LONG BYTE NOT NULL ,
             message_attributes LONG BYTE ,
-        )
-    </sql>
-    <sql name="createTable" db="derby">
-        CREATE TABLE ${table} (
+            )
+        </sql>
+        <sql name="createTable" db="derby">
+            CREATE TABLE ${table} (
             message_name varchar (200) NOT NULL,
             repository_name varchar (255) NOT NULL,
             message_state varchar (30) NOT NULL ,
@@ -331,461 +331,465 @@
             message_body blob NOT NULL ,
             message_attributes blob ,
             PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-</sqlDefs>
+            )
+        </sql>
+    </sqlDefs>
 
 
 <!-- SQL statements to support the BayesianAnalysis and the BayesianAnalysisFeeder mailets -->
 <!-- -->
-<sqlDefs name="org.apache.james.util.bayesian.JDBCBayesianAnalyzer">
+    <sqlDefs name="org.apache.james.util.bayesian.JDBCBayesianAnalyzer">
 
-    <sql name="hamTableName">bayesiananalysis_ham</sql>
-    <sql name="spamTableName">bayesiananalysis_spam</sql>
-    <sql name="messageCountsTableName">bayesiananalysis_messagecounts</sql>
+        <sql name="hamTableName">bayesiananalysis_ham</sql>
+        <sql name="spamTableName">bayesiananalysis_spam</sql>
+        <sql name="messageCountsTableName">bayesiananalysis_messagecounts</sql>
 
-    <!-- Statements used to retrieve the message counts. -->
-    <sql name="selectMessageCounts">SELECT HAMCOUNT, SPAMCOUNT FROM bayesiananalysis_messagecounts</sql>
+        <!-- Statements used to retrieve the message counts. -->
+        <sql name="selectMessageCounts">SELECT HAMCOUNT, SPAMCOUNT FROM bayesiananalysis_messagecounts</sql>
 
-    <!-- Statements used to initialize the message counts. -->
-    <sql name="initializeMessageCounts">INSERT INTO bayesiananalysis_messagecounts (HAMCOUNT, SPAMCOUNT) VALUES (0,0)</sql>
+        <!-- Statements used to initialize the message counts. -->
+        <sql name="initializeMessageCounts">INSERT INTO bayesiananalysis_messagecounts (HAMCOUNT, SPAMCOUNT) VALUES (0,0)</sql>
 
-    <!-- Statements used to update the ham message counts. -->
-    <sql name="updateHamMessageCounts">UPDATE bayesiananalysis_messagecounts SET HAMCOUNT=(HAMCOUNT + ?)</sql>
+        <!-- Statements used to update the ham message counts. -->
+        <sql name="updateHamMessageCounts">UPDATE bayesiananalysis_messagecounts SET HAMCOUNT=(HAMCOUNT + ?)</sql>
 
-    <!-- Statements used to update the spam message counts. -->
-    <sql name="updateSpamMessageCounts">UPDATE bayesiananalysis_messagecounts SET SPAMCOUNT=(SPAMCOUNT + ?)</sql>
+        <!-- Statements used to update the spam message counts. -->
+        <sql name="updateSpamMessageCounts">UPDATE bayesiananalysis_messagecounts SET SPAMCOUNT=(SPAMCOUNT + ?)</sql>
 
-    <!-- Statements used to retrieve the ham token counts. -->
-    <sql name="selectHamTokens">SELECT TOKEN, OCCURRENCES FROM bayesiananalysis_ham</sql>
+        <!-- Statements used to retrieve the ham token counts. -->
+        <sql name="selectHamTokens">SELECT TOKEN, OCCURRENCES FROM bayesiananalysis_ham</sql>
 
-    <!-- Statements used to retrieve the spam token counts. -->
-    <sql name="selectSpamTokens">SELECT TOKEN, OCCURRENCES FROM bayesiananalysis_spam</sql>
+        <!-- Statements used to retrieve the spam token counts. -->
+        <sql name="selectSpamTokens">SELECT TOKEN, OCCURRENCES FROM bayesiananalysis_spam</sql>
 
-    <!-- Statements used to insert the ham token counts. -->
-    <sql name="insertHamToken">INSERT INTO bayesiananalysis_ham (TOKEN, OCCURRENCES) VALUES (?,?)</sql>
+        <!-- Statements used to insert the ham token counts. -->
+        <sql name="insertHamToken">INSERT INTO bayesiananalysis_ham (TOKEN, OCCURRENCES) VALUES (?,?)</sql>
 
-    <!-- Statements used to insert the spam token counts. -->
-    <sql name="insertSpamToken">INSERT INTO bayesiananalysis_spam (TOKEN, OCCURRENCES) VALUES (?,?)</sql>
+        <!-- Statements used to insert the spam token counts. -->
+        <sql name="insertSpamToken">INSERT INTO bayesiananalysis_spam (TOKEN, OCCURRENCES) VALUES (?,?)</sql>
 
-    <!-- Statements used to update the ham token counts. -->
-    <sql name="updateHamToken">UPDATE bayesiananalysis_ham SET OCCURRENCES=(OCCURRENCES + ?) WHERE (TOKEN=?)</sql>
+        <!-- Statements used to update the ham token counts. -->
+        <sql name="updateHamToken">UPDATE bayesiananalysis_ham SET OCCURRENCES=(OCCURRENCES + ?) WHERE (TOKEN=?)</sql>
 
-    <!-- Statements used to update the spam token counts. -->
-    <sql name="updateSpamToken">UPDATE bayesiananalysis_spam SET OCCURRENCES=(OCCURRENCES + ?) WHERE (TOKEN=?)</sql>
+        <!-- Statements used to update the spam token counts. -->
+        <sql name="updateSpamToken">UPDATE bayesiananalysis_spam SET OCCURRENCES=(OCCURRENCES + ?) WHERE (TOKEN=?)</sql>
 
-    <!-- Statements used to delete ham tokens. -->
-    <sql name="deleteHamTokens">DELETE FROM bayesiananalysis_ham</sql>
-    
-    <!-- Statements used to delete spam tokens. -->
-    <sql name="deleteSpamTokens">DELETE FROM bayesiananalysis_spam</sql>
-    
-    <!-- Statements used to delete message counts. -->
-    <sql name="deleteMessageCounts">DELETE FROM bayesiananalysis_messagecounts</sql>
+        <!-- Statements used to delete ham tokens. -->
+        <sql name="deleteHamTokens">DELETE FROM bayesiananalysis_ham</sql>
+
+        <!-- Statements used to delete spam tokens. -->
+        <sql name="deleteSpamTokens">DELETE FROM bayesiananalysis_spam</sql>
+
+        <!-- Statements used to delete message counts. -->
+        <sql name="deleteMessageCounts">DELETE FROM bayesiananalysis_messagecounts</sql>
 
 
-    <!-- Statements used to create the "ham" table (the 'token' field must be case sensitive). -->
-    <sql name="createHamTable" db="mysql">
-        CREATE TABLE bayesiananalysis_ham (
+        <!-- Statements used to create the "ham" table (the 'token' field must be case sensitive). -->
+        <sql name="createHamTable" db="mysql">
+            CREATE TABLE bayesiananalysis_ham (
             token varchar(128) binary NOT NULL default '',
             occurrences int(11) NOT NULL default '0',
             PRIMARY KEY (token)
-        ) TYPE=InnoDB
-    </sql>
-    <sql name="createHamTable" db="mssql">
-        CREATE TABLE [bayesiananalysis_ham] (
-        [token] [varchar] (128) COLLATE Latin1_General_CS_AS NOT NULL,
-        [occurrences] [int] NOT NULL default (0),
+            ) TYPE=InnoDB
+        </sql>
+        <sql name="createHamTable" db="mssql">
+            CREATE TABLE [bayesiananalysis_ham] (
+            [token] [varchar] (128) COLLATE Latin1_General_CS_AS NOT NULL,
+            [occurrences] [int] NOT NULL default (0),
             PRIMARY KEY (token)
-        )
-    </sql>
-    <sql name="createHamTable" db="derby">
-        CREATE TABLE bayesiananalysis_ham (
+            )
+        </sql>
+        <sql name="createHamTable" db="derby">
+            CREATE TABLE bayesiananalysis_ham (
             token varchar(128) NOT NULL,
             occurrences INTEGER NOT NULL default 0,
             PRIMARY KEY (token)
-        )
-    </sql>
-    <sql name="createHamTable" db="postgresql">
-        CREATE TABLE bayesiananalysis_ham (
+            )
+        </sql>
+        <sql name="createHamTable" db="postgresql">
+            CREATE TABLE bayesiananalysis_ham (
             token varchar(128) NOT NULL,
             occurrences int NOT NULL default 0,
             PRIMARY KEY (token)
-        )
-    </sql>
+            )
+        </sql>
 
-    <!-- Statements used to create the "spam" table (the 'token' field must be case sensitive). -->
-    <sql name="createSpamTable" db="mysql">
-        CREATE TABLE bayesiananalysis_spam (
+        <!-- Statements used to create the "spam" table (the 'token' field must be case sensitive). -->
+        <sql name="createSpamTable" db="mysql">
+            CREATE TABLE bayesiananalysis_spam (
             token varchar(128) binary NOT NULL default '',
             occurrences int(11) NOT NULL default '0',
             PRIMARY KEY (token)
-        ) TYPE=InnoDB
-    </sql>
-    <sql name="createSpamTable" db="mssql">
-        CREATE TABLE [bayesiananalysis_spam] (
-        [token] [varchar] (128) COLLATE Latin1_General_CS_AS NOT NULL,
-        [occurrences] [int] NOT NULL default (0),
+            ) TYPE=InnoDB
+        </sql>
+        <sql name="createSpamTable" db="mssql">
+            CREATE TABLE [bayesiananalysis_spam] (
+            [token] [varchar] (128) COLLATE Latin1_General_CS_AS NOT NULL,
+            [occurrences] [int] NOT NULL default (0),
             PRIMARY KEY (token)
-        )
-    </sql>
-    <sql name="createSpamTable" db="derby">
-        CREATE TABLE bayesiananalysis_spam (
+            )
+        </sql>
+        <sql name="createSpamTable" db="derby">
+            CREATE TABLE bayesiananalysis_spam (
             token varchar (128) NOT NULL,
             occurrences INTEGER  NOT NULL default 0,
             PRIMARY KEY (token)
-        )
-    </sql>
-    <sql name="createSpamTable" db="postgresql">
-        CREATE TABLE bayesiananalysis_spam (
+            )
+        </sql>
+        <sql name="createSpamTable" db="postgresql">
+            CREATE TABLE bayesiananalysis_spam (
             token varchar (128) NOT NULL,
             occurrences int  NOT NULL default 0,
             PRIMARY KEY (token)
-        )
-    </sql>
+            )
+        </sql>
 
-    <!-- Statements used to create the "message counts" table. -->
-    <sql name="createMessageCountsTable" db="mysql">
-        CREATE TABLE bayesiananalysis_messagecounts (
+        <!-- Statements used to create the "message counts" table. -->
+        <sql name="createMessageCountsTable" db="mysql">
+            CREATE TABLE bayesiananalysis_messagecounts (
             hamcount int(11) NOT NULL default '0',
             spamcount int(11) NOT NULL default '0'
-        ) TYPE=InnoDB
-    </sql>
-    <sql name="createMessageCountsTable" db="mssql">
-        CREATE TABLE [bayesiananalysis_messagecounts] (
-        [hamcount] [int] NOT NULL default (0),
-        [spamcount] [int] NOT NULL default (0)
-        )
-    </sql>
-    <sql name="createMessageCountsTable" db="derby">
-        CREATE TABLE bayesiananalysis_messagecounts (
+            ) TYPE=InnoDB
+        </sql>
+        <sql name="createMessageCountsTable" db="mssql">
+            CREATE TABLE [bayesiananalysis_messagecounts] (
+            [hamcount] [int] NOT NULL default (0),
+            [spamcount] [int] NOT NULL default (0)
+            )
+        </sql>
+        <sql name="createMessageCountsTable" db="derby">
+            CREATE TABLE bayesiananalysis_messagecounts (
             hamcount INTEGER NOT NULL default 0,
             spamcount INTEGER  NOT NULL default 0
-        )
-    </sql>
-    <sql name="createMessageCountsTable" db="postgresql">
-        CREATE TABLE bayesiananalysis_messagecounts (
+            )
+        </sql>
+        <sql name="createMessageCountsTable" db="postgresql">
+            CREATE TABLE bayesiananalysis_messagecounts (
             hamcount int NOT NULL default 0,
             spamcount int  NOT NULL default 0
-        )
-    </sql>
-</sqlDefs>
+            )
+        </sql>
+    </sqlDefs>
 
 <!-- SQL statements to support the WhiteListManager mailet and the IsInWhiteList matcher -->
 <!-- -->
-<sqlDefs name="WhiteList">
+    <sqlDefs name="WhiteList">
 
-    <sql name="whiteListTableName">whitelist</sql>
+        <sql name="whiteListTableName">whitelist</sql>
 
-    <!-- Statements used to retrieve a single entry. -->
-    <sql name="selectByPK">SELECT localUser, localHost FROM whitelist where (localUser=? AND localHost=? AND remoteUser=? AND remoteHost=?)</sql>
+        <!-- Statements used to retrieve a single entry. -->
+        <sql name="selectByPK">SELECT localUser, localHost FROM whitelist where (localUser=? AND localHost=? AND remoteUser=? AND remoteHost=?)</sql>
 
-    <!-- Statements used to all entries by sender address. -->
-    <sql name="selectBySender">SELECT remoteUser, remoteHost FROM whitelist where (localUser=? AND localHost=?) ORDER BY remoteUser, remoteHost</sql>
+        <!-- Statements used to all entries by sender address. -->
+        <sql name="selectBySender">SELECT remoteUser, remoteHost FROM whitelist where (localUser=? AND localHost=?) ORDER BY remoteUser, remoteHost</sql>
 
-    <!-- Statements used to insert an entry. -->
-    <sql name="insert">INSERT INTO whitelist (localUser, localHost, remoteUser, remoteHost) VALUES (?,?,?,?)</sql>
+        <!-- Statements used to insert an entry. -->
+        <sql name="insert">INSERT INTO whitelist (localUser, localHost, remoteUser, remoteHost) VALUES (?,?,?,?)</sql>
 
-    <!-- Statements used to delete an entry. -->
-    <sql name="deleteByPK">DELETE FROM whitelist where (localUser=? AND localHost=? AND remoteUser=? AND remoteHost=?)</sql>
+        <!-- Statements used to delete an entry. -->
+        <sql name="deleteByPK">DELETE FROM whitelist where (localUser=? AND localHost=? AND remoteUser=? AND remoteHost=?)</sql>
 
-    <!-- Statements used to create the "whitelist" table. -->
-    <sql name="createWhiteListTable" db="hypersonic">
-        CREATE TABLE whitelist (
+        <!-- Statements used to create the "whitelist" table. -->
+        <sql name="createWhiteListTable" db="hypersonic">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )    </sql>
-    <sql name="createWhiteListTable" db="hsqldb">
-        CREATE CACHED TABLE ${table} (
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="hsqldb">
+            CREATE CACHED TABLE ${table} (
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )    </sql>
-    <sql name="createWhiteListTable" db="mysql">
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="mysql">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) character set latin1 NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) character set latin1 NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        ) TYPE=InnoDB
-    </sql>
-    <sql name="createWhiteListTable" db="mssql">
-        CREATE TABLE [whitelist] (
+            ) TYPE=InnoDB
+        </sql>
+        <sql name="createWhiteListTable" db="mssql">
+            CREATE TABLE [whitelist] (
             [localUser] [varchar] (64) NOT NULL,
             [localHost] [varchar] (255) NOT NULL,
             [remoteUser] [varchar] (64) NOT NULL,
             [remoteHost] [varchar] (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )
-    </sql>
-    <sql name="createWhiteListTable" db="oracle">
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="oracle">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )
-    </sql>
-    <sql name="createWhiteListTable" db="postgresql">
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="postgresql">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )
-    </sql>
-    <sql name="createWhiteListTable" db="sapdb">
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="sapdb">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )
-    </sql>
-    <sql name="createWhiteListTable" db="db2">
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="db2">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )
-    </sql>
-    <sql name="createWhiteListTable" db="ingres">
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="ingres">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )
-    </sql>
-    <sql name="createWhiteListTable" db="derby">
-        CREATE TABLE whitelist (
+            )
+        </sql>
+        <sql name="createWhiteListTable" db="derby">
+            CREATE TABLE whitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             remoteUser varchar (64) NOT NULL,
             remoteHost varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost, remoteUser, remoteHost)
-        )
-    </sql>
+            )
+        </sql>
 
-</sqlDefs>
+    </sqlDefs>
 
-<sqlDefs name="NetworkWhiteList">
+    <sqlDefs name="NetworkWhiteList">
 
-    <sql name="networkWhiteListTableName">networkWhitelist</sql>
+        <sql name="networkWhiteListTableName">networkWhitelist</sql>
 
-    <!-- Statements used to retrieve a single entry. -->
-    <sql name="selectNetwork">SELECT network FROM networkWhitelist where (localUser=? AND localHost=?)</sql>
+        <!-- Statements used to retrieve a single entry. -->
+        <sql name="selectNetwork">SELECT network FROM networkWhitelist where (localUser=? AND localHost=?)</sql>
 
-    <!-- Statements used to create the "whitelist" table. -->
-    <sql name="createNetworkWhiteListTable" db="hypersonic">
-        CREATE TABLE networkWhitelist (
+        <!-- Statements used to create the "whitelist" table. -->
+        <sql name="createNetworkWhiteListTable" db="hypersonic">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL,
             PRIMARY KEY (localUser, localHost)
-        )    </sql>
-    <sql name="createNetworkWhiteListTable" db="hsqldb">
-        CREATE CACHED TABLE ${table} (
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="hsqldb">
+            CREATE CACHED TABLE ${table} (
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-        )    </sql>
-    <sql name="createNetworkWhiteListTable" db="mysql">
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="mysql">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) character set latin1 NOT NULL,
             network varchar (255) NOT NULL
-        ) TYPE=InnoDB
-    </sql>
-    <sql name="createNetworkWhiteListTable" db="mssql">
-        CREATE TABLE [networkWhitelist] (
+            ) TYPE=InnoDB
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="mssql">
+            CREATE TABLE [networkWhitelist] (
             [localUser] [varchar] (64) NOT NULL,
             [localHost] [varchar] (255) NOT NULL,
             [network] [varchar] (255) NOT NULL
-        )
-    </sql>
-    <sql name="createNetworkWhiteListTable" db="oracle">
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="oracle">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-        )
-    </sql>
-    <sql name="createNetworkWhiteListTable" db="postgresql">
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="postgresql">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-        )
-    </sql>
-    <sql name="createNetworkWhiteListTable" db="sapdb">
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="sapdb">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-        )
-    </sql>
-    <sql name="createNetworkWhiteListTable" db="db2">
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="db2">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-        )
-    </sql>
-    <sql name="createNetworkWhiteListTable" db="ingres">
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="ingres">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-        )
-    </sql>
-    <sql name="createNetworkWhiteListTable" db="derby">
-        CREATE TABLE networkWhitelist (
+            )
+        </sql>
+        <sql name="createNetworkWhiteListTable" db="derby">
+            CREATE TABLE networkWhitelist (
             localUser varchar (64) NOT NULL,
             localHost varchar (255) NOT NULL,
             network varchar (255) NOT NULL
-        )
-    </sql>
+            )
+        </sql>
 
-</sqlDefs>
+    </sqlDefs>
 
 <!-- SQL statements to support the GreyList Handler-->
 <!-- -->
-<sqlDefs name="GreyList">
+    <sqlDefs name="GreyList">
 
-    <sql name="greyListTableName">greylist</sql>
+        <sql name="greyListTableName">greylist</sql>
 
-    <!-- Statements used to retrieve a single entry. -->
-    <sql name="selectQuery">SELECT create_time,count FROM greylist WHERE ipaddress = ? AND sender = ? AND recip = ?</sql>
+        <!-- Statements used to retrieve a single entry. -->
+        <sql name="selectQuery">SELECT create_time,count FROM greylist WHERE ipaddress = ? AND sender = ? AND recip = ?</sql>
 
-    <!-- Statements used to insert an entry. -->
-    <sql name="insertQuery">INSERT INTO greylist (ipaddress,sender,recip,count,create_time) values (?,?,?,?,?)</sql>
+        <!-- Statements used to insert an entry. -->
+        <sql name="insertQuery">INSERT INTO greylist (ipaddress,sender,recip,count,create_time) values (?,?,?,?,?)</sql>
 
-    <!-- Statements used to delete an entry. -->
-    <sql name="deleteQuery">DELETE FROM greylist WHERE create_time &lt; ? AND count = 0</sql>
-    
-    <!-- Statements used to delete an entry. -->
-    <sql name="deleteAutoWhitelistQuery">DELETE FROM greylist WHERE create_time &lt; ?</sql>
-    
-    <!-- Statements used to delete an entry. -->
-    <sql name="updateQuery">UPDATE greylist SET create_time = ? , count = ? WHERE ipaddress = ? AND sender = ? AND recip = ?</sql>
+        <!-- Statements used to delete an entry. -->
+        <sql name="deleteQuery">DELETE FROM greylist WHERE create_time &lt; ? AND count = 0</sql>
 
-    <!-- Statements used to create the "whitelist" table. -->
-    <sql name="createGreyListTable" db="hypersonic">
-        CREATE TABLE greylist (
-            ipaddress varchar (20) NOT NULL,
-            sender varchar (255) NOT NULL,
-            recip varchar (255) NOT NULL,
-            count int NOT NULL,
-            create_time datetime NOT NULL,           
-            PRIMARY KEY (ipaddress,sender,recip)
-        )    </sql>
-        
-    <sql name="createGreyListTable" db="hsqldb">
-        CREATE CACHED TABLE ${table} (
-        CREATE TABLE greylist (
-            ipaddress varchar (20) NOT NULL,
-            sender varchar (255) NOT NULL,
-            recip varchar (255) NOT NULL,
-            count int NOT NULL,
-            create_time timestamo NOT NULL,  
-            PRIMARY KEY (ipaddress,sender,recip)
-        )    </sql>
-    <sql name="createGreyListTable" db="mysql">
+        <!-- Statements used to delete an entry. -->
+        <sql name="deleteAutoWhitelistQuery">DELETE FROM greylist WHERE create_time &lt; ?</sql>
+
+        <!-- Statements used to delete an entry. -->
+        <sql name="updateQuery">UPDATE greylist SET create_time = ? , count = ? WHERE ipaddress = ? AND sender = ? AND recip = ?</sql>
+
+        <!-- Statements used to create the "whitelist" table. -->
+        <sql name="createGreyListTable" db="hypersonic">
             CREATE TABLE greylist (
             ipaddress varchar (20) NOT NULL,
             sender varchar (255) NOT NULL,
             recip varchar (255) NOT NULL,
             count int NOT NULL,
-            create_time datetime NOT NULL,  
+            create_time datetime NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        ) TYPE=InnoDB
-    </sql>
-    <sql name="createGreyListTable" db="mssql">
-        CREATE TABLE [greylist] (
+            )
+        </sql>
+        <sql name="createGreyListTable" db="hsqldb">
+            CREATE CACHED TABLE ${table} (
+            CREATE TABLE greylist (
+            ipaddress varchar (20) NOT NULL,
+            sender varchar (255) NOT NULL,
+            recip varchar (255) NOT NULL,
+            count int NOT NULL,
+            create_time timestamo NOT NULL,
+            PRIMARY KEY (ipaddress,sender,recip)
+            )
+        </sql>
+        <sql name="createGreyListTable" db="mysql">
+            CREATE TABLE greylist (
+            ipaddress varchar (20) NOT NULL,
+            sender varchar (255) NOT NULL,
+            recip varchar (255) NOT NULL,
+            count int NOT NULL,
+            create_time datetime NOT NULL,
+            PRIMARY KEY (ipaddress,sender,recip)
+            ) TYPE=InnoDB
+        </sql>
+        <sql name="createGreyListTable" db="mssql">
+            CREATE TABLE [greylist] (
             [ipaddress] [varchar] (20) NOT NULL,
             [sender] [varchar] (255) NOT NULL,
             [recip] [varchar] (255) NOT NULL,
             [count] [int] NOT NULL,
-            [create_time] [datetime] NOT NULL,  
+            [create_time] [datetime] NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        )
-    </sql>
-    <sql name="createGreyListTable" db="oracle">
+            )
+        </sql>
+        <sql name="createGreyListTable" db="oracle">
             CREATE TABLE greylist (
             ipaddress varchar2(20) NOT NULL,
             sender varchar2(255) NOT NULL,
             recip varchar2(255) NOT NULL,
             count int NOT NULL,
-            create_time datetime NOT NULL,  
+            create_time datetime NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        )
-    </sql>
-    <sql name="createGreyListTable" db="postgresql">
+            )
+        </sql>
+        <sql name="createGreyListTable" db="postgresql">
             CREATE TABLE greylist (
             ipaddress varchar (20) NOT NULL,
             sender varchar (255) NOT NULL,
             recip varchar (255) NOT NULL,
             count int NOT NULL,
-            create_time timestamp NOT NULL,  
+            create_time timestamp NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        )
-    </sql>
-    <sql name="createGreyListTable" db="sapdb">
+            )
+        </sql>
+        <sql name="createGreyListTable" db="sapdb">
             CREATE TABLE greylist (
             ipaddress varchar (20) NOT NULL,
             sender varchar (255) NOT NULL,
             recip varchar (255) NOT NULL,
             count int NOT NULL,
-            create_time date NOT NULL,  
+            create_time date NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        )
-    </sql>
-    <sql name="createGreyListTable" db="db2">
+            )
+        </sql>
+        <sql name="createGreyListTable" db="db2">
             CREATE TABLE greylist (
             ipaddress varchar (20) NOT NULL,
             sender varchar (255) NOT NULL,
             recip varchar (255) NOT NULL,
             count int NOT NULL,
-            create_time timestamp NOT NULL,  
+            create_time timestamp NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        )
-    </sql>
-    <sql name="createGreyListTable" db="ingres">
+            )
+        </sql>
+        <sql name="createGreyListTable" db="ingres">
             CREATE TABLE greylist (
             ipaddress varchar (20) NOT NULL,
             sender varchar (255) NOT NULL,
             recip varchar (255) NOT NULL,
             count int NOT NULL,
-            create_time date NOT NULL,  
+            create_time date NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        )
-    </sql>
-    <sql name="createGreyListTable" db="derby">
+            )
+        </sql>
+        <sql name="createGreyListTable" db="derby">
             CREATE TABLE greylist (
             ipaddress varchar (20) NOT NULL,
             sender varchar (255) NOT NULL,
             recip varchar (255) NOT NULL,
             count int NOT NULL,
-            create_time timestamp NOT NULL,  
+            create_time timestamp NOT NULL,
             PRIMARY KEY (ipaddress,sender,recip)
-        )
-    </sql>
-</sqlDefs>
+            )
+        </sql>
+    </sqlDefs>
 
 </sqlResources>
-

--- a/server/app/src/main/resources/sqlResources.xml
+++ b/server/app/src/main/resources/sqlResources.xml
@@ -130,11 +130,11 @@
     <!-- Statements used to insert a message into this repository. -->
     <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
     repository_name, message_state, error_message, sender, recipients,
-    remote_host, remote_addr, last_updated, message_body,
-    message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
+    remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
+    message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
 
     <!-- Statements used to retrieve a message stored in this repository. -->
-    <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+    <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
     <!-- Statements used to retrieve the body of a message stored in this repository. -->
     <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
@@ -160,6 +160,9 @@
     <!-- Statements used to list all messages stored in this repository. -->
     <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
 
+    <!-- Statements used to count messages stored in this repository. -->
+    <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
+
     <!-- Statements used to create the table associated with this class. -->
     <sql name="createTable" db="mysql">
         CREATE TABLE ${table} (
@@ -171,9 +174,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers longblob NULL ,
+            last_updated datetime NOT NULL,
             message_body longblob NOT NULL ,
             message_attributes longblob NULL ,
-            last_updated datetime NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -187,9 +191,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers varchar NULL ,
+            last_updated timestamp NOT NULL,
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -203,9 +208,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers varchar NULL ,
+            last_updated timestamp NOT NULL,
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -219,9 +225,10 @@
             [recipients] [text] NOT NULL ,
             [remote_host] [varchar] (255) NOT NULL ,
             [remote_addr] [varchar] (20) NOT NULL ,
+            [per_recipient_headers] [image] NULL ,
+            [last_updated] [datetime] NOT NULL,
             [message_body] [image] NOT NULL ,
             [message_attributes] [image] NULL ,
-            [last_updated] [datetime] NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -235,9 +242,10 @@
             recipients varchar2(1000) NOT NULL ,
             remote_host varchar2(100) NOT NULL ,
             remote_addr varchar2(20) NOT NULL ,
+            per_recipient_headers blob NULL ,
+            last_updated date NOT NULL ,
             message_body blob NOT NULL ,
             message_attributes blob NULL ,
-            last_updated date NOT NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -251,9 +259,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers oid NULL ,
+            last_updated timestamp NOT NULL,
             message_body bytea NOT NULL ,
             message_attributes bytea NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -267,9 +276,10 @@
             recipients long NOT NULL ,
             remote_host varchar (100) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers long byte NULL ,
+            last_updated date NOT NULL,
             message_body long byte NOT NULL ,
             message_attributes long byte NULL ,
-            last_updated date NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -283,9 +293,10 @@
             recipients varchar(1000) NOT NULL ,
             remote_host varchar(100) NOT NULL ,
             remote_addr varchar(20) NOT NULL ,
+            per_recipient_headers blob ,
+            last_updated timestamp NOT NULL ,
             message_body blob NOT NULL ,
             message_attributes blob ,
-            last_updated timestamp NOT NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -299,9 +310,10 @@
             recipients LONG VARCHAR NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers LONG BYTE ,
+            last_updated DATE NOT NULL
             message_body LONG BYTE NOT NULL ,
             message_attributes LONG BYTE ,
-            last_updated DATE NOT NULL
         )
     </sql>
     <sql name="createTable" db="derby">
@@ -314,9 +326,10 @@
             recipients long varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers blob ,
+            last_updated timestamp NOT NULL,
             message_body blob NOT NULL ,
             message_attributes blob ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>

--- a/server/data/data-jdbc/src/test/resources/sqlResources-mail.xml
+++ b/server/data/data-jdbc/src/test/resources/sqlResources-mail.xml
@@ -115,11 +115,11 @@
     <!-- Statements used to insert a message into this repository. -->
     <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
     repository_name, message_state, error_message, sender, recipients,
-    remote_host, remote_addr, last_updated, message_body,
-    message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
+    remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
+    message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
 
     <!-- Statements used to retrieve a message stored in this repository. -->
-    <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+    <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
     <!-- Statements used to retrieve the body of a message stored in this repository. -->
     <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
@@ -145,6 +145,9 @@
     <!-- Statements used to list all messages stored in this repository. -->
     <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
 
+    <!-- Statements used to count messages stored in this repository. -->
+    <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
+
     <!-- Statements used to create the table associated with this class. -->
     <sql name="createTable" db="mysql">
         CREATE TABLE ${table} (
@@ -156,9 +159,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers longblob NULL ,
+            last_updated datetime NOT NULL,
             message_body longblob NOT NULL ,
             message_attributes longblob NULL ,
-            last_updated datetime NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -172,9 +176,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers varchar NULL ,
+            last_updated timestamp NOT NULL,
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -188,9 +193,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers varchar NULL ,
+            last_updated timestamp NOT NULL,
             message_body varchar NOT NULL ,
             message_attributes varchar NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -204,9 +210,10 @@
             [recipients] [text] NOT NULL ,
             [remote_host] [varchar] (255) NOT NULL ,
             [remote_addr] [varchar] (20) NOT NULL ,
+            [per_recipient_headers] [image] NULL ,
+            [last_updated] [datetime] NOT NULL,
             [message_body] [image] NOT NULL ,
             [message_attributes] [image] NULL ,
-            [last_updated] [datetime] NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -220,9 +227,10 @@
             recipients varchar2(1000) NOT NULL ,
             remote_host varchar2(100) NOT NULL ,
             remote_addr varchar2(20) NOT NULL ,
+            per_recipient_headers blob NULL ,
+            last_updated date NOT NULL ,
             message_body blob NOT NULL ,
             message_attributes blob NULL ,
-            last_updated date NOT NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -236,9 +244,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers oid NULL ,
+            last_updated timestamp NOT NULL,
             message_body bytea NOT NULL ,
             message_attributes bytea NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -252,9 +261,10 @@
             recipients long NOT NULL ,
             remote_host varchar (100) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers long byte NULL ,
+            last_updated date NOT NULL,
             message_body long byte NOT NULL ,
             message_attributes long byte NULL ,
-            last_updated date NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -268,9 +278,10 @@
             recipients varchar(1000) NOT NULL ,
             remote_host varchar(100) NOT NULL ,
             remote_addr varchar(20) NOT NULL ,
+            per_recipient_headers blob ,
+            last_updated timestamp NOT NULL ,
             message_body blob NOT NULL ,
             message_attributes blob ,
-            last_updated timestamp NOT NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -284,9 +295,10 @@
             recipients LONG VARCHAR NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers LONG BYTE ,
+            last_updated DATE NOT NULL
             message_body LONG BYTE NOT NULL ,
             message_attributes LONG BYTE ,
-            last_updated DATE NOT NULL
         )
     </sql>
     <sql name="createTable" db="derby">
@@ -299,9 +311,10 @@
             recipients long varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers blob ,
+            last_updated timestamp NOT NULL,
             message_body blob NOT NULL ,
             message_attributes blob ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>

--- a/server/data/data-jdbc/src/test/resources/sqlResources-mail.xml
+++ b/server/data/data-jdbc/src/test/resources/sqlResources-mail.xml
@@ -19,306 +19,305 @@
 <!-- SQL Statements used by James for database access. -->
 <sqlResources>
 
-<!--
-     This section provided configuration to determine the determine the
-     database product which is being used for storage. Different database
-     products may require different SQL syntax.
+    <!--
+         This section provided configuration to determine the determine the
+         database product which is being used for storage. Different database
+         products may require different SQL syntax.
 
-     The jdbc database connection is examined to see if it matches with the
-     regular expressions specified in any of the defined matchers. The matchers
-     are processed in the over provided here, with the first successful match
-     defining the "db" value for this connection.
+         The jdbc database connection is examined to see if it matches with the
+         regular expressions specified in any of the defined matchers. The matchers
+         are processed in the over provided here, with the first successful match
+         defining the "db" value for this connection.
 
-     This value is then used to choose between different definitions for various
-     named sql statements, defined below. If no match is found,
-     the default sql statements are used.
--->
-<dbMatchers>
-    <dbMatcher db="mssql" databaseProductName="microsoft sql server"/>
-    <dbMatcher db="oracle" databaseProductName="oracle.*"/>
-    <dbMatcher db="mysql" databaseProductName="my.*"/>
-    <dbMatcher db="derby" databaseProductName="derby.*"/>
-    <dbMatcher db="postgresql" databaseProductName="postgres.*"/>
-    <dbMatcher db="hsqldb" databaseProductName="hsql.*"/>
-    <dbMatcher db="sapdb" databaseProductName="sap.*"/>
-    <dbMatcher db="hypersonic" databaseProductName="HypersonicSQL"/>
-    <dbMatcher db="db2" databaseProductName="db2.*"/>
-    <dbMatcher db="ingres" databaseProductName="ingres.*"/>
-</dbMatchers>
+         This value is then used to choose between different definitions for various
+         named sql statements, defined below. If no match is found,
+         the default sql statements are used.
+    -->
+    <dbMatchers>
+        <dbMatcher db="mssql" databaseProductName="microsoft sql server"/>
+        <dbMatcher db="oracle" databaseProductName="oracle.*"/>
+        <dbMatcher db="mysql" databaseProductName="my.*"/>
+        <dbMatcher db="derby" databaseProductName="derby.*"/>
+        <dbMatcher db="postgresql" databaseProductName="postgres.*"/>
+        <dbMatcher db="hsqldb" databaseProductName="hsql.*"/>
+        <dbMatcher db="sapdb" databaseProductName="sap.*"/>
+        <dbMatcher db="hypersonic" databaseProductName="HypersonicSQL"/>
+        <dbMatcher db="db2" databaseProductName="db2.*"/>
+        <dbMatcher db="ingres" databaseProductName="ingres.*"/>
+    </dbMatchers>
 
-<!--
-    With the following section it is possible to associate several name/value pairs
-        of options to a database product, identified by the "db" XML attribute name.
-    
-    An element without a "db" attribute, if used for an option name, will become a default value for such option.
-    Each option may have a "default default", i.e. a default that applies if no element with an empty
-        "db" attribute (default element) exists as said above;
-        such default default must be documented for such option below.
-    
-    The order of the XML elements is meaningless.
-    
-    Here only "getBody" and "getAttributes" option names are set, but others could be used in the future.
-    Option names:
-        "getBody" - a string (case insensitive) telling which JDBC ResultSet method will be used to
-            get the message body field for a database product.
-            The default default value is "useBytes"..
-            Values (case insensitive):
-                "useBytes"  - use getBytes(int).
-                "useBlob"   - use getBlob(int).
-        "getAttributes" - a string (case insensitive) telling which JDBC ResultSet method will be used to
-            get the message attributes field for a database product.
-           The default default value is "useBytes"..
-            Values (case insensitive):
-                "useBytes"  - use getBytes(int).
-                "useBlob"   - use getBlob(int).
--->
-<dbOptions>
-    <dbOption name="getBody" value="useBytes"/>
-    <dbOption name="getAttributes" value="useBytes"/>
-    <dbOption db="mssql" name="getBody" value="useBytes"/>
-    <dbOption db="mssql" name="getAttributes" value="useBytes"/>
-    <dbOption db="oracle" name="getBody" value="useBlob"/>
-    <dbOption db="oracle" name="getAttributes" value="useBlob"/>
-    <dbOption db="mysql" name="getBody" value="useBytes"/>
-    <dbOption db="mysql" name="getAttributes" value="useBytes"/>
-    <dbOption db="derby" name="getBody" value="useBytes"/>
-    <dbOption db="derby" name="getAttributes" value="useBytes"/>
-    <dbOption db="postgresql" name="getBody" value="useBytes"/>
-    <dbOption db="postgresql" name="getAttributes" value="useBytes"/>
-    <dbOption db="sapdb" name="getBody" value="useBytes"/>
-    <dbOption db="sapdb" name="getAttributes" value="useBytes"/>
-    <dbOption db="hypersonic" name="getBody" value="useBytes"/>
-    <dbOption db="hypersonic" name="getAttributes" value="useBytes"/>
-    <dbOption db="hsqldb" name="getBody" value="useBytes"/>
-    <dbOption db="hsqldb" name="getAttributes" value="useBytes"/>
-    <dbOption db="db2" name="getBody" value="useBlob"/>
-    <dbOption db="db2" name="getAttributes" value="useBlob"/>
-    <dbOption db="ingres" name="getBody" value="useBytes"/>
-    <dbOption db="ingres" name="getAttributes" value="useBytes"/>
-</dbOptions>
+    <!--
+        With the following section it is possible to associate several name/value pairs
+            of options to a database product, identified by the "db" XML attribute name.
+        
+        An element without a "db" attribute, if used for an option name, will become a default value for such option.
+        Each option may have a "default default", i.e. a default that applies if no element with an empty
+            "db" attribute (default element) exists as said above;
+            such default default must be documented for such option below.
+        
+        The order of the XML elements is meaningless.
+        
+        Here only "getBody" and "getAttributes" option names are set, but others could be used in the future.
+        Option names:
+            "getBody" - a string (case insensitive) telling which JDBC ResultSet method will be used to
+                get the message body field for a database product.
+                The default default value is "useBytes"..
+                Values (case insensitive):
+                    "useBytes"  - use getBytes(int).
+                    "useBlob"   - use getBlob(int).
+            "getAttributes" - a string (case insensitive) telling which JDBC ResultSet method will be used to
+                get the message attributes field for a database product.
+               The default default value is "useBytes"..
+                Values (case insensitive):
+                    "useBytes"  - use getBytes(int).
+                    "useBlob"   - use getBlob(int).
+    -->
+    <dbOptions>
+        <dbOption name="getBody" value="useBytes"/>
+        <dbOption name="getAttributes" value="useBytes"/>
+        <dbOption db="mssql" name="getBody" value="useBytes"/>
+        <dbOption db="mssql" name="getAttributes" value="useBytes"/>
+        <dbOption db="oracle" name="getBody" value="useBlob"/>
+        <dbOption db="oracle" name="getAttributes" value="useBlob"/>
+        <dbOption db="mysql" name="getBody" value="useBytes"/>
+        <dbOption db="mysql" name="getAttributes" value="useBytes"/>
+        <dbOption db="derby" name="getBody" value="useBytes"/>
+        <dbOption db="derby" name="getAttributes" value="useBytes"/>
+        <dbOption db="postgresql" name="getBody" value="useBytes"/>
+        <dbOption db="postgresql" name="getAttributes" value="useBytes"/>
+        <dbOption db="sapdb" name="getBody" value="useBytes"/>
+        <dbOption db="sapdb" name="getAttributes" value="useBytes"/>
+        <dbOption db="hypersonic" name="getBody" value="useBytes"/>
+        <dbOption db="hypersonic" name="getAttributes" value="useBytes"/>
+        <dbOption db="hsqldb" name="getBody" value="useBytes"/>
+        <dbOption db="hsqldb" name="getAttributes" value="useBytes"/>
+        <dbOption db="db2" name="getBody" value="useBlob"/>
+        <dbOption db="db2" name="getAttributes" value="useBlob"/>
+        <dbOption db="ingres" name="getBody" value="useBytes"/>
+        <dbOption db="ingres" name="getAttributes" value="useBytes"/>
+    </dbOptions>
 
-<!-- SQL statements for the JdbcMailRepository  -->
-<sqlDefs name="org.apache.james.mailrepository.jdbc.JDBCMailRepository">
+    <!-- SQL statements for the JdbcMailRepository  -->
+    <sqlDefs name="org.apache.james.mailrepository.jdbc.JDBCMailRepository">
 
-    <!-- Statements used to check whether a particular message exists in this repository. -->
-    <sql name="checkMessageExistsSQL">SELECT count(*) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to check whether a particular message exists in this repository. -->
+        <sql name="checkMessageExistsSQL">SELECT count(*) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update a message stored in this repository. -->
-    <sql name="updateMessageSQL">UPDATE ${table} SET message_state = ?, error_message = ?, sender = ?, recipients = ?, remote_host = ?, remote_addr = ?, last_updated = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update a message stored in this repository. -->
+        <sql name="updateMessageSQL">UPDATE ${table} SET message_state = ?, error_message = ?, sender = ?, recipients = ?, remote_host = ?, remote_addr = ?, last_updated = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update the body of a message stored in this repository. -->
-    <sql name="updateMessageBodySQL">UPDATE ${table} SET message_body = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update the body of a message stored in this repository. -->
+        <sql name="updateMessageBodySQL">UPDATE ${table} SET message_body = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update the attributes of a message stored in this repository. -->
-    <sql name="updateMessageAttributesSQL">UPDATE ${table} SET message_attributes = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update the attributes of a message stored in this repository. -->
+        <sql name="updateMessageAttributesSQL">UPDATE ${table} SET message_attributes = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to insert a message into this repository. -->
-    <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
-    repository_name, message_state, error_message, sender, recipients,
-    remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
-    message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
+        <!-- Statements used to insert a message into this repository. -->
+        <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
+        repository_name, message_state, error_message, sender, recipients,
+        remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
+        message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
 
-    <!-- Statements used to retrieve a message stored in this repository. -->
-    <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve a message stored in this repository. -->
+        <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the body of a message stored in this repository. -->
-    <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the body of a message stored in this repository. -->
+        <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the attributes of a message stored in this repository. -->
-    <sql name="retrieveMessageAttributesSQL">SELECT message_attributes FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the attributes of a message stored in this repository. -->
+        <sql name="retrieveMessageAttributesSQL">SELECT message_attributes FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the size of the body of a message stored in this repository. -->
-    <!-- NOTE: This statement is optional and need not be implemented for a particular database to be supported. -->
-    <sql name="retrieveMessageBodySizeSQL" db="mssql">SELECT datalength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="mysql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="hypersonic">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="hsqldb">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="postgresql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="oracle">SELECT dbms_lob.getlength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="db2">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="ingres">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="derby">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the size of the body of a message stored in this repository. -->
+        <!-- NOTE: This statement is optional and need not be implemented for a particular database to be supported. -->
+        <sql name="retrieveMessageBodySizeSQL" db="mssql">SELECT datalength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="mysql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="hypersonic">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="hsqldb">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="postgresql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="oracle">SELECT dbms_lob.getlength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="db2">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="ingres">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="derby">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to delete a message stored in this repository. -->
-    <sql name="removeMessageSQL">DELETE FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to delete a message stored in this repository. -->
+        <sql name="removeMessageSQL">DELETE FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to list all messages stored in this repository. -->
-    <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
+        <!-- Statements used to list all messages stored in this repository. -->
+        <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
 
-    <!-- Statements used to count messages stored in this repository. -->
-    <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
+        <!-- Statements used to count messages stored in this repository. -->
+        <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
 
-    <!-- Statements used to create the table associated with this class. -->
-    <sql name="createTable" db="mysql">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (100) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients text NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers longblob NULL ,
-            last_updated datetime NOT NULL,
-            message_body longblob NOT NULL ,
-            message_attributes longblob NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="hypersonic">
-        CREATE CACHED TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients varchar NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers varchar NULL ,
-            last_updated timestamp NOT NULL,
-            message_body varchar NOT NULL ,
-            message_attributes varchar NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="hsqldb">
-        CREATE CACHED TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients varchar NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers varchar NULL ,
-            last_updated timestamp NOT NULL,
-            message_body varchar NOT NULL ,
-            message_attributes varchar NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="mssql">
-        CREATE TABLE [${table}] (
-            [message_name] [varchar] (200) NOT NULL,
-            [repository_name] [varchar] (255) NOT NULL,
-            [message_state] [varchar] (30) NOT NULL ,
-            [error_message] [varchar] (1000) NULL ,
-            [sender] [varchar] (255) NULL ,
-            [recipients] [text] NOT NULL ,
-            [remote_host] [varchar] (255) NOT NULL ,
-            [remote_addr] [varchar] (20) NOT NULL ,
-            [per_recipient_headers] [image] NULL ,
-            [last_updated] [datetime] NOT NULL,
-            [message_body] [image] NOT NULL ,
-            [message_attributes] [image] NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="oracle">
-        CREATE TABLE ${table} (
-            message_name varchar2(200) NOT NULL ,
-            repository_name varchar2(255) NOT NULL ,
-            message_state varchar2(30) NOT NULL ,
-            error_message varchar2(200) NULL ,
-            sender varchar2(255) ,
-            recipients varchar2(1000) NOT NULL ,
-            remote_host varchar2(100) NOT NULL ,
-            remote_addr varchar2(20) NOT NULL ,
-            per_recipient_headers blob NULL ,
-            last_updated date NOT NULL ,
-            message_body blob NOT NULL ,
-            message_attributes blob NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="postgresql">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients text NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers oid NULL ,
-            last_updated timestamp NOT NULL,
-            message_body bytea NOT NULL ,
-            message_attributes bytea NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="sapdb">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (200) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (200) NULL ,
-            recipients long NOT NULL ,
-            remote_host varchar (100) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers long byte NULL ,
-            last_updated date NOT NULL,
-            message_body long byte NOT NULL ,
-            message_attributes long byte NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="db2">
-        CREATE TABLE ${table} (
-            message_name varchar(200) NOT NULL ,
-            repository_name varchar(255) NOT NULL ,
-            message_state varchar(30) NOT NULL ,
-            error_message varchar(200) ,
-            sender varchar(255) ,
-            recipients varchar(1000) NOT NULL ,
-            remote_host varchar(100) NOT NULL ,
-            remote_addr varchar(20) NOT NULL ,
-            per_recipient_headers blob ,
-            last_updated timestamp NOT NULL ,
-            message_body blob NOT NULL ,
-            message_attributes blob ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="ingres">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) ,
-            sender varchar (255) ,
-            recipients LONG VARCHAR NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers LONG BYTE ,
-            last_updated DATE NOT NULL
-            message_body LONG BYTE NOT NULL ,
-            message_attributes LONG BYTE ,
-        )
-    </sql>
-    <sql name="createTable" db="derby">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) ,
-            sender varchar (255) ,
-            recipients long varchar NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers blob ,
-            last_updated timestamp NOT NULL,
-            message_body blob NOT NULL ,
-            message_attributes blob ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-</sqlDefs>
+        <!-- Statements used to create the table associated with this class. -->
+        <sql name="createTable" db="mysql">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (100) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients text NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers longblob NULL ,
+                last_updated datetime NOT NULL,
+                message_body longblob NOT NULL ,
+                message_attributes longblob NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="hypersonic">
+            CREATE CACHED TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients varchar NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers varchar NULL ,
+                last_updated timestamp NOT NULL,
+                message_body varchar NOT NULL ,
+                message_attributes varchar NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="hsqldb">
+            CREATE CACHED TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients varchar NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers varchar NULL ,
+                last_updated timestamp NOT NULL,
+                message_body varchar NOT NULL ,
+                message_attributes varchar NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="mssql">
+            CREATE TABLE [${table}] (
+                [message_name] [varchar] (200) NOT NULL,
+                [repository_name] [varchar] (255) NOT NULL,
+                [message_state] [varchar] (30) NOT NULL ,
+                [error_message] [varchar] (1000) NULL ,
+                [sender] [varchar] (255) NULL ,
+                [recipients] [text] NOT NULL ,
+                [remote_host] [varchar] (255) NOT NULL ,
+                [remote_addr] [varchar] (20) NOT NULL ,
+                [per_recipient_headers] [image] NULL ,
+                [last_updated] [datetime] NOT NULL,
+                [message_body] [image] NOT NULL ,
+                [message_attributes] [image] NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="oracle">
+            CREATE TABLE ${table} (
+                message_name varchar2(200) NOT NULL ,
+                repository_name varchar2(255) NOT NULL ,
+                message_state varchar2(30) NOT NULL ,
+                error_message varchar2(200) NULL ,
+                sender varchar2(255) ,
+                recipients varchar2(1000) NOT NULL ,
+                remote_host varchar2(100) NOT NULL ,
+                remote_addr varchar2(20) NOT NULL ,
+                per_recipient_headers blob NULL ,
+                last_updated date NOT NULL ,
+                message_body blob NOT NULL ,
+                message_attributes blob NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="postgresql">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients text NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers oid NULL ,
+                last_updated timestamp NOT NULL,
+                message_body bytea NOT NULL ,
+                message_attributes bytea NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="sapdb">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (200) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (200) NULL ,
+                recipients long NOT NULL ,
+                remote_host varchar (100) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers long byte NULL ,
+                last_updated date NOT NULL,
+                message_body long byte NOT NULL ,
+                message_attributes long byte NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="db2">
+            CREATE TABLE ${table} (
+                message_name varchar(200) NOT NULL ,
+                repository_name varchar(255) NOT NULL ,
+                message_state varchar(30) NOT NULL ,
+                error_message varchar(200) ,
+                sender varchar(255) ,
+                recipients varchar(1000) NOT NULL ,
+                remote_host varchar(100) NOT NULL ,
+                remote_addr varchar(20) NOT NULL ,
+                per_recipient_headers blob ,
+                last_updated timestamp NOT NULL ,
+                message_body blob NOT NULL ,
+                message_attributes blob ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="ingres">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) ,
+                sender varchar (255) ,
+                recipients LONG VARCHAR NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers LONG BYTE ,
+                last_updated DATE NOT NULL
+                message_body LONG BYTE NOT NULL ,
+                message_attributes LONG BYTE ,
+            )
+        </sql>
+        <sql name="createTable" db="derby">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) ,
+                sender varchar (255) ,
+                recipients long varchar NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers blob ,
+                last_updated timestamp NOT NULL,
+                message_body blob NOT NULL ,
+                message_attributes blob ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+    </sqlDefs>
 
 </sqlResources>
-

--- a/server/data/data-jdbc/src/test/resources/sqlResources.xml
+++ b/server/data/data-jdbc/src/test/resources/sqlResources.xml
@@ -166,10 +166,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
-            message_body longblob NOT NULL ,
-            message_attributes longblob NULL ,
             per_recipient_headers longblob NULL ,
             last_updated datetime NOT NULL,
+            message_body longblob NOT NULL ,
+            message_attributes longblob NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -183,10 +183,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
-            message_body varchar NOT NULL ,
-            message_attributes varchar NULL ,
             per_recipient_headers varchar NULL ,
             last_updated timestamp NOT NULL,
+            message_body varchar NOT NULL ,
+            message_attributes varchar NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -200,10 +200,10 @@
             recipients varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
-            message_body varchar NOT NULL ,
-            message_attributes varchar NULL ,
             per_recipient_headers varchar NULL ,
             last_updated timestamp NOT NULL,
+            message_body varchar NOT NULL ,
+            message_attributes varchar NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -217,10 +217,10 @@
             [recipients] [text] NOT NULL ,
             [remote_host] [varchar] (255) NOT NULL ,
             [remote_addr] [varchar] (20) NOT NULL ,
-            [message_body] [image] NOT NULL ,
-            [message_attributes] [image] NULL ,
             [per_recipient_headers] [image] NULL ,
             [last_updated] [datetime] NOT NULL,
+            [message_body] [image] NOT NULL ,
+            [message_attributes] [image] NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -234,10 +234,10 @@
             recipients varchar2(1000) NOT NULL ,
             remote_host varchar2(100) NOT NULL ,
             remote_addr varchar2(20) NOT NULL ,
-            message_body blob NOT NULL ,
-            message_attributes blob NULL ,
             per_recipient_headers blob NULL ,
             last_updated date NOT NULL ,
+            message_body blob NOT NULL ,
+            message_attributes blob NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -251,10 +251,10 @@
             recipients text NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
+            per_recipient_headers oid NULL ,
+            last_updated timestamp NOT NULL,
             message_body bytea NOT NULL ,
             message_attributes bytea NULL ,
-            per_recipient_headers bytea NULL ,
-            last_updated timestamp NOT NULL,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -268,10 +268,10 @@
             recipients long NOT NULL ,
             remote_host varchar (100) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
-            message_body long byte NOT NULL ,
-            message_attributes long byte NULL ,
             per_recipient_headers long byte NULL ,
             last_updated date NOT NULL,
+            message_body long byte NOT NULL ,
+            message_attributes long byte NULL ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -285,10 +285,10 @@
             recipients varchar(1000) NOT NULL ,
             remote_host varchar(100) NOT NULL ,
             remote_addr varchar(20) NOT NULL ,
-            message_body blob NOT NULL ,
-            message_attributes blob ,
             per_recipient_headers blob ,
             last_updated timestamp NOT NULL ,
+            message_body blob NOT NULL ,
+            message_attributes blob ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>
@@ -302,10 +302,10 @@
             recipients LONG VARCHAR NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
-            message_body LONG BYTE NOT NULL ,
-            message_attributes LONG BYTE ,
             per_recipient_headers LONG BYTE ,
             last_updated DATE NOT NULL
+            message_body LONG BYTE NOT NULL ,
+            message_attributes LONG BYTE ,
         )
     </sql>
     <sql name="createTable" db="derby">
@@ -318,10 +318,10 @@
             recipients long varchar NOT NULL ,
             remote_host varchar (255) NOT NULL ,
             remote_addr varchar (20) NOT NULL ,
-            message_body blob NOT NULL ,
-            message_attributes blob ,
             per_recipient_headers blob ,
             last_updated timestamp NOT NULL,
+            message_body blob NOT NULL ,
+            message_attributes blob ,
             PRIMARY KEY (repository_name, message_name)
         )
     </sql>

--- a/server/data/data-jdbc/src/test/resources/sqlResources.xml
+++ b/server/data/data-jdbc/src/test/resources/sqlResources.xml
@@ -26,306 +26,305 @@
 
 <sqlResources>
 
-<!--
-     This section provided configuration to determine the
-     database product which is being used for storage. Different database
-     products may require different SQL syntax.
+    <!--
+         This section provided configuration to determine the
+         database product which is being used for storage. Different database
+         products may require different SQL syntax.
 
-     The jdbc database connection is examined to see if it matches with the
-     regular expressions specified in any of the defined matchers. The matchers
-     are processed in the over provided here, with the first successful match
-     defining the "db" value for this connection.
+         The jdbc database connection is examined to see if it matches with the
+         regular expressions specified in any of the defined matchers. The matchers
+         are processed in the over provided here, with the first successful match
+         defining the "db" value for this connection.
 
-     This value is then used to choose between different definitions for various
-     named sql statements, defined below. If no match is found,
-     the default sql statements are used.
--->
-<dbMatchers>
-    <dbMatcher db="mssql" databaseProductName="microsoft sql server"/>
-    <dbMatcher db="oracle" databaseProductName="oracle.*"/>
-    <dbMatcher db="mysql" databaseProductName="my.*"/>
-    <dbMatcher db="derby" databaseProductName="derby.*"/>
-    <dbMatcher db="postgresql" databaseProductName="postgres.*"/>
-    <dbMatcher db="hsqldb" databaseProductName="hsql.*"/>
-    <dbMatcher db="sapdb" databaseProductName="sap.*"/>
-    <dbMatcher db="hypersonic" databaseProductName="HypersonicSQL"/>
-    <dbMatcher db="db2" databaseProductName="db2.*"/>
-    <dbMatcher db="ingres" databaseProductName="ingres.*"/>
-</dbMatchers>
+         This value is then used to choose between different definitions for various
+         named sql statements, defined below. If no match is found,
+         the default sql statements are used.
+    -->
+    <dbMatchers>
+        <dbMatcher db="mssql" databaseProductName="microsoft sql server"/>
+        <dbMatcher db="oracle" databaseProductName="oracle.*"/>
+        <dbMatcher db="mysql" databaseProductName="my.*"/>
+        <dbMatcher db="derby" databaseProductName="derby.*"/>
+        <dbMatcher db="postgresql" databaseProductName="postgres.*"/>
+        <dbMatcher db="hsqldb" databaseProductName="hsql.*"/>
+        <dbMatcher db="sapdb" databaseProductName="sap.*"/>
+        <dbMatcher db="hypersonic" databaseProductName="HypersonicSQL"/>
+        <dbMatcher db="db2" databaseProductName="db2.*"/>
+        <dbMatcher db="ingres" databaseProductName="ingres.*"/>
+    </dbMatchers>
 
-<!--
-    With the following section it is possible to associate several name/value pairs
-        of options to a database product, identified by the "db" XML attribute name.
-    
-    An element without a "db" attribute, if used for an option name, will become a default value for such option.
-    Each option may have a "default default", i.e. a default that applies if no element with an empty
-        "db" attribute (default element) exists as said above;
-        such default default must be documented for such option below.
-    
-    The order of the XML elements is meaningless.
-    
-    Here only "getBody" and "getAttributes" option names are set, but others could be used in the future.
-    Option names:
-        "getBody" - a string (case insensitive) telling which JDBC ResultSet method will be used to
-            get the message body field for a database product.
-            The default default value is "useBytes"..
-            Values (case insensitive):
-                "useBytes"  - use getBytes(int).
-                "useBlob"   - use getBlob(int).
-        "getAttributes" - a string (case insensitive) telling which JDBC ResultSet method will be used to
-            get the message attributes field for a database product.
-           The default default value is "useBytes"..
-            Values (case insensitive):
-                "useBytes"  - use getBytes(int).
-                "useBlob"   - use getBlob(int).
--->
-<dbOptions>
-    <dbOption name="getBody" value="useBytes"/>
-    <dbOption name="getAttributes" value="useBytes"/>
-    <dbOption db="mssql" name="getBody" value="useBytes"/>
-    <dbOption db="mssql" name="getAttributes" value="useBytes"/>
-    <dbOption db="oracle" name="getBody" value="useBlob"/>
-    <dbOption db="oracle" name="getAttributes" value="useBlob"/>
-    <dbOption db="mysql" name="getBody" value="useBytes"/>
-    <dbOption db="mysql" name="getAttributes" value="useBytes"/>
-    <dbOption db="derby" name="getBody" value="useBytes"/>
-    <dbOption db="derby" name="getAttributes" value="useBytes"/>
-    <dbOption db="postgresql" name="getBody" value="useBytes"/>
-    <dbOption db="postgresql" name="getAttributes" value="useBytes"/>
-    <dbOption db="sapdb" name="getBody" value="useBytes"/>
-    <dbOption db="sapdb" name="getAttributes" value="useBytes"/>
-    <dbOption db="hypersonic" name="getBody" value="useBytes"/>
-    <dbOption db="hypersonic" name="getAttributes" value="useBytes"/>
-    <dbOption db="hsqldb" name="getBody" value="useBytes"/>
-    <dbOption db="hsqldb" name="getAttributes" value="useBytes"/>
-    <dbOption db="db2" name="getBody" value="useBlob"/>
-    <dbOption db="db2" name="getAttributes" value="useBlob"/>
-    <dbOption db="ingres" name="getBody" value="useBytes"/>
-    <dbOption db="ingres" name="getAttributes" value="useBytes"/>
-</dbOptions>
+    <!--
+        With the following section it is possible to associate several name/value pairs
+            of options to a database product, identified by the "db" XML attribute name.
+        
+        An element without a "db" attribute, if used for an option name, will become a default value for such option.
+        Each option may have a "default default", i.e. a default that applies if no element with an empty
+            "db" attribute (default element) exists as said above;
+            such default default must be documented for such option below.
+        
+        The order of the XML elements is meaningless.
+        
+        Here only "getBody" and "getAttributes" option names are set, but others could be used in the future.
+        Option names:
+            "getBody" - a string (case insensitive) telling which JDBC ResultSet method will be used to
+                get the message body field for a database product.
+                The default default value is "useBytes"..
+                Values (case insensitive):
+                    "useBytes"  - use getBytes(int).
+                    "useBlob"   - use getBlob(int).
+            "getAttributes" - a string (case insensitive) telling which JDBC ResultSet method will be used to
+                get the message attributes field for a database product.
+               The default default value is "useBytes"..
+                Values (case insensitive):
+                    "useBytes"  - use getBytes(int).
+                    "useBlob"   - use getBlob(int).
+    -->
+    <dbOptions>
+        <dbOption name="getBody" value="useBytes"/>
+        <dbOption name="getAttributes" value="useBytes"/>
+        <dbOption db="mssql" name="getBody" value="useBytes"/>
+        <dbOption db="mssql" name="getAttributes" value="useBytes"/>
+        <dbOption db="oracle" name="getBody" value="useBlob"/>
+        <dbOption db="oracle" name="getAttributes" value="useBlob"/>
+        <dbOption db="mysql" name="getBody" value="useBytes"/>
+        <dbOption db="mysql" name="getAttributes" value="useBytes"/>
+        <dbOption db="derby" name="getBody" value="useBytes"/>
+        <dbOption db="derby" name="getAttributes" value="useBytes"/>
+        <dbOption db="postgresql" name="getBody" value="useBytes"/>
+        <dbOption db="postgresql" name="getAttributes" value="useBytes"/>
+        <dbOption db="sapdb" name="getBody" value="useBytes"/>
+        <dbOption db="sapdb" name="getAttributes" value="useBytes"/>
+        <dbOption db="hypersonic" name="getBody" value="useBytes"/>
+        <dbOption db="hypersonic" name="getAttributes" value="useBytes"/>
+        <dbOption db="hsqldb" name="getBody" value="useBytes"/>
+        <dbOption db="hsqldb" name="getAttributes" value="useBytes"/>
+        <dbOption db="db2" name="getBody" value="useBlob"/>
+        <dbOption db="db2" name="getAttributes" value="useBlob"/>
+        <dbOption db="ingres" name="getBody" value="useBytes"/>
+        <dbOption db="ingres" name="getAttributes" value="useBytes"/>
+    </dbOptions>
 
-<!-- SQL statements for the JdbcMailRepository  -->
-<sqlDefs name="org.apache.james.mailrepository.jdbc.JDBCMailRepository">
+    <!-- SQL statements for the JdbcMailRepository  -->
+    <sqlDefs name="org.apache.james.mailrepository.jdbc.JDBCMailRepository">
 
-    <!-- Statements used to check whether a particular message exists in this repository. -->
-    <sql name="checkMessageExistsSQL">SELECT count(*) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to check whether a particular message exists in this repository. -->
+        <sql name="checkMessageExistsSQL">SELECT count(*) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update a message stored in this repository. -->
-    <sql name="updateMessageSQL">UPDATE ${table} SET message_state = ?, error_message = ?, sender = ?, recipients = ?, remote_host = ?, remote_addr = ?, last_updated = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update a message stored in this repository. -->
+        <sql name="updateMessageSQL">UPDATE ${table} SET message_state = ?, error_message = ?, sender = ?, recipients = ?, remote_host = ?, remote_addr = ?, last_updated = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update the body of a message stored in this repository. -->
-    <sql name="updateMessageBodySQL">UPDATE ${table} SET message_body = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update the body of a message stored in this repository. -->
+        <sql name="updateMessageBodySQL">UPDATE ${table} SET message_body = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to update the attributes of a message stored in this repository. -->
-    <sql name="updateMessageAttributesSQL">UPDATE ${table} SET message_attributes = ? WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to update the attributes of a message stored in this repository. -->
+        <sql name="updateMessageAttributesSQL">UPDATE ${table} SET message_attributes = ? WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to insert a message into this repository. -->
-    <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
-    repository_name, message_state, error_message, sender, recipients,
-    remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
-    message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
+        <!-- Statements used to insert a message into this repository. -->
+        <sql name="insertMessageSQL">INSERT INTO ${table} (message_name,
+        repository_name, message_state, error_message, sender, recipients,
+        remote_host, remote_addr, per_recipient_headers, last_updated, message_body,
+        message_attributes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</sql>
 
-    <!-- Statements used to retrieve a message stored in this repository. -->
-    <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve a message stored in this repository. -->
+        <sql name="retrieveMessageSQL">SELECT message_state, error_message, sender, recipients, remote_host, remote_addr, per_recipient_headers, last_updated FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the body of a message stored in this repository. -->
-    <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the body of a message stored in this repository. -->
+        <sql name="retrieveMessageBodySQL">SELECT message_body FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the attributes of a message stored in this repository. -->
-    <sql name="retrieveMessageAttributesSQL">SELECT message_attributes FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the attributes of a message stored in this repository. -->
+        <sql name="retrieveMessageAttributesSQL">SELECT message_attributes FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to retrieve the size of the body of a message stored in this repository. -->
-    <!-- NOTE: This statement is optional and need not be implemented for a particular database to be supported. -->
-    <sql name="retrieveMessageBodySizeSQL" db="mssql">SELECT datalength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="mysql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="hypersonic">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="hsqldb">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="postgresql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="oracle">SELECT dbms_lob.getlength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="db2">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="ingres">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
-    <sql name="retrieveMessageBodySizeSQL" db="derby">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to retrieve the size of the body of a message stored in this repository. -->
+        <!-- NOTE: This statement is optional and need not be implemented for a particular database to be supported. -->
+        <sql name="retrieveMessageBodySizeSQL" db="mssql">SELECT datalength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="mysql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="hypersonic">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="hsqldb">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="postgresql">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="oracle">SELECT dbms_lob.getlength(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="db2">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="ingres">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <sql name="retrieveMessageBodySizeSQL" db="derby">SELECT length(message_body) FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to delete a message stored in this repository. -->
-    <sql name="removeMessageSQL">DELETE FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
+        <!-- Statements used to delete a message stored in this repository. -->
+        <sql name="removeMessageSQL">DELETE FROM ${table} WHERE message_name = ? AND repository_name = ?</sql>
 
-    <!-- Statements used to list all messages stored in this repository. -->
-    <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
+        <!-- Statements used to list all messages stored in this repository. -->
+        <sql name="listMessagesSQL">SELECT message_name, message_state, last_updated FROM ${table} WHERE repository_name = ? ORDER BY last_updated ASC</sql>
 
-    <!-- Statements used to count messages stored in this repository. -->
-    <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
+        <!-- Statements used to count messages stored in this repository. -->
+        <sql name="countMessagesSQL">SELECT COUNT(*) FROM ${table}</sql>
 
-    <!-- Statements used to create the table associated with this class. -->
-    <sql name="createTable" db="mysql">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (100) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients text NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers longblob NULL ,
-            last_updated datetime NOT NULL,
-            message_body longblob NOT NULL ,
-            message_attributes longblob NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="hypersonic">
-        CREATE CACHED TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients varchar NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers varchar NULL ,
-            last_updated timestamp NOT NULL,
-            message_body varchar NOT NULL ,
-            message_attributes varchar NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="hsqldb">
-        CREATE CACHED TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients varchar NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers varchar NULL ,
-            last_updated timestamp NOT NULL,
-            message_body varchar NOT NULL ,
-            message_attributes varchar NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="mssql">
-        CREATE TABLE [${table}] (
-            [message_name] [varchar] (200) NOT NULL,
-            [repository_name] [varchar] (255) NOT NULL,
-            [message_state] [varchar] (30) NOT NULL ,
-            [error_message] [varchar] (1000) NULL ,
-            [sender] [varchar] (255) NULL ,
-            [recipients] [text] NOT NULL ,
-            [remote_host] [varchar] (255) NOT NULL ,
-            [remote_addr] [varchar] (20) NOT NULL ,
-            [per_recipient_headers] [image] NULL ,
-            [last_updated] [datetime] NOT NULL,
-            [message_body] [image] NOT NULL ,
-            [message_attributes] [image] NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="oracle">
-        CREATE TABLE ${table} (
-            message_name varchar2(200) NOT NULL ,
-            repository_name varchar2(255) NOT NULL ,
-            message_state varchar2(30) NOT NULL ,
-            error_message varchar2(200) NULL ,
-            sender varchar2(255) ,
-            recipients varchar2(1000) NOT NULL ,
-            remote_host varchar2(100) NOT NULL ,
-            remote_addr varchar2(20) NOT NULL ,
-            per_recipient_headers blob NULL ,
-            last_updated date NOT NULL ,
-            message_body blob NOT NULL ,
-            message_attributes blob NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="postgresql">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (255) NULL ,
-            recipients text NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers oid NULL ,
-            last_updated timestamp NOT NULL,
-            message_body bytea NOT NULL ,
-            message_attributes bytea NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="sapdb">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (200) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) NULL ,
-            sender varchar (200) NULL ,
-            recipients long NOT NULL ,
-            remote_host varchar (100) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers long byte NULL ,
-            last_updated date NOT NULL,
-            message_body long byte NOT NULL ,
-            message_attributes long byte NULL ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="db2">
-        CREATE TABLE ${table} (
-            message_name varchar(200) NOT NULL ,
-            repository_name varchar(255) NOT NULL ,
-            message_state varchar(30) NOT NULL ,
-            error_message varchar(200) ,
-            sender varchar(255) ,
-            recipients varchar(1000) NOT NULL ,
-            remote_host varchar(100) NOT NULL ,
-            remote_addr varchar(20) NOT NULL ,
-            per_recipient_headers blob ,
-            last_updated timestamp NOT NULL ,
-            message_body blob NOT NULL ,
-            message_attributes blob ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-    <sql name="createTable" db="ingres">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) ,
-            sender varchar (255) ,
-            recipients LONG VARCHAR NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers LONG BYTE ,
-            last_updated DATE NOT NULL
-            message_body LONG BYTE NOT NULL ,
-            message_attributes LONG BYTE ,
-        )
-    </sql>
-    <sql name="createTable" db="derby">
-        CREATE TABLE ${table} (
-            message_name varchar (200) NOT NULL,
-            repository_name varchar (255) NOT NULL,
-            message_state varchar (30) NOT NULL ,
-            error_message varchar (200) ,
-            sender varchar (255) ,
-            recipients long varchar NOT NULL ,
-            remote_host varchar (255) NOT NULL ,
-            remote_addr varchar (20) NOT NULL ,
-            per_recipient_headers blob ,
-            last_updated timestamp NOT NULL,
-            message_body blob NOT NULL ,
-            message_attributes blob ,
-            PRIMARY KEY (repository_name, message_name)
-        )
-    </sql>
-</sqlDefs>
+        <!-- Statements used to create the table associated with this class. -->
+        <sql name="createTable" db="mysql">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (100) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients text NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers longblob NULL ,
+                last_updated datetime NOT NULL,
+                message_body longblob NOT NULL ,
+                message_attributes longblob NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="hypersonic">
+            CREATE CACHED TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients varchar NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers varchar NULL ,
+                last_updated timestamp NOT NULL,
+                message_body varchar NOT NULL ,
+                message_attributes varchar NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="hsqldb">
+            CREATE CACHED TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients varchar NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers varchar NULL ,
+                last_updated timestamp NOT NULL,
+                message_body varchar NOT NULL ,
+                message_attributes varchar NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="mssql">
+            CREATE TABLE [${table}] (
+                [message_name] [varchar] (200) NOT NULL,
+                [repository_name] [varchar] (255) NOT NULL,
+                [message_state] [varchar] (30) NOT NULL ,
+                [error_message] [varchar] (1000) NULL ,
+                [sender] [varchar] (255) NULL ,
+                [recipients] [text] NOT NULL ,
+                [remote_host] [varchar] (255) NOT NULL ,
+                [remote_addr] [varchar] (20) NOT NULL ,
+                [per_recipient_headers] [image] NULL ,
+                [last_updated] [datetime] NOT NULL,
+                [message_body] [image] NOT NULL ,
+                [message_attributes] [image] NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="oracle">
+            CREATE TABLE ${table} (
+                message_name varchar2(200) NOT NULL ,
+                repository_name varchar2(255) NOT NULL ,
+                message_state varchar2(30) NOT NULL ,
+                error_message varchar2(200) NULL ,
+                sender varchar2(255) ,
+                recipients varchar2(1000) NOT NULL ,
+                remote_host varchar2(100) NOT NULL ,
+                remote_addr varchar2(20) NOT NULL ,
+                per_recipient_headers blob NULL ,
+                last_updated date NOT NULL ,
+                message_body blob NOT NULL ,
+                message_attributes blob NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="postgresql">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (255) NULL ,
+                recipients text NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers oid NULL ,
+                last_updated timestamp NOT NULL,
+                message_body bytea NOT NULL ,
+                message_attributes bytea NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="sapdb">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (200) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) NULL ,
+                sender varchar (200) NULL ,
+                recipients long NOT NULL ,
+                remote_host varchar (100) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers long byte NULL ,
+                last_updated date NOT NULL,
+                message_body long byte NOT NULL ,
+                message_attributes long byte NULL ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="db2">
+            CREATE TABLE ${table} (
+                message_name varchar(200) NOT NULL ,
+                repository_name varchar(255) NOT NULL ,
+                message_state varchar(30) NOT NULL ,
+                error_message varchar(200) ,
+                sender varchar(255) ,
+                recipients varchar(1000) NOT NULL ,
+                remote_host varchar(100) NOT NULL ,
+                remote_addr varchar(20) NOT NULL ,
+                per_recipient_headers blob ,
+                last_updated timestamp NOT NULL ,
+                message_body blob NOT NULL ,
+                message_attributes blob ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+        <sql name="createTable" db="ingres">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) ,
+                sender varchar (255) ,
+                recipients LONG VARCHAR NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers LONG BYTE ,
+                last_updated DATE NOT NULL
+                message_body LONG BYTE NOT NULL ,
+                message_attributes LONG BYTE ,
+            )
+        </sql>
+        <sql name="createTable" db="derby">
+            CREATE TABLE ${table} (
+                message_name varchar (200) NOT NULL,
+                repository_name varchar (255) NOT NULL,
+                message_state varchar (30) NOT NULL ,
+                error_message varchar (200) ,
+                sender varchar (255) ,
+                recipients long varchar NOT NULL ,
+                remote_host varchar (255) NOT NULL ,
+                remote_addr varchar (20) NOT NULL ,
+                per_recipient_headers blob ,
+                last_updated timestamp NOT NULL,
+                message_body blob NOT NULL ,
+                message_attributes blob ,
+                PRIMARY KEY (repository_name, message_name)
+            )
+        </sql>
+    </sqlDefs>
 
 </sqlResources>
-


### PR DESCRIPTION
As [discussed on Gitter](https://gitter.im/apache/james-project?at=5daee7dca3f0b1784969e164) and described in a [Jira issue](https://issues.apache.org/jira/browse/JAMES-2929), this aligns and fixes the SQL resources only and changes the column type for `per_recepient_headers` to OID (for postgres only), so that it can work on postgres at all. The OID part is the quick workaround described in the related issue [JAMES-2828](https://issues.apache.org/jira/browse/JAMES-2828), for which I am looking into a proper solution.

Got rid of some trailing whitespace along the way.