### PR TITLE
JAMES-2911 Unable to send mail from James using an SMTP gateway

### DIFF
--- a/server/app/pom.xml
+++ b/server/app/pom.xml
@@ -312,6 +312,12 @@
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-mailet-dkim</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.javamail</groupId>
+                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>


### PR DESCRIPTION
[This](https://issues.apache.org/jira/browse/JAMES-2911) is a dependency/packaging issue. Adding an exclusion for the Geronimo javamail implementation to the Spring app's `pom.xml` made it work out-of-the-box again.

Someone more involved in the project might want to re-visit [JAMES-2827 remove geronimo library](https://github.com/apache/james-project/commit/82e2bf9fb7cdee4088aac954a856216c160ea033), since it actually *removes* exclusions in `server/mailet/dkim/pom.xml`, which is how the Geronimo `.jar`s in question came in. Is the activation `.jar` also supposed be excluded? If so, it should probably added to the Spring app's exclusions as well.

That aside, there's quite a few of other Geronimo `.jar`s in the project that end up being packaged in the Spring app - for JTA and JMS, there's even two different versions present...