### PR TITLE
JAMES-2972 Incorrect attribute name in the mailet configuration

### DIFF
--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToHeader.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToHeader.java
@@ -53,7 +53,7 @@ import net.fortuna.ical4j.model.component.VEvent;
  *
  * <pre>
  *     <code>
- *         &lt;mailet matcher=??? class=ICALToHeader&gt;
+ *         &lt;mailet match=??? class=ICALToHeader&gt;
  *             &lt;attribute&gt;icalendars&lt;/attribute&gt;
  *         &lt;/mailet&gt;
  *     </code>

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
@@ -78,7 +78,7 @@ import net.fortuna.ical4j.model.Calendar;
  *
  * <pre>
  *     <code>
- *         &lt;mailet matcher=??? class=ICALToJsonAttribute&gt;
+ *         &lt;mailet match=??? class=ICALToJsonAttribute&gt;
  *             &lt;sourceAttribute&gt;icalendars&lt;/sourceAttribute&gt;
  *             &lt;destinationAttribute&gt;icalendarJson&lt;/destinationAttribute&gt;
  *         &lt;/mailet&gt;

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/Null.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/Null.java
@@ -23,15 +23,20 @@ package org.apache.james.transport.mailets;
 
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simplest Mailet which destroys any incoming messages
  * by setting their state to GHOST
  */
 public class Null extends GenericMailet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Null.class);
 
     @Override
     public void service(Mail mail) {
+        LOGGER.debug("Null mailet is destroying mail {} from {} for {}", mail.getName(), mail.getMaybeSender(),
+                mail.getRecipients());
         mail.setState(Mail.GHOST);
     }
 

--- a/server/app/src/main/resources/mailetcontainer.xml
+++ b/server/app/src/main/resources/mailetcontainer.xml
@@ -56,13 +56,13 @@
        <!-- Important check to avoid looping -->
        <mailet match="RelayLimit=30" class="Null"/>
 
-        <mailet matcher="All" class="WithPriority">
+        <mailet match="All" class="WithPriority">
             <priority>8</priority>
         </mailet>
 
-        <mailet matcher="HasPriority=8" class="Null"/>
-        <mailet matcher="AtLeastPriority=8" class="Null"/>
-        <mailet matcher="AtMostPriority=8" class="Null"/>
+        <mailet match="HasPriority=8" class="Null"/>
+        <mailet match="AtLeastPriority=8" class="Null"/>
+        <mailet match="AtMostPriority=8" class="Null"/>
 
 
         <!-- Check attachment extensions for possible viruses -->

--- a/server/app/src/main/resources/mailetcontainer.xml
+++ b/server/app/src/main/resources/mailetcontainer.xml
@@ -56,14 +56,22 @@
        <!-- Important check to avoid looping -->
        <mailet match="RelayLimit=30" class="Null"/>
 
+        <!-- The WithPriority mailet allows to set a priority attribute on the mail. If the
+             attribute is set and priority handling is enabled it will take care of moving the
+             Mails with higher priority to the head of the queue (so the mails are faster handled). -->
+        <!--
         <mailet match="All" class="WithPriority">
             <priority>8</priority>
         </mailet>
-
+        -->
+        <!-- Using the following three matchers you can control the mail processing flow based
+             on the priority attribute. Note that if a mail's priority is set to 8, then all of
+             the below will match. -->
+        <!--
         <mailet match="HasPriority=8" class="Null"/>
         <mailet match="AtLeastPriority=8" class="Null"/>
         <mailet match="AtMostPriority=8" class="Null"/>
-
+        -->
 
         <!-- Check attachment extensions for possible viruses -->
        <!-- The "-z" option requests the check to be non-recursively applied -->

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
@@ -342,6 +342,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
                 } else {
                     // default matcher is All
                     matcher = matcherLoader.getMatcher(createMatcherConfig("All"));
+                    LOGGER.debug("Mailet {} has no 'match' attribute. Defaulting to match all mails.", mailetClassName);
                 }
 
                 // The matcher itself should log that it's been inited.

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/MetricsMailet.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/MetricsMailet.java
@@ -36,7 +36,7 @@ import com.google.common.base.Preconditions;
  *
  * Example :
  *
- * &lt;mailet matcher="all" class="MetricsMailet"&gt;
+ * &lt;mailet match="all" class="MetricsMailet"&gt;
  *     &lt;metricName&gt;relayDenied&lt;/metricName&gt;
  * &lt;/mailet&gt;
  *

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderDomainRepository.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderDomainRepository.java
@@ -56,7 +56,7 @@ import com.github.fge.lambdas.consumers.ThrowingConsumer;
  *
  *  Example:
  *
- * &lt;mailet matcher="All" class="ToSenderDomainRepository"&gt;
+ * &lt;mailet match="All" class="ToSenderDomainRepository"&gt;
  *     &lt;urlPrefix&gt;cassandra://var/mail/sendersRepositories/&lt;/urlPrefix&gt;
  *     &lt;passThrough&gt;false&lt;/passThrough&gt;
  *     &lt;allowRepositoryCreation&gt;true&lt;/allowRepositoryCreation&gt;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WithStorageDirective.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WithStorageDirective.java
@@ -45,7 +45,7 @@ import com.google.common.base.Strings;
  *
  *  Example:
  *
- *  <mailet matcher="IsMarkedAsSpam" class="WithStorageDirective">
+ *  <mailet match="IsMarkedAsSpam" class="WithStorageDirective">
  *      <targetFolderName>Spam</targetFolderName>
  *  </mailet>
  */

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/filter/JMAPFiltering.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/filter/JMAPFiltering.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  *
  * Example:
  *
- *  &lt;mailet matcher="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/&gt;
+ *  &lt;mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/&gt;
  */
 public class JMAPFiltering extends GenericMailet {
 


### PR DESCRIPTION
This fixes [JAMES-2972](https://issues.apache.org/jira/browse/JAMES-2972) by correcting all mailet's `matcher` attributes to `match`. It deactivates the `WithPriority` mailet and related matchers in the spring app's `mailetcontainer.xml`, since in the current state of the config, each and every mail will be dropped more or less silently.

Then I took the liberty to add two log messages on level DEBUG:

1. When a mailet's `match` attribute is empty, it [defaults to `match="All"` upon initializiation](https://github.com/apache/james-project/blob/master/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java#L343-L344). When that happens, a log message is now emitted.
    `Mailet WithPriority has no 'match' attribute. Defaulting to match all mails.`


2. A log message is now emitted when the `Null` mailet destroys a message. 
    `Null mailet is destroying mail Mail1573732431806-e461b5de-5567-4d21-bb9a-da193a791067 from MaybeSender{mailAddress=Optional[james@localhost]} for [nina@localhost]`

There is the requirement noted in JAMES-2972 to align the spring app's and docker-run-spring-app's `mailetcontainer.xml` with each other. [In the chat it was noted](https://gitter.im/apache/james-project?at=5dca5d81ea7d147cb3640f33), that the docker-run-spring-app's version should be preferred. But that version is very terse and does not have comments at all. Should the verbose one really be ditched? It'd recommend it the other way around (besides properly formatting the file).

----

NB: There are *a lot* of `mailetcontainer.xml`s in the project, but none is as "documented" as the spring app one.

```
size  crc32    location

3906  54a74d69 server/mailet/mailetcontainer-api/src/main/resources/mailetcontainer.xml
3946  e63a173d server/container/cli-integration/src/test/resources/mailetcontainer.xml
4008  5d7a5513 server/container/guice/jpa-smtp-mariadb/sample-configuration/mailetcontainer.xml
4008  5d7a5513 server/container/guice/jpa-smtp/sample-configuration/mailetcontainer.xml
4090  3b631531 mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/resources/mailetcontainer.xml
4090  3b631531 mpt/impl/smtp/cassandra/src/test/resources/mailetcontainer.xml
4209  77197879 dockerfiles/run/guice/jpa-smtp/destination/conf/mailetcontainer.xml
4233  b7604959 server/container/guice/memory-guice/sample-configuration/mailetcontainer.xml
4422  e1bd239a server/container/guice/cassandra-ldap-guice/src/test/resources/mailetcontainer.xml
4422  e1bd239a server/container/guice/cassandra-rabbitmq-ldap-guice/src/test/resources/mailetcontainer.xml
4484  b02a6ca0 server/protocols/webadmin-integration-test/src/test/resources/mailetcontainer.xml
4506  4898698d server/container/guice/jpa-smtp-mariadb/src/test/resources/mailetcontainer.xml
4506  4898698d server/container/guice/jpa-smtp/src/test/resources/mailetcontainer.xml
4543  4b3ae506 server/container/guice/jpa-guice/src/test/resources/mailetcontainer.xml
5363  2b193774 server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/mailetcontainer.xml
5365  9a3c1faa server/protocols/jmap-draft-integration-testing/cassandra-jmap-draft-integration-testing/src/test/resources/mailetcontainer.xml
5365  9a3c1faa server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/mailetcontainer.xml
5511  eeab8845 dockerfiles/run/guice/jpa/destination/conf/mailetcontainer.xml
5544  819ee4a5 dockerfiles/run/spring/destination/conf/mailetcontainer.xml
5709  ca2e8418 server/container/guice/cassandra-rabbitmq-guice/src/test/resources/mailetcontainer.xml
5833  23de4b5b dockerfiles/run/guice/cassandra-ldap/destination/conf/mailetcontainer.xml
5858  f6a91174 dockerfiles/packaging/guice/cassandra/package/etc/james/templates/mailetcontainer.xml
5863  7ad26bc2 server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
5926  f4a69f67 dockerfiles/run/guice/memory/destination/conf/mailetcontainer.xml
5938  1c46209b dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/mailetcontainer.xml
5938  1c46209b dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/mailetcontainer.xml
5938  1c46209b dockerfiles/run/guice/cassandra/destination/conf/mailetcontainer.xml
6043  7f97674b server/container/guice/cassandra-guice/src/test/resources/mailetcontainer.xml
6828  85519195 examples/custom-mailets/src/main/resources/mailetcontainer.xml
22941 1e55d2da server/app/src/main/resources/mailetcontainer.xml
```