### PR TITLE
JAMES-2986 NetMatcher's comma-separation requires space to be present

### DIFF
--- a/server/dns-service/dnsservice-library/src/main/java/org/apache/james/dnsservice/library/netmatcher/NetMatcher.java
+++ b/server/dns-service/dnsservice-library/src/main/java/org/apache/james/dnsservice/library/netmatcher/NetMatcher.java
@@ -20,7 +20,6 @@ package org.apache.james.dnsservice.library.netmatcher;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -34,6 +33,8 @@ import org.apache.james.dnsservice.library.inetnetwork.model.InetNetwork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Splitter;
+
 /**
  * NetMatcher Class is used to check if an ipAddress match a network.
  * 
@@ -43,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public class NetMatcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(NetMatcher.class);
 
-    public static final String NETS_SEPARATOR_PATTERN = ",\\s*";
+    public static final String NETS_SEPARATOR = ",";
 
     /**
      * The DNS Service used to build InetNetworks.
@@ -83,7 +84,7 @@ public class NetMatcher {
 
     public NetMatcher(String commaSeparatedNets, DNSService dnsServer) {
         this.dnsServer = dnsServer;
-        List<String> nets = Arrays.asList(commaSeparatedNets.split(NETS_SEPARATOR_PATTERN));
+        List<String> nets = Splitter.on(NETS_SEPARATOR).trimResults().splitToList(commaSeparatedNets);
         initInetNetworks(nets);
     }
 

--- a/server/dns-service/dnsservice-library/src/main/java/org/apache/james/dnsservice/library/netmatcher/NetMatcher.java
+++ b/server/dns-service/dnsservice-library/src/main/java/org/apache/james/dnsservice/library/netmatcher/NetMatcher.java
@@ -20,6 +20,7 @@ package org.apache.james.dnsservice.library.netmatcher;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -33,8 +34,6 @@ import org.apache.james.dnsservice.library.inetnetwork.model.InetNetwork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Splitter;
-
 /**
  * NetMatcher Class is used to check if an ipAddress match a network.
  * 
@@ -44,7 +43,7 @@ import com.google.common.base.Splitter;
 public class NetMatcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(NetMatcher.class);
 
-    public static final String NETS_SEPARATOR = ", ";
+    public static final String NETS_SEPARATOR_PATTERN = ",\\s*";
 
     /**
      * The DNS Service used to build InetNetworks.
@@ -84,7 +83,7 @@ public class NetMatcher {
 
     public NetMatcher(String commaSeparatedNets, DNSService dnsServer) {
         this.dnsServer = dnsServer;
-        List<String> nets = Splitter.on(NETS_SEPARATOR).splitToList(commaSeparatedNets);
+        List<String> nets = Arrays.asList(commaSeparatedNets.split(NETS_SEPARATOR_PATTERN));
         initInetNetworks(nets);
     }
 

--- a/server/dns-service/dnsservice-library/src/test/java/org/apache/james/dnsservice/library/netmatcher/NetMatcherTest.java
+++ b/server/dns-service/dnsservice-library/src/test/java/org/apache/james/dnsservice/library/netmatcher/NetMatcherTest.java
@@ -34,6 +34,16 @@ public class NetMatcherTest {
     private static NetMatcher netMatcher;
 
     /**
+     * Test ability to split expressions even when comma is not followed by a space.
+     */
+    @Test
+    public void testSplitterDoesNotRequireSpaceAfterComma() {
+        netMatcher = new NetMatcher("127.0.0.1,192.168.100.14/24,10.*", DNSFixture.DNS_SERVER_IPV4_MOCK);
+        assertThat(netMatcher.toString())
+                .isEqualTo("[10.0.0.0/255.0.0.0, 127.0.0.1/255.255.255.255, 192.168.100.0/255.255.255.0]");
+    }
+
+    /**
      * Test for IPV4 uniqueness.
      */
     @Test


### PR DESCRIPTION
Fixes [JAMES-2986](https://issues.apache.org/jira/browse/JAMES-2986#).

Allows for "true comma-separation" as in, don't require a space to follow the comma.

Test is included.