### PR TITLE
JAMES-3187 Provisionned docker: add a cli helper script

### DIFF
--- a/dockerfiles/run/guice/provisioned/Dockerfile
+++ b/dockerfiles/run/guice/provisioned/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM linagora/james-jpa-guice
+FROM linagora/james-jpa-guice:james-project-3.4.0
 
 # Install git
 RUN apt-get update
@@ -15,6 +15,7 @@ RUN cp /root/wait-for-it/wait-for-it.sh /usr/bin/wait-for-it.sh
 
 COPY startup.sh /root
 COPY initialdata.sh /root
+COPY james-cli /usr/local/bin/
 
 RUN chmod +x /root/startup.sh
 RUN chmod +x /root/initialdata.sh

--- a/dockerfiles/run/guice/provisioned/james-cli
+++ b/dockerfiles/run/guice/provisioned/james-cli
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+java -jar /root/james-cli.jar -h 127.0.0.1 -p 9999 "$@"


### PR DESCRIPTION
Turns the pain of

```
docker exec james java -jar /root/james-cli.jar -h 127.0.0.1 -p 9999 listUsers
```

Into:

```
docker exec james james-cli listUsers
```

See https://github.com/apache/james-project/pull/191#discussion_r426521321

Question:

 - Shouldn't we generalize the adoption to all of our docker images ?
 - Doing so will simplyfy the README by making no difference for CLI invocation between Guice and spring profiles...
 - Also, packaging this change as part of upcoming 3.5.0 wouldcompose well with the ongoing documentation effort.