### PR TITLE
Update gitignore to ignore jenv and Eclipse configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ dockerfiles/run/**/glowroot
 .m2
 test-run.log
 build
+.java-version
+/**/.project
+/**/.classpath
+/**/.settings/


### PR DESCRIPTION
As per [JAMES-3185](https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3185):

I am using jenv (which allows me to select the correct version of java for compiling James) and Eclispe as my IDE. These tools have configuration files that should not be committed, but make my local git repository messy. Would be great to update .gitignore to allow users of those tools to ignore the config files.