### PR TITLE
JAMES-3187 Add webadmin enabled by default to jpa-guice docker image

### DIFF
--- a/dockerfiles/run/guice/jpa/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/jpa/destination/conf/webadmin.properties
@@ -1,0 +1,48 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+#  This template file can be used as example for James Server configuration
+#  DO NOT USE IT AS SUCH AND ADAPT IT TO YOUR NEEDS
+
+# Read https://james.apache.org/server/config-webadmin.html for further details
+
+enabled=true
+port=8000
+host=localhost
+
+# Defaults to false
+https.enabled=false
+
+# Compulsory when enabling HTTPS
+#https.keystore=/path/to/keystore
+#https.password=password
+
+# Optional when enabling HTTPS (self signed)
+#https.trust.keystore
+#https.trust.password
+
+# Defaults to false
+#jwt.enabled=true
+
+# Defaults to false
+#cors.enable=true
+#cors.origin
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+#extensions.routes=


### PR DESCRIPTION
Relates to https://github.com/apache/james-project/pull/191/commits/5905a1dfad8c4e97a7a0fb34b5201b66a23bec73#r426520378

