### PR TITLE
[RELEASE] git-commit-id-plugin should not fail when no git directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3305,6 +3305,7 @@
                     </includeOnlyProperties>
                     <skip>false</skip>
                     <useNativeGit>true</useNativeGit>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <gitDescribe>
                         <skip>false</skip>
                         <always>false</always>


### PR DESCRIPTION
People compiling downloaded sources don't have a git environment setted up,
we should not abort their compilation, while keeping useful git information
shipped into the JARs when there is a git environment.