### PR TITLE
Redirect notifications to the new notifications@james.apache.org ML

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -7,3 +7,9 @@ github:
     - imap
     - smtp
     - jmap
+
+notifications:
+  commits:      notifications@james.apache.org
+  issues:       notifications@james.apache.org
+  pullrequests: notifications@james.apache.org
+  jira_options: link label comment


### PR DESCRIPTION
Following comments from https://issues.apache.org/jira/browse/INFRA-20735 and https://www.mail-archive.com/server-dev@james.apache.org/msg68227.html

Should not merge before the ML is created (I believe as I commiter I do not have the right to create it myself^^)

