### PR TITLE
Improve readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -161,17 +161,17 @@ You need a running *rabbitmq* in docker. To achieve this run:
 
 You need a running *s3* compatible objectstorage in docker. To achieve this run:
 
-    $ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 zenko/cloudserver:8.2.6
+    $ docker run -d -p 8080:8000 --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 zenko/cloudserver:8.2.6
 
 You need a running *ElasticSearch* in docker. To achieve this run:
 
     $ docker run -d --name=elasticsearch --env 'discovery.type=single-node' docker.elastic.co/elasticsearch/elasticsearch:6.3.2
 
-If you want to use all the JMAP search capabilities, you may also need to start Tika:
+If you want to handle attachment text extraction before indexing in ElasticSearch (this makes attachments searchable)
+and if you want to use all the JMAP search capabilities, you also need to start *Tika*.
+See http://james.apache.org/server/config-elasticsearch.html#Tika_Configuration[Tika configuration documentation] for more info.
 
     $ docker run -d --name=tika apache/tika:1.24
-
-You can find more explanation on the need of Tika in this page http://james.apache.org/server/config-elasticsearch.html
 
 We need to provide the key we will use for TLS. For obvious reasons, this is not provided in this git.
 
@@ -190,7 +190,8 @@ To run this container :
 
 Where :
 
-- HOSTNAME: is the hostname you want to give to your James container. This DNS entry will be used to send mail to your James server.
+- HOSTNAME is the hostname you want to give to your James container. This DNS entry will be used to send mail to your James server.
+- link to tika is only needed if you started tika earlier.
 
 Webadmin port binding is restricted to loopback as users are not authenticated by default on webadmin server. Thus you should avoid exposing it in production.
 Note that the above example assumes `127.0.0.1` is your loopback interface for convenience but you should change it if this is not the case on your machine.
@@ -215,18 +216,6 @@ See the https://github.com/glowroot/glowroot/wiki/Agent-Installation-(with-Embed
 Or by mapping the 4000 port to the IP of the desired network interface, for example `-p 127.0.0.1:4000:4000`.
 
 
-==== Handling attachment indexing
-
-You can handle attachment text extraction before indexing in ElasticSearch. This makes attachments searchable. To enable this:
-
-Run tika:
-
-    $ docker run --name tika apache/tika:1.24
-
-Add a link for the tika container in the above command line:
-
-    $ docker run --hostname HOSTNAME -p "25:25" -p 80:80 -p "110:110" -p "143:143" -p "465:465" -p "587:587" -p "993:993" --link cassandra:cassandra --link rabbitmq:rabbitmq
-    --link elasticsearch:elasticsearch --link tika:tika --name james_run -t james_run
 
 === Run James with Guice + Cassandra + ElasticSearch
 
@@ -250,11 +239,11 @@ You need a running *ElasticSearch* in docker. To achieve this run:
 
     $ docker run -d --name=elasticsearch --env 'discovery.type=single-node' docker.elastic.co/elasticsearch/elasticsearch:6.3.2
 
-If you want to use all the JMAP search capabilities, you may also need to start Tika:
+If you want to handle attachment text extraction before indexing in ElasticSearch (this makes attachments searchable)
+and if you want to use all the JMAP search capabilities, you also need to start *Tika*.
+See http://james.apache.org/server/config-elasticsearch.html#Tika_Configuration[Tika configuration documentation] for more info.
 
     $ docker run -d --name=tika apache/tika:1.24
-
-You can find more explanation on the need of Tika in this page http://james.apache.org/server/config-elasticsearch.html
 
 We need to provide the key we will use for TLS. For obvious reasons, this is not provided in this git.
 
@@ -272,24 +261,13 @@ To run this container :
 
 Where :
 
-- HOSTNAME: is the hostname you want to give to your James container. This DNS entry will be used to send mail to your James server.
+- HOSTNAME is the hostname you want to give to your James container. This DNS entry will be used to send mail to your James server.
+- link to tika is only needed if you started tika earlier.
 
 Webadmin port binding is restricted to loopback as users are not authenticated by default on webadmin server. Thus you should avoid exposing it in production.
 Note that the above example assumes `127.0.0.1` is your loopback interface for convenience but you should change it if this is not the case on your machine.
 
 To have log file accessible on a volume, add *-v  $PWD/logs:/logs* option to the above command line, where *$PWD/logs* is your local directory to put files in.
-
-==== Handling attachment indexing
-
-You can handle attachment text extraction before indexing in ElasticSearch. This makes attachments searchable. To enable this:
-
-Run tika:
-
-    $ docker run --name tika apache/tika:1.24
-
-Add a link for the tika container in the above command line:
-
-    $ docker run --hostname HOSTNAME -p "25:25" -p 80:80 -p "110:110" -p "143:143" -p "465:465" -p "587:587" -p "993:993" --link cassandra:cassandra --link elasticsearch:elasticsearch --link tika:tika --name james_run -t james_run
 
 === Run James with Guice + JPA + Lucene
 

--- a/README.adoc
+++ b/README.adoc
@@ -40,8 +40,6 @@ There is many other ways one can help us: packaging, communication, etc ...
 = How to...
 
  * link:#how-to-try-james[How to try James]
- * link:#how-to-build-and-publish-the-website[How to build and publish the website]
- * link:#how-to-release-via-maven-release-plugin[How to release via maven release plugin]
  * link:#how-to-check-the-compilation[How to check the compilation]
  * link:#how-to-run-james-in-docker[How to run James in Docker]
  ** link:#run-james-with-%2Dguice-%2Dcassandra-%2Drabbitmq-%2Ds3-%2Delasticsearch[Run James with Guice + Cassandra + RabbitMQ + S3 + ElasticSearch]
@@ -58,6 +56,9 @@ There is many other ways one can help us: packaging, communication, etc ...
  ** link:#how-to-check-the-merge-of-a-commit[How to check the merge of a commit]
  * link:#generating-a-package-for-james[Generating a package for James]
  * link:#know-more-about-james-design[Know more about James design]
+ * link:#articles-for-james-community[Articles for James community]
+ ** link:#how-to-build-and-publish-the-website[How to build and publish the website]
+ ** link:#how-to-release-via-maven-release-plugin[How to release via maven release plugin]
 
 == How to try James
 
@@ -85,74 +86,6 @@ A default domain, james.local, has been created. You can see this by running:
 James will respond to IMAP port 143 and SMTP port 25.
 You have to create users before playing with james. You may also want to create other domains.
 Follow the 'Useful commands' section for more information about James CLI.
-
-
-== How to build and publish the website
-
- 1. Install Apache Maven 3.0.2+ and make its binary 'mvn' available on your PATH.
-    See http://maven.apache.org/download.html#Installation.
- 2. run "mvn clean site"
- 3. Test the built site in your browser from the {path}/target/site folder
- 4. If everything looks OK, deploy the site using "mvn clean site-deploy".
- 5. Wait for the changes to replicate to the Apache web server or setup 140.211.11.10:80 as
-    a proxy to review the changes (described here: http://www.apache.org/dev/project-site.html)
-
-To deploy the technical reports use the "-Psite-reports" profile.
-
-For wagon-ssh-external configuration see
-http://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-ssh-external.html
-
-You can alternatively use a docker container to build the website :
-
-You need to build the homepage by:
-
-    $ docker build -t james/homepage dockerfiles/site/homepage
-    $ docker run -v $PWD:/origin -v $PWD/site:/destination james/homepage master
-
-In order to test the homepage, you can use this command:
-
-    $ docker run --rm -v $PWD/site:/srv/jekyll  -p 4000:4000 -it jekyll/minimal:3.8.3 jekyll serve
-
-the site will be available at http://localhost:4000/
-
-Then you build the other pages by:
-
-    $ docker build -t james/site dockerfiles/site/website
-    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD:/origin -v $PWD/site:/destination james/site master
-
-If you need to update the current site, checkout the branch asf-site from Apache git:
-
-    $ git clone https://git-wip-us.apache.org/repos/asf/james-site.git
-    $ cd james-site
-    $ git checkout origin/asf-site -b asf-site
-
-And replace in the previous commands `$PWD/site` by `<james-site-clone-directory>/content`, for example:
-
-    $ docker run -v $PWD:/origin -v $PWD/../james-site/content:/destination james/homepage master
-    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD/../james-site/content:/origin -v $PWD/site:/destination james/site master
-
-Then just push the new site:
-
-    $ cd ../james-site
-    $ git push origin asf-site
-
-== How to release via maven release plugin
-
-See details on http://www.apache.org/dev/publishing-maven-artifacts.html
-
-In short, just follow the 'standard' process:
-
-* Prepare pom for release
-* publish snapshot
-* prepare release
-* stage the release for a vote (don't forget to close the staging repository)
-* vote
-* release
-
-Don't forget to add your key to https://downloads.apache.org/james/KEYS
-
-    $ ssh people.apache.org
-    $ cd /www/www.apache.org/dist/james
 
 
 == How to check the compilation
@@ -576,3 +509,76 @@ By default James is configured without LDAP support.
 == Know more about James design
 
 James comes with a https://james.apache.org/documentation.html[Documentation] and https://github.com/linagora/james-project/tree/master/src/adr[Architectural Decision Records].
+
+== Articles for James community
+
+=== How to build and publish the website
+
+The source code of website https://james.apache.org[james.apache.org] is located in src/homepage.
+Here are the instructions how to publish new changes to the website.
+
+1. Install Apache Maven 3.0.2+ and make its binary 'mvn' available on your PATH.
+See http://maven.apache.org/download.html#Installation.
+2. run "mvn clean site"
+3. Test the built site in your browser from the {path}/target/site folder
+4. If everything looks OK, deploy the site using "mvn clean site-deploy".
+5. Wait for the changes to replicate to the Apache web server or setup 140.211.11.10:80 as
+a proxy to review the changes (described here: http://www.apache.org/dev/project-site.html)
+
+To deploy the technical reports use the "-Psite-reports" profile.
+
+For wagon-ssh-external configuration see
+http://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-ssh-external.html
+
+You can alternatively use a docker container to build the website :
+
+You need to build the homepage by:
+
+    $ docker build -t james/homepage dockerfiles/site/homepage
+    $ docker run -v $PWD:/origin -v $PWD/site:/destination james/homepage master
+
+In order to test the homepage, you can use this command:
+
+    $ docker run --rm -v $PWD/site:/srv/jekyll  -p 4000:4000 -it jekyll/minimal:3.8.3 jekyll serve
+
+the site will be available at http://localhost:4000/
+
+Then you build the other pages by:
+
+    $ docker build -t james/site dockerfiles/site/website
+    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD:/origin -v $PWD/site:/destination james/site master
+
+If you need to update the current site, checkout the branch asf-site from Apache git:
+
+    $ git clone https://git-wip-us.apache.org/repos/asf/james-site.git
+    $ cd james-site
+    $ git checkout origin/asf-site -b asf-site
+
+And replace in the previous commands `$PWD/site` by `<james-site-clone-directory>/content`, for example:
+
+    $ docker run -v $PWD:/origin -v $PWD/../james-site/content:/destination james/homepage master
+    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD/../james-site/content:/origin -v $PWD/site:/destination james/site master
+
+Then just push the new site:
+
+    $ cd ../james-site
+    $ git push origin asf-site
+
+=== How to release via maven release plugin
+
+See details on http://www.apache.org/dev/publishing-maven-artifacts.html
+
+In short, just follow the 'standard' process:
+
+* Prepare pom for release
+* publish snapshot
+* prepare release
+* stage the release for a vote (don't forget to close the staging repository)
+* vote
+* release
+
+Don't forget to add your key to https://downloads.apache.org/james/KEYS
+
+    $ ssh people.apache.org
+    $ cd /www/www.apache.org/dist/james
+

--- a/README.adoc
+++ b/README.adoc
@@ -161,7 +161,7 @@ You need a running *rabbitmq* in docker. To achieve this run:
 
 You need a running *s3* compatible objectstorage in docker. To achieve this run:
 
-    $ docker run -d -p 8080:8000 --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 zenko/cloudserver:8.2.6
+    $ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 zenko/cloudserver:8.2.6
 
 You need a running *ElasticSearch* in docker. To achieve this run:
 
@@ -490,73 +490,5 @@ James comes with a https://james.apache.org/documentation.html[Documentation] an
 
 == Articles for James community
 
-=== How to build and publish the website
-
-The source code of website https://james.apache.org[james.apache.org] is located in src/homepage.
-Here are the instructions how to publish new changes to the website.
-
-1. Install Apache Maven 3.0.2+ and make its binary 'mvn' available on your PATH.
-See http://maven.apache.org/download.html#Installation.
-2. run "mvn clean site"
-3. Test the built site in your browser from the {path}/target/site folder
-4. If everything looks OK, deploy the site using "mvn clean site-deploy".
-5. Wait for the changes to replicate to the Apache web server or setup 140.211.11.10:80 as
-a proxy to review the changes (described here: http://www.apache.org/dev/project-site.html)
-
-To deploy the technical reports use the "-Psite-reports" profile.
-
-For wagon-ssh-external configuration see
-http://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-ssh-external.html
-
-You can alternatively use a docker container to build the website :
-
-You need to build the homepage by:
-
-    $ docker build -t james/homepage dockerfiles/site/homepage
-    $ docker run -v $PWD:/origin -v $PWD/site:/destination james/homepage master
-
-In order to test the homepage, you can use this command:
-
-    $ docker run --rm -v $PWD/site:/srv/jekyll  -p 4000:4000 -it jekyll/minimal:3.8.3 jekyll serve
-
-the site will be available at http://localhost:4000/
-
-Then you build the other pages by:
-
-    $ docker build -t james/site dockerfiles/site/website
-    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD:/origin -v $PWD/site:/destination james/site master
-
-If you need to update the current site, checkout the branch asf-site from Apache git:
-
-    $ git clone https://git-wip-us.apache.org/repos/asf/james-site.git
-    $ cd james-site
-    $ git checkout origin/asf-site -b asf-site
-
-And replace in the previous commands `$PWD/site` by `<james-site-clone-directory>/content`, for example:
-
-    $ docker run -v $PWD:/origin -v $PWD/../james-site/content:/destination james/homepage master
-    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD/../james-site/content:/origin -v $PWD/site:/destination james/site master
-
-Then just push the new site:
-
-    $ cd ../james-site
-    $ git push origin asf-site
-
-=== How to release via maven release plugin
-
-See details on http://www.apache.org/dev/publishing-maven-artifacts.html
-
-In short, just follow the 'standard' process:
-
-* Prepare pom for release
-* publish snapshot
-* prepare release
-* stage the release for a vote (don't forget to close the staging repository)
-* vote
-* release
-
-Don't forget to add your key to https://downloads.apache.org/james/KEYS
-
-    $ ssh people.apache.org
-    $ cd /www/www.apache.org/dist/james
-
+* link:docs/modules/community/pages/website.adoc[How to build and publish the website]
+* link:docs/modules/community/pages/release.adoc[How to release via maven release plugin]

--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ There is many other ways one can help us: packaging, communication, etc ...
  * link:#how-to-try-james[How to try James]
  * link:#how-to-check-the-compilation[How to check the compilation]
  * link:#how-to-run-james-in-docker[How to run James in Docker]
- ** link:#run-james-with-%2Dguice-%2Dcassandra-%2Drabbitmq-%2Ds3-%2Delasticsearch[Run James with Guice + Cassandra + RabbitMQ + S3 + ElasticSearch]
+ ** link:#run-james-with-guice-%2Dcassandra-%2Drabbitmq-%2Ds3-%2Delasticsearch[Run James with Guice + Cassandra + RabbitMQ + S3 + ElasticSearch]
  ** link:#run-james-with-guice-%2Dcassandra-%2Delasticsearch[Run James with Guice + Cassandra + ElasticSearch]
  ** link:#run-james-with-guice-%2Djpa-%2Dlucene[Run James with Guice + JPA + Lucene]
  ** link:#run-james-with-spring-%2Djpa[Run James with Spring + JPA]

--- a/README.adoc
+++ b/README.adoc
@@ -131,10 +131,10 @@ If you are using a a fresh installation of Docker, your DOCKER_HOST should be un
 
 This feature is available for three configurations :
 
- * Guice + Cassandra + RabbitMQ + S3 + ElasticSearch
- * Guice + Cassandra + ElasticSearch
- * Guice + JPA + Lucene
- * Spring + JPA
+ * link:#run-james-with-guice-%2Dcassandra-%2Drabbitmq-%2Ds3-%2Delasticsearch[Guice + Cassandra + RabbitMQ + S3 + ElasticSearch]
+ * link:#run-james-with-guice-%2Dcassandra-%2Delasticsearch[Guice + Cassandra + ElasticSearch]
+ * link:#run-james-with-guice-%2Djpa-%2Dlucene[Guice + JPA + Lucene]
+ * link:#run-james-with-spring-%2Djpa[Spring + JPA]
 
 
 === Run James with Guice + Cassandra + RabbitMQ + S3 + ElasticSearch

--- a/docs/modules/community/nav.adoc
+++ b/docs/modules/community/nav.adoc
@@ -3,6 +3,8 @@
 ** xref:contributing.adoc[]
 ** xref:guidelines.adoc[]
 ** xref:download.adoc[]
+** xref:website.adoc[]
+** xref:release.adoc[]
 ** xref:support.adoc[]
 ** Apache Software Foundation
 *** https://www.apache.org/[ASF]

--- a/docs/modules/community/pages/index.adoc
+++ b/docs/modules/community/pages/index.adoc
@@ -27,6 +27,11 @@ and bug reports. We more than welcome non-coding contributions.
 
 You can find more information on how to contribute to the James project on the xref:contributing.adoc[contributing] section.
 
+== Articles for contributors
+
+** xref:website.adoc[]
+** xref:release.adoc[]
+
 == The Apache Software Foundation
 
 James is a project belonging to the https://www.apache.org/[Apache Software Foundation [ASF\]]. Thus, the Apache Jame project

--- a/docs/modules/community/pages/mailing-lists.adoc
+++ b/docs/modules/community/pages/mailing-lists.adoc
@@ -17,7 +17,7 @@ You can browse the mailing list archives online using the https://lists.apache.o
 *Low traffic*
 mailto:server-user-subscribe@james.apache.org[Subscribe]
 mailto:server-user-unsubscribe@james.apache.org[Unsubscribe]
-https://lists.apache.org/list.html?server-user@james.apache.org[Archive]
+link:++https://lists.apache.org/list.html?server-user@james.apache.org++[Archive]
 
 This is the list where users of the Apache James (Server) meet and discuss issues. Developers are also expected to be
 subscribed to this list to offer support to users of Apache James (Server).
@@ -27,7 +27,7 @@ subscribed to this list to offer support to users of Apache James (Server).
 *Medium traffic*
 mailto:server-dev-subscribe@james.apache.org[Subscribe]
 mailto:server-dev-unsubscribe@james.apache.org[Unsubscribe]
-https://lists.apache.org/list.html?server-dev@james.apache.org[Archive]
+link:++https://lists.apache.org/list.html?server-dev@james.apache.org++[Archive]
 
 This is the list where participating developers of the Apache James Project meet and discuss issues, code changes/additions,
 etc. Do not send mail to this list with usage questions or configuration problems -- that's what server-user@james is for.
@@ -37,7 +37,7 @@ etc. Do not send mail to this list with usage questions or configuration problem
 *Medium traffic*
 mailto:mime4j-dev-subscribe@james.apache.org[Subscribe]
 mailto:mime4j-dev-unsubscribe@james.apache.org[Unsubscribe]
-https://lists.apache.org/list.html?mime4j-dev@james.apache.org[Archive]
+link:++https://lists.apache.org/list.html?mime4j-dev@james.apache.org++[Archive]
 
 Discussions on the http://james.apache.org/mime4j[Mime4j] parser library.
 
@@ -46,7 +46,7 @@ Discussions on the http://james.apache.org/mime4j[Mime4j] parser library.
 *Low traffic*
 mailto:general-subscribe@james.apache.org[Subscribe]
 mailto:general-unsubscribe@james.apache.org[Unsubscribe]
-https://lists.apache.org/list.html?general@james.apache.org[Archive]
+link:++https://lists.apache.org/list.html?general@james.apache.org++[Archive]
 
 This is the list for general discussions related to the running of the project, it is the public list of the
 James project management committee (PMC) and is a public list opened to all. Do not send mail to this list with James
@@ -57,7 +57,7 @@ software problems -- that's what server-user@james is for.
 *High traffic*
 mailto:notifications-subscribe@james.apache.org[Subscribe]
 mailto:notifications-unsubscribe@james.apache.org[Unsubscribe]
-https://lists.apache.org/list.html?notifications@james.apache.org[Archive]
+link:++https://lists.apache.org/list.html?notifications@james.apache.org++[Archive]
 
 Subscribers to this list get notices of each and every code change, build results, testing notices, etc. This list is
 not for asking help, raising issues or starting discussions on the james product -- other mailing lists are specifically

--- a/docs/modules/community/pages/release.adoc
+++ b/docs/modules/community/pages/release.adoc
@@ -1,0 +1,17 @@
+= How to create an official Apache James release
+
+Read details about http://www.apache.org/dev/publishing-maven-artifacts.html[Publishing Maven releases to Maven Central Repository]
+
+In short, just follow the 'standard' process:
+
+* prepare pom for release
+* publish snapshot
+* prepare release
+* stage the release for a vote (don't forget to close the staging repository)
+* vote
+* release
+
+Don't forget to add your key to https://downloads.apache.org/james/KEYS
+
+    $ ssh people.apache.org
+    $ cd /www/www.apache.org/dist/james

--- a/docs/modules/community/pages/release.adoc
+++ b/docs/modules/community/pages/release.adoc
@@ -1,4 +1,4 @@
-= How to create an official Apache James release
+= Creating an official Apache James release
 
 Read details about http://www.apache.org/dev/publishing-maven-artifacts.html[Publishing Maven releases to Maven Central Repository]
 

--- a/docs/modules/community/pages/website.adoc
+++ b/docs/modules/community/pages/website.adoc
@@ -1,0 +1,51 @@
+= Building and publishing the website
+
+The source code of website https://james.apache.org[james.apache.org] is located in src/homepage.
+Here are the instructions how to publish new changes to the website.
+
+1. Install Apache Maven 3.0.2+ and make its binary 'mvn' available on your PATH.
+See http://maven.apache.org/download.html#Installation.
+2. run "mvn clean site"
+3. Test the built site in your browser from the {path}/target/site folder
+4. If everything looks OK, deploy the site using "mvn clean site-deploy".
+5. Wait for the changes to replicate to the Apache web server or setup 140.211.11.10:80 as
+a proxy to review the changes (described here: http://www.apache.org/dev/project-site.html)
+
+To deploy the technical reports use the "-Psite-reports" profile.
+
+For wagon-ssh-external configuration see
+http://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-ssh-external.html
+
+You can alternatively use a docker container to build the website :
+
+You need to build the homepage by:
+
+    $ docker build -t james/homepage dockerfiles/site/homepage
+    $ docker run -v $PWD:/origin -v $PWD/site:/destination james/homepage master
+
+In order to test the homepage, you can use this command:
+
+    $ docker run --rm -v $PWD/site:/srv/jekyll  -p 4000:4000 -it jekyll/minimal:3.8.3 jekyll serve
+
+the site will be available at http://localhost:4000/
+
+Then you build the other pages by:
+
+    $ docker build -t james/site dockerfiles/site/website
+    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD:/origin -v $PWD/site:/destination james/site master
+
+If you need to update the current site, checkout the branch asf-site from Apache git:
+
+    $ git clone https://git-wip-us.apache.org/repos/asf/james-site.git
+    $ cd james-site
+    $ git checkout origin/asf-site -b asf-site
+
+And replace in the previous commands `$PWD/site` by `<james-site-clone-directory>/content`, for example:
+
+    $ docker run -v $PWD:/origin -v $PWD/../james-site/content:/destination james/homepage master
+    $ docker run -v $PWD/.m2:/root/.m2 -v $PWD/../james-site/content:/origin -v $PWD/site:/destination james/site master
+
+Then just push the new site:
+
+    $ cd ../james-site
+    $ git push origin asf-site


### PR DESCRIPTION
* move sections (publishing website, releasing) that are only relevant to few community members to the end of the readme
* fix broken link in table of contents
* turn different configuration list items into links to respective sections
* remove separate chapters "Handling attachment indexing" and include the same info into respective place in documentation (to avoid information being repeated in several places)