### PR TITLE
Rename tests with conflicting names 

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinIntegrationTest.java
@@ -55,7 +55,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
-public class SpamAssassinTest {
+public class SpamAssassinIntegrationTest {
     private static final String SPAM_CONTENT = "XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X";
 
     @ClassRule

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIngtegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIngtegrationTest.java
@@ -51,7 +51,7 @@ import org.junit.rules.TemporaryFolder;
 
 import io.restassured.specification.RequestSpecification;
 
-public class ToRepositoryTest {
+public class ToRepositoryIngtegrationTest {
     private static final String RECIPIENT = "touser@" + DEFAULT_DOMAIN;
     public static final MailRepositoryUrl CUSTOM_REPOSITORY = MailRepositoryUrl.from("memory://var/mail/custom/");
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIngtegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIngtegrationTest.java
@@ -51,7 +51,7 @@ import org.junit.rules.TemporaryFolder;
 
 import io.restassured.specification.RequestSpecification;
 
-public class ToRepositoryIngtegrationTest {
+public class ToRepositoryIntegrationTest {
     private static final String RECIPIENT = "touser@" + DEFAULT_DOMAIN;
     public static final MailRepositoryUrl CUSTOM_REPOSITORY = MailRepositoryUrl.from("memory://var/mail/custom/");
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToSenderDomainRepositoryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToSenderDomainRepositoryIntegrationTest.java
@@ -41,7 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class ToSenderDomainRepositoryTest {
+public class ToSenderDomainRepositoryIntegrationTest {
 
     private static final String RECIPIENT = "touser@" + DEFAULT_DOMAIN;
     private static final String CUSTOM_REPOSITORY_PREFIX = "memory://var/mail/custom/";


### PR DESCRIPTION
tests exist with same name and package in https://github.com/apache/james-project/tree/master/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets