### PR TITLE
Redirect to JMAP session resource from /.well-known/jmap

### DIFF
--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPRoutes.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPRoutes.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 
 import java.util.stream.Stream;
@@ -40,6 +41,10 @@ public interface JMAPRoutes {
             .header("Access-Control-Allow-Origin", "*")
             .header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT")
             .header("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept"));
+    }
+
+    static JMAPRoute.Action redirectTo(String location) {
+        return (req, res) -> res.status(PERMANENT_REDIRECT).header("Location", location).send();
     }
 
     default Mono<Void> handleInternalError(HttpServerResponse response, Logger logger, Throwable e) {


### PR DESCRIPTION
Section 2.2 of RFC 8620 is as follows:

> ## 2.2. Service Autodiscovery
>
> There are two standardised autodiscovery methods in use for Internet protocols:
>
> - **DNS SRV** (see [@!RFC2782], [@!RFC6186], and [@!RFC6764])
> - **.well-known/servicename** (see [@!RFC8615])
>
> A JMAP-supporting host for the domain `example.com` SHOULD publish a SRV record `_jmap._tcp.example.com` that gives a *hostname* and *port* (usually port `443`). The JMAP Session resource is then `https://${hostname}[:${port}]/.well-known/jmap` (following any redirects).
>
> If the client has a username in the form of an email address, it MAY use the domain portion of this to attempt autodiscovery of the JMAP server.

James' implementation exposes the JMAP Session Resource at `/jmap/session`. Clients which expect it at `/.well-known/jmap` are unable to find it.

The spec language ("SHOULD") is a strong recommendation and not a requirement, so it's acceptable if there's a good reason to disregard it - but I'm not personally aware of one, and in any case the choice ought to be documented somewhere. I tried to set up a James server for testing a JMAP client implementation and couldn't figure out why it wasn't working until I dug into the source code.