### PR TITLE
Use RFC6570 Level 1 URI Template for JMAP downloadUrl

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
@@ -102,7 +102,7 @@ object SessionRoutesContract {
                          |  },
                          |  "username" : "bob@domain.tld",
                          |  "apiUrl" : "http://domain.com/jmap",
-                         |  "downloadUrl" : "http://domain.com/download/$accountId/$blobId/?type=$type&name=$name",
+                         |  "downloadUrl" : "http://domain.com/download/{accountId}/{blobId}/?type={type}&name={name}",
                          |  "uploadUrl" : "http://domain.com/upload",
                          |  "eventSourceUrl" : "http://domain.com/eventSource",
                          |  "state" : "000001"

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
@@ -36,7 +36,7 @@ object JmapRfc8621Configuration {
 case class JmapRfc8621Configuration(urlPrefixString: String) {
   val urlPrefix: URL = new URL(urlPrefixString)
   val apiUrl: URL = new URL(s"$urlPrefixString/jmap")
-  val downloadUrl: URL = new URL(urlPrefixString + "/download/$accountId/$blobId/?type=$type&name=$name")
+  val downloadUrl: URL = new URL(urlPrefixString + "/download/{accountId}/{blobId}/?type={type}&name={name}")
   val uploadUrl: URL = new URL(s"$urlPrefixString/upload")
   val eventSourceUrl: URL = new URL(s"$urlPrefixString/eventSource")
 }

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/http/SessionRoutesTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/http/SessionRoutesTest.scala
@@ -114,7 +114,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
       .thenReturn
         .getBody
         .asString()
-    val downloadPath: String = "download/$accountId/$blobId/?type=$type&name=$name"
+    val downloadPath: String = "download/{accountId}/{blobId}/?type={type}&name={name}"
     val expectedJson = s"""{
                          |  "capabilities" : {
                          |    "urn:ietf:params:jmap:core" : {

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/JmapRfc8621ConfigurationTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/JmapRfc8621ConfigurationTest.scala
@@ -42,7 +42,7 @@ class JmapRfc8621ConfigurationTest extends AnyWordSpec with Matchers {
       val jmapRfc8621Configuration: JmapRfc8621Configuration = JmapRfc8621Configuration.from(providedConfiguration())
 
       jmapRfc8621Configuration.apiUrl must be(new URL("http://random-domain.com/jmap"))
-      jmapRfc8621Configuration.downloadUrl must be(new URL("http://random-domain.com/download/$accountId/$blobId/?type=$type&name=$name "))
+      jmapRfc8621Configuration.downloadUrl must be(new URL("http://random-domain.com/download/{accountId}/{blobId}/?type={type}&name={name}"))
       jmapRfc8621Configuration.uploadUrl must be(new URL("http://random-domain.com/upload"))
       jmapRfc8621Configuration.eventSourceUrl must be(new URL("http://random-domain.com/eventSource"))
     }
@@ -51,7 +51,7 @@ class JmapRfc8621ConfigurationTest extends AnyWordSpec with Matchers {
       val jmapRfc8621Configuration: JmapRfc8621Configuration = JmapRfc8621Configuration.from(emptyConfiguration)
 
       jmapRfc8621Configuration.apiUrl must be(new URL("http://localhost/jmap"))
-      jmapRfc8621Configuration.downloadUrl must be(new URL("http://localhost/download/$accountId/$blobId/?type=$type&name=$name"))
+      jmapRfc8621Configuration.downloadUrl must be(new URL("http://localhost/download/{accountId}/{blobId}/?type={type}&name={name}"))
       jmapRfc8621Configuration.uploadUrl must be(new URL("http://localhost/upload"))
       jmapRfc8621Configuration.eventSourceUrl must be(new URL("http://localhost/eventSource"))
     }


### PR DESCRIPTION
Section 2 of [RFC8620](https://tools.ietf.org/html/rfc8620) describes the `downloadUrl` property of the JMAP Session resource as follows:

> **downloadUrl**: `String` The URL endpoint to use when downloading files, in URI Template (level 1) format [RFC6570](https://tools.ietf.org/html/rfc6570). The URL MUST contain variables called `accountId`, `blobId`, `type`, and `name`. The use of these variables is described in Section 6.2. Due to potential encoding issues with slashes in content types, it is RECOMMENDED to put the `type` variable in the query section of the URL.

I've updated the `downloadUrl` property to be returned in the correct Level 1 URI Template format by surrounding each expression with curly braces rather than the previous leading-`$` format.