### PR TITLE
JAMES-3225 fixes flaky RabbitMQEventBusTest

### DIFF
--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
@@ -118,13 +118,13 @@ class KeyRegistrationHandler {
     }
 
     void stop() {
-        receiverSubscriber.filter(Predicate.not(Disposable::isDisposed))
-            .ifPresent(Disposable::dispose);
-        receiver.close();
         sender.delete(QueueSpecification.queue(registrationQueue.asString()))
             .timeout(TOPOLOGY_CHANGES_TIMEOUT)
             .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.elastic()))
             .block();
+        receiverSubscriber.filter(Predicate.not(Disposable::isDisposed))
+                .ifPresent(Disposable::dispose);
+        receiver.close();
     }
 
     Mono<Registration> register(MailboxListener.ReactiveMailboxListener listener, RegistrationKey key) {


### PR DESCRIPTION
EventBusConcurrentTestContract.SingleEventBusConcurrentContract#concurrentDispatchShouldDeliverAllEventsToListenersWithSingleEventBus
Before this patch I was able to trigger the bug within 300 executions
After this patch I ran over 2500 executions without triggering the
exception