### PR TITLE
JAMES-3476 improve documentation

### DIFF
--- a/grafana-reporting/BlobStore-1543222647953-dashboard.json
+++ b/grafana-reporting/BlobStore-1543222647953-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -789,7 +789,7 @@
   "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/CacheBlobStore-15911761170000-dashboard.json
+++ b/grafana-reporting/CacheBlobStore-15911761170000-dashboard.json
@@ -491,7 +491,7 @@
   "refresh": "10s",
   "schemaVersion": 25,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/Cassandra_driver-1504068385404-dashboard.json
+++ b/grafana-reporting/Cassandra_driver-1504068385404-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -710,7 +710,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/DeletedMessagesVault-1563771591074-dashboard.json
+++ b/grafana-reporting/DeletedMessagesVault-1563771591074-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -662,7 +662,7 @@
   "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/IMAP_board-1488774825351-dashboard.json
+++ b/grafana-reporting/IMAP_board-1488774825351-dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_ELASTICSEARCH",
-      "label": "ElasticSearch",
+      "name": "DS_JAMES_ES",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -47,7 +47,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 8,
           "legend": {
@@ -140,7 +140,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 7,
           "legend": {
@@ -253,7 +253,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -366,7 +366,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -491,7 +491,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 10,
           "legend": {
@@ -604,7 +604,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 11,
           "legend": {
@@ -717,7 +717,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 16,
           "legend": {
@@ -830,7 +830,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 21,
           "legend": {
@@ -955,7 +955,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 13,
           "legend": {
@@ -1068,7 +1068,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 14,
           "legend": {
@@ -1181,7 +1181,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 15,
           "legend": {
@@ -1294,7 +1294,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 20,
           "legend": {
@@ -1419,7 +1419,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 9,
           "legend": {
@@ -1532,7 +1532,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 17,
           "legend": {
@@ -1645,7 +1645,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 18,
           "legend": {
@@ -1758,7 +1758,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 19,
           "legend": {
@@ -1883,7 +1883,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 22,
           "legend": {
@@ -1996,7 +1996,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 23,
           "legend": {
@@ -2109,7 +2109,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 24,
           "legend": {
@@ -2230,7 +2230,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/IMAP_count_board-1488774815587-dashboard.json
+++ b/grafana-reporting/IMAP_count_board-1488774815587-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -2086,7 +2086,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/JAMES_DNS_dashboard-1491268903944-dashboard.json
+++ b/grafana-reporting/JAMES_DNS_dashboard-1491268903944-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -1205,7 +1205,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/JMAP_board-1488774804236-dashboard.json
+++ b/grafana-reporting/JMAP_board-1488774804236-dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_ELASTICSEARCH",
-      "label": "ElasticSearch",
+      "name": "DS_JAMES_ES",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -47,7 +47,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 23,
           "legend": {
@@ -160,7 +160,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -273,7 +273,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 11,
           "legend": {
@@ -386,7 +386,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 21,
           "legend": {
@@ -511,7 +511,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 10,
           "legend": {
@@ -624,7 +624,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -737,7 +737,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 16,
           "legend": {
@@ -850,7 +850,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 7,
           "legend": {
@@ -975,7 +975,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 13,
           "legend": {
@@ -1088,7 +1088,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 14,
           "legend": {
@@ -1201,7 +1201,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 15,
           "legend": {
@@ -1314,7 +1314,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 20,
           "legend": {
@@ -1439,7 +1439,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 9,
           "legend": {
@@ -1552,7 +1552,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 17,
           "legend": {
@@ -1665,7 +1665,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 24,
           "legend": {
@@ -1778,7 +1778,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 25,
           "legend": {
@@ -1903,7 +1903,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 22,
           "legend": {
@@ -2016,7 +2016,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 18,
           "legend": {
@@ -2129,7 +2129,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 19,
           "legend": {
@@ -2242,7 +2242,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 26,
           "legend": {
@@ -2367,7 +2367,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 27,
           "legend": {
@@ -2488,7 +2488,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/JMAP_count_board-1488774795514-dashboard.json
+++ b/grafana-reporting/JMAP_count_board-1488774795514-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -1399,7 +1399,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/James_JVM-1504068360629-dashboard.json
+++ b/grafana-reporting/James_JVM-1504068360629-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -1112,7 +1112,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/MAILET-1490071694187-dashboard.json
+++ b/grafana-reporting/MAILET-1490071694187-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -2250,7 +2250,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/MATCHER-1490071813409-dashboard.json
+++ b/grafana-reporting/MATCHER-1490071813409-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -632,7 +632,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/MailQueue-1490071879988-dashboard.json
+++ b/grafana-reporting/MailQueue-1490071879988-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -1048,7 +1048,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/MailboxListeners rate-1552903378376.json
+++ b/grafana-reporting/MailboxListeners rate-1552903378376.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -794,7 +794,7 @@
   "refresh": false,
   "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/MailboxListeners-1528958667486-dashboard.json
+++ b/grafana-reporting/MailboxListeners-1528958667486-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -745,7 +745,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/MessageFastViewProjection-1575520507952.json
+++ b/grafana-reporting/MessageFastViewProjection-1575520507952.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -396,7 +396,7 @@
   "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/Miscalleneous-1490072265151-dashboard.json
+++ b/grafana-reporting/Miscalleneous-1490072265151-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -1612,7 +1612,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/PreDeletionHooks-1553684324244-dashboard.json
+++ b/grafana-reporting/PreDeletionHooks-1553684324244-dashboard.json
@@ -147,7 +147,7 @@
   "refresh": false,
   "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/README.md
+++ b/grafana-reporting/README.md
@@ -1,14 +1,23 @@
 # Grafana reporting
 
+This is a collection of Grafana dashboards to display James metrics.
+
+## Run Grafana 
+
 The following command allow you to run a fresh grafana server :
 
 ```
 docker run -i -p 3000:3000 grafana/grafana
 ```
 
-Once running, you need to set up an ElasticSearch data-source :
+## Configure a data source
+Once running, you need to set up an [ElasticSearch data-source](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/).
+You can do this either from UI or from a configuration file.
+
+## Setting up via UI
+ - name it DS_JAMES_ES
  - select proxy mode
- - Select version 2.x of ElasticSearch
+ - Select version 6.x of ElasticSearch
  - make the URL point your ES node
  - Specify the index name. By default, it should be :
 
@@ -16,9 +25,35 @@ Once running, you need to set up an ElasticSearch data-source :
 [james-metrics-]YYYY-MM
 ```
 
-Import the different dashboards in this directory.
+## Setting up using a configuration file
 
-You then need to enable reporting through ElasticSearch. Modify your James ElasticSearch configuration file accordingly.
+Look up file grafana-datasource.yaml from Grafana and add following data source into it:
+
+```
+apiVersion: 1
+
+datasources:
+  - name: DS_JAMES_ES
+    type: elasticsearch
+    access: proxy
+    database: "[james-metrics-]YYYY-MM"
+    url: http://elasticsearch:9200
+    version: 6
+    editable: true
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+```
+
+## Getting dashboards
+
+Import the different dashboard JSON files in this directory to Grafana via UI
+or paste the files into Grafana dashboards folder (/var/lib/grafana/dashboards by default) 
+
+## Enable reporting from James configuration
+
+You then need to enable James to report its stats into ElasticSearch.
+Modify your James ElasticSearch configuration file accordingly.
 To help you doing this, you can take a look to [GitHub](https://github.com/apache/james-project/blob/master/dockerfiles/run/guice/cassandra/destination/conf/elasticsearch.properties).
 Note that you need to run a guice version of James.
 

--- a/grafana-reporting/SMTP_board-1488774774172-dashboard.json
+++ b/grafana-reporting/SMTP_board-1488774774172-dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_ELASTICSEARCH",
-      "label": "ElasticSearch",
+      "name": "DS_JAMES_ES",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -47,7 +47,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 8,
           "legend": {
@@ -140,7 +140,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 7,
           "legend": {
@@ -265,7 +265,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 10,
           "legend": {
@@ -378,7 +378,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 11,
           "legend": {
@@ -503,7 +503,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -616,7 +616,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_ELASTICSEARCH}",
+          "datasource": "${DS_JAMES_ES}",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -737,7 +737,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/SMTP_count_board-1488774761350-dashboard.json
+++ b/grafana-reporting/SMTP_count_board-1488774761350-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -697,7 +697,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/SpamAssassin-1522226824255-dashboard.json
+++ b/grafana-reporting/SpamAssassin-1522226824255-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -697,7 +697,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },

--- a/grafana-reporting/Tika-1522226794419-dashboard.json
+++ b/grafana-reporting/Tika-1522226794419-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_JAMES_ES",
-      "label": "james es",
+      "label": "James Elasticsearch",
       "description": "",
       "type": "datasource",
       "pluginId": "elasticsearch",
@@ -1034,7 +1034,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": ["James"],
   "templating": {
     "list": []
   },


### PR DESCRIPTION
- Improve readme and add examples for file based configuration
- Add tag name "James" for each file (good to distinguish if you have other non-James dashboards running in the same Grafana server)
- Fix elasticsearch version (2 -> 6)
- Use unified data source name (DS_JAMES_ES) in all scripts (currently some dashboards like Imap_board and JMAP_board use DS_ELASTICSEARCH instead as datasource name)