### PR TITLE
JAMES-2453 Remove JUNIT 4 usages in server/protocols

### DIFF
--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
@@ -30,23 +30,23 @@ import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.spamassassin.SpamAssassinResult;
 import org.apache.james.spamassassin.mock.MockSpamd;
-import org.apache.james.spamassassin.mock.MockSpamdTestRule;
+import org.apache.james.spamassassin.mock.MockSpamdExtension;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.apache.james.util.Port;
 import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
 import org.apache.mailet.base.test.FakeMail;
 import org.apache.mailet.base.test.FakeMailetConfig;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.steveash.guavate.Guavate;
 
 public class SpamAssassinTest {
 
     public static final DomainList NO_DOMAIN_LIST = null;
-    @Rule
-    public MockSpamdTestRule spamd = new MockSpamdTestRule();
+    @RegisterExtension
+    public MockSpamdExtension spamd = new MockSpamdExtension();
 
     private SpamAssassin mailet = new SpamAssassin(new RecordingMetricFactory(), MemoryUsersRepository.withVirtualHosting(NO_DOMAIN_LIST));
 

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
@@ -42,16 +42,17 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.steveash.guavate.Guavate;
 
-public class SpamAssassinTest {
+class SpamAssassinTest {
 
-    public static final DomainList NO_DOMAIN_LIST = null;
+    private static final DomainList NO_DOMAIN_LIST = null;
+
     @RegisterExtension
-    public MockSpamdExtension spamd = new MockSpamdExtension();
+    MockSpamdExtension spamd = new MockSpamdExtension();
 
     private SpamAssassin mailet = new SpamAssassin(new RecordingMetricFactory(), MemoryUsersRepository.withVirtualHosting(NO_DOMAIN_LIST));
 
     @Test
-    public void initShouldSetDefaultSpamdHostWhenNone() throws Exception {
+    void initShouldSetDefaultSpamdHostWhenNone() throws Exception {
         mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .build());
@@ -60,7 +61,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldSetDefaultSpamdPortWhenNone() throws Exception {
+    void initShouldSetDefaultSpamdPortWhenNone() throws Exception {
         mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .build());
@@ -69,7 +70,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldSetSpamdHostWhenPresent() throws Exception {
+    void initShouldSetSpamdHostWhenPresent() throws Exception {
         String spamdHost = "any.host";
         mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
@@ -80,7 +81,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void getSpamHostShouldReturnDefaultValueWhenEmpty() throws Exception {
+    void getSpamHostShouldReturnDefaultValueWhenEmpty() throws Exception {
         mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_HOST, "")
@@ -90,7 +91,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldSetDefaultSpamdPortWhenDefault() throws Exception {
+    void initShouldSetDefaultSpamdPortWhenDefault() throws Exception {
         mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .build());
@@ -99,7 +100,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldThrowWhenSpamdPortIsNotNumber() {
+    void initShouldThrowWhenSpamdPortIsNotNumber() {
         assertThatThrownBy(() -> mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_PORT, "noNumber")
@@ -107,7 +108,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldThrowWhenSpamdPortIsNegative() {
+    void initShouldThrowWhenSpamdPortIsNegative() {
         assertThatThrownBy(() -> mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_PORT, "-1")
@@ -115,7 +116,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldThrowWhenSpamdPortIsZero() {
+    void initShouldThrowWhenSpamdPortIsZero() {
         assertThatThrownBy(() -> mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_PORT, "0")
@@ -123,7 +124,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldThrowWhenSpamdPortTooBig() {
+    void initShouldThrowWhenSpamdPortTooBig() {
         assertThatThrownBy(() -> mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_PORT,
@@ -132,7 +133,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void initShouldSetSpamPortWhenPresent() throws Exception {
+    void initShouldSetSpamPortWhenPresent() throws Exception {
         int spamPort = 1000;
         mailet.init(FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
@@ -143,7 +144,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void serviceShouldWriteSpamAttributeOnMail() throws Exception {
+    void serviceShouldWriteSpamAttributeOnMail() throws Exception {
         FakeMailetConfig mailetConfiguration = FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_HOST, "localhost")
@@ -177,7 +178,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void serviceShouldWriteMessageAsNotSpamWhenNotSpam() throws Exception {
+    void serviceShouldWriteMessageAsNotSpamWhenNotSpam() throws Exception {
         FakeMailetConfig mailetConfiguration = FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_HOST, "localhost")
@@ -213,7 +214,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void serviceShouldWriteMessageAsSpamWhenSpam() throws Exception {
+    void serviceShouldWriteMessageAsSpamWhenSpam() throws Exception {
         FakeMailetConfig mailetConfiguration = FakeMailetConfig.builder()
             .mailetName("SpamAssassin")
             .setProperty(SpamAssassin.SPAMD_HOST, "localhost")
@@ -249,7 +250,7 @@ public class SpamAssassinTest {
     }
 
     @Test
-    public void getMailetInfoShouldReturnSpamAssasinMailetInformation() {
+    void getMailetInfoShouldReturnSpamAssasinMailetInformation() {
         assertThat(mailet.getMailetInfo()).isEqualTo("Checks message against SpamAssassin");
     }
 

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtConfigurationTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtConfigurationTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
-public class JwtConfigurationTest {
+class JwtConfigurationTest {
     private static final String INVALID_PUBLIC_KEY = "invalidPublicKey";
     private static final String VALID_PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----\n" +
         "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtlChO/nlVP27MpdkG0Bh\n" +
@@ -39,32 +39,32 @@ public class JwtConfigurationTest {
         "-----END PUBLIC KEY-----";
 
     @Test
-    public void getJwtPublicKeyPemShouldReturnEmptyWhenEmptyPublicKey() {
+    void getJwtPublicKeyPemShouldReturnEmptyWhenEmptyPublicKey() {
         JwtConfiguration jwtConfiguration = new JwtConfiguration(Optional.empty());
 
         assertThat(jwtConfiguration.getJwtPublicKeyPem()).isNotPresent();
     }
 
     @Test
-    public void constructorShouldThrowWhenNullPublicKey() {
+    void constructorShouldThrowWhenNullPublicKey() {
         assertThatThrownBy(() -> new JwtConfiguration(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void constructorShouldThrowWhenNonePublicKey() {
+    void constructorShouldThrowWhenNonePublicKey() {
         assertThatThrownBy(() -> new JwtConfiguration(Optional.of("")))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void constructorShouldThrowWhenInvalidPublicKey() {
+    void constructorShouldThrowWhenInvalidPublicKey() {
         assertThatThrownBy(() -> new JwtConfiguration(Optional.of(INVALID_PUBLIC_KEY)))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void getJwtPublicKeyPemShouldReturnWhenValidPublicKey() {
+    void getJwtPublicKeyPemShouldReturnWhenValidPublicKey() {
         JwtConfiguration jwtConfiguration = new JwtConfiguration(Optional.of(VALID_PUBLIC_KEY));
 
         assertThat(jwtConfiguration.getJwtPublicKeyPem()).isPresent();

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtConfigurationTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtConfigurationTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JwtConfigurationTest {
     private static final String INVALID_PUBLIC_KEY = "invalidPublicKey";
@@ -39,32 +39,32 @@ public class JwtConfigurationTest {
         "-----END PUBLIC KEY-----";
 
     @Test
-    public void getJwtPublicKeyPemShouldReturnEmptyWhenEmptyPublicKey() throws Exception {
+    public void getJwtPublicKeyPemShouldReturnEmptyWhenEmptyPublicKey() {
         JwtConfiguration jwtConfiguration = new JwtConfiguration(Optional.empty());
 
         assertThat(jwtConfiguration.getJwtPublicKeyPem()).isNotPresent();
     }
 
     @Test
-    public void constructorShouldThrowWhenNullPublicKey() throws Exception {
+    public void constructorShouldThrowWhenNullPublicKey() {
         assertThatThrownBy(() -> new JwtConfiguration(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void constructorShouldThrowWhenNonePublicKey() throws Exception {
+    public void constructorShouldThrowWhenNonePublicKey() {
         assertThatThrownBy(() -> new JwtConfiguration(Optional.of("")))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void constructorShouldThrowWhenInvalidPublicKey() throws Exception {
+    public void constructorShouldThrowWhenInvalidPublicKey() {
         assertThatThrownBy(() -> new JwtConfiguration(Optional.of(INVALID_PUBLIC_KEY)))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void getJwtPublicKeyPemShouldReturnWhenValidPublicKey() throws Exception {
+    public void getJwtPublicKeyPemShouldReturnWhenValidPublicKey() {
         JwtConfiguration jwtConfiguration = new JwtConfiguration(Optional.of(VALID_PUBLIC_KEY));
 
         assertThat(jwtConfiguration.getJwtPublicKeyPem()).isPresent();

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtTokenVerifierTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtTokenVerifierTest.java
@@ -26,9 +26,9 @@ import java.util.Optional;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JwtTokenVerifierTest {
 
@@ -65,15 +65,12 @@ public class JwtTokenVerifierTest {
         "bmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.";
     private JwtTokenVerifier sut;
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         PublicKeyProvider pubKeyProvider = new PublicKeyProvider(getJWTConfiguration(), new PublicKeyReader());
         sut = new JwtTokenVerifier(pubKeyProvider);

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtTokenVerifierTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/JwtTokenVerifierTest.java
@@ -24,13 +24,11 @@ import java.security.Security;
 import java.util.Optional;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class JwtTokenVerifierTest {
+class JwtTokenVerifierTest {
 
     private static final String PUBLIC_PEM_KEY = "-----BEGIN PUBLIC KEY-----\n" +
             "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtlChO/nlVP27MpdkG0Bh\n" +
@@ -66,12 +64,12 @@ public class JwtTokenVerifierTest {
     private JwtTokenVerifier sut;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         Security.addProvider(new BouncyCastleProvider());
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         PublicKeyProvider pubKeyProvider = new PublicKeyProvider(getJWTConfiguration(), new PublicKeyReader());
         sut = new JwtTokenVerifier(pubKeyProvider);
     }
@@ -81,12 +79,12 @@ public class JwtTokenVerifierTest {
     }
 
     @Test
-    public void shouldReturnTrueOnValidSignature() {
+    void shouldReturnTrueOnValidSignature() {
         assertThat(sut.verify(VALID_TOKEN_WITHOUT_ADMIN)).isTrue();
     }
 
     @Test
-    public void shouldReturnFalseOnMismatchingSigningKey() {
+    void shouldReturnFalseOnMismatchingSigningKey() {
         String invalidToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.Pd6t82" +
                 "tPL3EZdkeYxw_DV2KimE1U2FvuLHmfR_mimJ5US3JFU4J2Gd94O7rwpSTGN1B9h-_lsTebo4ua4xHsTtmczZ9xa8a_kWKaSkqFjNFa" +
                 "Fp6zcoD6ivCu03SlRqsQzSRHXo6TKbnqOt9D6Y2rNa3C4igSwoS0jUE4BgpXbc0";
@@ -95,7 +93,7 @@ public class JwtTokenVerifierTest {
     }
 
     @Test
-    public void verifyShouldReturnFalseWhenSubjectIsNull() {
+    void verifyShouldReturnFalseWhenSubjectIsNull() {
         String tokenWithNullSubject = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOm51bGwsIm5hbWUiOiJKb2huIERvZSJ9.EB" +
                 "_1grWDy_kFelXs3AQeiP13ay4eG_134dWB9XPRSeWsuPs8Mz2UY-VHDxLGD-fAqv-xKXr4QFEnS7iZkdpe0tPLNSwIjqeqkC6KqQln" +
                 "oC1okqWVWBDOcf7Acp1Jzp_cFTUhL5LkHvZDsyCdq5T9OOVVkzO4A9RrzIUsTrYPtRCBuYJ3ggR33cKpw191PulPGNH70rZqpUfDXe" +
@@ -106,7 +104,7 @@ public class JwtTokenVerifierTest {
     }
     
     @Test
-    public void verifyShouldReturnFalseWhenEmptySubject() {
+    void verifyShouldReturnFalseWhenEmptySubject() {
         String tokenWithEmptySubject = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UifQ.UdY" +
                 "s2PPzFCegUYspoDCnlJR_bJm8_z1InOv4v3tq8SJETQUarOXlhb_n6y6ujVvmJiSx9dI24Hc3Czi3RGUOXbnBDj1WPfd0aVSiUSqZr" +
                 "MCHBt5vjCYqAseDaP3w4aiiFb6EV3tteJFeBLZx8XlKPYxlzRLLUADDyDSQvrFBBPxfsvCETZovKdo9ofIN64o-yx23ss63yE6oIOd" +
@@ -118,48 +116,48 @@ public class JwtTokenVerifierTest {
     }
 
     @Test
-    public void verifyShouldNotAcceptNoneAlgorithm() {
+    void verifyShouldNotAcceptNoneAlgorithm() {
         assertThat(sut.verify(TOKEN_NONE_ALGORITHM)).isFalse();
     }
 
     @Test
-    public void verifyShouldNotAcceptNoneAlgorithmWithoutSignature() {
+    void verifyShouldNotAcceptNoneAlgorithmWithoutSignature() {
         assertThat(sut.verify(TOKEN_NONE_ALGORITHM_NO_SIGNATURE)).isFalse();
     }
 
     @Test
-    public void shouldReturnUserLoginFromValidToken() {
+    void shouldReturnUserLoginFromValidToken() {
         assertThat(sut.extractLogin(VALID_TOKEN_WITHOUT_ADMIN)).isEqualTo("1234567890");
     }
 
     @Test
-    public void hasAttributeShouldReturnFalseOnNoneAlgorithm() throws Exception {
+    void hasAttributeShouldReturnFalseOnNoneAlgorithm() throws Exception {
         boolean authorized = sut.hasAttribute("admin", true, TOKEN_NONE_ALGORITHM);
 
         assertThat(authorized).isFalse();
     }
 
     @Test
-    public void hasAttributeShouldReturnFalseOnNoneAlgorithmWithoutSignature() throws Exception {
+    void hasAttributeShouldReturnFalseOnNoneAlgorithmWithoutSignature() throws Exception {
         boolean authorized = sut.hasAttribute("admin", true, TOKEN_NONE_ALGORITHM_NO_SIGNATURE);
 
         assertThat(authorized).isFalse();
     }
 
     @Test
-    public void hasAttributeShouldReturnTrueIfClaimValid() throws Exception {
+    void hasAttributeShouldReturnTrueIfClaimValid() throws Exception {
         boolean authorized = sut.hasAttribute("admin", true, VALID_TOKEN_ADMIN_TRUE);
 
         assertThat(authorized).isTrue();
     }
 
     @Test
-    public void extractLoginShouldWorkWithAdminClaim() {
+    void extractLoginShouldWorkWithAdminClaim() {
         assertThat(sut.extractLogin(VALID_TOKEN_ADMIN_TRUE)).isEqualTo("admin@open-paas.org");
     }
 
     @Test
-    public void hasAttributeShouldThrowIfClaimInvalid() throws Exception {
+    void hasAttributeShouldThrowIfClaimInvalid() throws Exception {
         boolean authorized = sut.hasAttribute("admin", true, VALID_TOKEN_ADMIN_FALSE);
 
         assertThat(authorized).isFalse();

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyProviderTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyProviderTest.java
@@ -26,8 +26,8 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Optional;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class PublicKeyProviderTest {
 
@@ -41,7 +41,7 @@ public class PublicKeyProviderTest {
             "kwIDAQAB\n" +
             "-----END PUBLIC KEY-----";
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         Security.addProvider(new BouncyCastleProvider());
     }

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyProviderTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyProviderTest.java
@@ -29,7 +29,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class PublicKeyProviderTest {
+class PublicKeyProviderTest {
 
     private static final String PUBLIC_PEM_KEY = "-----BEGIN PUBLIC KEY-----\n" +
             "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtlChO/nlVP27MpdkG0Bh\n" +
@@ -42,12 +42,12 @@ public class PublicKeyProviderTest {
             "-----END PUBLIC KEY-----";
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         Security.addProvider(new BouncyCastleProvider());
     }
 
     @Test
-    public void getShouldNotThrowWhenPEMKeyProvided() {
+    void getShouldNotThrowWhenPEMKeyProvided() {
 
         JwtConfiguration configWithPEMKey = new JwtConfiguration(Optional.of(PUBLIC_PEM_KEY));
 
@@ -57,7 +57,7 @@ public class PublicKeyProviderTest {
     }
 
     @Test
-    public void getShouldThrowWhenPEMKeyNotProvided() {
+    void getShouldThrowWhenPEMKeyNotProvided() {
         JwtConfiguration configWithPEMKey = new JwtConfiguration(Optional.empty());
 
         PublicKeyProvider sut = new PublicKeyProvider(configWithPEMKey, new PublicKeyReader());

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyReaderTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyReaderTest.java
@@ -28,7 +28,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class PublicKeyReaderTest {
+class PublicKeyReaderTest {
 
     private static final String PUBLIC_PEM_KEY = "-----BEGIN PUBLIC KEY-----\n" +
             "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtlChO/nlVP27MpdkG0Bh\n" +
@@ -41,22 +41,22 @@ public class PublicKeyReaderTest {
             "-----END PUBLIC KEY-----";
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         Security.addProvider(new BouncyCastleProvider());
     }
 
     @Test
-    public void fromPEMShouldReturnEmptyWhenEmptyProvided() {
+    void fromPEMShouldReturnEmptyWhenEmptyProvided() {
         assertThat(new PublicKeyReader().fromPEM(Optional.empty())).isEmpty();
     }
 
     @Test
-    public void fromPEMShouldReturnEmptyWhenInvalidPEMKey() {
+    void fromPEMShouldReturnEmptyWhenInvalidPEMKey() {
         assertThat(new PublicKeyReader().fromPEM(Optional.of("blabla"))).isEmpty();
     }
 
     @Test
-    public void fromPEMShouldReturnRSAPublicKeyWhenValidPEMKey() {
+    void fromPEMShouldReturnRSAPublicKeyWhenValidPEMKey() {
         assertThat(new PublicKeyReader().fromPEM(Optional.of(PUBLIC_PEM_KEY))).isPresent();
     }
 }

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyReaderTest.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/PublicKeyReaderTest.java
@@ -25,8 +25,8 @@ import java.security.Security;
 import java.util.Optional;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class PublicKeyReaderTest {
 
@@ -40,7 +40,7 @@ public class PublicKeyReaderTest {
             "kwIDAQAB\n" +
             "-----END PUBLIC KEY-----";
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         Security.addProvider(new BouncyCastleProvider());
     }

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -31,9 +31,9 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-public class IMAPServerTest {
+class IMAPServerTest {
     @Test
-    public void getImapConfigurationShouldReturnDefaultValuesWhenEmpty() {
+    void getImapConfigurationShouldReturnDefaultValuesWhenEmpty() {
         ImapConfiguration imapConfiguration = IMAPServer.getImapConfiguration(new BaseHierarchicalConfiguration());
 
         ImapConfiguration expectImapConfiguration = ImapConfiguration.builder()
@@ -47,7 +47,7 @@ public class IMAPServerTest {
     }
 
     @Test
-    public void getImapConfigurationShouldReturnSetValue() {
+    void getImapConfigurationShouldReturnSetValue() {
         HierarchicalConfiguration<ImmutableNode> configurationBuilder = new BaseHierarchicalConfiguration();
         configurationBuilder.addProperty("enableIdle", "false");
         configurationBuilder.addProperty("idleTimeInterval", "1");

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -27,18 +27,13 @@ import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.apache.james.imap.api.ImapConfiguration;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
 public class IMAPServerTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void getImapConfigurationShouldReturnDefaultValuesWhenEmpty() throws Exception {
+    public void getImapConfigurationShouldReturnDefaultValuesWhenEmpty() {
         ImapConfiguration imapConfiguration = IMAPServer.getImapConfiguration(new BaseHierarchicalConfiguration());
 
         ImapConfiguration expectImapConfiguration = ImapConfiguration.builder()
@@ -52,7 +47,7 @@ public class IMAPServerTest {
     }
 
     @Test
-    public void getImapConfigurationShouldReturnSetValue() throws Exception {
+    public void getImapConfigurationShouldReturnSetValue() {
         HierarchicalConfiguration<ImmutableNode> configurationBuilder = new BaseHierarchicalConfiguration();
         configurationBuilder.addProperty("enableIdle", "false");
         configurationBuilder.addProperty("idleTimeInterval", "1");

--- a/server/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
+++ b/server/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
@@ -50,10 +50,10 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.jboss.netty.util.HashedWheelTimer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import com.google.inject.name.Names;
 
@@ -73,7 +73,7 @@ public class POP3ServerTest {
     private POP3Server pop3Server;
     private HashedWheelTimer hashedWheelTimer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         hashedWheelTimer = new HashedWheelTimer();
         setUpServiceManager();
@@ -81,7 +81,7 @@ public class POP3ServerTest {
         pop3Configuration = new POP3TestConfiguration();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         try {
             if (pop3Client != null) {
@@ -422,12 +422,8 @@ public class POP3ServerTest {
 
     }
 
-    /**
-     * Test for JAMES-1202 - This was failing before as the more then one connection to the same
-     * mailbox was not handled the right way
-     */
     @Test
-    @Ignore
+    @Disabled("Test for JAMES-1202 - This was failing before as the more then one connection to the same mailbox was not handled the right way")
     public void testStatUidlListTwoConnections() throws Exception {
         finishSetUp(pop3Configuration);
 

--- a/server/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
+++ b/server/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.inject.name.Names;
 
-public class POP3ServerTest {
+class POP3ServerTest {
     private static final DomainList NO_DOMAIN_LIST = null;
 
     private POP3TestConfiguration pop3Configuration;
@@ -74,7 +74,7 @@ public class POP3ServerTest {
     private HashedWheelTimer hashedWheelTimer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         hashedWheelTimer = new HashedWheelTimer();
         setUpServiceManager();
         setUpPOP3Server();
@@ -82,7 +82,7 @@ public class POP3ServerTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         try {
             if (pop3Client != null) {
                 if (pop3Client.isConnected()) {
@@ -99,7 +99,7 @@ public class POP3ServerTest {
     }
 
     @Test
-    public void testAuthenticationFail() throws Exception {
+    void testAuthenticationFail() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -114,7 +114,7 @@ public class POP3ServerTest {
     }
 
     @Test
-    public void testUnknownUser() throws Exception {
+    void testUnknownUser() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -127,7 +127,7 @@ public class POP3ServerTest {
     }
 
     @Test
-    public void testKnownUserEmptyInbox() throws Exception {
+    void testKnownUserEmptyInbox() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -176,7 +176,7 @@ public class POP3ServerTest {
      */
 
     @Test
-    public void testUnknownCommand() throws Exception {
+    void testUnknownCommand() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -189,7 +189,7 @@ public class POP3ServerTest {
     }
 
     @Test
-    public void testUidlCommand() throws Exception {
+    void testUidlCommand() throws Exception {
         finishSetUp(pop3Configuration);
 
         Username username = Username.of("foo");
@@ -229,7 +229,7 @@ public class POP3ServerTest {
     }
 
     @Test
-    public void testMiscCommandsWithWithoutAuth() throws Exception {
+    void testMiscCommandsWithWithoutAuth() throws Exception {
         finishSetUp(pop3Configuration);
 
         usersRepository.addUser(Username.of("foo"), "bar");
@@ -284,7 +284,7 @@ public class POP3ServerTest {
     }
 
     @Test
-    public void testKnownUserInboxWithMessages() throws Exception {
+    void testKnownUserInboxWithMessages() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -374,7 +374,7 @@ public class POP3ServerTest {
      * Test for JAMES-1202 -  Which shows that UIDL,STAT and LIST all show the same message numbers.
      */
     @Test
-    public void testStatUidlList() throws Exception {
+    void testStatUidlList() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -424,7 +424,7 @@ public class POP3ServerTest {
 
     @Test
     @Disabled("Test for JAMES-1202 - This was failing before as the more then one connection to the same mailbox was not handled the right way")
-    public void testStatUidlListTwoConnections() throws Exception {
+    void testStatUidlListTwoConnections() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -548,7 +548,7 @@ public class POP3ServerTest {
      */
     
     @Test
-    public void testIpStored() throws Exception {
+    void testIpStored() throws Exception {
 
         finishSetUp(pop3Configuration);
 
@@ -566,7 +566,7 @@ public class POP3ServerTest {
     }
 
     @Test
-    public void testCapa() throws Exception {
+    void testCapa() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();
@@ -635,7 +635,7 @@ public class POP3ServerTest {
      */
     // See JAMES-1136
     @Test
-    public void testDeadlockOnRetr() throws Exception {
+    void testDeadlockOnRetr() throws Exception {
         finishSetUp(pop3Configuration);
 
         pop3Client = new POP3Client();

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/DSNTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/DSNTest.java
@@ -75,14 +75,14 @@ import org.apache.mailet.DsnParameters;
 import org.apache.mailet.Mail;
 import org.assertj.core.api.SoftAssertions;
 import org.jboss.netty.util.HashedWheelTimer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.TypeLiteral;
 
-public class DSNTest {
+class DSNTest {
     public static final String LOCAL_DOMAIN = "example.local";
     public static final Username BOB = Username.of("bob@localhost");
     public static final String PASSWORD = "bobpwd";
@@ -100,8 +100,8 @@ public class DSNTest {
 
     private SMTPServer smtpServer;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         domainList = new MemoryDomainList(new InMemoryDNSService()
             .registerMxRecord(Domain.LOCALHOST.asString(), "127.0.0.1")
             .registerMxRecord(Domain.LOCALHOST.asString(), "127.0.0.1")
@@ -178,14 +178,14 @@ public class DSNTest {
             .build();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         smtpServer.destroy();
         hashedWheelTimer.stop();
     }
 
     @Test
-    public void ehloShouldAdvertiseDsnExtension() throws Exception {
+    void ehloShouldAdvertiseDsnExtension() throws Exception {
         smtpServer.configure(FileConfigurationProvider.getConfig(
             ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
         smtpServer.init();
@@ -211,7 +211,7 @@ public class DSNTest {
     }
 
     @Test
-    public void dsnParametersShouldBeSetOnTheFinalEmail() throws Exception {
+    void dsnParametersShouldBeSetOnTheFinalEmail() throws Exception {
         smtpServer.configure(FileConfigurationProvider.getConfig(
             ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
         smtpServer.init();
@@ -238,7 +238,7 @@ public class DSNTest {
     }
 
     @Test
-    public void multipleRecipientsShouldBeSupported() throws Exception {
+    void multipleRecipientsShouldBeSupported() throws Exception {
         smtpServer.configure(FileConfigurationProvider.getConfig(
             ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
         smtpServer.init();
@@ -270,7 +270,7 @@ public class DSNTest {
     }
 
     @Test
-    public void notifyCanBeOmitted() throws Exception {
+    void notifyCanBeOmitted() throws Exception {
         smtpServer.configure(FileConfigurationProvider.getConfig(
             ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
         smtpServer.init();
@@ -296,7 +296,7 @@ public class DSNTest {
     }
 
     @Test
-    public void orcptCanBeOmitted() throws Exception {
+    void orcptCanBeOmitted() throws Exception {
         smtpServer.configure(FileConfigurationProvider.getConfig(
             ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
         smtpServer.init();
@@ -322,7 +322,7 @@ public class DSNTest {
     }
 
     @Test
-    public void retCanBeOmitted() throws Exception {
+    void retCanBeOmitted() throws Exception {
         smtpServer.configure(FileConfigurationProvider.getConfig(
             ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
         smtpServer.init();
@@ -348,7 +348,7 @@ public class DSNTest {
     }
 
     @Test
-    public void envIdCanBeOmitted() throws Exception {
+    void envIdCanBeOmitted() throws Exception {
         smtpServer.configure(FileConfigurationProvider.getConfig(
             ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
         smtpServer.init();

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/POP3BeforeSMTPHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/POP3BeforeSMTPHandlerTest.java
@@ -26,9 +26,9 @@ import java.time.Duration;
 import org.apache.james.protocols.lib.POP3BeforeSMTPHelper;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class POP3BeforeSMTPHandlerTest {
+class POP3BeforeSMTPHandlerTest {
 
     private SMTPSession mockedSession;
 
@@ -59,7 +59,7 @@ public class POP3BeforeSMTPHandlerTest {
     }
 
     @Test
-    public void testAuthWorks() {
+    void testAuthWorks() {
 
         POP3BeforeSMTPHandler handler = new POP3BeforeSMTPHandler();
 
@@ -72,7 +72,7 @@ public class POP3BeforeSMTPHandlerTest {
     }
 
     @Test
-    public void testIPGetRemoved() {
+    void testIPGetRemoved() {
         long sleepTime = 100;
         POP3BeforeSMTPHandler handler = new POP3BeforeSMTPHandler();
 
@@ -92,7 +92,7 @@ public class POP3BeforeSMTPHandlerTest {
     }
 
     @Test
-    public void testThrowExceptionOnIllegalExpireTime() {
+    void testThrowExceptionOnIllegalExpireTime() {
         boolean exception = false;
         POP3BeforeSMTPHandler handler = new POP3BeforeSMTPHandler();
 
@@ -107,7 +107,7 @@ public class POP3BeforeSMTPHandlerTest {
     }
 
     @Test
-    public void testValidExpireTime() {
+    void testValidExpireTime() {
         boolean exception = false;
         POP3BeforeSMTPHandler handler = new POP3BeforeSMTPHandler();
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -87,10 +87,10 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.apache.mailet.Mail;
 import org.jboss.netty.util.HashedWheelTimer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,7 +207,7 @@ public class SMTPServerTest {
 
     private SMTPServer smtpServer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         domainList = new MemoryDomainList(new InMemoryDNSService()
@@ -369,8 +369,8 @@ public class SMTPServerTest {
         }
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() {
         smtpServer.destroy();
         hashedWheelTimer.stop();
     }
@@ -640,7 +640,7 @@ public class SMTPServerTest {
     }
 
     // FIXME
-    @Ignore
+    @Disabled
     @Test
     public void testEmptyMessageReceivedHeader() throws Exception {
         init(smtpConfiguration);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
@@ -34,8 +34,8 @@ import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
 import org.apache.james.smtpserver.fastfail.SPFHandler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Preconditions;
 
@@ -46,7 +46,7 @@ public class SPFHandlerTest {
 
     private boolean relaying = false;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         setupMockedDnsService();
         setRelayingAllowed(false);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
@@ -39,13 +39,13 @@ import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
 import org.apache.james.smtpserver.fastfail.SpamAssassinHandler;
 import org.apache.james.spamassassin.SpamAssassinResult;
 import org.apache.james.spamassassin.mock.MockSpamd;
-import org.apache.james.spamassassin.mock.MockSpamdTestRule;
+import org.apache.james.spamassassin.mock.MockSpamdExtension;
 import org.apache.mailet.Attribute;
 import org.apache.mailet.AttributeValue;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.test.FakeMail;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Preconditions;
 
@@ -116,8 +116,8 @@ public class SpamAssassinHandlerTest {
 
     }
 
-    @Rule
-    public MockSpamdTestRule spamd = new MockSpamdTestRule();
+    @RegisterExtension
+    MockSpamdExtension spamd = new MockSpamdExtension();
 
     private Mail setupMockedMail(MimeMessage message) throws MessagingException {
         return FakeMail.builder()

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Preconditions;
 
-public class SpamAssassinHandlerTest {
+class SpamAssassinHandlerTest {
 
     private static final String SPAMD_HOST = "localhost";
     private static final Attribute FLAG_MAIL_ATTRIBUTE_NO = new Attribute(SpamAssassinResult.FLAG_MAIL, AttributeValue.of("NO"));
@@ -126,14 +126,14 @@ public class SpamAssassinHandlerTest {
             .build();
     }
 
-    public MimeMessage setupMockedMimeMessage(String text) throws MessagingException {
+    private MimeMessage setupMockedMimeMessage(String text) throws MessagingException {
         return MimeMessageBuilder.mimeMessageBuilder()
             .setText(text)
             .build();
     }
 
     @Test
-    public void testNonSpam() throws Exception {
+    void testNonSpam() throws Exception {
         SMTPSession session = setupMockedSMTPSession(setupMockedMail(setupMockedMimeMessage("test")));
 
         SpamAssassinHandler handler = new SpamAssassinHandler(new RecordingMetricFactory());
@@ -150,7 +150,7 @@ public class SpamAssassinHandlerTest {
     }
 
     @Test
-    public void testSpam() throws Exception {
+    void testSpam() throws Exception {
         SMTPSession session = setupMockedSMTPSession(setupMockedMail(setupMockedMimeMessage(MockSpamd.GTUBE)));
 
         SpamAssassinHandler handler = new SpamAssassinHandler(new RecordingMetricFactory());
@@ -166,7 +166,7 @@ public class SpamAssassinHandlerTest {
     }
 
     @Test
-    public void testSpamReject() throws Exception {
+    void testSpamReject() throws Exception {
         SMTPSession session = setupMockedSMTPSession(setupMockedMail(setupMockedMimeMessage(MockSpamd.GTUBE)));
 
         SpamAssassinHandler handler = new SpamAssassinHandler(new RecordingMetricFactory());

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
@@ -45,7 +45,7 @@ import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
 import org.apache.james.smtpserver.fastfail.URIRBLHandler;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.test.FakeMail;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Preconditions;
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Preconditions;
 
-public class URIRBLHandlerTest {
+class URIRBLHandlerTest {
 
     private static final String BAD_DOMAIN1 = "bad.domain.de";
     private static final String BAD_DOMAIN2 = "bad2.domain.de";
@@ -125,13 +125,13 @@ public class URIRBLHandlerTest {
             .build();
     }
 
-    public MimeMessage setupMockedMimeMessage(String text) throws MessagingException {
+    private MimeMessage setupMockedMimeMessage(String text) throws MessagingException {
         return MimeMessageBuilder.mimeMessageBuilder()
             .setText(text)
             .build();
     }
 
-    public MimeMessage setupMockedMimeMessageMP(String text) throws MessagingException {
+    private MimeMessage setupMockedMimeMessageMP(String text) throws MessagingException {
         return MimeMessageBuilder.mimeMessageBuilder()
             .setMultipartWithBodyParts(
                 MimeMessageBuilder.bodyPartBuilder()
@@ -175,7 +175,7 @@ public class URIRBLHandlerTest {
     }
 
     @Test
-    public void testNotBlocked() throws IOException, MessagingException {
+    void testNotBlocked() throws IOException, MessagingException {
 
         ArrayList<String> servers = new ArrayList<>();
         servers.add(URISERVER);
@@ -193,7 +193,7 @@ public class URIRBLHandlerTest {
     }
 
     @Test
-    public void testBlocked() throws IOException, MessagingException {
+    void testBlocked() throws IOException, MessagingException {
 
         ArrayList<String> servers = new ArrayList<>();
         servers.add(URISERVER);
@@ -211,7 +211,7 @@ public class URIRBLHandlerTest {
     }
 
     @Test
-    public void testBlockedMultiPart() throws IOException, MessagingException {
+    void testBlockedMultiPart() throws IOException, MessagingException {
 
         ArrayList<String> servers = new ArrayList<>();
         servers.add(URISERVER);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -41,8 +41,8 @@ import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.apache.james.smtpserver.fastfail.ValidRcptHandler;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.memory.MemoryUsersRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import com.google.common.base.Preconditions;
 
@@ -62,7 +62,7 @@ public class ValidRcptHandlerTest {
     private MailAddress user1mail;
     private MailAddress invalidUserEmail;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         MemoryDomainList memoryDomainList = new MemoryDomainList(mock(DNSService.class));
         memoryDomainList.configure(DomainListConfiguration.builder()

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import com.google.common.base.Preconditions;
 
-public class ValidRcptHandlerTest {
+class ValidRcptHandlerTest {
     private static final Username VALID_USER = Username.of("postmaster");
     private static final String INVALID_USER = "invalid";
     private static final String USER1 = "user1";
@@ -54,7 +54,7 @@ public class ValidRcptHandlerTest {
     private static final String PASSWORD = "xxx";
     private static final boolean RELAYING_ALLOWED = true;
     private static final MaybeSender MAYBE_SENDER = MaybeSender.of(SENDER);
-    public static final Domain DOMAIN_1 = Domain.of("domain.tld");
+    private static final Domain DOMAIN_1 = Domain.of("domain.tld");
 
     private ValidRcptHandler handler;
     private MemoryRecipientRewriteTable memoryRecipientRewriteTable;
@@ -63,7 +63,7 @@ public class ValidRcptHandlerTest {
     private MailAddress invalidUserEmail;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         MemoryDomainList memoryDomainList = new MemoryDomainList(mock(DNSService.class));
         memoryDomainList.configure(DomainListConfiguration.builder()
             .defaultDomain(Domain.LOCALHOST)
@@ -128,7 +128,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldRejectNotExistingLocalUsersWhenNoRelay() {
+    void doRcptShouldRejectNotExistingLocalUsersWhenNoRelay() {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
         HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, invalidUserEmail).getResult();
@@ -137,7 +137,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDenyNotExistingLocalUsersWhenRelay() {
+    void doRcptShouldDenyNotExistingLocalUsersWhenRelay() {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
         HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, invalidUserEmail).getResult();
@@ -146,7 +146,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDeclineNonLocalUsersWhenRelay() throws Exception {
+    void doRcptShouldDeclineNonLocalUsersWhenRelay() throws Exception {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
@@ -156,7 +156,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDeclineNonLocalUsersWhenNoRelay() throws Exception {
+    void doRcptShouldDeclineNonLocalUsersWhenNoRelay() throws Exception {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
@@ -166,7 +166,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDeclineValidUsersWhenNoRelay() throws Exception {
+    void doRcptShouldDeclineValidUsersWhenNoRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
         HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, validUserEmail).getResult();
@@ -175,7 +175,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDeclineValidUsersWhenRelay() throws Exception {
+    void doRcptShouldDeclineValidUsersWhenRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
         HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, validUserEmail).getResult();
@@ -184,7 +184,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDeclineWhenHasAddressMapping() throws Exception {
+    void doRcptShouldDeclineWhenHasAddressMapping() throws Exception {
         memoryRecipientRewriteTable.addAddressMapping(MappingSource.fromUser(USER1, Domain.LOCALHOST), "address");
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
@@ -195,7 +195,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDenyWhenHasMappingLoop() throws Exception {
+    void doRcptShouldDenyWhenHasMappingLoop() throws Exception {
         memoryRecipientRewriteTable.addAddressMapping(MappingSource.fromUser(USER1, Domain.LOCALHOST), USER2 + "@domain.tld");
         memoryRecipientRewriteTable.addAddressMapping(MappingSource.fromUser(USER2, DOMAIN_1), USER1 + "@domain.tld");
         // The loop needs to be created by a domain mapping
@@ -209,7 +209,7 @@ public class ValidRcptHandlerTest {
     }
 
     @Test
-    public void doRcptShouldDeclineWhenHasErrorMapping() throws Exception {
+    void doRcptShouldDeclineWhenHasErrorMapping() throws Exception {
         memoryRecipientRewriteTable.addErrorMapping(MappingSource.fromUser(USER1, Domain.LOCALHOST), "554 BOUNCE");
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
@@ -31,12 +31,12 @@ import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
 import org.apache.james.smtpserver.fastfail.ValidRcptMX;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
-public class ValidRcptMXTest {
+class ValidRcptMXTest {
 
     private static final String INVALID_HOST = "invalid.host.de";
 
@@ -81,7 +81,7 @@ public class ValidRcptMXTest {
     }
 
     @Test
-    public void testRejectLoopbackMX() throws Exception {
+    void testRejectLoopbackMX() throws Exception {
         String bannedAddress = "172.53.64.2";
 
         DNSService dns = new InMemoryDNSService()

--- a/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/dto/VersionRequestTest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/dto/VersionRequestTest.java
@@ -23,35 +23,35 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.backends.cassandra.versions.SchemaVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class VersionRequestTest {
+class VersionRequestTest {
     @Test
-    public void parseShouldThrowWhenNullVersion() throws Exception {
+    void parseShouldThrowWhenNullVersion() {
         assertThatThrownBy(() -> CassandraVersionRequest.parse(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void parseShouldThrowWhenNonIntegerVersion() throws Exception {
+    void parseShouldThrowWhenNonIntegerVersion() {
         assertThatThrownBy(() -> CassandraVersionRequest.parse("NoInt"))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void parseShouldThrowWhenNegativeVersion() throws Exception {
+    void parseShouldThrowWhenNegativeVersion() {
         assertThatThrownBy(() -> CassandraVersionRequest.parse("-1"))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void parseShouldThrowWhenZeroVersion() throws Exception {
+    void parseShouldThrowWhenZeroVersion() {
         assertThatThrownBy(() -> CassandraVersionRequest.parse("0"))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void parseShouldParseTheVersionValue() throws Exception {
+    void parseShouldParseTheVersionValue() {
         CassandraVersionRequest cassandraVersionRequest = CassandraVersionRequest.parse("1");
 
         assertThat(cassandraVersionRequest.getValue()).isEqualTo(new SchemaVersion(1));

--- a/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/routes/CassandraMigrationRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/routes/CassandraMigrationRoutesTest.java
@@ -52,10 +52,10 @@ import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.dto.WebAdminMigrationTaskAdditionalInformationDTO;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -63,7 +63,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import reactor.core.publisher.Mono;
 
-public class CassandraMigrationRoutesTest {
+class CassandraMigrationRoutesTest {
     private static final SchemaVersion LATEST_VERSION = new SchemaVersion(3);
     private static final SchemaVersion CURRENT_VERSION = new SchemaVersion(2);
     private static final SchemaVersion OLDER_VERSION = new SchemaVersion(1);
@@ -98,19 +98,19 @@ public class CassandraMigrationRoutesTest {
             .build();
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         createServer();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         webAdminServer.destroy();
         taskManager.stop();
     }
 
     @Test
-    public void getShouldReturnTheCurrentVersion() {
+    void getShouldReturnTheCurrentVersion() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(CURRENT_VERSION)));
 
         Integer version =
@@ -127,7 +127,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void getShouldReturnTheLatestVersionWhenSetUpTheLatestVersion() {
+    void getShouldReturnTheLatestVersionWhenSetUpTheLatestVersion() {
         Integer version =
             when()
                 .get("/latest")
@@ -141,9 +141,9 @@ public class CassandraMigrationRoutesTest {
         assertThat(version).isEqualTo(LATEST_VERSION.getValue());
     }
 
-    @Ignore
+    @Disabled
     @Test
-    public void postShouldReturnConflictWhenMigrationOnRunning() {
+    void postShouldReturnConflictWhenMigrationOnRunning() {
         when()
             .post("/upgrade")
         .then()
@@ -151,7 +151,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldReturnErrorCodeWhenInvalidVersion() {
+    void postShouldReturnErrorCodeWhenInvalidVersion() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(OLDER_VERSION)));
 
         Map<String, Object> errors = given()
@@ -176,7 +176,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldDoMigrationToNewVersion() {
+    void postShouldDoMigrationToNewVersion() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(OLDER_VERSION)));
 
         String taskId = with()
@@ -198,7 +198,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldCreateTaskWhenCurrentVersionIsNewerThan() {
+    void postShouldCreateTaskWhenCurrentVersionIsNewerThan() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(CURRENT_VERSION)));
 
         String taskId =  given()
@@ -217,7 +217,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldNotUpdateVersionWhenCurrentVersionIsNewerThan() {
+    void postShouldNotUpdateVersionWhenCurrentVersionIsNewerThan() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(CURRENT_VERSION)));
 
         String taskId =  given()
@@ -236,7 +236,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldPositionLocationHeader() {
+    void postShouldPositionLocationHeader() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(CURRENT_VERSION)));
 
         given()
@@ -248,7 +248,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldDoMigrationToLatestVersion() {
+    void postShouldDoMigrationToLatestVersion() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(OLDER_VERSION)));
 
         String taskId = with()
@@ -267,7 +267,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldReturnTaskIdAndLocation() {
+    void postShouldReturnTaskIdAndLocation() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(OLDER_VERSION)));
 
         when()
@@ -278,7 +278,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void createdTaskShouldHaveDetails() {
+    void createdTaskShouldHaveDetails() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(OLDER_VERSION)));
 
         String taskId = with()
@@ -301,7 +301,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldCreateTaskWhenItIsUpToDate() {
+    void postShouldCreateTaskWhenItIsUpToDate() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(LATEST_VERSION)));
 
         String taskId = with()
@@ -318,7 +318,7 @@ public class CassandraMigrationRoutesTest {
     }
 
     @Test
-    public void postShouldNotUpdateVersionWhenItIsUpToDate() {
+    void postShouldNotUpdateVersionWhenItIsUpToDate() {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(Mono.just(Optional.of(LATEST_VERSION)));
 
         String taskId = with()

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/FixedPortSupplierTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/FixedPortSupplierTest.java
@@ -22,36 +22,34 @@ package org.apache.james.webadmin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class FixedPortSupplierTest {
-
+class FixedPortSupplierTest {
     @Test
-    public void toIntShouldThrowOnNegativePort() {
+    void toIntShouldThrowOnNegativePort() {
         assertThatThrownBy(() -> new FixedPortSupplier(-1)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void toIntShouldThrowOnNullPort() {
+    void toIntShouldThrowOnNullPort() {
         assertThatThrownBy(() -> new FixedPortSupplier(0)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void toIntShouldThrowOnTooBigNumbers() {
+    void toIntShouldThrowOnTooBigNumbers() {
         assertThatThrownBy(() -> new FixedPortSupplier(65536)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void toIntShouldReturnedDesiredPort() {
+    void toIntShouldReturnedDesiredPort() {
         int expectedPort = 452;
         assertThat(new FixedPortSupplier(expectedPort).get().getValue()).isEqualTo(expectedPort);
     }
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(FixedPortSupplier.class).verify();
     }
-
 }

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/RandomPortSupplierTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/RandomPortSupplierTest.java
@@ -21,14 +21,12 @@ package org.apache.james.webadmin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RandomPortSupplierTest {
-
+class RandomPortSupplierTest {
     @Test
-    public void toIntShouldReturnTwoTimeTheSameResult() {
+    void toIntShouldReturnTwoTimeTheSameResult() {
         RandomPortSupplier testee = new RandomPortSupplier();
         assertThat(testee.get().getValue()).isEqualTo(testee.get().getValue());
     }
-
 }

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/TlsConfigurationTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/TlsConfigurationTest.java
@@ -20,50 +20,41 @@
 package org.apache.james.webadmin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class TlsConfigurationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
+class TlsConfigurationTest {
     @Test
-    public void buildShouldThrowWhenNotEnabled() {
-        expectedException.expect(IllegalStateException.class);
-
-        TlsConfiguration.builder().build();
+    void buildShouldThrowWhenNotEnabled() {
+        assertThatThrownBy(() -> TlsConfiguration.builder().build())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void buildShouldThrowWhenEnableWithoutKeystore() {
-        expectedException.expect(IllegalStateException.class);
-
-        TlsConfiguration.builder().build();
+    void buildShouldThrowWhenEnableWithoutKeystore() {
+        assertThatThrownBy(() -> TlsConfiguration.builder().build())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void selfSignedShouldThrowOnNullKeyStorePath() {
-        expectedException.expect(NullPointerException.class);
-
-        TlsConfiguration.builder()
-            .selfSigned(null, "abc");
+    void selfSignedShouldThrowOnNullKeyStorePath() {
+        assertThatThrownBy(() -> TlsConfiguration.builder()
+            .selfSigned(null, "abc"))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void selfSignedShouldThrowOnNullKeyStorePassword() {
-        expectedException.expect(NullPointerException.class);
-
-        TlsConfiguration.builder()
-            .selfSigned("abc", null);
+    void selfSignedShouldThrowOnNullKeyStorePassword() {
+        assertThatThrownBy(() -> TlsConfiguration.builder()
+            .selfSigned("abc", null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void buildShouldWorkOnSelfSignedHttps() {
+    void buildShouldWorkOnSelfSignedHttps() {
         assertThat(
             TlsConfiguration.builder()
                 .selfSigned("abcd", "efgh")
@@ -72,7 +63,7 @@ public class TlsConfigurationTest {
     }
 
     @Test
-    public void buildShouldWorkOnTrustedHttps() {
+    void buildShouldWorkOnTrustedHttps() {
         assertThat(
             TlsConfiguration.builder()
                 .raw("a", "b", "c", "d")
@@ -81,7 +72,7 @@ public class TlsConfigurationTest {
     }
 
     @Test
-    public void shouldRespectBeanContract() {
+    void shouldRespectBeanContract() {
         EqualsVerifier.forClass(TlsConfiguration.class).verify();
     }
 

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminConfigurationTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminConfigurationTest.java
@@ -20,29 +20,23 @@
 package org.apache.james.webadmin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class WebAdminConfigurationTest {
-
-    public static final FixedPortSupplier PORT = new FixedPortSupplier(80);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+class WebAdminConfigurationTest {
+    static final FixedPortSupplier PORT = new FixedPortSupplier(80);
 
     @Test
-    public void buildShouldThrowWhenNoPortButEnabled() {
-        expectedException.expect(IllegalStateException.class);
-
-        WebAdminConfiguration.builder().enabled().build();
+    void buildShouldThrowWhenNoPortButEnabled() {
+        assertThatThrownBy(() -> WebAdminConfiguration.builder().enabled().build())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void buildShouldWorkWithoutPortWhenDisabled() {
+    void buildShouldWorkWithoutPortWhenDisabled() {
         assertThat(WebAdminConfiguration.builder()
             .disabled()
             .build())
@@ -51,14 +45,13 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void buildShouldFailOnNoEnable() {
-        expectedException.expect(IllegalStateException.class);
-
-        WebAdminConfiguration.builder().port(PORT).build();
+    void buildShouldFailOnNoEnable() {
+        assertThatThrownBy(() -> WebAdminConfiguration.builder().port(PORT).build())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void builderShouldBuildWithRightPort() {
+    void builderShouldBuildWithRightPort() {
         assertThat(
             WebAdminConfiguration.builder()
                 .enabled()
@@ -70,7 +63,7 @@ public class WebAdminConfigurationTest {
 
 
     @Test
-    public void builderShouldBuildWithEnable() {
+    void builderShouldBuildWithEnable() {
         assertThat(
             WebAdminConfiguration.builder()
                 .enabled()
@@ -81,7 +74,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldAcceptHttps() {
+    void builderShouldAcceptHttps() {
         TlsConfiguration tlsConfiguration = TlsConfiguration.builder()
             .selfSigned("abcd", "efgh")
             .build();
@@ -97,7 +90,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldReturnTlsEnableWhenTlsConfiguration() {
+    void builderShouldReturnTlsEnableWhenTlsConfiguration() {
         TlsConfiguration tlsConfiguration = TlsConfiguration.builder()
             .selfSigned("abcd", "efgh")
             .build();
@@ -113,7 +106,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldReturnTlsDisableWhenNoTlsConfiguration() {
+    void builderShouldReturnTlsDisableWhenNoTlsConfiguration() {
         assertThat(
             WebAdminConfiguration.builder()
                 .enabled()
@@ -124,7 +117,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldCORSEnabled() {
+    void builderShouldCORSEnabled() {
         assertThat(
             WebAdminConfiguration.builder()
                 .enabled()
@@ -136,7 +129,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldAcceptAllOriginsByDefault() {
+    void builderShouldAcceptAllOriginsByDefault() {
         assertThat(
             WebAdminConfiguration.builder()
                 .enabled()
@@ -148,7 +141,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldCORSDisabled() {
+    void builderShouldCORSDisabled() {
         assertThat(
             WebAdminConfiguration.builder()
                 .enabled()
@@ -160,7 +153,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldCORSWithOrigin() {
+    void builderShouldCORSWithOrigin() {
         String origin = "linagora.com";
         assertThat(
             WebAdminConfiguration.builder()
@@ -174,7 +167,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldDefineHostWithDefault() {
+    void builderShouldDefineHostWithDefault() {
         assertThat(
             WebAdminConfiguration.builder()
                 .enabled()
@@ -185,7 +178,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void builderShouldDefineHostWithSetting() {
+    void builderShouldDefineHostWithSetting() {
         String host = "any.host";
         assertThat(
             WebAdminConfiguration.builder()
@@ -198,8 +191,7 @@ public class WebAdminConfigurationTest {
     }
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(WebAdminConfiguration.class).verify();
     }
-
 }

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminServerTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminServerTest.java
@@ -27,17 +27,16 @@ import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.util.Port;
 import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import org.apache.james.webadmin.mdc.LoggingRequestFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
 import io.restassured.RestAssured;
 import spark.Service;
 
-public class WebAdminServerTest {
-
+class WebAdminServerTest {
     @Test
-    public void getPortShouldThrowWhenNotConfigured() {
+    void getPortShouldThrowWhenNotConfigured() {
         WebAdminServer server = new WebAdminServer(
             WebAdminConfiguration.TEST_CONFIGURATION,
             ImmutableList.of(),
@@ -49,7 +48,7 @@ public class WebAdminServerTest {
     }
 
     @Test
-    public void getPortShouldReturnPortWhenConfigured() {
+    void getPortShouldReturnPortWhenConfigured() {
         WebAdminServer server = WebAdminUtils.createWebAdminServer().start();
 
         Port port = server.getPort();
@@ -58,7 +57,7 @@ public class WebAdminServerTest {
     }
 
     @Test
-    public void aSecondRouteWithSameEndpointShouldNotOverridePreviouslyDefinedRoutes() {
+    void aSecondRouteWithSameEndpointShouldNotOverridePreviouslyDefinedRoutes() {
         String firstAnswer = "1";
         String secondAnswer = "2";
         WebAdminServer server = WebAdminUtils.createWebAdminServer(
@@ -81,7 +80,7 @@ public class WebAdminServerTest {
     }
 
     @Test
-    public void aSecondRouteWithSameEndpointShouldNotOverridePreviouslyDefinedRoutesWhenPublic() {
+    void aSecondRouteWithSameEndpointShouldNotOverridePreviouslyDefinedRoutesWhenPublic() {
         String firstAnswer = "1";
         String secondAnswer = "2";
         WebAdminServer server = WebAdminUtils.createWebAdminServer(
@@ -104,7 +103,7 @@ public class WebAdminServerTest {
     }
 
     @Test
-    public void privateRoutesShouldBePrioritizedOverPublicRoutes() {
+    void privateRoutesShouldBePrioritizedOveroutes() {
         String firstAnswer = "1";
         String secondAnswer = "2";
         WebAdminServer server = WebAdminUtils.createWebAdminServer(

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/mdc/RequestIdTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/mdc/RequestIdTest.java
@@ -19,13 +19,13 @@
 
 package org.apache.james.webadmin.mdc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class RequestIdTest {
+class RequestIdTest {
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(RequestId.class).verify();
     }
 }

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/ErrorRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/ErrorRoutesTest.java
@@ -34,19 +34,19 @@ import static org.hamcrest.Matchers.equalTo;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.utils.ErrorResponder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.restassured.RestAssured;
 
-public class ErrorRoutesTest {
+class ErrorRoutesTest {
     private static final String NOT_FOUND = "notFound";
 
     private WebAdminServer webAdminServer;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         webAdminServer = WebAdminUtils.createWebAdminServer(new ErrorRoutes())
             .start();
 
@@ -56,13 +56,13 @@ public class ErrorRoutesTest {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         webAdminServer.destroy();
     }
 
     @Test
-    public void defineInternalErrorShouldReturnInternalErrorJsonFormat() {
+    void defineInternalErrorShouldReturnInternalErrorJsonFormat() {
         when()
             .get(INTERNAL_SERVER_ERROR)
         .then()
@@ -73,7 +73,7 @@ public class ErrorRoutesTest {
     }
 
     @Test
-    public void defineNotFoundShouldReturnNotFoundJsonFormat() {
+    void defineNotFoundShouldReturnNotFoundJsonFormat() {
         when()
             .get(NOT_FOUND)
         .then()
@@ -84,7 +84,7 @@ public class ErrorRoutesTest {
     }
 
     @Test
-    public void defineJsonExtractExceptionShouldReturnBadRequestJsonFormat() {
+    void defineJsonExtractExceptionShouldReturnBadRequestJsonFormat() {
         when()
             .get(JSON_EXTRACT_EXCEPTION)
         .then()
@@ -96,7 +96,7 @@ public class ErrorRoutesTest {
     }
 
     @Test
-    public void defineIllegalExceptionShouldReturnBadRequestJsonFormat() {
+    void defineIllegalExceptionShouldReturnBadRequestJsonFormat() {
         when()
             .get(INVALID_ARGUMENT_EXCEPTION)
         .then()

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/HealthCheckRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/HealthCheckRoutesTest.java
@@ -38,17 +38,16 @@ import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
 import io.restassured.RestAssured;
 import net.javacrumbs.jsonunit.core.Option;
 import reactor.core.publisher.Mono;
 
-public class HealthCheckRoutesTest {
-
+class HealthCheckRoutesTest {
     private static final String NAME_1 = "component-1";
     private static final String NAME_2 = "component-2";
     private static final String NAME_3 = "component 3";
@@ -76,8 +75,8 @@ public class HealthCheckRoutesTest {
     private WebAdminServer webAdminServer;
     private Set<HealthCheck> healthChecks;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         healthChecks = new HashSet<>();
         webAdminServer = WebAdminUtils.createWebAdminServer(new HealthCheckRoutes(healthChecks, new JsonTransformer()))
             .start();
@@ -87,13 +86,13 @@ public class HealthCheckRoutesTest {
             .build();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         webAdminServer.destroy();
     }
 
     @Test
-    public void validateHealthChecksShouldReturnOkWhenNoHealthChecks() {
+    void validateHealthChecksShouldReturnOkWhenNoHealthChecks() {
         String healthCheckBody =
             "{\"status\":\"healthy\"," +
             " \"checks\":[]}";
@@ -110,7 +109,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void validateHealthChecksShouldReturnOkWhenHealthChecksAreHealthy() {
+    void validateHealthChecksShouldReturnOkWhenHealthChecksAreHealthy() {
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_1)));
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_2)));
         String healthCheckBody =
@@ -142,7 +141,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void validateHealthChecksShouldReturnInternalErrorWhenOneHealthCheckIsUnhealthy() {
+    void validateHealthChecksShouldReturnInternalErrorWhenOneHealthCheckIsUnhealthy() {
         healthChecks.add(healthCheck(Result.unhealthy(COMPONENT_NAME_1, "cause")));
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_2)));
         String healthCheckBody =
@@ -174,7 +173,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void validateHealthChecksShouldReturnInternalErrorWhenAllHealthChecksAreUnhealthy() {
+    void validateHealthChecksShouldReturnInternalErrorWhenAllHealthChecksAreUnhealthy() {
         healthChecks.add(healthCheck(Result.unhealthy(COMPONENT_NAME_1, "cause")));
         healthChecks.add(healthCheck(Result.unhealthy(COMPONENT_NAME_2, SAMPLE_CAUSE)));
         String healthCheckBody =
@@ -206,7 +205,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void validateHealthChecksShouldReturnInternalErrorWhenOneHealthCheckIsDegraded() {
+    void validateHealthChecksShouldReturnInternalErrorWhenOneHealthCheckIsDegraded() {
         healthChecks.add(healthCheck(Result.degraded(COMPONENT_NAME_1, "cause")));
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_2)));
         String healthCheckBody =
@@ -238,7 +237,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void validateHealthChecksShouldReturnInternalErrorWhenAllHealthCheckAreDegraded() {
+    void validateHealthChecksShouldReturnInternalErrorWhenAllHealthCheckAreDegraded() {
         healthChecks.add(healthCheck(Result.degraded(COMPONENT_NAME_1, "cause")));
         healthChecks.add(healthCheck(Result.degraded(COMPONENT_NAME_2, "cause")));
         String healthCheckBody =
@@ -270,7 +269,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void validateHealthChecksShouldReturnStatusUnHealthyWhenOneIsUnHealthyAndOtherIsDegraded() {
+    void validateHealthChecksShouldReturnStatusUnHealthyWhenOneIsUnHealthyAndOtherIsDegraded() {
         healthChecks.add(healthCheck(Result.degraded(COMPONENT_NAME_1, "cause")));
         healthChecks.add(healthCheck(Result.unhealthy(COMPONENT_NAME_2, "cause")));
         String healthCheckBody =
@@ -301,7 +300,7 @@ public class HealthCheckRoutesTest {
     }
     
     @Test
-    public void performHealthCheckShouldReturnOkWhenHealthCheckIsHealthy() {
+    void performHealthCheckShouldReturnOkWhenHealthCheckIsHealthy() {
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_1)));
         
         given()
@@ -317,7 +316,7 @@ public class HealthCheckRoutesTest {
     }
     
     @Test
-    public void performHealthCheckShouldReturnNotFoundWhenComponentNameIsUnknown() {
+    void performHealthCheckShouldReturnNotFoundWhenComponentNameIsUnknown() {
         
         given()
             .pathParam("componentName", "unknown")
@@ -332,7 +331,7 @@ public class HealthCheckRoutesTest {
     }
     
     @Test
-    public void performHealthCheckShouldReturnInternalErrorWhenHealthCheckIsDegraded() {
+    void performHealthCheckShouldReturnInternalErrorWhenHealthCheckIsDegraded() {
         healthChecks.add(healthCheck(Result.degraded(COMPONENT_NAME_1, "the cause")));
         
         given()
@@ -348,7 +347,7 @@ public class HealthCheckRoutesTest {
     }
     
     @Test
-    public void performHealthCheckShouldReturnInternalErrorWhenHealthCheckIsUnhealthy() {
+    void performHealthCheckShouldReturnInternalErrorWhenHealthCheckIsUnhealthy() {
         healthChecks.add(healthCheck(Result.unhealthy(COMPONENT_NAME_1, SAMPLE_CAUSE)));
         
         given()
@@ -364,7 +363,7 @@ public class HealthCheckRoutesTest {
     }
     
     @Test
-    public void performHealthCheckShouldReturnProperlyEscapedComponentName() {
+    void performHealthCheckShouldReturnProperlyEscapedComponentName() {
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_3)));
         
         given()
@@ -379,7 +378,7 @@ public class HealthCheckRoutesTest {
     }
     
     @Test
-    public void performHealthCheckShouldWorkWithEscapedPathParam() {
+    void performHealthCheckShouldWorkWithEscapedPathParam() {
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_3)));
         
         // disable URL encoding
@@ -397,7 +396,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void getHealthchecksShouldReturnEmptyWhenNoHealthChecks() {
+    void getHealthchecksShouldReturnEmptyWhenNoHealthChecks() {
         when()
            .get(HealthCheckRoutes.CHECKS)
         .then()
@@ -407,7 +406,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void getHealthchecksShouldReturnHealthCheckWhenHealthCheckPresent() {
+    void getHealthchecksShouldReturnHealthCheckWhenHealthCheckPresent() {
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_3)));
         when()
            .get(HealthCheckRoutes.CHECKS)
@@ -419,7 +418,7 @@ public class HealthCheckRoutesTest {
     }
 
     @Test
-    public void getHealthchecksShouldReturnHealthChecksWhenHealthChecksPresent() {
+    void getHealthchecksShouldReturnHealthChecksWhenHealthChecksPresent() {
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_2)));
         healthChecks.add(healthCheck(Result.healthy(COMPONENT_NAME_3)));
         when()

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/tasks/TaskFromRequestTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/tasks/TaskFromRequestTest.java
@@ -29,17 +29,17 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskId;
 import org.apache.james.task.TaskManager;
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spark.Request;
 import spark.Response;
 
-public class TaskFromRequestTest {
+class TaskFromRequestTest {
     static final Task TASK = mock(Task.class);
     static final String UUID_VALUE = "ce5316cb-c924-40eb-9ca0-c5828e276297";
 
     @Test
-    public void handleShouldReturnCreatedWithTaskIdHeader() throws Exception {
+    void handleShouldReturnCreatedWithTaskIdHeader() throws Exception {
         Request request = mock(Request.class);
         Response response = mock(Response.class);
 

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/utils/JsonExtractorTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/utils/JsonExtractorTest.java
@@ -22,64 +22,64 @@ package org.apache.james.webadmin.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
-public class JsonExtractorTest {
+class JsonExtractorTest {
 
     private JsonExtractor<Request> jsonExtractor;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         jsonExtractor = new JsonExtractor<>(Request.class);
     }
 
     @Test
-    public void parseShouldThrowOnNullInput() throws Exception {
+    void parseShouldThrowOnNullInput() {
         assertThatThrownBy(() -> jsonExtractor.parse(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void parseShouldThrowOnEmptyInput() throws Exception {
+    void parseShouldThrowOnEmptyInput() {
         assertThatThrownBy(() -> jsonExtractor.parse("")).isInstanceOf(JsonExtractException.class);
     }
 
     @Test
-    public void parseShouldThrowOnBrokenJson() throws Exception {
+    void parseShouldThrowOnBrokenJson() {
         assertThatThrownBy(() -> jsonExtractor.parse("{\"field1\":\"broken")).isInstanceOf(JsonExtractException.class);
     }
 
     @Test
-    public void parseShouldThrowOnEmptyJson() throws Exception {
+    void parseShouldThrowOnEmptyJson() {
         assertThatThrownBy(() -> jsonExtractor.parse("{}")).isInstanceOf(JsonExtractException.class);
     }
 
     @Test
-    public void parseShouldThrowOnMissingMandatoryField() throws Exception {
+    void parseShouldThrowOnMissingMandatoryField() {
         assertThatThrownBy(() -> jsonExtractor.parse("{\"field1\":\"any\"}")).isInstanceOf(JsonExtractException.class);
     }
 
     @Test
-    public void parseShouldThrowOnValidationProblemIllegalArgumentException() throws Exception {
+    void parseShouldThrowOnValidationProblemIllegalArgumentException() {
         assertThatThrownBy(() -> jsonExtractor.parse("{\"field1\":\"\",\"field2\":\"any\"}")).isInstanceOf(JsonExtractException.class);
     }
 
     @Test
-    public void parseShouldThrowOnValidationProblemNPE() throws Exception {
+    void parseShouldThrowOnValidationProblemNPE() {
         assertThatThrownBy(() -> jsonExtractor.parse("{\"field1\":null,\"field2\":\"any\"}")).isInstanceOf(JsonExtractException.class);
     }
 
     @Test
-    public void parseShouldThrowOnExtraFiled() throws Exception {
+    void parseShouldThrowOnExtraFiled() {
         assertThatThrownBy(() -> jsonExtractor.parse("{\"field1\":\"value\",\"field2\":\"any\",\"extra\":\"extra\"}")).isInstanceOf(JsonExtractException.class);
     }
 
     @Test
-    public void parseShouldInstantiateDestinationClass() throws Exception {
+    void parseShouldInstantiateDestinationClass() throws Exception {
         String field1 = "value1";
         String field2 = "value2";
         Request request = jsonExtractor.parse("{\"field1\":\"" + field1 + "\",\"field2\":\"" + field2 + "\"}");

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/utils/ParametersExtractorTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/utils/ParametersExtractorTest.java
@@ -27,15 +27,15 @@ import java.util.Optional;
 
 import org.apache.james.util.streams.Limit;
 import org.apache.james.util.streams.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spark.HaltException;
 import spark.Request;
 
-public class ParametersExtractorTest {
+class ParametersExtractorTest {
 
     @Test
-    public void extractLimitShouldReturnUnlimitedWhenNotInParameters() {
+    void extractLimitShouldReturnUnlimitedWhenNotInParameters() {
         Request request = mock(Request.class);
         when(request.queryParams("limit"))
             .thenReturn(null);
@@ -46,7 +46,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractLimitShouldReturnUnlimitedWhenPresentInParametersButEmpty() {
+    void extractLimitShouldReturnUnlimitedWhenPresentInParametersButEmpty() {
         Request request = mock(Request.class);
         when(request.queryParams("limit"))
             .thenReturn("");
@@ -57,7 +57,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractLimitShouldReturnTheLimitWhenPresentInParameters() {
+    void extractLimitShouldReturnTheLimitWhenPresentInParameters() {
         Request request = mock(Request.class);
         when(request.queryParams("limit"))
             .thenReturn("123");
@@ -68,7 +68,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractLimitShouldThrowWhenNegativeLimit() {
+    void extractLimitShouldThrowWhenNegativeLimit() {
         Request request = mock(Request.class);
         when(request.queryParams("limit"))
             .thenReturn("-123");
@@ -78,7 +78,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractLimitShouldThrowWhenZeroLimit() {
+    void extractLimitShouldThrowWhenZeroLimit() {
         Request request = mock(Request.class);
         when(request.queryParams("limit"))
             .thenReturn("0");
@@ -88,7 +88,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractOffsetShouldReturnNoneWhenNotInParameters() {
+    void extractOffsetShouldReturnNoneWhenNotInParameters() {
         Request request = mock(Request.class);
         when(request.queryParams("offset"))
             .thenReturn(null);
@@ -99,7 +99,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractOffsetShouldReturnNoneWhenPresentInParametersButEmpty() {
+    void extractOffsetShouldReturnNoneWhenPresentInParametersButEmpty() {
         Request request = mock(Request.class);
         when(request.queryParams("offset"))
             .thenReturn("");
@@ -110,7 +110,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractOffsetShouldReturnTheOffsetWhenPresentInParameters() {
+    void extractOffsetShouldReturnTheOffsetWhenPresentInParameters() {
         Request request = mock(Request.class);
         when(request.queryParams("offset"))
             .thenReturn("123");
@@ -121,7 +121,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractOffsetShouldThrowWhenNegativeOffset() {
+    void extractOffsetShouldThrowWhenNegativeOffset() {
         Request request = mock(Request.class);
         when(request.queryParams("offset"))
             .thenReturn("-123");
@@ -131,7 +131,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractOffsetShouldReturnNoneWhenZeroLimit() {
+    void extractOffsetShouldReturnNoneWhenZeroLimit() {
         Request request = mock(Request.class);
         when(request.queryParams("offset"))
             .thenReturn("0");
@@ -144,7 +144,7 @@ public class ParametersExtractorTest {
     
 
     @Test
-    public void extractPositiveDoubleShouldReturnEmptyWhenNotInParameters() {
+    void extractPositiveDoubleShouldReturnEmptyWhenNotInParameters() {
         String parameterName = "param";
         Request request = mock(Request.class);
         when(request.queryParams(parameterName))
@@ -156,7 +156,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractPositiveDoubleShouldReturnNoneWhenPresentInParametersButEmpty() {
+    void extractPositiveDoubleShouldReturnNoneWhenPresentInParametersButEmpty() {
         String parameterName = "param";
         Request request = mock(Request.class);
         when(request.queryParams(parameterName))
@@ -168,7 +168,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractPositiveDoubleShouldReturnTheDoubleWhenPresentInParameters() {
+    void extractPositiveDoubleShouldReturnTheDoubleWhenPresentInParameters() {
         String parameterName = "param";
         Request request = mock(Request.class);
         when(request.queryParams(parameterName))
@@ -180,7 +180,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractPositiveDoubleShouldThrowWhenNegativePositiveDouble() {
+    void extractPositiveDoubleShouldThrowWhenNegativePositiveDouble() {
         String parameterName = "param";
         Request request = mock(Request.class);
         when(request.queryParams(parameterName))
@@ -193,7 +193,7 @@ public class ParametersExtractorTest {
     }
 
     @Test
-    public void extractPositiveDoubleShouldReturnZeroWhenZeroLimit() {
+    void extractPositiveDoubleShouldReturnZeroWhenZeroLimit() {
         String parameterName = "param";
         Request request = mock(Request.class);
         when(request.queryParams(parameterName))

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/dto/UsersQuotaDetailsDTOTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/dto/UsersQuotaDetailsDTOTest.java
@@ -21,26 +21,24 @@ package org.apache.james.webadmin.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import javax.mail.internet.AddressException;
-
 import org.apache.james.core.Username;
 import org.apache.james.core.quota.QuotaCountLimit;
 import org.apache.james.core.quota.QuotaCountUsage;
 import org.apache.james.core.quota.QuotaSizeLimit;
 import org.apache.james.core.quota.QuotaSizeUsage;
 import org.apache.james.mailbox.model.Quota;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class UsersQuotaDetailsDTOTest {
+class UsersQuotaDetailsDTOTest {
 
     @Test
-    public void builderShouldThrowWhenUserIsNull() {
+    void builderShouldThrowWhenUserIsNull() {
         assertThatThrownBy(() -> UsersQuotaDetailsDTO.builder().build())
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void builderShouldThrowWhenDetailIsNull() {
+    void builderShouldThrowWhenDetailIsNull() {
         assertThatThrownBy(() -> UsersQuotaDetailsDTO.builder()
                 .user(Username.of("user@domain.org"))
                 .build())
@@ -48,7 +46,7 @@ public class UsersQuotaDetailsDTOTest {
     }
 
     @Test
-    public void builderShouldWork() throws AddressException {
+    void builderShouldWork() {
         Username username = Username.of("user@domain.org");
         QuotaDetailsDTO quotaDetailsDTO = QuotaDetailsDTO.builder()
                 .occupation(

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueDTOTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueDTOTest.java
@@ -20,29 +20,24 @@ package org.apache.james.webadmin.dto;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.Rule;
-import org.junit.Test;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
 
-public class MailQueueDTOTest {
-
-    @Rule
-    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
-
+class MailQueueDTOTest {
     @Test
-    public void buildShouldThrowWhenNameIsNull() {
+    void buildShouldThrowWhenNameIsNull() {
         assertThatThrownBy(() -> MailQueueDTO.builder().build())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void buildShouldThrowWhenNameIsEmpty() {
+    void buildShouldThrowWhenNameIsEmpty() {
         assertThatThrownBy(() -> MailQueueDTO.builder().name("").build())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void builderShouldCreateTheRightObject() {
+    void builderShouldCreateTheRightObject() {
         String name = "name";
         int size = 123;
 
@@ -50,8 +45,9 @@ public class MailQueueDTOTest {
             .name(name)
             .size(size)
             .build();
-
-        softly.assertThat(mailQueueDTO.getName()).isEqualTo(name);
-        softly.assertThat(mailQueueDTO.getSize()).isEqualTo(size);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailQueueDTO.getName()).isEqualTo(name);
+            softly.assertThat(mailQueueDTO.getSize()).isEqualTo(size);
+        });
     }
 }

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueItemDTOTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueItemDTOTest.java
@@ -28,31 +28,26 @@ import org.apache.james.queue.api.Mails;
 import org.apache.james.queue.api.ManageableMailQueue;
 import org.apache.james.queue.api.ManageableMailQueue.MailQueueItemView;
 import org.apache.mailet.base.test.FakeMail;
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.Rule;
-import org.junit.Test;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
 
 import com.github.steveash.guavate.Guavate;
 
-public class MailQueueItemDTOTest {
-
-    @Rule
-    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
-
+class MailQueueItemDTOTest {
     @Test
-    public void buildShouldThrowWhenNameIsNull() {
+    void buildShouldThrowWhenNameIsNull() {
         assertThatThrownBy(() -> MailQueueItemDTO.builder().build())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void buildShouldThrowWhenNameIsEmpty() {
+    void buildShouldThrowWhenNameIsEmpty() {
         assertThatThrownBy(() -> MailQueueItemDTO.builder().name("").build())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromShouldCreateTheRightObject() throws Exception {
+    void fromShouldCreateTheRightObject() throws Exception {
         FakeMail mail = Mails.defaultMail().name("name").build();
         ZonedDateTime date = ZonedDateTime.parse("2018-01-02T11:22:02Z");
         MailQueueItemView mailQueueItemView = new ManageableMailQueue.DefaultMailQueueItemView(mail, date);
@@ -61,9 +56,11 @@ public class MailQueueItemDTOTest {
                 .map(MailAddress::asString)
                 .collect(Guavate.toImmutableList());
 
-        softly.assertThat(mailQueueItemDTO.getName()).isEqualTo(mail.getName());
-        softly.assertThat(mailQueueItemDTO.getSender()).isEqualTo(mail.getMaybeSender().get().asString());
-        softly.assertThat(mailQueueItemDTO.getRecipients()).isEqualTo(expectedRecipients);
-        softly.assertThat(mailQueueItemDTO.getNextDelivery()).contains(date);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailQueueItemDTO.getName()).isEqualTo(mail.getName());
+            softly.assertThat(mailQueueItemDTO.getSender()).isEqualTo(mail.getMaybeSender().get().asString());
+            softly.assertThat(mailQueueItemDTO.getRecipients()).isEqualTo(expectedRecipients);
+            softly.assertThat(mailQueueItemDTO.getNextDelivery()).contains(date);
+        });
     }
 }

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesUnitTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesUnitTest.java
@@ -28,40 +28,39 @@ import org.apache.james.queue.api.ManageableMailQueue;
 import org.apache.james.task.Hostname;
 import org.apache.james.task.MemoryTaskManager;
 import org.apache.james.webadmin.utils.JsonTransformer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class MailQueueRoutesUnitTest {
-
+class MailQueueRoutesUnitTest {
     MailQueueRoutes testee;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         MemoryTaskManager taskManager = new MemoryTaskManager(new Hostname("foo"));
         MailQueueFactory<ManageableMailQueue> mailQueueFactory = null;
         testee = new MailQueueRoutes(mailQueueFactory, new JsonTransformer(), taskManager);
     }
 
     @Test
-    public void isDelayedShouldReturnEmptyWhenNull() {
+    void isDelayedShouldReturnEmptyWhenNull() {
         Optional<Boolean> delayed = testee.isDelayed(null);
         assertThat(delayed).isEmpty();
     }
 
     @Test
-    public void isDelayedShouldBeEqualsToTrueWhenTrue() {
+    void isDelayedShouldBeEqualsToTrueWhenTrue() {
         Optional<Boolean> delayed = testee.isDelayed("true");
         assertThat(delayed).contains(true);
     }
 
     @Test
-    public void isDelayedShouldBeEqualsToFalseWhenFalse() {
+    void isDelayedShouldBeEqualsToFalseWhenFalse() {
         Optional<Boolean> delayed = testee.isDelayed("false");
         assertThat(delayed).contains(false);
     }
 
     @Test
-    public void isDelayedShouldBeEqualsToFalseWhenOtherValue() {
+    void isDelayedShouldBeEqualsToFalseWhenOtherValue() {
         Optional<Boolean> delayed = testee.isDelayed("abc");
         assertThat(delayed).contains(false);
     }

--- a/server/protocols/webadmin/webadmin-mailrepository/src/test/java/org/apache/james/webadmin/routes/MailRepositoriesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/test/java/org/apache/james/webadmin/routes/MailRepositoriesRoutesTest.java
@@ -86,9 +86,9 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders.Header;
 import org.apache.mailet.base.test.FakeMail;
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
@@ -97,7 +97,7 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.parsing.Parser;
 
-public class MailRepositoriesRoutesTest {
+class MailRepositoriesRoutesTest {
 
     private static final MailRepositoryUrl URL_MY_REPO = MailRepositoryUrl.from("memory://myRepo");
     private static final MailRepositoryUrl URL_MY_REPO_OTHER = MailRepositoryUrl.from("other://myRepo");
@@ -112,8 +112,8 @@ public class MailRepositoriesRoutesTest {
     private ManageableMailQueue spoolQueue;
     private ManageableMailQueue customQueue;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         createMailRepositoryStore();
 
         MemoryTaskManager taskManager = new MemoryTaskManager(new Hostname("foo"));
@@ -141,13 +141,13 @@ public class MailRepositoriesRoutesTest {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         webAdminServer.destroy();
     }
 
     @Test
-    public void putMailRepositoryShouldReturnOkWhenRepositoryIsCreated() {
+    void putMailRepositoryShouldReturnOkWhenRepositoryIsCreated() {
         given()
             .params("protocol", "memory")
         .when()
@@ -161,7 +161,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void putMailRepositoryShouldReturnOkWhenRepositoryAlreadyExists() {
+    void putMailRepositoryShouldReturnOkWhenRepositoryAlreadyExists() {
         given()
             .params("protocol", "memory")
         .when()
@@ -185,7 +185,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void putMailRepositoryShouldReturnInvalidArgumentWhenProtocolIsUnsupported() {
+    void putMailRepositoryShouldReturnInvalidArgumentWhenProtocolIsUnsupported() {
         given()
             .params("protocol", "unsupported")
         .when()
@@ -201,7 +201,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void getMailRepositoriesShouldReturnEmptyWhenEmpty() {
+    void getMailRepositoriesShouldReturnEmptyWhenEmpty() {
         List<Object> mailRepositories =
             when()
                 .get()
@@ -217,7 +217,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void getMailRepositoriesShouldReturnRepositoryWhenOne() throws Exception {
+    void getMailRepositoriesShouldReturnRepositoryWhenOne() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         when()
@@ -230,7 +230,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void getMailRepositoriesShouldDeduplicateAccordingToPath() throws Exception {
+    void getMailRepositoriesShouldDeduplicateAccordingToPath() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
         mailRepositoryStore.create(URL_MY_REPO_OTHER);
 
@@ -244,7 +244,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void getMailRepositoriesShouldReturnTwoRepositoriesWhenTwo() throws Exception {
+    void getMailRepositoriesShouldReturnTwoRepositoriesWhenTwo() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
         mailRepositoryStore.create(MailRepositoryUrl.from("memory://mySecondRepo"));
 
@@ -264,7 +264,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnNotFoundWhenNoRepository() {
+    void listingKeysShouldReturnNotFoundWhenNoRepository() {
         when()
             .get(MY_REPO_MAILS)
         .then()
@@ -273,7 +273,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnEmptyWhenNoMail() throws Exception {
+    void listingKeysShouldReturnEmptyWhenNoMail() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         when()
@@ -284,7 +284,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnContainedKeys() throws Exception {
+    void listingKeysShouldReturnContainedKeys() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -303,7 +303,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldMergeRepositoryContentWhenSamePath() throws Exception {
+    void listingKeysShouldMergeRepositoryContentWhenSamePath() throws Exception {
         MailRepository mailRepository1 = mailRepositoryStore.create(URL_MY_REPO);
         MailRepository mailRepository2 = mailRepositoryStore.create(URL_MY_REPO_OTHER);
 
@@ -323,7 +323,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldApplyLimitAndOffset() throws Exception {
+    void listingKeysShouldApplyLimitAndOffset() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -348,7 +348,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldApplyLimitWhenSeveralRepositories() throws Exception {
+    void listingKeysShouldApplyLimitWhenSeveralRepositories() throws Exception {
         MailRepository mailRepository1 = mailRepositoryStore.create(URL_MY_REPO);
         MailRepository mailRepository2 = mailRepositoryStore.create(URL_MY_REPO_OTHER);
 
@@ -372,7 +372,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnErrorOnInvalidOffset() {
+    void listingKeysShouldReturnErrorOnInvalidOffset() {
         given()
             .param("offset", "invalid")
         .when()
@@ -385,7 +385,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnErrorOnNegativeOffset() {
+    void listingKeysShouldReturnErrorOnNegativeOffset() {
         given()
             .param("offset", "-1")
         .when()
@@ -398,7 +398,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnEmptyWhenOffsetExceedsSize() throws Exception {
+    void listingKeysShouldReturnEmptyWhenOffsetExceedsSize() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -421,7 +421,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void offsetShouldBeAplliedOnTheMergedViewOfMailRepositories() throws Exception {
+    void offsetShouldBeAplliedOnTheMergedViewOfMailRepositories() throws Exception {
         MailRepository mailRepository1 = mailRepositoryStore.create(URL_MY_REPO);
         MailRepository mailRepository2 = mailRepositoryStore.create(URL_MY_REPO_OTHER);
 
@@ -448,7 +448,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnErrorOnInvalidLimit() {
+    void listingKeysShouldReturnErrorOnInvalidLimit() {
         given()
             .param("limit", "invalid")
         .when()
@@ -461,7 +461,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldReturnErrorOnNegativeLimit() {
+    void listingKeysShouldReturnErrorOnNegativeLimit() {
         given()
             .param("limit", "-1")
         .when()
@@ -474,7 +474,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void listingKeysShouldIgnoreZeroedOffset() throws Exception {
+    void listingKeysShouldIgnoreZeroedOffset() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -495,7 +495,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void zeroLimitShouldNotBeValid() {
+    void zeroLimitShouldNotBeValid() {
         given()
             .param("limit", "0")
         .when()
@@ -508,7 +508,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingRepositoryShouldReturnNotFoundWhenNone() {
+    void retrievingRepositoryShouldReturnNotFoundWhenNone() {
         given()
             .get(PATH_ESCAPED_MY_REPO)
         .then()
@@ -516,7 +516,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingRepositoryShouldReturnBasicInformation() throws Exception {
+    void retrievingRepositoryShouldReturnBasicInformation() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         given()
@@ -529,7 +529,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingRepositorySizeShouldReturnZeroWhenEmpty() throws Exception {
+    void retrievingRepositorySizeShouldReturnZeroWhenEmpty() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         given()
@@ -541,7 +541,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingRepositorySizeShouldReturnNumberOfContainedMails() throws Exception {
+    void retrievingRepositorySizeShouldReturnNumberOfContainedMails() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -557,7 +557,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingRepositorySizeShouldReturnNumberOfContainedMailsWhenSeveralRepositoryWithSamePath() throws Exception {
+    void retrievingRepositorySizeShouldReturnNumberOfContainedMailsWhenSeveralRepositoryWithSamePath() throws Exception {
         MailRepository mailRepository1 = mailRepositoryStore.create(URL_MY_REPO);
         MailRepository mailRepository2 = mailRepositoryStore.create(URL_MY_REPO_OTHER);
 
@@ -578,7 +578,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldDisplayItsInformation() throws Exception {
+    void retrievingAMailShouldDisplayItsInformation() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         String name = NAME_1;
@@ -617,7 +617,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldDisplayAllAdditionalFieldsWhenRequested() throws Exception {
+    void retrievingAMailShouldDisplayAllAdditionalFieldsWhenRequested() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name = NAME_1;
 
@@ -720,7 +720,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldDisplayAllValidAdditionalFieldsWhenRequested() throws Exception {
+    void retrievingAMailShouldDisplayAllValidAdditionalFieldsWhenRequested() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         String name = NAME_1;
@@ -751,7 +751,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldDisplayCorrectlyEncodedHeadersInValidAdditionalFieldsWhenRequested() throws Exception {
+    void retrievingAMailShouldDisplayCorrectlyEncodedHeadersInValidAdditionalFieldsWhenRequested() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name = NAME_1;
         String sender = "sender@domain";
@@ -779,7 +779,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldDisplayAllValidAdditionalFieldsEvenTheDuplicatedOnesWhenRequested() throws Exception {
+    void retrievingAMailShouldDisplayAllValidAdditionalFieldsEvenTheDuplicatedOnesWhenRequested() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name = NAME_1;
         String sender = "sender@domain";
@@ -809,7 +809,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldFailWhenAnUnknownFieldIsRequested() throws Exception {
+    void retrievingAMailShouldFailWhenAnUnknownFieldIsRequested() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name = NAME_1;
         String sender = "sender@domain";
@@ -834,7 +834,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldNotFailWhenOnlyNameProperty() throws Exception {
+    void retrievingAMailShouldNotFailWhenOnlyNameProperty() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -853,7 +853,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void retrievingAMailShouldFailWhenUnknown() throws Exception {
+    void retrievingAMailShouldFailWhenUnknown() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         String name = "name";
@@ -867,7 +867,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void downloadingAMailShouldReturnTheEml() throws Exception {
+    void downloadingAMailShouldReturnTheEml() throws Exception {
         RestAssured.requestSpecification = new RequestSpecBuilder().setPort(webAdminServer.getPort().getValue())
                 .setBasePath(MailRepositoriesRoutes.MAIL_REPOSITORIES)
                 .build();
@@ -900,7 +900,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void downloadingAMailShouldFailWhenUnknown() throws Exception {
+    void downloadingAMailShouldFailWhenUnknown() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         RestAssured.requestSpecification = new RequestSpecBuilder().setPort(webAdminServer.getPort().getValue())
@@ -921,7 +921,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void deletingAMailShouldRemoveIt() throws Exception {
+    void deletingAMailShouldRemoveIt() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -943,7 +943,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void deletingAMailShouldReturnOkWhenExist() throws Exception {
+    void deletingAMailShouldReturnOkWhenExist() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -957,7 +957,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void deletingAMailShouldReturnOkWhenNotExist() throws Exception {
+    void deletingAMailShouldReturnOkWhenNotExist() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         when()
@@ -967,7 +967,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void deletingAllMailsShouldCreateATask() throws Exception {
+    void deletingAllMailsShouldCreateATask() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         when()
@@ -979,7 +979,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void clearTaskShouldHaveDetails() throws Exception {
+    void clearTaskShouldHaveDetails() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -1011,7 +1011,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void clearTaskShouldRemoveAllTheMailsFromTheMailRepository() throws Exception {
+    void clearTaskShouldRemoveAllTheMailsFromTheMailRepository() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
 
         mailRepository.store(FakeMail.builder()
@@ -1038,7 +1038,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void patchShouldReturnNotFoundWhenNoMailRepository() {
+    void patchShouldReturnNotFoundWhenNoMailRepository() {
         when()
             .delete(PATH_ESCAPED_MY_REPO + "/mails")
         .then()
@@ -1049,7 +1049,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void deleteShouldReturnNotFoundWhenNoMailRepository() {
+    void deleteShouldReturnNotFoundWhenNoMailRepository() {
         when()
             .delete(PATH_ESCAPED_MY_REPO + "/mails/any")
         .then()
@@ -1060,7 +1060,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldCreateATask() throws Exception {
+    void reprocessingAllTaskShouldCreateATask() throws Exception {
         mailRepositoryStore.create(URL_MY_REPO);
 
         given()
@@ -1074,7 +1074,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldRejectInvalidActions() {
+    void reprocessingAllTaskShouldRejectInvalidActions() {
         given()
             .param("action", "invalid")
         .when()
@@ -1088,7 +1088,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldRequireAction() {
+    void reprocessingAllTaskShouldRequireAction() {
         when()
             .patch(PATH_ESCAPED_MY_REPO + "/mails")
         .then()
@@ -1100,7 +1100,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldIncludeDetailsWhenDefaultValues() throws Exception {
+    void reprocessingAllTaskShouldIncludeDetailsWhenDefaultValues() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1134,7 +1134,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldIncludeDetails() throws Exception {
+    void reprocessingAllTaskShouldIncludeDetails() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name1 = "name1";
         String name2 = "name2";
@@ -1173,7 +1173,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldNotFailWhenSeveralRepositoriesWithSamePath() throws Exception {
+    void reprocessingAllTaskShouldNotFailWhenSeveralRepositoriesWithSamePath() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepositoryStore.create(URL_MY_REPO_OTHER);
         String name1 = "name1";
@@ -1203,7 +1203,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldClearMailRepository() throws Exception {
+    void reprocessingAllTaskShouldClearMailRepository() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name1 = "name1";
         String name2 = "name2";
@@ -1233,7 +1233,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldClearBothMailRepositoriesWhenSamePath() throws Exception {
+    void reprocessingAllTaskShouldClearBothMailRepositoriesWhenSamePath() throws Exception {
         MailRepository mailRepository1 = mailRepositoryStore.create(URL_MY_REPO);
         MailRepository mailRepository2 = mailRepositoryStore.create(URL_MY_REPO_OTHER);
         String name1 = "name1";
@@ -1265,7 +1265,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldEnqueueMailsOnDefaultQueue() throws Exception {
+    void reprocessingAllTaskShouldEnqueueMailsOnDefaultQueue() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1292,7 +1292,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldEnqueueMailsOfBothRepositoriesOnDefaultQueueWhenSamePath() throws Exception {
+    void reprocessingAllTaskShouldEnqueueMailsOfBothRepositoriesOnDefaultQueueWhenSamePath() throws Exception {
         MailRepository mailRepository1 = mailRepositoryStore.create(URL_MY_REPO);
         MailRepository mailRepository2 = mailRepositoryStore.create(URL_MY_REPO_OTHER);
         mailRepository1.store(FakeMail.builder()
@@ -1320,7 +1320,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
+    void reprocessingAllTaskShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String state1 = "state1";
         String state2 = "state2";
@@ -1351,7 +1351,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldOverWriteStateWhenProcessorSpecified() throws Exception {
+    void reprocessingAllTaskShouldOverWriteStateWhenProcessorSpecified() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String state1 = "state1";
         String state2 = "state2";
@@ -1384,7 +1384,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingAllTaskShouldEnqueueMailsOnSpecifiedQueue() throws Exception {
+    void reprocessingAllTaskShouldEnqueueMailsOnSpecifiedQueue() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1412,7 +1412,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldCreateATask() throws Exception {
+    void reprocessingOneTaskShouldCreateATask() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1429,7 +1429,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldRejectInvalidActions() throws Exception {
+    void reprocessingOneTaskShouldRejectInvalidActions() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1448,7 +1448,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldRequireAction() throws Exception {
+    void reprocessingOneTaskShouldRequireAction() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1465,7 +1465,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldIncludeDetailsWhenDefaultValues() throws Exception {
+    void reprocessingOneTaskShouldIncludeDetailsWhenDefaultValues() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name1 = "name1";
         String name2 = "name2";
@@ -1500,7 +1500,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldIncludeDetails() throws Exception {
+    void reprocessingOneTaskShouldIncludeDetails() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name1 = "name1";
         String name2 = "name2";
@@ -1538,7 +1538,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldNotFailWhenSeveralRepositoryWithSamePath() throws Exception {
+    void reprocessingOneTaskShouldNotFailWhenSeveralRepositoryWithSamePath() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepositoryStore.create(URL_MY_REPO_OTHER);
         String name1 = "name1";
@@ -1568,7 +1568,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldRemoveMailFromRepository() throws Exception {
+    void reprocessingOneTaskShouldRemoveMailFromRepository() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String name1 = "name1";
         String name2 = "name2";
@@ -1598,7 +1598,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldEnqueueMailsOnDefaultQueue() throws Exception {
+    void reprocessingOneTaskShouldEnqueueMailsOnDefaultQueue() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1625,7 +1625,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
+    void reprocessingOneTaskShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String state1 = "state1";
         String state2 = "state2";
@@ -1656,7 +1656,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldOverWriteStateWhenProcessorSpecified() throws Exception {
+    void reprocessingOneTaskShouldOverWriteStateWhenProcessorSpecified() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         String state1 = "state1";
         String state2 = "state2";
@@ -1689,7 +1689,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldEnqueueMailsOnSpecifiedQueue() throws Exception {
+    void reprocessingOneTaskShouldEnqueueMailsOnSpecifiedQueue() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1717,7 +1717,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldNotEnqueueUnknownMailKey() throws Exception {
+    void reprocessingOneTaskShouldNotEnqueueUnknownMailKey() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1743,7 +1743,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldNotRemoveMailFromRepositoryWhenUnknownMailKey() throws Exception {
+    void reprocessingOneTaskShouldNotRemoveMailFromRepositoryWhenUnknownMailKey() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)
@@ -1768,7 +1768,7 @@ public class MailRepositoriesRoutesTest {
     }
 
     @Test
-    public void reprocessingOneTaskShouldFailWhenUnknownMailKey() throws Exception {
+    void reprocessingOneTaskShouldFailWhenUnknownMailKey() throws Exception {
         MailRepository mailRepository = mailRepositoryStore.create(URL_MY_REPO);
         mailRepository.store(FakeMail.builder()
             .name(NAME_1)

--- a/server/protocols/webadmin/webadmin-mailrepository/src/test/java/org/apache/james/webadmin/service/MailRepositoryStoreServiceTest.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/test/java/org/apache/james/webadmin/service/MailRepositoryStoreServiceTest.java
@@ -41,10 +41,10 @@ import org.apache.james.util.streams.Offset;
 import org.apache.james.webadmin.dto.MailKeyDTO;
 import org.apache.james.webadmin.dto.SingleMailRepositoryResponse;
 import org.apache.mailet.base.test.FakeMail;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class MailRepositoryStoreServiceTest {
+class MailRepositoryStoreServiceTest {
     private static final MailRepositoryPath FIRST_REPOSITORY_PATH = MailRepositoryPath.from("repository");
     private static final MailRepositoryPath SECOND_REPOSITORY_PATH = MailRepositoryPath.from("repository2");
     private static final MailKey NAME_1 = new MailKey("name1");
@@ -54,22 +54,22 @@ public class MailRepositoryStoreServiceTest {
     private MailRepositoryStoreService testee;
     private MemoryMailRepository repository;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mailRepositoryStore = mock(MailRepositoryStore.class);
         repository = new MemoryMailRepository();
         testee = new MailRepositoryStoreService(mailRepositoryStore);
     }
 
     @Test
-    public void listMailRepositoriesShouldReturnEmptyWhenEmpty() {
+    void listMailRepositoriesShouldReturnEmptyWhenEmpty() {
         when(mailRepositoryStore.getPaths()).thenReturn(Stream.empty());
 
         assertThat(testee.listMailRepositories()).isEmpty();
     }
 
     @Test
-    public void listMailRepositoriesShouldReturnOneRepositoryWhenOne() {
+    void listMailRepositoriesShouldReturnOneRepositoryWhenOne() {
         when(mailRepositoryStore.getPaths())
             .thenReturn(Stream.of(FIRST_REPOSITORY_PATH));
         assertThat(testee.listMailRepositories())
@@ -78,7 +78,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void listMailRepositoriesShouldReturnTwoRepositoriesWhentwo() {
+    void listMailRepositoriesShouldReturnTwoRepositoriesWhentwo() {
         when(mailRepositoryStore.getPaths())
             .thenReturn(Stream.of(FIRST_REPOSITORY_PATH, SECOND_REPOSITORY_PATH));
         assertThat(testee.listMailRepositories())
@@ -87,7 +87,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void listMailsShouldThrowWhenMailRepositoryStoreThrows() throws Exception {
+    void listMailsShouldThrowWhenMailRepositoryStoreThrows() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH))
             .thenThrow(new MailRepositoryStore.MailRepositoryStoreException("message"));
 
@@ -96,7 +96,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void listMailsShouldReturnEmptyWhenMailRepositoryIsEmpty() throws Exception {
+    void listMailsShouldReturnEmptyWhenMailRepositoryIsEmpty() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH)).thenReturn(Stream.of(repository));
 
         assertThat(testee.listMails(FIRST_REPOSITORY_PATH, Offset.none(), Limit.unlimited()).get())
@@ -104,7 +104,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void listMailsShouldReturnContainedMailKeys() throws Exception {
+    void listMailsShouldReturnContainedMailKeys() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH)).thenReturn(Stream.of(repository));
 
         repository.store(FakeMail.builder()
@@ -119,7 +119,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void listMailsShouldApplyLimitAndOffset() throws Exception {
+    void listMailsShouldApplyLimitAndOffset() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH)).thenReturn(Stream.of(repository));
 
         repository.store(FakeMail.builder()
@@ -137,7 +137,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void retrieveMessageShouldThrownWhenUnknownRepository() throws Exception {
+    void retrieveMessageShouldThrownWhenUnknownRepository() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH)).thenReturn(Stream.of());
 
         assertThatThrownBy(() -> testee.retrieveMessage(FIRST_REPOSITORY_PATH, NAME_1))
@@ -145,7 +145,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void retrieveMessageShouldThrowWhenMailRepositoryStoreThrows() throws Exception {
+    void retrieveMessageShouldThrowWhenMailRepositoryStoreThrows() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH))
             .thenThrow(new MailRepositoryStore.MailRepositoryStoreException("message"));
 
@@ -154,7 +154,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void retrieveMessageShouldReturnEmptyWhenMailNotFound() throws Exception {
+    void retrieveMessageShouldReturnEmptyWhenMailNotFound() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH)).thenReturn(Stream.of(repository));
 
         assertThat(testee.retrieveMessage(FIRST_REPOSITORY_PATH, NAME_1))
@@ -162,7 +162,7 @@ public class MailRepositoryStoreServiceTest {
     }
 
     @Test
-    public void retrieveMessageShouldReturnTheMessageWhenMailExists() throws Exception {
+    void retrieveMessageShouldReturnTheMessageWhenMailExists() throws Exception {
         when(mailRepositoryStore.getByPath(FIRST_REPOSITORY_PATH)).thenReturn(Stream.of(repository));
 
         FakeMail mail = FakeMail.builder()

--- a/server/protocols/webadmin/webadmin-mailrepository/src/test/java/org/apache/james/webadmin/service/ReprocessingServiceTest.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/test/java/org/apache/james/webadmin/service/ReprocessingServiceTest.java
@@ -42,14 +42,14 @@ import org.apache.james.queue.api.ManageableMailQueue;
 import org.apache.james.queue.api.RawMailQueueItemDecoratorFactory;
 import org.apache.james.queue.memory.MemoryMailQueueFactory;
 import org.apache.mailet.base.test.FakeMail;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.consumers.ConsumerChainer;
 import com.google.common.collect.ImmutableList;
 
-public class ReprocessingServiceTest {
+class ReprocessingServiceTest {
     private static final String MEMORY_PROTOCOL = "memory";
     private static final MailRepositoryPath PATH = MailRepositoryPath.from("path");
     private static final String NAME_1 = "key-1";
@@ -69,8 +69,8 @@ public class ReprocessingServiceTest {
     private FakeMail mail2;
     private FakeMail mail3;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         mailRepositoryStore = createMemoryMailRepositoryStore();
 
         queueFactory = new MemoryMailQueueFactory(new RawMailQueueItemDecoratorFactory());
@@ -94,7 +94,7 @@ public class ReprocessingServiceTest {
     }
 
     @Test
-    public void reprocessingOneShouldEnqueueMail() throws Exception {
+    void reprocessingOneShouldEnqueueMail() throws Exception {
         MailRepository repository = mailRepositoryStore.select(MailRepositoryUrl.fromPathAndProtocol(PATH, MEMORY_PROTOCOL));
         repository.store(mail1);
         repository.store(mail2);
@@ -109,7 +109,7 @@ public class ReprocessingServiceTest {
     }
 
     @Test
-    public void reprocessingOneShouldRemoveMailFromRepository() throws Exception {
+    void reprocessingOneShouldRemoveMailFromRepository() throws Exception {
         MailRepository repository = mailRepositoryStore.select(MailRepositoryUrl.fromPathAndProtocol(PATH, MEMORY_PROTOCOL));
         repository.store(mail1);
         repository.store(mail2);
@@ -122,7 +122,7 @@ public class ReprocessingServiceTest {
     }
 
     @Test
-    public void reprocessingShouldEmptyRepository() throws Exception {
+    void reprocessingShouldEmptyRepository() throws Exception {
         MailRepository repository = mailRepositoryStore.select(MailRepositoryUrl.fromPathAndProtocol(PATH, MEMORY_PROTOCOL));
         repository.store(mail1);
         repository.store(mail2);
@@ -135,7 +135,7 @@ public class ReprocessingServiceTest {
     }
 
     @Test
-    public void reprocessingShouldEnqueueAllMails() throws Exception {
+    void reprocessingShouldEnqueueAllMails() throws Exception {
         MailRepository repository = mailRepositoryStore.select(MailRepositoryUrl.fromPathAndProtocol(PATH, MEMORY_PROTOCOL));
         repository.store(mail1);
         repository.store(mail2);
@@ -150,7 +150,7 @@ public class ReprocessingServiceTest {
     }
 
     @Test
-    public void reprocessingShouldNotFailOnConcurrentDeletion() throws Exception {
+    void reprocessingShouldNotFailOnConcurrentDeletion() throws Exception {
         MailRepository repository = mailRepositoryStore.select(MailRepositoryUrl.fromPathAndProtocol(PATH, MEMORY_PROTOCOL));
         repository.store(mail1);
         repository.store(mail2);

--- a/third-party/spamassassin/src/test/java/org/apache/james/spamassassin/mock/MockSpamdExtension.java
+++ b/third-party/spamassassin/src/test/java/org/apache/james/spamassassin/mock/MockSpamdExtension.java
@@ -23,25 +23,29 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.james.util.concurrent.NamedThreadFactory;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
-public class MockSpamdTestRule extends ExternalResource {
+public class MockSpamdExtension implements AfterEachCallback, BeforeEachCallback {
 
     private ExecutorService executor = Executors.newSingleThreadExecutor(NamedThreadFactory.withClassName(getClass()));
     private MockSpamd spamd = new MockSpamd();
 
     @Override
-    protected void before() throws Throwable {
+    public void afterEach(ExtensionContext extensionContext) {
+        executor.shutdownNow();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
         spamd.bind();
         executor.execute(spamd);
     }
 
     public int getPort() {
         return spamd.getPort();
-    }
-
-    @Override
-    protected void after() {
-        executor.shutdownNow();
     }
 }

--- a/third-party/spamassassin/src/test/java/org/apache/james/spamassassin/mock/MockSpamdExtension.java
+++ b/third-party/spamassassin/src/test/java/org/apache/james/spamassassin/mock/MockSpamdExtension.java
@@ -24,10 +24,8 @@ import java.util.concurrent.Executors;
 
 import org.apache.james.util.concurrent.NamedThreadFactory;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.rules.ExternalResource;
 
 public class MockSpamdExtension implements AfterEachCallback, BeforeEachCallback {
 


### PR DESCRIPTION
(Except soon-to-be-deprecated JMAP draft)

Now we remain:

```
$ grep 'import org.junit.Test;' * -R | wc -l
357
```

119 being caused by JMAP draft