### PR TITLE
JAMES-3500 Fasten deploy: -T1C

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ pipeline {
             when { branch 'master' }
             steps {
                 echo 'Deploying'
-                sh 'mvn -B -e deploy -Pdeploy -DskipTests'
+                sh 'mvn -B -e deploy -Pdeploy -DskipTests -T2C'
             }
         }
    }


### PR DESCRIPTION
Deploying means uploading each jar generated by the build
to Apache Snapshot repository.

As a contributor, I hate it: it takes ages to complete, as
tons of small objects are uploaded sequencially.

A good way to speed things up is to leverage maven concurrency: instead of uploading one stuff at the same time,
we end up uploading 16 stuff at the same time.

This could take the deploy phase, currently taking 1h+ down to 5 minutes.