### PR TITLE
JAMES-3431 Fix various issues reported on DSN

### DIFF
--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -22,6 +22,7 @@ package org.apache.mailet;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -71,6 +72,11 @@ public class AttributeValue<T> {
     public static AttributeValue<Float> of(Float value) {
         Preconditions.checkNotNull(value, "value should not be null");
         return new AttributeValue<>(value, Serializer.FLOAT_SERIALIZER);
+    }
+
+    public static AttributeValue<ZonedDateTime> of(ZonedDateTime value) {
+        Preconditions.checkNotNull(value, "value should not be null");
+        return new AttributeValue<>(value, Serializer.DATE_SERIALIZER);
     }
 
     public static AttributeValue<Double> of(Double value) {
@@ -135,6 +141,9 @@ public class AttributeValue<T> {
         }
         if (value instanceof Double) {
             return of((Double) value);
+        }
+        if (value instanceof ZonedDateTime) {
+            return of((ZonedDateTime) value);
         }
         if (value instanceof Collection<?>) {
             return of(((Collection<AttributeValue<?>>) value));

--- a/mailet/api/src/main/java/org/apache/mailet/Serializer.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Serializer.java
@@ -19,11 +19,14 @@
 
 package org.apache.mailet;
 
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +83,7 @@ public interface Serializer<T> {
                     LONG_SERIALIZER,
                     FLOAT_SERIALIZER,
                     DOUBLE_SERIALIZER,
+                    DATE_SERIALIZER,
                     MESSAGE_ID_DTO_SERIALIZER,
                     new Serializer.ArbitrarySerializableSerializer<>(),
                     URL_SERIALIZER,
@@ -266,6 +270,36 @@ public interface Serializer<T> {
     }
 
     Serializer<Double> DOUBLE_SERIALIZER = new DoubleSerializer();
+
+    class DateSerializer implements Serializer<ZonedDateTime> {
+        @Override
+        public JsonNode serialize(ZonedDateTime object) {
+            String serialized = object.format(ISO_DATE_TIME);
+            return TextNode.valueOf(serialized);
+        }
+
+        @Override
+        public Optional<ZonedDateTime> deserialize(JsonNode json) {
+            if (json instanceof TextNode) {
+                String serialized = json.asText();
+                return Optional.of(ZonedDateTime.parse(serialized, ISO_DATE_TIME));
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        @Override
+        public String getName() {
+            return "DateSerializer";
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+    }
+
+    Serializer<ZonedDateTime> DATE_SERIALIZER = new DateSerializer();
 
     class MessageIdDtoSerializer implements Serializer<MessageIdDto> {
 

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -326,6 +327,46 @@ class AttributeValueTest {
         void fromJsonStringShouldThrowOnIntNode() {
             assertThatIllegalStateException()
                 .isThrownBy(() -> AttributeValue.fromJsonString("{\"serializer\":\"DoubleSerializer\",\"value\": 1}"));
+        }
+    }
+
+    @Nested
+    class DateSerialization {
+        @Test
+        void dateShouldBeSerializedAndBack() {
+            AttributeValue<ZonedDateTime> expected = AttributeValue.of(ZonedDateTime.parse("2015-10-30T16:12:00Z"));
+
+            JsonNode json = expected.toJson();
+            AttributeValue<?> actual = AttributeValue.fromJson(json);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        void nullDoubleShouldThrowAnException() {
+            assertThatNullPointerException()
+                .isThrownBy(() -> AttributeValue.of((Double) null));
+        }
+
+        @Test
+        void fromJsonStringShouldReturnDoubleAttributeValueWhenDouble() throws Exception {
+            AttributeValue<ZonedDateTime> expected = AttributeValue.of(ZonedDateTime.parse("2015-10-30T16:12:00Z"));
+
+            AttributeValue<?> actual = AttributeValue.fromJsonString("{\"serializer\":\"DateSerializer\",\"value\":\"2015-10-30T16:12:00Z\"}");
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        void fromJsonStringShouldThrowOnMalformedFormattedJson() {
+            assertThatIllegalStateException()
+                .isThrownBy(() -> AttributeValue.fromJsonString("{\"serializer\":\"DateSerializer\",\"value\": []}"));
+        }
+
+        @Test
+        void fromJsonStringShouldThrowOnIntNode() {
+            assertThatIllegalStateException()
+                .isThrownBy(() -> AttributeValue.fromJsonString("{\"serializer\":\"DateSerializer\",\"value\": 1}"));
         }
     }
 

--- a/mailet/base/src/main/java/org/apache/mailet/base/DateFormats.java
+++ b/mailet/base/src/main/java/org/apache/mailet/base/DateFormats.java
@@ -26,6 +26,6 @@ import java.util.Locale;
 public interface DateFormats {
 
     DateTimeFormatter RFC822_DATE_FORMAT =
-        DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss 'XXXXX' (z)", Locale.US);
+        DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss Z", Locale.US);
 }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -64,7 +64,10 @@ import org.apache.james.transport.util.ReplyToUtils;
 import org.apache.james.transport.util.SenderUtils;
 import org.apache.james.transport.util.SpecialAddressesUtils;
 import org.apache.james.transport.util.TosUtils;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeName;
 import org.apache.mailet.AttributeUtils;
+import org.apache.mailet.AttributeValue;
 import org.apache.mailet.DsnParameters;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.DateFormats;
@@ -469,6 +472,14 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
             .flatMap(DsnParameters::getEnvIdParameter)
             .ifPresent(envId -> buffer.append("Original-Envelope-Id: ")
                 .append(envId.asString())
+                .append(LINE_BREAK));
+        originalMail.getAttribute(AttributeName.of("dsn-arrival-date"))
+            .map(Attribute::getValue)
+            .map(AttributeValue::value)
+            .filter(ZonedDateTime.class::isInstance)
+            .map(ZonedDateTime.class::cast)
+            .ifPresent(arrivalDate -> buffer.append("Arrival-Date: ")
+                .append(arrivalDate.format(dateFormatter))
                 .append(LINE_BREAK));
 
         for (MailAddress rec : originalMail.getRecipients()) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -434,9 +434,14 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
                 .collect(Collectors.joining(", ")));
         builder.append(LINE_BREAK).append(LINE_BREAK);
         if (action.shouldIncludeDiagnostic()) {
-            builder.append("Error message:").append(LINE_BREAK);
-            builder.append(AttributeUtils.getValueAndCastFromMail(originalMail, DELIVERY_ERROR, String.class).orElse("")).append(LINE_BREAK);
-            builder.append(LINE_BREAK);
+            Optional<String> deliveryError = AttributeUtils.getValueAndCastFromMail(originalMail, DELIVERY_ERROR, String.class);
+
+            deliveryError.or(() -> Optional.ofNullable(originalMail.getErrorMessage()))
+                .ifPresent(message -> {
+                    builder.append("Error message:").append(LINE_BREAK);
+                    builder.append(message).append(LINE_BREAK);
+                    builder.append(LINE_BREAK);
+                });
         }
 
         MimeBodyPart bodyPart = new MimeBodyPart();

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -1364,4 +1364,102 @@ public class DSNBounceTest {
         SharedByteArrayInputStream actualContent = (SharedByteArrayInputStream) content.getBodyPart(1).getContent();
         assertThat(IOUtils.toString(actualContent, StandardCharsets.UTF_8)).isEqualTo(expectedContent);
     }
+
+    @Test
+    void errorMessagePartShouldNotBeAddedWhenNoError() throws Exception {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName(MAILET_NAME)
+            .mailetContext(fakeMailContext)
+            .setProperty("defaultStatus", "4.0.0")
+            .build();
+        dsnBounce.init(mailetConfig);
+
+        MailAddress senderMailAddress = new MailAddress("sender@domain.com");
+        FakeMail mail = FakeMail.builder()
+            .name(MAILET_NAME)
+            .sender(senderMailAddress)
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setText("My content"))
+            .recipient("recipient@domain.com")
+            .lastUpdated(Date.from(Instant.parse("2016-09-08T14:25:52.000Z")))
+            .remoteAddr("remoteHost")
+            .build();
+        mail.setDsnParameters(DsnParameters.builder().envId(DsnParameters.EnvId.of("xyz")).build().get());
+
+        dsnBounce.service(mail);
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+        MimeMessage sentMessage = sentMail.getMsg();
+
+        assertThat(MimeMessageUtil.asString(sentMessage))
+            .doesNotContain("Error message:");
+    }
+
+    @Test
+    void errorShouldBeAdded() throws Exception {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName(MAILET_NAME)
+            .mailetContext(fakeMailContext)
+            .setProperty("defaultStatus", "4.0.0")
+            .build();
+        dsnBounce.init(mailetConfig);
+
+        MailAddress senderMailAddress = new MailAddress("sender@domain.com");
+        FakeMail mail = FakeMail.builder()
+            .name(MAILET_NAME)
+            .sender(senderMailAddress)
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setText("My content"))
+            .recipient("recipient@domain.com")
+            .lastUpdated(Date.from(Instant.parse("2016-09-08T14:25:52.000Z")))
+            .remoteAddr("remoteHost")
+            .errorMessage("This is what happen...")
+            .build();
+        mail.setDsnParameters(DsnParameters.builder().envId(DsnParameters.EnvId.of("xyz")).build().get());
+
+        dsnBounce.service(mail);
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+        MimeMessage sentMessage = sentMail.getMsg();
+
+        assertThat(MimeMessageUtil.asString(sentMessage))
+            .contains("Error message:\nThis is what happen...");
+    }
+
+    @Test
+    void deliveryErrorShouldBeAdded() throws Exception {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName(MAILET_NAME)
+            .mailetContext(fakeMailContext)
+            .setProperty("defaultStatus", "4.0.0")
+            .build();
+        dsnBounce.init(mailetConfig);
+
+        MailAddress senderMailAddress = new MailAddress("sender@domain.com");
+        FakeMail mail = FakeMail.builder()
+            .name(MAILET_NAME)
+            .sender(senderMailAddress)
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setText("My content"))
+            .recipient("recipient@domain.com")
+            .lastUpdated(Date.from(Instant.parse("2016-09-08T14:25:52.000Z")))
+            .remoteAddr("remoteHost")
+            .attribute(new Attribute(AttributeName.of("delivery-error"), AttributeValue.of("This is what happen...")))
+            .build();
+        mail.setDsnParameters(DsnParameters.builder().envId(DsnParameters.EnvId.of("xyz")).build().get());
+
+        dsnBounce.service(mail);
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+        MimeMessage sentMessage = sentMail.getMsg();
+
+        assertThat(MimeMessageUtil.asString(sentMessage))
+            .contains("Error message:\nThis is what happen...");
+    }
 }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -29,6 +29,7 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 
@@ -45,6 +46,8 @@ import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.transport.mailets.redirect.SpecialAddress;
 import org.apache.james.util.MimeMessageUtil;
 import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.AttributeValue;
 import org.apache.mailet.DsnParameters;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.DateFormats;
@@ -1260,6 +1263,50 @@ public class DSNBounceTest {
         String expectedContent = "Reporting-MTA: dns; myhost\n" +
             "Received-From-MTA: dns; 111.222.333.444\n" +
             "Original-Envelope-Id: xyz\n" +
+            "\n" +
+            "Final-Recipient: rfc822; recipient@domain.com\n" +
+            "Action: failed\n" +
+            "Status: Delivery error\n" +
+            "Diagnostic-Code: X-James; Delivery error\n" +
+            "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+        MimeMessage sentMessage = sentMail.getMsg();
+        MimeMultipart content = (MimeMultipart) sentMessage.getContent();
+        SharedByteArrayInputStream actualContent = (SharedByteArrayInputStream) content.getBodyPart(1).getContent();
+        assertThat(IOUtils.toString(actualContent, StandardCharsets.UTF_8)).isEqualTo(expectedContent);
+    }
+
+    @Test
+    void ArrivalDateShouldBePositioned() throws Exception {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName(MAILET_NAME)
+            .mailetContext(fakeMailContext)
+            .build();
+        dsnBounce.init(mailetConfig);
+
+        MailAddress senderMailAddress = new MailAddress("sender@domain.com");
+        FakeMail mail = FakeMail.builder()
+            .name(MAILET_NAME)
+            .sender(senderMailAddress)
+            .attribute(DELIVERY_ERROR_ATTRIBUTE)
+            .attribute(new Attribute(AttributeName.of("dsn-arrival-date"), AttributeValue.of(ZonedDateTime.parse("2015-10-30T16:12:00Z"))))
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setText("My content"))
+            .recipient("recipient@domain.com")
+            .lastUpdated(Date.from(Instant.parse("2016-09-08T14:25:52.000Z")))
+            .remoteAddr("remoteHost")
+            .build();
+        mail.setDsnParameters(DsnParameters.builder().envId(DsnParameters.EnvId.of("xyz")).build().get());
+
+        dsnBounce.service(mail);
+
+        String expectedContent = "Reporting-MTA: dns; myhost\n" +
+            "Received-From-MTA: dns; 111.222.333.444\n" +
+            "Original-Envelope-Id: xyz\n" +
+            "Arrival-Date: Fri, 30 Oct 2015 16:12:00 XXXXX (UTC)\n" +
             "\n" +
             "Final-Recipient: rfc822; recipient@domain.com\n" +
             "Action: failed\n" +

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -761,7 +761,7 @@ public class DSNBounceTest {
                 "Action: failed\n" +
                 "Status: Delivery error\n" +
                 "Diagnostic-Code: X-James; Delivery error\n" +
-                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
             List<SentMail> sentMails = fakeMailContext.getSentMails();
             assertThat(sentMails).hasSize(1);
@@ -876,7 +876,7 @@ public class DSNBounceTest {
                 "Final-Recipient: rfc822; recipient@domain.com\n" +
                 "Action: delivered\n" +
                 "Status: unknown\n" +
-                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
             List<SentMail> sentMails = fakeMailContext.getSentMails();
             assertThat(sentMails).hasSize(1);
@@ -995,7 +995,7 @@ public class DSNBounceTest {
                 "Action: delayed\n" +
                 "Status: Delivery error\n" +
                 "Diagnostic-Code: X-James; Delivery error\n" +
-                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
             List<SentMail> sentMails = fakeMailContext.getSentMails();
             assertThat(sentMails).hasSize(1);
@@ -1110,7 +1110,7 @@ public class DSNBounceTest {
                 "Final-Recipient: rfc822; recipient@domain.com\n" +
                 "Action: relayed\n" +
                 "Status: unknown\n" +
-                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
             List<SentMail> sentMails = fakeMailContext.getSentMails();
             assertThat(sentMails).hasSize(1);
@@ -1225,7 +1225,7 @@ public class DSNBounceTest {
                 "Final-Recipient: rfc822; recipient@domain.com\n" +
                 "Action: expanded\n" +
                 "Status: unknown\n" +
-                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+                "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
             List<SentMail> sentMails = fakeMailContext.getSentMails();
             assertThat(sentMails).hasSize(1);
@@ -1268,7 +1268,7 @@ public class DSNBounceTest {
             "Action: failed\n" +
             "Status: Delivery error\n" +
             "Diagnostic-Code: X-James; Delivery error\n" +
-            "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+            "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
         List<SentMail> sentMails = fakeMailContext.getSentMails();
         assertThat(sentMails).hasSize(1);
@@ -1306,13 +1306,13 @@ public class DSNBounceTest {
         String expectedContent = "Reporting-MTA: dns; myhost\n" +
             "Received-From-MTA: dns; 111.222.333.444\n" +
             "Original-Envelope-Id: xyz\n" +
-            "Arrival-Date: Fri, 30 Oct 2015 16:12:00 XXXXX (UTC)\n" +
+            "Arrival-Date: Fri, 30 Oct 2015 16:12:00 +0000\n" +
             "\n" +
             "Final-Recipient: rfc822; recipient@domain.com\n" +
             "Action: failed\n" +
             "Status: Delivery error\n" +
             "Diagnostic-Code: X-James; Delivery error\n" +
-            "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+            "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
         List<SentMail> sentMails = fakeMailContext.getSentMails();
         assertThat(sentMails).hasSize(1);
@@ -1354,7 +1354,7 @@ public class DSNBounceTest {
             "Action: failed\n" +
             "Status: 4.0.0\n" +
             "Diagnostic-Code: X-James; 4.0.0\n" +
-            "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 XXXXX (UTC)\n";
+            "Last-Attempt-Date: Thu, 8 Sep 2016 14:25:52 +0000\n";
 
         List<SentMail> sentMails = fakeMailContext.getSentMails();
         assertThat(sentMails).hasSize(1);

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -1280,7 +1280,7 @@ public class DSNBounceTest {
     }
 
     @Test
-    void ArrivalDateShouldBePositioned() throws Exception {
+    void arrivalDateShouldBePositioned() throws Exception {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
             .mailetName(MAILET_NAME)
             .mailetContext(fakeMailContext)

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/dsn/DSNMessageHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/dsn/DSNMessageHook.java
@@ -23,6 +23,7 @@ import static org.apache.james.smtpserver.dsn.DSNMailParameterHook.DSN_ENVID;
 import static org.apache.james.smtpserver.dsn.DSNMailParameterHook.DSN_RET;
 import static org.apache.james.smtpserver.dsn.DSNRcptParameterHook.DSN_RCPT_PARAMETERS;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
@@ -30,6 +31,9 @@ import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.smtpserver.JamesMessageHook;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.AttributeValue;
 import org.apache.mailet.DsnParameters;
 import org.apache.mailet.Mail;
 
@@ -47,6 +51,7 @@ public class DSNMessageHook implements JamesMessageHook {
 
         DsnParameters.of(envId, ret, rcptParameters)
             .ifPresent(mail::setDsnParameters);
+        mail.setAttribute(new Attribute(AttributeName.of("dsn-arrival-date"), AttributeValue.of(ZonedDateTime.now())));
         return HookResult.DECLINED;
     }
 }


### PR DESCRIPTION
Otto, Karsten Andreas reported the following issues so far regarding DSN

```
 1. When I send a mail to an unknown user, the DSN report (part 1) has no text after "Error message:". There is a comment in the mail MailDispatcher class that might explain it?
    // In order for this server to meet the requirements of the SMTP
    // specification, mails on the ERROR processor must be returned to
    // the sender. Note that this email doesn't include any details
    // regarding the details of the failure(s).
    // In the future we may wish to address this.
    Anyways, this is no big issue for us, as we can describe the problem in the <messageString>. But the empty text is confusing, I thought it to be a bug at first.
    => Please change the report generation to just hide the "Error message:" part if there is no error message to report.

 2. I see a strange date format in the DSN report (part 2), e.g.
    Last-Attempt-Date: Mon, 15 Feb 2021 15:45:20 XXXXX (CET)
    According to rfc3464#section-2.3.7 this header must use the numeric timezone format (+hh:mm/-hh:mm). Does the XXXXX serve any special purpose?
    => Please fix this date format here to comply with the RFC.

 3. We would also like to have the Arrival-Date (rfc3464#section-2.2.5) header in the DSN report (part 2) as well. In the past I found it a useful diagnostic in conjunction with Last-Attempt-Date, especially with delayed delivery cases. Does James per chance already record the timestamp on each incoming mail?
    => Please add the Arrival-Date header to the DSN report. Record the necessary timestamp on mail arrival if James does not have this data already. 
```