### PR TITLE
JAMES-3470 Bind Cassandra changes DAOs in singleton scope

### DIFF
--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
@@ -35,6 +35,8 @@ import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.cassandra.change.CassandraEmailChangeRepository;
 import org.apache.james.jmap.cassandra.change.CassandraMailboxChangeRepository;
 import org.apache.james.jmap.cassandra.change.CassandraStateFactory;
+import org.apache.james.jmap.cassandra.change.EmailChangeRepositoryDAO;
+import org.apache.james.jmap.cassandra.change.MailboxChangeRepositoryDAO;
 import org.apache.james.mailbox.AttachmentContentLoader;
 import org.apache.james.mailbox.AttachmentManager;
 import org.apache.james.mailbox.Authenticator;
@@ -165,6 +167,8 @@ public class CassandraMailboxModule extends AbstractModule {
         bind(NoMailboxPathLocker.class).in(Scopes.SINGLETON);
         bind(UserRepositoryAuthenticator.class).in(Scopes.SINGLETON);
         bind(UserRepositoryAuthorizator.class).in(Scopes.SINGLETON);
+        bind(EmailChangeRepositoryDAO.class).in(Scopes.SINGLETON);
+        bind(MailboxChangeRepositoryDAO.class).in(Scopes.SINGLETON);
 
         bind(ReIndexerImpl.class).in(Scopes.SINGLETON);
         bind(MessageIdReIndexerImpl.class).in(Scopes.SINGLETON);

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/MailboxChangeRepositoryDAO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/MailboxChangeRepositoryDAO.java
@@ -62,7 +62,7 @@ import com.google.common.collect.ImmutableSet;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-class MailboxChangeRepositoryDAO {
+public class MailboxChangeRepositoryDAO {
     private final CassandraAsyncExecutor executor;
     private final UserType zonedDateTimeUserType;
     private final PreparedStatement insertStatement;


### PR DESCRIPTION
This avoids re-preparing several time the same Cassandra queries