### PR TITLE
JAMES-1717 VacationMailet should avoid logging when no ReplyTo headers

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.mailet;
 
 import java.time.ZonedDateTime;
 import java.util.Locale;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.mail.MessagingException;
@@ -71,8 +72,10 @@ public class VacationMailet extends GenericMailet {
             if (!mail.hasSender()) {
                 return;
             }
-            if (!automaticallySentMailDetector.isAutomaticallySent(mail)
-                    && mail.getMessage().getReplyTo().length > 0) {
+            boolean hasReplyToHeaderField = Optional.ofNullable(mail.getMessage().getReplyTo())
+                .map(replyToFields -> replyToFields.length > 0)
+                .orElse(false);
+            if (!automaticallySentMailDetector.isAutomaticallySent(mail) && hasReplyToHeaderField) {
                 ZonedDateTime processingDate = zonedDateTimeProvider.get();
                 mail.getRecipients()
                     .forEach(mailAddress -> manageVacation(mailAddress, mail, processingDate));


### PR DESCRIPTION
Some instances of MimeMessage might return null when the requested header
do not exist resulting in a NPE, that got logged.

Behaviour is not altered, as in both case we do abort the processing.