### PR TITLE
JAMES-3506 Avoid copies when reading byte buffers

### DIFF
--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CassandraBlobStoreCache.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CassandraBlobStoreCache.java
@@ -121,6 +121,9 @@ public class CassandraBlobStoreCache implements BlobStoreCache {
 
     private byte[] toByteArray(Row row) {
         ByteBuffer byteBuffer = row.getBytes(DATA);
+        if (byteBuffer.hasArray()) {
+            return byteBuffer.array();
+        }
         byte[] data = new byte[byteBuffer.remaining()];
         byteBuffer.get(data);
         return data;

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -72,8 +72,7 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
     @Override
     public Response onLine(SMTPSession session, ByteBuffer lineByteBuffer, LineHandler<SMTPSession> next) {
 
-        byte[] line = new byte[lineByteBuffer.remaining()];
-        lineByteBuffer.get(line, 0, line.length);
+        byte[] line = readBytes(lineByteBuffer);
 
         MimeMessageInputStreamSource mmiss = session.getAttachment(SMTPConstants.DATA_MIMEMESSAGE_STREAMSOURCE, State.Transaction)
             .orElseThrow(() -> new RuntimeException("'" + SMTPConstants.DATA_MIMEMESSAGE_STREAMSOURCE.asString() + "' has not been filled."));
@@ -133,6 +132,18 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
             return response;
         }
         return null;
+    }
+
+    private byte[] readBytes(ByteBuffer line) {
+        line.rewind();
+
+        if (line.hasArray()) {
+            return line.array();
+        } else {
+            byte[] bline = new byte[line.remaining()];
+            line.get(bline);
+            return bline;
+        }
     }
 
     protected Response processExtensions(SMTPSession session, Mail mail) {


### PR DESCRIPTION
https://docs.oracle.com/javase/7/docs/api/java/nio/ByteBuffer.html#hasArray()

```
Tells whether or not this buffer is backed by an accessible byte array.

If this method returns true then the array and arrayOffset methods may safely be invoked. 
```

https://docs.oracle.com/javase/7/docs/api/java/nio/ByteBuffer.html#array()

```
Returns the byte array that backs this buffer  (optional operation). 
```

As I understand that you feel concerned I will open a separated PR, But still want this code merged.