### PR TITLE
JAMES-3506 Avoid a full body read within VacationMailet

### DIFF
--- a/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/AutomaticallySentMailDetectorImplTest.java
+++ b/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/AutomaticallySentMailDetectorImplTest.java
@@ -261,6 +261,7 @@ class AutomaticallySentMailDetectorImplTest {
     void isMdnSentAutomaticallyShouldBeDetected() throws Exception {
         MimeMessage message = new MimeMessage(Session.getDefaultInstance(new Properties()));
         MimeMultipart multipart = new MimeMultipart();
+        multipart.setSubType("report");
         MimeBodyPart scriptPart = new MimeBodyPart();
         scriptPart.setDataHandler(
                 new DataHandler(
@@ -380,6 +381,7 @@ class AutomaticallySentMailDetectorImplTest {
     void isMdnSentAutomaticallyShouldDetectBigMDN() throws Exception {
         MimeMessage message = MimeMessageUtil.defaultMimeMessage();
         MimeMultipart multipart = new MimeMultipart();
+        multipart.setSubType("report");
         MimeBodyPart scriptPart = new MimeBodyPart();
         scriptPart.setDataHandler(
             new DataHandler(


### PR DESCRIPTION
In order to see if a part have the message/disposition-notification content type
a full parsing of the message is required.

MDNs falls in the category of automatically
generated reports described in RFC-1892

The Multipart/Report Content Type for the Reporting of Mail System Administrative Messages

The Multipart/Report MIME content-type is a general "family" or
   "container" type for electronic mail reports of any kind.

So:

 - Not only we are more generic
 - But also we save a full message read and parsing