### PR TITLE
JAMES-3499 Distributed guice module should not depend on activemq

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-ldap/Dockerfile
@@ -19,8 +19,8 @@ EXPOSE 25 110 143 465 587 993 4000 8000
 WORKDIR /root
 
 # Get data we need to run James : build results and configuration
-ADD destination/james-server-cassandra-ldap-guice.jar /root/james-server.jar
-ADD destination/james-server-cassandra-ldap-guice.lib /root/james-server-cassandra-ldap-guice.lib
+ADD destination/james-server-cassandra-guice.jar /root/james-server.jar
+ADD destination/james-server-cassandra-guice.lib /root/james-server-cassandra-guice.lib
 ADD destination/james-server-cli.jar /root/james-cli.jar
 ADD destination/james-server-cli.lib /root/james-server-cli.lib
 ADD destination/conf /root/conf

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/Dockerfile
@@ -19,8 +19,8 @@ EXPOSE 25 110 143 465 587 993 4000 8000
 WORKDIR /root
 
 # Get data we need to run James : build results and configuration
-ADD destination/james-server-cassandra-rabbitmq-ldap-guice.jar /root/james-server.jar
-ADD destination/james-server-cassandra-rabbitmq-ldap-guice.lib /root/james-server-cassandra-rabbitmq-ldap-guice.lib
+ADD destination/james-server-cassandra-rabbitmq-guice.jar /root/james-server.jar
+ADD destination/james-server-cassandra-rabbitmq-guice.lib /root/james-server-cassandra-rabbitmq-guice.lib
 ADD destination/james-server-cli.jar /root/james-cli.jar
 ADD destination/james-server-cli.lib /root/james-server-cli.lib
 ADD destination/conf /root/conf

--- a/server/container/guice/distributed/pom.xml
+++ b/server/container/guice/distributed/pom.xml
@@ -62,10 +62,6 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-cassandra-guice</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-cassandra</artifactId>
         </dependency>
         <dependency>

--- a/server/protocols/webadmin/webadmin-mailbox/pom.xml
+++ b/server/protocols/webadmin/webadmin-mailbox/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-elasticsearch</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>


### PR DESCRIPTION
When building custom servers using the James Guice toolkits, this allows having distributed modules without the ActiveMQ dependency.