### PR TITLE
JAMES-3316 Modularize JMAP routes and authentication mechanism

### DIFF
--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPRoutesHandler.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPRoutesHandler.java
@@ -33,6 +33,11 @@ public class JMAPRoutesHandler {
         this.routes = ImmutableSet.copyOf(routes);
     }
 
+    public JMAPRoutesHandler(Version version, Set<JMAPRoutes> routes) {
+        this.version = version;
+        this.routes = routes;
+    }
+
     Stream<JMAPRoute> routes(Version versionRequest) {
         if (version.equals(versionRequest)) {
             return routes.stream()

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/Authenticator.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/Authenticator.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.jmap.http;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.james.jmap.exceptions.UnauthorizedException;
@@ -33,6 +34,10 @@ import reactor.netty.http.server.HttpServerRequest;
 
 public class Authenticator {
     public static Authenticator of(MetricFactory metricFactory, AuthenticationStrategy... authenticationStrategies) {
+        return of(metricFactory, ImmutableList.copyOf(authenticationStrategies));
+    }
+
+    public static Authenticator of(MetricFactory metricFactory, Collection<AuthenticationStrategy> authenticationStrategies) {
         return new Authenticator(ImmutableList.copyOf(authenticationStrategies), metricFactory);
     }
 


### PR DESCRIPTION
This allow third party to reuse the existing Guice modules while adding
their own extra routes and authentication mechanism.

We are writing our first JMAP extensions in a third part project, this work is a prelude to an `extend JMAP` user guide :muscle:  :muscle: 