### PR TITLE
JAMES-3519: Allow ElasticSearchConfiguration customization

### DIFF
--- a/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ClientProvider.java
+++ b/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ClientProvider.java
@@ -53,8 +53,6 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
@@ -185,8 +183,7 @@ public class ClientProvider implements Provider<ReactorElasticSearchClient> {
     private final ReactorElasticSearchClient client;
 
     @Inject
-    @VisibleForTesting
-    ClientProvider(ElasticSearchConfiguration configuration) {
+    public ClientProvider(ElasticSearchConfiguration configuration) {
         this.httpAsyncClientConfigurer = new HttpAsyncClientConfigurer(configuration);
         this.configuration = configuration;
         this.elasticSearchRestHighLevelClient = connect(configuration);

--- a/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ElasticSearchConfiguration.java
+++ b/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ElasticSearchConfiguration.java
@@ -191,9 +191,9 @@ public class ElasticSearchConfiguration {
             }
         }
 
-        static class Builder {
+        public static class Builder {
 
-            interface RequireSSLStrategyTrustStore {
+            public interface RequireSSLStrategyTrustStore {
                 RequireHostNameVerifier sslStrategy(SSLValidationStrategy strategy, Optional<SSLTrustStore> trustStore);
 
                 default RequireHostNameVerifier strategyIgnore() {
@@ -209,7 +209,7 @@ public class ElasticSearchConfiguration {
                 }
             }
 
-            interface RequireHostNameVerifier {
+            public interface RequireHostNameVerifier {
                 ReadyToBuild hostNameVerifier(HostNameVerifier hostNameVerifier);
 
                 default ReadyToBuild acceptAnyHostNameVerifier() {
@@ -221,7 +221,7 @@ public class ElasticSearchConfiguration {
                 }
             }
 
-            static class ReadyToBuild {
+            public static class ReadyToBuild {
                 private final SSLValidationStrategy sslValidationStrategy;
                 private final HostNameVerifier hostNameVerifier;
                 private Optional<SSLTrustStore> sslTrustStore;
@@ -247,7 +247,7 @@ public class ElasticSearchConfiguration {
             return new SSLConfiguration(SSLValidationStrategy.DEFAULT, HostNameVerifier.DEFAULT, Optional.empty());
         }
 
-        static Builder.RequireSSLStrategyTrustStore builder() {
+        public static Builder.RequireSSLStrategyTrustStore builder() {
             return (strategy, trustStore) -> hostNameVerifier -> new Builder.ReadyToBuild(strategy, hostNameVerifier, trustStore);
         }
 


### PR DESCRIPTION
Builders related to ElasticSearchConfiguration are using default access modifier, preventing users from creating their own configuration in their product.