### PR TITLE
JAMES-3316 Allow custom properties payload for custom capabilities in…

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.MailboxSession
 import org.apache.james.utils.DataProbeImpl
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.reactivestreams.Publisher
+import play.api.libs.json.{JsObject, Json}
 import reactor.core.scala.publisher.SMono
 
 object CustomMethodContract {
@@ -75,7 +76,7 @@ object CustomMethodContract {
       |      "url": "http://domain.com/jmap/ws"
       |    },
       |    "urn:apache:james:params:jmap:mail:quota": {},
-      |    "$CUSTOM": {},
+      |    "$CUSTOM": {"custom": "property"},
       |    "urn:apache:james:params:jmap:mail:shares": {},
       |    "urn:ietf:params:jmap:vacationresponse":{}
       |  },
@@ -113,7 +114,7 @@ object CustomMethodContract {
       |        },
       |        "urn:apache:james:params:jmap:mail:quota": {},
       |        "urn:apache:james:params:jmap:mail:shares": {},
-      |        "$CUSTOM": {},
+      |        "$CUSTOM": {"custom": "property"},
       |        "urn:ietf:params:jmap:vacationresponse":{}
       |      }
       |    }
@@ -137,7 +138,9 @@ object CustomMethodContract {
       |}""".stripMargin
 }
 
-case class CustomCapabilityProperties() extends CapabilityProperties
+case class CustomCapabilityProperties() extends CapabilityProperties {
+  override def jsonify(): JsObject = Json.obj(("custom", "property"))
+}
 
 case class CustomCapability(properties: CustomCapabilityProperties = CustomCapabilityProperties(), identifier: CapabilityIdentifier = CUSTOM) extends Capability
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
@@ -88,42 +88,19 @@ object ResponseSerializer {
 
   private implicit val usernameWrites: Writes[Username] = username => JsString(username.asString)
   private implicit val urlWrites: Writes[URL] = url => JsString(url.toString)
-  private implicit val coreCapabilityWrites: Writes[CoreCapabilityProperties] = Json.writes[CoreCapabilityProperties]
-  private implicit val mailCapabilityWrites: Writes[MailCapabilityProperties] = Json.writes[MailCapabilityProperties]
+  val coreCapabilityWrites: OWrites[CoreCapabilityProperties] = Json.writes[CoreCapabilityProperties]
+  val mailCapabilityWrites: OWrites[MailCapabilityProperties] = Json.writes[MailCapabilityProperties]
   private implicit val maxDelayedSendWrites: Writes[MaxDelayedSend] = Json.valueWrites[MaxDelayedSend]
   private implicit val ehloNameWrites: Writes[EhloName] = Json.valueWrites[EhloName]
   private implicit val ehloArgsWrites: Writes[EhloArgs] = Json.valueWrites[EhloArgs]
   private implicit val supportsPushWrites: Writes[SupportsPush] = Json.valueWrites[SupportsPush]
-  private implicit val submissionPropertiesWrites: Writes[SubmissionProperties] = Json.writes[SubmissionProperties]
-  private implicit val webSocketPropertiesWrites: Writes[WebSocketCapabilityProperties] = Json.writes[WebSocketCapabilityProperties]
-  private implicit val quotaCapabilityWrites: Writes[QuotaCapabilityProperties] = OWrites[QuotaCapabilityProperties](_ => Json.obj())
-  private implicit val sharesCapabilityWrites: Writes[SharesCapabilityProperties] = OWrites[SharesCapabilityProperties](_ => Json.obj())
-  private implicit val vacationResponseCapabilityWrites: Writes[VacationResponseCapabilityProperties] = OWrites[VacationResponseCapabilityProperties](_ => Json.obj())
-  private implicit val submissionCapabilityWrites: Writes[SubmissionCapability] = OWrites[SubmissionCapability](_ => Json.obj())
-  private implicit val webSocketCapabilityWrites: Writes[WebSocketCapability] = OWrites[WebSocketCapability](_ => Json.obj())
+  val submissionPropertiesWrites: OWrites[SubmissionProperties] = Json.writes[SubmissionProperties]
+  val webSocketPropertiesWrites: OWrites[WebSocketCapabilityProperties] = Json.writes[WebSocketCapabilityProperties]
 
   private implicit val setCapabilityWrites: Writes[Set[_ <: Capability]] =
     (set: Set[_ <: Capability]) => {
-      set.foldLeft(JsObject.empty)((jsObject, capability) => {
-        capability match {
-          case capability: CoreCapability =>
-            jsObject.+(capability.identifier.value, coreCapabilityWrites.writes(capability.properties))
-          case capability: MailCapability =>
-            jsObject.+(capability.identifier.value, mailCapabilityWrites.writes(capability.properties))
-          case capability: QuotaCapability =>
-            jsObject.+(capability.identifier.value, quotaCapabilityWrites.writes(capability.properties))
-          case capability: SharesCapability =>
-            jsObject.+(capability.identifier.value, sharesCapabilityWrites.writes(capability.properties))
-          case capability: VacationResponseCapability =>
-            jsObject.+(capability.identifier.value, vacationResponseCapabilityWrites.writes(capability.properties))
-          case capability: SubmissionCapability =>
-            jsObject.+(capability.identifier.value, submissionPropertiesWrites.writes(capability.properties))
-          case capability: WebSocketCapability =>
-            jsObject.+(capability.identifier.value, webSocketPropertiesWrites.writes(capability.properties))
-          case _ =>
-            jsObject.+(capability.identifier.value, JsObject(Map[String, JsValue]()))
-        }
-      })
+      set.foldLeft(JsObject.empty)((jsObject, capability) =>
+        jsObject.+(capability.identifier.value, capability.properties.jsonify))
     }
 
   private implicit val capabilitiesWrites: Writes[Capabilities] = capabilities => setCapabilityWrites.writes(capabilities.capabilities)


### PR DESCRIPTION
… JMAP session

Currently, extra capability needed to have empty properties as the JSON generation
of the session capability payload was not modular.

We add an indirection level (the capability properties becomes JSON aware) in order to
permit that.

Session in a conveniant mean to convey information regarding JMAP extensions thus
customizing its payload is critical.