### PR TITLE
JAMES-3529 Validate version when set Filter

### DIFF
--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/FilteringManagement.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/FilteringManagement.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.api.filtering;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.core.Username;
 import org.reactivestreams.Publisher;
@@ -29,14 +30,14 @@ import com.google.common.collect.ImmutableList;
 
 public interface FilteringManagement {
 
-    Publisher<Void> defineRulesForUser(Username username, List<Rule> rules);
+    Publisher<Version> defineRulesForUser(Username username, List<Rule> rules, Optional<Version> ifInState);
 
-    default Publisher<Void> defineRulesForUser(Username username, Rule... rules) {
-        return defineRulesForUser(username, Arrays.asList(rules));
+    default Publisher<Version> defineRulesForUser(Username username, Optional<Version> ifInState, Rule... rules) {
+        return defineRulesForUser(username, Arrays.asList(rules), ifInState);
     }
 
-    default Publisher<Void> clearRulesForUser(Username username) {
-        return defineRulesForUser(username, ImmutableList.of());
+    default Publisher<Version> clearRulesForUser(Username username, Optional<Version> ifInState) {
+        return defineRulesForUser(username, ImmutableList.of(), ifInState);
     }
 
     Publisher<Rules> listRulesForUser(Username username);

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/FilteringManagement.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/FilteringManagement.java
@@ -36,8 +36,8 @@ public interface FilteringManagement {
         return defineRulesForUser(username, Arrays.asList(rules), ifInState);
     }
 
-    default Publisher<Version> clearRulesForUser(Username username, Optional<Version> ifInState) {
-        return defineRulesForUser(username, ImmutableList.of(), ifInState);
+    default Publisher<Version> clearRulesForUser(Username username) {
+        return defineRulesForUser(username, ImmutableList.of(), Optional.empty());
     }
 
     Publisher<Rules> listRulesForUser(Username username);

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Version.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Version.java
@@ -56,4 +56,8 @@ public class Version {
     public String asString() {
         return String.valueOf(version);
     }
+
+    public int asInteger() {
+        return version;
+    }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/DefineRulesCommand.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/DefineRulesCommand.java
@@ -21,10 +21,12 @@ package org.apache.james.jmap.api.filtering.impl;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.james.core.Username;
 import org.apache.james.eventsourcing.Command;
 import org.apache.james.jmap.api.filtering.Rule;
+import org.apache.james.jmap.api.filtering.Version;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -33,17 +35,23 @@ public class DefineRulesCommand implements Command {
 
     private final Username username;
     private final List<Rule> rules;
+    private final Optional<Version> ifInState;
 
-    public DefineRulesCommand(Username username, List<Rule> rules) {
+    public DefineRulesCommand(Username username, List<Rule> rules, Optional<Version> ifInState) {
         Preconditions.checkNotNull(username);
         Preconditions.checkNotNull(rules);
 
         this.username = username;
         this.rules = rules;
+        this.ifInState = ifInState;
     }
 
     public List<Rule> getRules() {
         return rules;
+    }
+
+    public Optional<Version> getIfInState() {
+        return ifInState;
     }
 
     public Username getUsername() {
@@ -56,14 +64,15 @@ public class DefineRulesCommand implements Command {
             DefineRulesCommand that = (DefineRulesCommand) o;
 
             return Objects.equals(this.username, that.username)
-                && Objects.equals(this.rules, that.rules);
+                && Objects.equals(this.rules, that.rules)
+                && Objects.equals(this.ifInState, that.ifInState);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(username, rules);
+        return Objects.hash(username, rules, ifInState);
     }
 
     @Override
@@ -71,6 +80,7 @@ public class DefineRulesCommand implements Command {
         return MoreObjects.toStringHelper(this)
             .add("user", username)
             .add("rules", rules)
+            .add("ifInState", ifInState)
             .toString();
     }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/DefineRulesCommandHandler.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/DefineRulesCommandHandler.java
@@ -46,7 +46,7 @@ public class DefineRulesCommandHandler implements CommandHandler<DefineRulesComm
         FilteringAggregateId aggregateId = new FilteringAggregateId(storeCommand.getUsername());
 
         return Mono.from(eventStore.getEventsOfAggregate(aggregateId))
-        .map(history -> FilteringAggregate.load(aggregateId, history).defineRules(storeCommand.getRules()));
+            .map(history -> FilteringAggregate.load(aggregateId, history).defineRules(storeCommand));
     }
 
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregate.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregate.java
@@ -68,7 +68,7 @@ public class FilteringAggregate {
 
     public List<? extends Event> defineRules(DefineRulesCommand storeCommand) {
         Preconditions.checkArgument(shouldNotContainDuplicates(storeCommand.getRules()));
-        Preconditions.checkArgument(expectedState(storeCommand.getIfInState()));
+        Preconditions.checkArgument(expectedState(storeCommand.getIfInState()), "Provided state must be as same as the current state");
         ImmutableList<RuleSetDefined> events = ImmutableList.of(
             new RuleSetDefined(aggregateId, history.getNextEventId(), ImmutableList.copyOf(storeCommand.getRules())));
         events.forEach(this::apply);

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregate.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregate.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.api.filtering.impl;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.eventsourcing.Event;
 import org.apache.james.eventsourcing.EventId;
@@ -65,10 +66,11 @@ public class FilteringAggregate {
         this.history = history;
     }
 
-    public List<? extends Event> defineRules(List<Rule> rules) {
-        Preconditions.checkArgument(shouldNotContainDuplicates(rules));
+    public List<? extends Event> defineRules(DefineRulesCommand storeCommand) {
+        Preconditions.checkArgument(shouldNotContainDuplicates(storeCommand.getRules()));
+        Preconditions.checkArgument(expectedState(storeCommand.getIfInState()));
         ImmutableList<RuleSetDefined> events = ImmutableList.of(
-            new RuleSetDefined(aggregateId, history.getNextEventId(), ImmutableList.copyOf(rules)));
+            new RuleSetDefined(aggregateId, history.getNextEventId(), ImmutableList.copyOf(storeCommand.getRules())));
         events.forEach(this::apply);
         return events;
     }
@@ -79,6 +81,14 @@ public class FilteringAggregate {
             .distinct()
             .count();
         return uniqueIdCount == rules.size();
+    }
+
+    private boolean expectedState(Optional<Version> ifInState) {
+        return ifInState.map(requestedVersion -> history.getVersionAsJava()
+                .map(eventId -> new Version(eventId.value()))
+                .orElse(Version.INITIAL)
+                .equals(requestedVersion))
+            .orElse(true);
     }
 
     public Rules listRules() {

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/FilteringManagementContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/FilteringManagementContract.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.core.Username;
 import org.apache.james.eventsourcing.eventstore.EventStore;
@@ -37,7 +38,6 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface FilteringManagementContract {
@@ -66,7 +66,7 @@ public interface FilteringManagementContract {
     default void listingRulesShouldReturnDefinedRules(EventStore eventStore) {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
 
-        Mono.from(testee.defineRulesForUser(USERNAME, RULE_1, RULE_2)).block();
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_1, RULE_2)).block();
 
         assertThat(Mono.from(testee.listRulesForUser(USERNAME)).block())
             .isEqualTo(new Rules(ImmutableList.of(RULE_1, RULE_2), new Version(0)));
@@ -76,8 +76,8 @@ public interface FilteringManagementContract {
     default void listingRulesShouldReturnLastDefinedRules(EventStore eventStore) {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
 
-        Mono.from(testee.defineRulesForUser(USERNAME, RULE_1, RULE_2)).block();
-        Mono.from(testee.defineRulesForUser(USERNAME, RULE_2, RULE_1)).block();
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_1, RULE_2)).block();
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.of(new Version(0)), RULE_2, RULE_1)).block();
 
         assertThat(Mono.from(testee.listRulesForUser(USERNAME)).block())
             .isEqualTo(new Rules(ImmutableList.of(RULE_2, RULE_1), new Version(1)));
@@ -87,7 +87,7 @@ public interface FilteringManagementContract {
     default void definingRulesShouldThrowWhenDuplicateRules(EventStore eventStore) {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
 
-        assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, RULE_1, RULE_1)).block())
+        assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_1, RULE_1)).block())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -95,7 +95,7 @@ public interface FilteringManagementContract {
     default void definingRulesShouldThrowWhenNullUser(EventStore eventStore) {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
 
-        assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(null, RULE_1, RULE_1)).block())
+        assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(null, Optional.empty(), RULE_1, RULE_1)).block())
             .isInstanceOf(NullPointerException.class);
     }
 
@@ -104,14 +104,14 @@ public interface FilteringManagementContract {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
 
         List<Rule> rules = null;
-        assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, rules)).block())
+        assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, rules, Optional.empty())).block())
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     default void definingRulesShouldKeepOrdering(EventStore eventStore) {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
-        Mono.from(testee.defineRulesForUser(USERNAME, RULE_3, RULE_2, RULE_1)).block();
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
 
 
         assertThat(Mono.from(testee.listRulesForUser(USERNAME)).block())
@@ -122,8 +122,8 @@ public interface FilteringManagementContract {
     default void definingEmptyRuleListShouldRemoveExistingRules(EventStore eventStore) {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
 
-        Mono.from(testee.defineRulesForUser(USERNAME, RULE_3, RULE_2, RULE_1)).block();
-        Mono.from(testee.clearRulesForUser(USERNAME)).block();
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
+        Mono.from(testee.clearRulesForUser(USERNAME, Optional.of(new Version(0)))).block();
 
         assertThat(Mono.from(testee.listRulesForUser(USERNAME)).block())
             .isEqualTo(new Rules(ImmutableList.of(), new Version(1)));
@@ -133,11 +133,37 @@ public interface FilteringManagementContract {
     default void allFieldsAndComparatorShouldWellBeStored(EventStore eventStore) {
         FilteringManagement testee = instantiateFilteringManagement(eventStore);
 
-        Mono.from(testee.defineRulesForUser(USERNAME, RULE_FROM, RULE_RECIPIENT, RULE_SUBJECT, RULE_TO, RULE_1)).block();
-
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_FROM, RULE_RECIPIENT, RULE_SUBJECT, RULE_TO, RULE_1)).block();
 
         assertThat(Mono.from(testee.listRulesForUser(USERNAME)).block())
             .isEqualTo(new Rules(ImmutableList.of(RULE_FROM, RULE_RECIPIENT, RULE_SUBJECT, RULE_TO, RULE_1), new Version(0)));
     }
 
+    @Test
+    default void setRulesWithEmptyVersionShouldSucceed(EventStore eventStore) {
+        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+
+        assertThat(Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block())
+            .isEqualTo(new Version(0));
+    }
+
+    @Test
+    default void modifyExistingRulesWithWrongCurrentVersionShouldFail(EventStore eventStore) {
+        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
+
+        assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, Optional.of(new Version(1)), RULE_2, RULE_1)).block())
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    default void modifyExistingRulesWithRightVersionShouldSucceed(EventStore eventStore) {
+        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+
+        Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
+
+        assertThat(Mono.from(testee.defineRulesForUser(USERNAME, Optional.of(new Version(0)), RULE_3, RULE_2)).block())
+            .isEqualTo(new Version(1));
+    }
 }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/impl/DefineRulesCommandTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/impl/DefineRulesCommandTest.java
@@ -23,6 +23,8 @@ import static org.apache.james.jmap.api.filtering.RuleFixture.RULE_1;
 import static org.apache.james.jmap.api.filtering.RuleFixture.RULE_2;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Optional;
+
 import org.apache.james.core.Username;
 import org.junit.jupiter.api.Test;
 
@@ -40,13 +42,13 @@ class DefineRulesCommandTest {
 
     @Test
     void constructorShouldThrowWhenNullUser() {
-        assertThatThrownBy(() -> new DefineRulesCommand(null, ImmutableList.of(RULE_1, RULE_2)))
+        assertThatThrownBy(() -> new DefineRulesCommand(null, ImmutableList.of(RULE_1, RULE_2), Optional.empty()))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void constructorShouldThrowWhenNullRuleList() {
-        assertThatThrownBy(() -> new DefineRulesCommand(Username.of("adam@james.org"), null))
+        assertThatThrownBy(() -> new DefineRulesCommand(Username.of("adam@james.org"), null, Optional.empty()))
             .isInstanceOf(NullPointerException.class);
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
@@ -24,6 +24,7 @@ import static org.apache.james.util.ReactorUtils.context;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -155,7 +156,7 @@ public class SetFilterMethod implements Method {
         ensureNoDuplicatedRules(rules);
         ensureNoMultipleMailboxesRules(rules);
 
-        return Mono.from(filteringManagement.defineRulesForUser(username, rules))
+        return Mono.from(filteringManagement.defineRulesForUser(username, rules, Optional.empty()))
             .thenReturn(JmapResponse.builder()
                 .methodCallId(methodCallId)
                 .responseName(RESPONSE_NAME)

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringExtension.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringExtension.java
@@ -26,6 +26,7 @@ import static org.apache.james.jmap.mailet.filter.JMAPFilteringFixture.USER_1_AD
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.mail.MessagingException;
@@ -116,7 +117,7 @@ public class JMAPFilteringExtension implements BeforeEachCallback, ParameterReso
                     .build())
                 .collect(ImmutableList.toImmutableList());
 
-            Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME, rules)).block();
+            Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME, rules, Optional.empty())).block();
         }
 
         public FakeMail asMail(MimeMessageBuilder mimeMessageBuilder) throws MessagingException {

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
@@ -694,6 +694,7 @@ class JMAPFilteringTest {
             MailboxId mailbox3Id = testSystem.createMailbox(RECIPIENT_1_USERNAME, "RECIPIENT_1_MAILBOX_3");
 
             Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME,
+                Optional.empty(),
                 Rule.builder()
                     .id(Rule.Id.of("1"))
                     .name("rule 1")
@@ -731,6 +732,7 @@ class JMAPFilteringTest {
             MailboxId mailbox3Id = testSystem.createMailbox(RECIPIENT_1_USERNAME, "RECIPIENT_1_MAILBOX_3");
 
             Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME,
+                Optional.empty(),
                 Rule.builder()
                     .id(Rule.Id.of("1"))
                     .name("rule 1")
@@ -755,6 +757,7 @@ class JMAPFilteringTest {
             MailboxId mailbox1Id = testSystem.createMailbox(RECIPIENT_1_USERNAME, "RECIPIENT_1_MAILBOX_1");
 
             Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME,
+                Optional.empty(),
                 Rule.builder()
                     .id(Rule.Id.of("1"))
                     .name("rule 1")
@@ -824,6 +827,7 @@ class JMAPFilteringTest {
         void serviceShouldNotThrowWhenUnknownMailboxId(JMAPFilteringTestSystem testSystem) throws Exception {
             String unknownMailboxId = "4242";
             Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME,
+                Optional.empty(),
                 Rule.builder()
                     .id(Rule.Id.of("1"))
                     .name("rule 1")
@@ -842,6 +846,7 @@ class JMAPFilteringTest {
         void mailDirectiveShouldNotBeSetWhenUnknownMailboxId(JMAPFilteringTestSystem testSystem) throws Exception {
             String unknownMailboxId = "4242";
             Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME,
+                Optional.empty(),
                 Rule.builder()
                     .id(Rule.Id.of("1"))
                     .name("rule 1")
@@ -862,6 +867,7 @@ class JMAPFilteringTest {
         void rulesWithInvalidMailboxIdsShouldBeSkept(JMAPFilteringTestSystem testSystem) throws Exception {
             String unknownMailboxId = "4242";
             Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME,
+                Optional.empty(),
                 Rule.builder()
                     .id(Rule.Id.of("1"))
                     .name("rule 1")
@@ -890,6 +896,7 @@ class JMAPFilteringTest {
             String unknownMailboxId = "4242";
 
             Mono.from(testSystem.getFilteringManagement().defineRulesForUser(RECIPIENT_1_USERNAME,
+                Optional.empty(),
                 Rule.builder()
                     .id(Rule.Id.of("1"))
                     .name("rule 1")


### PR DESCRIPTION
As a client I do not want to override over people changes.

If I reset based on an outdated filter version, those changes should be rejected.