### PR TITLE
JAMES-3225 Verify identity should also apply for unauthenticated users

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -22,7 +22,6 @@ import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.core.Username;
-import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -42,22 +41,37 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
         .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH)
             + " Incorrect Authentication for Specified Email Address")
         .build();
+    private static final HookResult AUTH_REQUIRED = HookResult.builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .smtpReturnCode(SMTPRetCode.AUTH_REQUIRED)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH)
+            + " Authentication Required")
+        .build();
     
     @Override
     public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (session.getUsername() != null) {
-            MaybeSender senderAddress = session.getAttachment(SMTPSession.SENDER, ProtocolSession.State.Transaction).orElse(MaybeSender.nullSender());
-            
             // Check if the sender address is the same as the user which was used to authenticate.
             // Its important to ignore case here to fix JAMES-837. This is save todo because if the handler is called
             // the user was already authenticated
+            System.out.println(session.getUsername());
+            System.out.println(sender);
+
+
             if (isAnonymous(sender)
                 || !senderMatchSessionUser(sender, session)
-                || !belongsToLocalDomain(senderAddress)) {
+                || !belongsToLocalDomain(sender)) {
                 return INVALID_AUTH;
             }
+            return HookResult.DECLINED;
+        } else {
+            // Validate that unauthenticated users do not use local addresses in MAIL FROM
+            if (belongsToLocalDomain(sender)) {
+                return AUTH_REQUIRED;
+            } else {
+                return HookResult.DECLINED;
+            }
         }
-        return HookResult.DECLINED;
     }
 
     private boolean isAnonymous(MaybeSender maybeSender) {

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpIdentityVerificationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpIdentityVerificationTest.java
@@ -80,6 +80,18 @@ class SmtpIdentityVerificationTest {
     }
 
     @Test
+    void rejectUnauthenticatedSendersUsingLocalDomains(@TempDir File temporaryFolder) throws Exception {
+        createJamesServer(temporaryFolder, SmtpConfiguration.builder()
+            .requireAuthentication()
+            .verifyIdentity());
+
+        assertThatThrownBy(() ->
+            messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+                .sendMessage(USER, USER))
+            .isEqualTo(new SMTPSendingException(SmtpSendingStep.RCPT, "530 5.7.1 Authentication Required\n"));
+    }
+
+    @Test
     void smtpShouldAcceptMessageWhenIdentityIsNotMatchingButNotChecked(@TempDir File temporaryFolder) throws Exception {
         createJamesServer(temporaryFolder, SmtpConfiguration.builder()
             .requireAuthentication()


### PR DESCRIPTION
Given this SMTP configuration:

```
   <smtpserver enabled="true">
        ...
        <authRequired>true</authRequired>
        <verifyIdentity>true</verifyIdentity>
   </smtpserver>
```

A non authenticated user can pretend to be a local user...