### PR TITLE
JAMES-3225 Verify identity should also apply for unauthenticated users

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -63,7 +63,7 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
             return HookResult.DECLINED;
         } else {
             // Validate that unauthenticated users do not use local addresses in MAIL FROM
-            if (belongsToLocalDomain(sender)) {
+            if (belongsToLocalDomain(sender) && !session.isRelayingAllowed()) {
                 return AUTH_REQUIRED;
             } else {
                 return HookResult.DECLINED;

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
@@ -85,7 +85,8 @@ interface MailsShouldBeWellReceived {
     default void mailsContentWithUnicodeCharactersShouldBeKeptUnChanged(GuiceJamesServer server) throws Exception {
         server.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
-            .addUser(JAMES_USER, PASSWORD);
+            .addUser(JAMES_USER, PASSWORD)
+            .addUser(SENDER, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
         mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
@@ -102,7 +103,7 @@ interface MailsShouldBeWellReceived {
                 .recipient(JAMES_USER)
                 .mimeMessage(mimeMessage);
 
-            sender.sendMessage(mail);
+            sender.authenticate(SENDER, PASSWORD).sendMessage(mail);
         }
 
         CALMLY_AWAIT.until(() -> server.getProbe(SpoolerProbe.class).processingFinished());
@@ -123,7 +124,8 @@ interface MailsShouldBeWellReceived {
     default void mailsShouldBeWellReceived(GuiceJamesServer server) throws Exception {
         server.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
-            .addUser(JAMES_USER, PASSWORD);
+            .addUser(JAMES_USER, PASSWORD)
+            .addUser(SENDER, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
         mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
@@ -132,7 +134,7 @@ interface MailsShouldBeWellReceived {
         String message = Resources.toString(Resources.getResource("eml/htmlMail.eml"), StandardCharsets.UTF_8);
 
         try (SMTPMessageSender sender = new SMTPMessageSender(Domain.LOCALHOST.asString())) {
-            sender.connect(JAMES_SERVER_HOST, smtpPort);
+            sender.connect(JAMES_SERVER_HOST, smtpPort).authenticate(SENDER, PASSWORD);
             sendUniqueMessage(sender, message);
         }
 
@@ -152,7 +154,8 @@ interface MailsShouldBeWellReceived {
         server.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
             .addUser(JAMES_USER, PASSWORD)
-            .addUser(OTHER_USER, PASSWORD_OTHER);
+            .addUser(OTHER_USER, PASSWORD_OTHER)
+            .addUser(SENDER, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
         mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
@@ -162,7 +165,7 @@ interface MailsShouldBeWellReceived {
         String message = Resources.toString(Resources.getResource("eml/htmlMail.eml"), StandardCharsets.UTF_8);
 
         try (SMTPMessageSender sender = new SMTPMessageSender(Domain.LOCALHOST.asString())) {
-            sender.connect(JAMES_SERVER_HOST, smtpPort);
+            sender.connect(JAMES_SERVER_HOST, smtpPort).authenticate(SENDER, PASSWORD);
             sendUniqueMessageToTwoUsers(sender, message);
         }
 
@@ -184,8 +187,9 @@ interface MailsShouldBeWellReceived {
     @Test
     default void mailsShouldBeWellReceivedByTenRecipient(GuiceJamesServer server) throws Exception {
         server.getProbe(DataProbeImpl.class).fluent()
-                .addDomain(DOMAIN)
-                .addUser(JAMES_USER, PASSWORD);
+            .addDomain(DOMAIN)
+            .addUser(JAMES_USER, PASSWORD)
+            .addUser(SENDER, PASSWORD);
 
         ImmutableList<String> users = generateNUsers(10);
 
@@ -203,7 +207,7 @@ interface MailsShouldBeWellReceived {
         String message = Resources.toString(Resources.getResource("eml/htmlMail.eml"), StandardCharsets.UTF_8);
 
         try (SMTPMessageSender sender = new SMTPMessageSender(Domain.LOCALHOST.asString())) {
-            sender.connect(JAMES_SERVER_HOST, smtpPort);
+            sender.connect(JAMES_SERVER_HOST, smtpPort).authenticate(SENDER, PASSWORD);
             sendUniqueMessageToUsers(sender, message, users);
         }
 
@@ -227,7 +231,8 @@ interface MailsShouldBeWellReceived {
     default void oneHundredMailsShouldBeWellReceived(GuiceJamesServer server) throws Exception {
         server.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
-            .addUser(JAMES_USER, PASSWORD);
+            .addUser(JAMES_USER, PASSWORD)
+            .addUser(SENDER, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
         mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
@@ -240,7 +245,7 @@ interface MailsShouldBeWellReceived {
         try (SMTPMessageSender sender = new SMTPMessageSender(Domain.LOCALHOST.asString())) {
             Mono.fromRunnable(
                 Throwing.runnable(() -> {
-                    sender.connect(JAMES_SERVER_HOST, smtpPort);
+                    sender.connect(JAMES_SERVER_HOST, smtpPort).authenticate(SENDER, PASSWORD);
                     sendUniqueMessage(sender, message);
             }))
                 .repeat(messageCount - 1)

--- a/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerTest.java
+++ b/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerTest.java
@@ -75,6 +75,7 @@ class JPAJamesServerTest implements JamesServerContract {
         // ~ 12 KB email
         int imapPort = jamesServer.getProbe(ImapGuiceProbe.class).getImapPort();
         smtpMessageSender.connect(JAMES_SERVER_HOST, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(USER, PASSWORD)
             .sendMessageWithHeaders(USER, USER, "header: toto\\r\\n\\r\\n" + Strings.repeat("0123456789\n", 1024));
         AWAIT.until(() -> testIMAPClient.connect(JAMES_SERVER_HOST, imapPort)
             .login(USER, PASSWORD)

--- a/server/container/guice/memory-guice/pom.xml
+++ b/server/container/guice/memory-guice/pom.xml
@@ -55,6 +55,12 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-store</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-mailet-icalendar</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/DisabledSpoolerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/DisabledSpoolerTest.java
@@ -72,6 +72,7 @@ class DisabledSpoolerTest {
     @Test
     void emailsShouldNotBeDequeuedWhenZeroSpoolerThreads(GuiceJamesServer server) throws Exception {
         smtpMessageSender.connect(LOCALHOST_IP, server.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE.asString(), ALICE_PASSWORD)
             .sendMessageWithHeaders(ALICE.asString(), BOB.asString(), MESSAGE);
 
         Thread.sleep(5000);

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJmapJamesServerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJmapJamesServerTest.java
@@ -39,7 +39,7 @@ class MemoryJmapJamesServerTest {
     }
 
     @Nested
-    class JmapJamesServerTest implements JmapJamesServerContract {
+    class JmapJamesServerTest implements JmapJamesServerContract, MailsShouldBeWellReceived {
         @RegisterExtension
         JamesServerExtension jamesServerExtension = extensionBuilder().build();
     }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/AddDeliveredToHeaderTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/AddDeliveredToHeaderTest.java
@@ -36,9 +36,9 @@ import org.apache.james.transport.mailets.AddDeliveredToHeader;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.SMTPMessageSender;
 import org.apache.james.utils.TestIMAPClient;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -58,6 +58,7 @@ class AddDeliveredToHeaderTest {
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
         dataProbe.addDomain(DEFAULT_DOMAIN);
         dataProbe.addUser(RECIPIENT, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
     }
 
     @AfterEach
@@ -68,6 +69,7 @@ class AddDeliveredToHeaderTest {
     @Test
     void receivedMessagesShouldContainDeliveredToHeaders() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/BounceIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/BounceIntegrationTest.java
@@ -83,6 +83,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, DSNBounce.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, SENDER_PASSWORD)
             .sendMessage(SENDER, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -96,6 +97,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, DSNBounce.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, SENDER_PASSWORD)
             .sendMessageWithHeaders(SENDER, RECIPIENT,
                 "From: " + OTHER + "\r\n" +
                     "To: " + RECIPIENT + "\r\n" +
@@ -115,6 +117,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, DSNBounce.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, SENDER_PASSWORD)
             .sendMessageWithHeaders(SENDER, RECIPIENT,
                 "From: " + OTHER + "\r\n" +
                     "To: " + RECIPIENT + "\r\n" +
@@ -151,6 +154,7 @@ class BounceIntegrationTest {
                 .fluent()
                 .addDomain(DEFAULT_DOMAIN)
                 .addUser(RECIPIENT, PASSWORD)
+                .addUser("any@" + DEFAULT_DOMAIN, PASSWORD)
                 .addUser(SENDER, SENDER_PASSWORD)
                 .addUser(OTHER, OTHER_PASSWORD)
                 .addUser(POSTMASTER, POSTMASTER_PASSWORD);
@@ -161,6 +165,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, Bounce.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, SENDER_PASSWORD)
             .sendMessage(SENDER, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -174,6 +179,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, Forward.class, Pair.of("forwardTo", SENDER));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate("any@" + DEFAULT_DOMAIN, PASSWORD)
             .sendMessage("any@" + DEFAULT_DOMAIN, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -187,6 +193,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, Redirect.class, Pair.of("recipients", SENDER));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate("any@" + DEFAULT_DOMAIN, PASSWORD)
             .sendMessage("any@" + DEFAULT_DOMAIN, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -200,6 +207,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, Resend.class, Pair.of("recipients", SENDER));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate("any@" + DEFAULT_DOMAIN, PASSWORD)
             .sendMessage("any@" + DEFAULT_DOMAIN, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -213,6 +221,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, NotifySender.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, SENDER_PASSWORD)
             .sendMessage(SENDER, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -226,6 +235,7 @@ class BounceIntegrationTest {
         setup(temporaryFolder, NotifyPostmaster.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate("any@" + DEFAULT_DOMAIN, PASSWORD)
             .sendMessage("any@" + DEFAULT_DOMAIN, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/CommonMailetConfigurationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/CommonMailetConfigurationTest.java
@@ -57,6 +57,7 @@ class CommonMailetConfigurationTest {
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
         dataProbe.addDomain(DEFAULT_DOMAIN);
         dataProbe.addUser(RECIPIENT, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
     }
 
     @AfterEach
@@ -71,6 +72,7 @@ class CommonMailetConfigurationTest {
     @Test
     void simpleMailShouldBeSent() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -82,6 +84,7 @@ class CommonMailetConfigurationTest {
     @Test
     void simpleMailShouldBeSentToUpperCaseRecipient() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT.toUpperCase(Locale.US));
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DKIMIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DKIMIntegrationTest.java
@@ -131,6 +131,7 @@ class DKIMIntegrationTest {
         dataProbe.addDomain(DEFAULT_DOMAIN);
 
         dataProbe.addUser(RECIPIENT, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
     }
 
     @AfterEach
@@ -141,6 +142,7 @@ class DKIMIntegrationTest {
     @Test
     void incomingMessageShouldBeReceivedSignedAndChecked() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
@@ -38,6 +38,7 @@ import org.apache.james.dnsservice.api.InMemoryDNSService;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.probe.DataProbe;
@@ -97,6 +98,9 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(directResolutionTransport())
                 .putProcessor(CommonProcessors.bounces()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .doNotVerifyIdentity()
+                .build())
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -132,6 +136,7 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         awaitAtMostOneMinute
@@ -157,6 +162,7 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -184,6 +190,7 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -220,6 +227,7 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         awaitAtMostOneMinute

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
@@ -36,6 +36,7 @@ import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.probe.DataProbe;
@@ -88,6 +89,9 @@ class GatewayRemoteDeliveryIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
             .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .doNotVerifyIdentity()
+                .build())
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -117,6 +121,7 @@ class GatewayRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         awaitAtMostOneMinute.untilAsserted(this::assertMessageReceivedByTheSmtpServer);
@@ -137,6 +142,7 @@ class GatewayRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         awaitAtMostOneMinute
@@ -158,6 +164,7 @@ class GatewayRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         awaitAtMostOneMinute
@@ -180,6 +187,7 @@ class GatewayRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         // Wait for bounce being sent before checking no email is sent
@@ -206,6 +214,7 @@ class GatewayRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -236,6 +245,7 @@ class GatewayRemoteDeliveryIntegrationTest {
         dataProbe.addUser(FROM, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/RecipientRewriteTableIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/RecipientRewriteTableIntegrationTest.java
@@ -80,6 +80,7 @@ public class RecipientRewriteTableIntegrationTest {
         dataProbe.addUser(RECIPIENT, PASSWORD);
         dataProbe.addUser(ANY_AT_JAMES, PASSWORD);
         dataProbe.addUser(OTHER_AT_JAMES, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
 
         webAdminApi = WebAdminUtils.spec(jamesServer.getProbe(WebAdminGuiceProbe.class).getWebAdminPort());
     }
@@ -92,6 +93,7 @@ public class RecipientRewriteTableIntegrationTest {
     @Test
     void rrtServiceShouldNotImpactRecipientsNotMatchingAnyRRT() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -107,6 +109,7 @@ public class RecipientRewriteTableIntegrationTest {
         dataProbe.addAddressMapping(RECIPIENT_LOCAL_PART, DEFAULT_DOMAIN, OTHER_AT_JAMES);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -127,6 +130,7 @@ public class RecipientRewriteTableIntegrationTest {
         dataProbe.addAddressMapping(RECIPIENT_LOCAL_PART, DEFAULT_DOMAIN, OTHER_AT_JAMES);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -146,6 +150,7 @@ public class RecipientRewriteTableIntegrationTest {
         dataProbe.addAddressMapping(RECIPIENT_LOCAL_PART, DEFAULT_DOMAIN, OTHER_AT_JAMES);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -166,6 +171,7 @@ public class RecipientRewriteTableIntegrationTest {
         dataProbe.addUser(ANY_AT_ANOTHER_DOMAIN, PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, ANY_AT_JAMES);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -180,6 +186,7 @@ public class RecipientRewriteTableIntegrationTest {
         dataProbe.addDomainAliasMapping(DEFAULT_DOMAIN, JAMES_ANOTHER_DOMAIN);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, ANY_AT_JAMES);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -195,6 +202,7 @@ public class RecipientRewriteTableIntegrationTest {
         webAdminApi.put(ForwardRoutes.ROOT_PATH + "/" + RECIPIENT + "/targets/" + OTHER_AT_JAMES);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -215,6 +223,7 @@ public class RecipientRewriteTableIntegrationTest {
         webAdminApi.put(ForwardRoutes.ROOT_PATH + "/" + ANY_AT_JAMES + "/targets/" + OTHER_AT_JAMES);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, GROUP);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -235,6 +244,7 @@ public class RecipientRewriteTableIntegrationTest {
         dataProbe.addUser("user@domain1.com", PASSWORD);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, "user@domain2.com");
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SenderIsLocalIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SenderIsLocalIntegrationTest.java
@@ -92,6 +92,7 @@ class SenderIsLocalIntegrationTest {
     @Test
     void shouldMatchLocalSender() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT);
 
         awaitAtMostOneMinute.until(() -> probe.getRepositoryMailCount(LOCAL_SENDER_REPOSITORY) == 1);
@@ -102,6 +103,7 @@ class SenderIsLocalIntegrationTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + RECIPIENT + "/sources/" + ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(ALIAS, RECIPIENT);
 
         awaitAtMostOneMinute.until(() -> probe.getRepositoryMailCount(LOCAL_SENDER_REPOSITORY) == 1);

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SieveDelivery.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SieveDelivery.java
@@ -61,6 +61,7 @@ class SieveDelivery {
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
         dataProbe.addDomain(DEFAULT_DOMAIN);
         dataProbe.addUser(RECIPIENT, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
 
         jamesServer.getProbe(MailboxProbeImpl.class)
             .createMailbox(MailboxConstants.USER_NAMESPACE, RECIPIENT, TARGETED_MAILBOX);
@@ -79,6 +80,7 @@ class SieveDelivery {
             "fileinto \"" + TARGETED_MAILBOX + "\";");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SizeGreaterThanIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SizeGreaterThanIntegrationTest.java
@@ -83,6 +83,7 @@ class SizeGreaterThanIntegrationTest {
     public void mailShouldGoToErrorRepositoryWhenSizeExceeded() throws Exception {
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessageWithHeaders(SENDER, RECIPIENT, "01234567\r\n".repeat(1025));
 
         awaitAtMostOneMinute.until(() -> jamesServer.getProbe(MailRepositoryProbeImpl.class).getRepositoryMailCount(ERROR_REPOSITORY) == 1);
@@ -91,6 +92,7 @@ class SizeGreaterThanIntegrationTest {
     @Test
     public void mailShouldBeDeliveredWhenSizeWithinLimit() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessageWithHeaders(SENDER, RECIPIENT, "01234567\r\n".repeat(1000));
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpAuthIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpAuthIntegrationTest.java
@@ -32,6 +32,7 @@ import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
@@ -79,6 +80,9 @@ class SmtpAuthIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE)
             .withMailetContainer(mailetContainer)
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .doNotVerifyIdentity()
+                .build())
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpNullSenderTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpNullSenderTest.java
@@ -27,6 +27,7 @@ import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMin
 import java.io.File;
 
 import org.apache.james.mailets.TemporaryJamesServer;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.probe.DataProbe;
@@ -52,6 +53,9 @@ class SmtpNullSenderTest {
     @BeforeEach
     void setUp(@TempDir File temporaryFolder) throws Exception {
         jamesServer = TemporaryJamesServer.builder()
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .doNotVerifyIdentity()
+                .build())
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/extensions/SMTPHeloHooksTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/extensions/SMTPHeloHooksTest.java
@@ -94,6 +94,7 @@ public class SMTPHeloHooksTest {
             .addHook(RecordingHeloHook.class.getCanonicalName()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, TO);
 
         awaitAtMostOneMinute.until(() -> resultChecker.getResults().size() > 0);
@@ -107,6 +108,7 @@ public class SMTPHeloHooksTest {
             .addHook(DeclinedHeloHook.class.getCanonicalName()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, TO);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -121,6 +123,7 @@ public class SMTPHeloHooksTest {
             .addHook(OkHeloHook.class.getCanonicalName()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, TO);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -136,6 +139,7 @@ public class SMTPHeloHooksTest {
             .addHook(DenyHeloHook.class.getCanonicalName()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, TO);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -152,7 +156,7 @@ public class SMTPHeloHooksTest {
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort());
 
-        assertThatThrownBy(() -> messageSender.sendMessage(FROM, TO))
+        assertThatThrownBy(() -> messageSender.authenticate(FROM, PASSWORD).sendMessage(FROM, TO))
             .isInstanceOf(SMTPSendingException.class)
             .hasMessageContaining("Error upon step Helo: 554 Email rejected");
     }
@@ -164,7 +168,7 @@ public class SMTPHeloHooksTest {
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort());
 
-        assertThatThrownBy(() -> messageSender.sendMessage(FROM, TO))
+        assertThatThrownBy(() -> messageSender.authenticate(FROM, PASSWORD).sendMessage(FROM, TO))
             .isInstanceOf(SMTPSendingException.class)
             .hasMessageContaining("Error upon step Helo: 554 Email rejected");
     }
@@ -176,7 +180,7 @@ public class SMTPHeloHooksTest {
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort());
 
-        assertThatThrownBy(() -> messageSender.sendMessage(FROM, TO))
+        assertThatThrownBy(() -> messageSender.authenticate(FROM, PASSWORD).sendMessage(FROM, TO))
             .isInstanceOf(SMTPSendingException.class)
             .hasMessageContaining("Error upon step Helo: 451 Temporary problem. Please try again later");
     }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AddFooterTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AddFooterTest.java
@@ -76,6 +76,7 @@ class AddFooterTest {
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
         dataProbe.addDomain(DEFAULT_DOMAIN);
         dataProbe.addUser(RECIPIENT, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
     }
 
     @AfterEach
@@ -86,6 +87,7 @@ class AddFooterTest {
     @Test
     void shouldAddFooterWhenSimpleMessage() throws Exception {
         smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
@@ -105,6 +107,7 @@ class AddFooterTest {
     @Test
     void shouldAddFooterWhenMultipartMessage() throws Exception {
         smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AliasMappingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AliasMappingTest.java
@@ -133,6 +133,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -151,6 +152,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -169,6 +171,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + UPPER_BOB_ADDRESS + "/sources/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -187,6 +190,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + UPPER_BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -206,6 +210,7 @@ class AliasMappingTest {
         webAdminApi.put(ForwardRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/targets/" + CEDRIC_ADDRESS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -225,6 +230,7 @@ class AliasMappingTest {
         webAdminApi.put(ForwardRoutes.ROOT_PATH + "/" + ALICE_ADDRESS + "/targets/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(CEDRIC_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -244,6 +250,7 @@ class AliasMappingTest {
         webAdminApi.put(GroupsRoutes.ROOT_PATH + "/" + GROUP_ADDRESS + "/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -263,6 +270,7 @@ class AliasMappingTest {
         webAdminApi.put(GroupsRoutes.ROOT_PATH + "/" + GROUP_ADDRESS + "/" + BOB_ADDRESS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -282,6 +290,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ALIAS + "/sources/" + BOB_ALIAS_2);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -301,6 +310,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + ALICE_ADDRESS + "/sources/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(CEDRIC_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -327,6 +337,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + aliasWithEncodedSlash);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -347,6 +358,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + userWithEncodedSlash + "/sources/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -366,6 +378,7 @@ class AliasMappingTest {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + userWithEncodedAt + "/sources/" + aliasWithEncodedAt);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -386,6 +399,7 @@ class AliasMappingTest {
         webAdminApi.put("/domains/" + DOMAIN_2 + "/aliases/" + DOMAIN);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -404,6 +418,7 @@ class AliasMappingTest {
         webAdminApi.put(GroupsRoutes.ROOT_PATH + "/" + GROUP_ADDRESS + "/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(ALICE_ADDRESS, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
@@ -100,6 +100,7 @@ class AmqpForwardAttachmentTest {
         DataProbe dataprobe = jamesServer.getProbe(DataProbeImpl.class);
         dataprobe.addDomain(DEFAULT_DOMAIN);
         dataprobe.addUser(RECIPIENT, PASSWORD);
+        dataprobe.addUser(FROM, PASSWORD);
     }
 
     @AfterEach
@@ -120,6 +121,7 @@ class AmqpForwardAttachmentTest {
             .setSubject("test");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DlpIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DlpIntegrationTest.java
@@ -117,6 +117,7 @@ class DlpIntegrationTest {
             .put("/dlp/rules/" + DEFAULT_DOMAIN);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
@@ -150,6 +151,7 @@ class DlpIntegrationTest {
             .put("/dlp/rules/" + DEFAULT_DOMAIN);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
@@ -189,6 +191,7 @@ class DlpIntegrationTest {
             .put("/dlp/rules/" + DEFAULT_DOMAIN);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
@@ -228,6 +231,7 @@ class DlpIntegrationTest {
             .put("/dlp/rules/" + DEFAULT_DOMAIN);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DomainMappingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DomainMappingTest.java
@@ -114,6 +114,7 @@ class DomainMappingTest {
         webAdminApi.body(DOMAIN1).put("/domainMappings/" + DOMAIN2);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -132,6 +133,7 @@ class DomainMappingTest {
         webAdminApi.put("/domains/" + DOMAIN1 + "/aliases/" + DOMAIN2);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -151,6 +153,7 @@ class DomainMappingTest {
         webAdminApi.put("/domains/" + DOMAIN2 + "/aliases/" + DOMAIN1);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -170,6 +173,7 @@ class DomainMappingTest {
         webAdminApi.put("/domains/" + DOMAIN1 + "/aliases/" + DOMAIN2);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -189,6 +193,7 @@ class DomainMappingTest {
         webAdminApi.put("/domains/" + DOMAIN1 + "/aliases/" + DOMAIN2);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
@@ -210,6 +215,7 @@ class DomainMappingTest {
         webAdminApi.put("/domains/" + DOMAIN1 + "/aliases/" + DOMAIN2);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingRelayTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingRelayTest.java
@@ -111,6 +111,7 @@ class GroupMappingRelayTest {
         webAdminApi.put(GroupsRoutes.ROOT_PATH + "/" + GROUP_ON_DOMAIN1 + "/" + externalMail);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingTest.java
@@ -37,6 +37,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailets.TemporaryJamesServer;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetContainer;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.modules.MailboxProbeImpl;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
@@ -88,6 +89,9 @@ class GroupMappingTest {
 
         jamesServer = TemporaryJamesServer.builder()
             .withMailetContainer(mailetContainer)
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .doNotVerifyIdentity()
+                .build())
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ICSAttachmentWorkflowTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ICSAttachmentWorkflowTest.java
@@ -488,6 +488,7 @@ public class ICSAttachmentWorkflowTest {
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
         dataProbe.addDomain(DEFAULT_DOMAIN);
         dataProbe.addUser(RECIPIENT, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
 
         messageWithoutICSAttached = MimeMessageBuilder.mimeMessageBuilder()
             .setMultipartWithBodyParts(
@@ -550,6 +551,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void calendarAttachmentShouldNotBePublishedInMQWhenNoICalAttachment() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithoutICSAttached)
@@ -567,6 +569,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void calendarAttachmentShouldBePublishedInMQWhenMatchingWorkflowConfiguration() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithICSAttached)
@@ -600,6 +603,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void headersShouldNotBeAddedInMailWhenNoICalAttachment() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithoutICSAttached)
@@ -622,6 +626,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void headersShouldBeAddedInMailWhenOneICalAttachment() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithICSAttached)
@@ -643,6 +648,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void headersShouldBeAddedInMailWhenOneBase64ICalAttachment() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithICSBase64Attached)
@@ -664,6 +670,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void base64CalendarAttachmentShouldBePublishedInMQWhenMatchingWorkflowConfiguration() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithICSBase64Attached)
@@ -690,6 +697,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void yahooBase64CalendarAttachmentShouldBePublishedInMQWhenMatchingWorkflowConfiguration() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(yahooInvitationMessage)
@@ -717,6 +725,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void headersShouldBeFilledOnlyWithOneICalAttachmentWhenMailHasSeveral() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithThreeICSAttached)
@@ -738,6 +747,7 @@ public class ICSAttachmentWorkflowTest {
     @Test
     void pipelineShouldSendSeveralJSONOverRabbitMQWhenSeveralAttachments() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(messageWithThreeICSAttached)
@@ -777,6 +787,7 @@ public class ICSAttachmentWorkflowTest {
         MimeMessage calendarMessage = MimeMessageUtil.mimeMessageFromStream(ClassLoader.getSystemResourceAsStream("eml/calendar.eml"));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(calendarMessage)

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/IsOverQuotaMatcherTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/IsOverQuotaMatcherTest.java
@@ -113,6 +113,7 @@ class IsOverQuotaMatcherTest {
             .put("/quota/users/" + RECIPIENT + "/size");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         TestIMAPClient messageReader = testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -131,6 +132,7 @@ class IsOverQuotaMatcherTest {
             .put("/quota/domains/" + DEFAULT_DOMAIN + "/size");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         TestIMAPClient messageReader = testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -149,6 +151,7 @@ class IsOverQuotaMatcherTest {
             .put("/quota/users/" + RECIPIENT + "/size");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -164,6 +167,7 @@ class IsOverQuotaMatcherTest {
             .put("/quota/users/" + RECIPIENT + "/count");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         TestIMAPClient messageReader = testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -182,6 +186,7 @@ class IsOverQuotaMatcherTest {
             .put("/quota/domains/" + DEFAULT_DOMAIN + "/count");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         TestIMAPClient messageReader = testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -200,6 +205,7 @@ class IsOverQuotaMatcherTest {
             .put("/quota/users/" + RECIPIENT + "/count");
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, RECIPIENT);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -108,6 +108,7 @@ class MailReprocessingIntegrationTest {
     void reprocessingShouldAllowToTargetASpecificProcessor() throws Exception {
         // Given an incoming email
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
@@ -136,6 +137,7 @@ class MailReprocessingIntegrationTest {
     void reprocessingShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
         // Given an incoming email
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
@@ -180,6 +182,7 @@ class MailReprocessingIntegrationTest {
     void reprocessingShouldProcessAsErrorWhenUnknownMailProcessor() throws Exception {
         // Given an incoming email
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinIntegrationTest.java
@@ -104,6 +104,7 @@ class SpamAssassinIntegrationTest {
     @Test
     void spamAssassinShouldAppendNewHeaderOnMessage() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(mailWithContent("This is the content", RECIPIENT));
 
         messageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -120,6 +121,7 @@ class SpamAssassinIntegrationTest {
     @Test
     void spamAssassinShouldAppendNewHeaderWhichDetectIsSpamWhenSpamMessage() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(mailWithContent(SPAM_CONTENT, RECIPIENT));
 
         messageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -135,6 +137,7 @@ class SpamAssassinIntegrationTest {
     @Test
     void spamAssassinShouldAppendNewHeaderWhichNoWhenNonSpamMessage() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(mailWithContent("This is the content", RECIPIENT));
 
         messageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
@@ -150,6 +153,7 @@ class SpamAssassinIntegrationTest {
     @Test
     void spamAssassinShouldAppendNewHeaderPerRecipientOnMessage() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(mailWithContent("This is the content", RECIPIENT, RECIPIENT2));
 
         messageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
@@ -89,6 +89,7 @@ class StripAttachmentTest {
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
         dataProbe.addDomain(DEFAULT_DOMAIN);
         dataProbe.addUser(RECIPIENT, PASSWORD);
+        dataProbe.addUser(FROM, PASSWORD);
     }
 
     @AfterEach
@@ -120,6 +121,7 @@ class StripAttachmentTest {
             .build();
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIntegrationTest.java
@@ -99,6 +99,7 @@ class ToRepositoryIntegrationTest {
     @Test
     void incomingShouldBeStoredInProcessorByDefault() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT)
             .sendMessage(RECIPIENT, RECIPIENT);
 
@@ -108,6 +109,7 @@ class ToRepositoryIntegrationTest {
     @Test
     void userShouldBeAbleToAccessReprocessedMails() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT)
             .sendMessage(RECIPIENT, RECIPIENT);
 
@@ -138,6 +140,7 @@ class ToRepositoryIntegrationTest {
     @Test
     void userShouldBeAbleToAccessReprocessedMail() throws Exception {
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT)
             .sendMessage(RECIPIENT, RECIPIENT);
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToSenderDomainRepositoryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToSenderDomainRepositoryIntegrationTest.java
@@ -74,6 +74,7 @@ class ToSenderDomainRepositoryIntegrationTest {
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT);
 
         awaitAtMostOneMinute.until(
@@ -95,6 +96,7 @@ class ToSenderDomainRepositoryIntegrationTest {
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT);
 
         awaitAtMostOneMinute.until(
@@ -118,6 +120,7 @@ class ToSenderDomainRepositoryIntegrationTest {
         probe.createRepository(DOMAIN_URL);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT);
 
         awaitAtMostOneMinute.until(
@@ -144,6 +147,7 @@ class ToSenderDomainRepositoryIntegrationTest {
         MailRepositoryProbeImpl mailRepositoryProbe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT);
 
         awaitAtMostOneMinute.until(
@@ -167,6 +171,7 @@ class ToSenderDomainRepositoryIntegrationTest {
         probe.createRepository(DOMAIN_URL);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT);
 
         awaitAtMostOneMinute.until(
@@ -187,6 +192,7 @@ class ToSenderDomainRepositoryIntegrationTest {
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(RECIPIENT, PASSWORD)
             .sendMessage(RECIPIENT, RECIPIENT)
             .sendMessage(RECIPIENT, RECIPIENT);
 

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -5818,7 +5818,7 @@ public abstract class SetMessagesMethodTest {
             .recipient(fromAddress)
             .build();
         try (SMTPMessageSender messageSender = SMTPMessageSender.noAuthentication(LOCALHOST_IP, jmapServer.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue(), DOMAIN)) {
-            messageSender.sendMessage(mail);
+            messageSender.authenticate(USERNAME.asString(), PASSWORD).sendMessage(mail);
         }
 
         calmlyAwait.atMost(30, TimeUnit.SECONDS).until(() -> isAnyMessageFoundInInbox(accessToken));

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPTestConfiguration.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPTestConfiguration.java
@@ -131,9 +131,7 @@ public class SMTPTestConfiguration extends BaseHierarchicalConfiguration {
         addProperty("tls.[@startTLS]", startTLS);
         addProperty("tls.keystore", "test_keystore");
         addProperty("tls.secret", "jamestest");
-        if (verifyIdentity) {
-            addProperty("verifyIdentity", verifyIdentity);
-        }
+        addProperty("verifyIdentity", verifyIdentity);
 
         // add the rbl handler
         if (useRBL) {


### PR DESCRIPTION
Given this SMTP configuration:

```
   <smtpserver enabled="true">
        ...
        <authRequired>true</authRequired>
        <verifyIdentity>true</verifyIdentity>
   </smtpserver>
```

A non authenticated user can pretend to be a local user...