### PR TITLE
JAMES-2884 Refresh the annotated JMAP documentation

### DIFF
--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/jmap/intro.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/jmap/intro.mdown
@@ -70,9 +70,6 @@ alphabetical character.
 
 ## The Int and UnsignedInt Data Types
 
-> :warning:
-> Implemented
-
 Where `Int` is given as a data type, it means an integer in the range -2^53+1 <= value <= 2^53-1, the safe range for integers stored in a floating-point double, represented as a JSON `Number`.
 
 Where `UnsignedInt` is given as a data type, it means an `Int` where the value MUST be in the range 0 <= value <= 2^53-1.

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/intro.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/intro.mdown
@@ -132,9 +132,8 @@ This represents support for the VacationResponse data type and associated API me
 
 ### urn:apache:james:params:jmap:mail:shares extension
 
-<aside class="notice">
-  Implemented
-</aside>
+> :information_source:
+> Implemented
 
 This extension is specific to the Apache James server as it relies on a common shared storage allowing arbitrary cross-account entity access.
 
@@ -145,9 +144,8 @@ This extension to the JMAP specification enables to:
 
 ### urn:apache:james:params:jmap:mail:quota
 
-<aside class="notice">
-  Implemented
-</aside>
+> :information_source:
+> Implemented
 
 This represents support for the Quota data type and associated API methods. Servers supporting this specification MUST add this property to the capabilities object.
 

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/mailbox.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/mailbox.mdown
@@ -117,7 +117,7 @@ This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *
 ## Mailbox/changes
 
 > :warning:
-> Naive implementation
+> isSubscribed changes will not be returned by this call.
 
 This is a standard "/changes" method as described in [@!RFC8620], Section 5.2 but with one extra argument to the response:
 

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/mailbox.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/mailbox.mdown
@@ -198,7 +198,6 @@ For **destroy**:
 
 > :warning:
 > Restrictions:
-> - "parentId" updates only succeeds if the given mailbox has no child.
 > - all updates to shared mailboxes by a sharee are forbidden.
 > - Updates to server-set fields are rejected, even if they match the server value.
 > - as "role" and "sortOrder" are server-set by the current James implementation, updating them is not supported.

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/message.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/message.mdown
@@ -727,8 +727,6 @@ If zero properties are specified on the FilterCondition, the condition MUST alwa
 > - allInThreadHaveKeyword
 > - someInThreadHaveKeyword
 > - noneInThreadHaveKeyword
-> - text
-> - body
 >
 > Also please note that inMailbox and inMailboxOtherThan filters are rejected
 > when nested in operator. They need to be specified in a filter condition.

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/message.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/message.mdown
@@ -656,9 +656,6 @@ and response:
 
 ## Email/changes
 
-> :warning:
->  Not implemented yet: Naive implementation
-
 This is a standard "/changes" method as described in [@!RFC8620], Section 5.2. If generating intermediate states for a large set of changes, it is recommended that newer changes be returned first, as these are generally of more interest to users.
 
 ## Email/query


### PR DESCRIPTION
While doing an inventory about the status of the JMAP implementation within the James server, I had the idea to review it in order to reference all JMAP related issues / partial implementation within the JIRA bugtracker. Which pointed out that I forgot many!

Of course, the doc turned out to be slightly outdated, here is my humble attempt to improve that matter of fact.

TODO: the annotated documentation should include links to the JIRA, in where we likely can better describe the issue. Who know, maybe even someone would be inspired and decide to help us fix stuff?