### PR TITLE
JAMES-2754 Authenticate SMTP transaction in DeploymentValidation

### DIFF
--- a/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/DeploymentValidation.java
+++ b/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/DeploymentValidation.java
@@ -90,7 +90,9 @@ public abstract class DeploymentValidation {
     @Test
     public void validateDeploymentWithMailsFromSmtp() throws Exception {
         SMTPMessageSender smtpMessageSender = new SMTPMessageSender("another-domain");
-        smtpSystem.connect(smtpMessageSender).sendMessage("test@" + DOMAIN, USER_ADDRESS);
+        smtpSystem.connect(smtpMessageSender)
+            .authenticate(USER_ADDRESS, PASSWORD)
+            .sendMessage(USER_ADDRESS, USER_ADDRESS);
         imapClient.connect(getConfiguration().getAddress(), getConfiguration().getImapPort().getValue());
         imapClient.login(USER_ADDRESS, PASSWORD);
         awaitAtMostTenSeconds.until(this::checkMailDelivery);


### PR DESCRIPTION
Otherwise it get rejected by the server as an unauthenticated
remote third part is claiming a local identity...