### PR TITLE
JAMES-3432 Upload routes was unstable

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
@@ -32,7 +32,7 @@ import org.apache.james.jmap.rfc8621.contract.UploadContract.{BIG_INPUT, VALID_I
 import org.apache.james.utils.DataProbeImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.{BeforeEach, RepeatedTest, Test}
 import play.api.libs.json.{JsString, Json}
 
 object UploadContract {
@@ -55,7 +55,7 @@ trait UploadContract {
       .build
   }
 
-  @Test
+  @RepeatedTest(50)
   def shouldUploadFileAndAllowToDownloadIt(): Unit = {
     val uploadResponse: String = `given`
       .basePath("")


### PR DESCRIPTION
One time out of 25 the uploaded content was altered (Different SHA 256 in
the data store). Several Apache CI builds had been failing because of this.

Investigating this, I found that a piped input stream strategy was not
hitting this pitfall (RectorUtils::toInputStream). I thus incriminate
some weird data races on the Reactor side...

However, changing the reactor-netty logic (converting to byta array then to byte buffer again) also solve the test stability (I know! I do not
understand it either).

As the piped inputStream strategy (https://github.com/apache/james-project/pull/370) both mobilises significant resources
and cannot handle exception, then I think the dark magic trick is worth a try.