### PR TITLE
JAMES-3556 JMAP eventUrl s/closeAfter/closeafter/

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EventSourceContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EventSourceContract.scala
@@ -51,7 +51,7 @@ trait EventSourceContract {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val status = HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -67,7 +67,7 @@ trait EventSourceContract {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val status = HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -81,7 +81,7 @@ trait EventSourceContract {
   }
 
   @Test
-  def closeAfterQueryParamIsCompulsory(server: GuiceJamesServer): Unit = {
+  def closeafterQueryParamIsCompulsory(server: GuiceJamesServer): Unit = {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val status = HttpClient.create
@@ -99,11 +99,11 @@ trait EventSourceContract {
   }
 
   @Test
-  def shouldRejectInvalidCloseAfter(server: GuiceJamesServer): Unit = {
+  def shouldRejectInvalidCloseafter(server: GuiceJamesServer): Unit = {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val status = HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeAfter=bad")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeafter=bad")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -121,7 +121,7 @@ trait EventSourceContract {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val status = HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=bad&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=bad&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -139,7 +139,7 @@ trait EventSourceContract {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val status = HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=bad&ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=bad&ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -157,7 +157,7 @@ trait EventSourceContract {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val status = HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=Email&ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=Email&ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
       })
@@ -175,7 +175,7 @@ trait EventSourceContract {
 
     val seq = new ListBuffer[String]()
     HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -202,7 +202,7 @@ trait EventSourceContract {
 
     val seq = new ListBuffer[String]()
     HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=Email&ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=Email&ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -231,7 +231,7 @@ trait EventSourceContract {
 
     val seq = new ListBuffer[String]()
     HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=Mailbox,Email,VacationResponse,Thread,Identity,EmailSubmission,EmailDelivery&ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=Mailbox,Email,VacationResponse,Thread,Identity,EmailSubmission,EmailDelivery&ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -264,7 +264,7 @@ trait EventSourceContract {
 
     val seq = new ListBuffer[String]()
     HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=1&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=1&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -292,7 +292,7 @@ trait EventSourceContract {
 
     val seq = new ListBuffer[String]()
     HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -320,12 +320,12 @@ trait EventSourceContract {
   }
 
   @Test
-  def sseShouldCloseAfterEventWhenCloseAfterState(server: GuiceJamesServer): Unit = {
+  def sseShouldCloseafterEventWhenCloseafterState(server: GuiceJamesServer): Unit = {
     val port = server.getProbe(classOf[JmapGuiceProbe]).getJmapPort.getValue
 
     val seq = new ListBuffer[String]()
     HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeAfter=state")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeafter=state")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)
@@ -359,7 +359,7 @@ trait EventSourceContract {
 
     val seq = new ListBuffer[String]()
     HttpClient.create
-      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeAfter=no")
+      .baseUrl(s"http://127.0.0.1:$port/eventSource?types=*&ping=0&closeafter=no")
       .headers(builder => {
         builder.add("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
         builder.add("Accept", ACCEPT_RFC8621_VERSION_HEADER)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/EventSourceRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/EventSourceRoutes.scala
@@ -85,10 +85,10 @@ object EventSourceOptions {
     }
 
   private def retrieveCloseAfter(request: HttpServerRequest): Either[IllegalArgumentException, CloseAfter] =
-    queryParam(request, "closeAfter") match {
-      case None => Left(new IllegalArgumentException("closeAfter parameter is compulsory"))
+    queryParam(request, "closeafter") match {
+      case None => Left(new IllegalArgumentException("closeafter parameter is compulsory"))
       case Some(List(value)) => CloseAfter.parse(value)
-      case _ => Left(new IllegalArgumentException("closeAfter query parameter must be constituted of a single string value"))
+      case _ => Left(new IllegalArgumentException("closeafter query parameter must be constituted of a single string value"))
     }
 
   private def queryParam(httpRequest: HttpServerRequest, parameterName: String): Option[List[String]] = queryParam(parameterName, httpRequest.uri)


### PR DESCRIPTION
According to rfc6570 section 2.3 variable names in URI templates
are case sensitive.

RFC 8620 section 2 defines a variable closeafter for the eventSourceUrl.

James calls this variable closeAfter

(I admit that this is confusing as other parts of the spec use camelCase
for the variable names)

(Reported by Daniel Gultsch)