### PR TITLE
JAMES-3559 Allow to window push notifications

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/jmap.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/jmap.properties
@@ -16,3 +16,11 @@ jwt.publickeypem.url=file://conf/jwt_publickey
 # Should simple Email/query be resolved against a Cassandra projection, or should we resolve them against ElasticSearch?
 # This enables a higher resilience, but the projection needs to be correctly populated. False by default.
 # view.email.query.enabled=true
+
+# Optional. Omitting this property leads to windowing being disables. James will
+# then directly forward all StateChanges to the end user without attempting to
+# buffer and aggregating them.
+# If specified, James will delay stateChanges for that given amount of time and will attempt
+# to aggregate subsequent state changes together before returning them to the client.
+# Units: ms, s, min, h, d (default s)
+# push.aggregation.window.duration=2s

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/jmap.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/jmap.properties
@@ -16,3 +16,11 @@ jwt.publickeypem.url=file://conf/jwt_publickey
 # Should simple Email/query be resolved against a Cassandra projection, or should we resolve them against ElasticSearch?
 # This enables a higher resilience, but the projection needs to be correctly populated. False by default.
 # view.email.query.enabled=true
+
+# Optional. Omitting this property leads to windowing being disables. James will
+# then directly forward all StateChanges to the end user without attempting to
+# buffer and aggregating them.
+# If specified, James will delay stateChanges for that given amount of time and will attempt
+# to aggregate subsequent state changes together before returning them to the client.
+# Units: ms, s, min, h, d (default s)
+# push.aggregation.window.duration=2s

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/jmap.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/jmap.properties
@@ -16,3 +16,11 @@ jwt.publickeypem.url=file://conf/jwt_publickey
 # Should simple Email/query be resolved against a Cassandra projection, or should we resolve them against ElasticSearch?
 # This enables a higher resilience, but the projection needs to be correctly populated. False by default.
 # view.email.query.enabled=true
+
+# Optional. Omitting this property leads to windowing being disables. James will
+# then directly forward all StateChanges to the end user without attempting to
+# buffer and aggregating them.
+# If specified, James will delay stateChanges for that given amount of time and will attempt
+# to aggregate subsequent state changes together before returning them to the client.
+# Units: ms, s, min, h, d (default s)
+# push.aggregation.window.duration=2s

--- a/dockerfiles/run/guice/cassandra/destination/conf/jmap.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/jmap.properties
@@ -16,3 +16,11 @@ jwt.publickeypem.url=file://conf/jwt_publickey
 # Should simple Email/query be resolved against a Cassandra projection, or should we resolve them against ElasticSearch?
 # This enables a higher resilience, but the projection needs to be correctly populated. False by default.
 # view.email.query.enabled=true
+
+# Optional. Omitting this property leads to windowing being disables. James will
+# then directly forward all StateChanges to the end user without attempting to
+# buffer and aggregating them.
+# If specified, James will delay stateChanges for that given amount of time and will attempt
+# to aggregate subsequent state changes together before returning them to the client.
+# Units: ms, s, min, h, d (default s)
+# push.aggregation.window.duration=2s

--- a/docs/modules/servers/pages/distributed/configure/jmap.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jmap.adoc
@@ -48,6 +48,10 @@ This enables a higher resilience, but the projection needs to be correctly popul
 Defaults to draft for legacy reasons (avoid breaking changes) but setting the value to
 rfc-8621 allow compatibility with other third party apps.
 
+| push.aggregation.window.duration
+| Optional. Omitting this property leads to windowing being disables. James will then directly forward all StateChanges to the end user without attempting to buffer and aggregating them.
+| If specified, James will delay stateChanges for that given amount of time and will attempt to aggregate subsequent state changes together before returning them to the client. Units: ms, s, min, h, d (default s)
+
 |===
 
 == Wire tapping

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketAggregateContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketAggregateContract.scala
@@ -1,0 +1,153 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.jmap.rfc8621.contract
+
+import java.net.URI
+
+import javax.mail.Flags
+import org.apache.james.GuiceJamesServer
+import org.apache.james.jmap.api.change.State
+import org.apache.james.jmap.api.model.AccountId
+import org.apache.james.jmap.core.PushState
+import org.apache.james.jmap.draft.JmapGuiceProbe
+import org.apache.james.jmap.rfc8621.contract.Fixture._
+import org.apache.james.mailbox.MessageManager.AppendCommand
+import org.apache.james.mailbox.model.{MailboxPath, MessageId}
+import org.apache.james.mime4j.dom.Message
+import org.apache.james.modules.MailboxProbeImpl
+import org.apache.james.utils.DataProbeImpl
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{BeforeEach, Test, Timeout}
+import sttp.capabilities.WebSockets
+import sttp.client3.monad.IdMonad
+import sttp.client3.okhttp.OkHttpSyncBackend
+import sttp.client3.{Identity, RequestT, SttpBackend, asWebSocket, basicRequest}
+import sttp.model.Uri
+import sttp.monad.MonadError
+import sttp.monad.syntax.MonadErrorOps
+import sttp.ws.WebSocketFrame
+import sttp.ws.WebSocketFrame.Text
+
+import scala.jdk.CollectionConverters._
+
+trait WebSocketAggregateContract {
+  private lazy val backend: SttpBackend[Identity, WebSockets] = OkHttpSyncBackend()
+  private lazy implicit val monadError: MonadError[Identity] = IdMonad
+
+  @BeforeEach
+  def setUp(server: GuiceJamesServer): Unit = {
+    server.getProbe(classOf[DataProbeImpl])
+      .fluent()
+      .addDomain(DOMAIN.asString())
+      .addUser(ANDRE.asString(), ANDRE_PASSWORD)
+      .addUser(BOB.asString(), BOB_PASSWORD)
+  }
+
+  @Test
+  @Timeout(180)
+  def pushEnableRequestsShouldBeProcessed(server: GuiceJamesServer): Unit = {
+    val bobPath = MailboxPath.inbox(BOB)
+    val accountId: AccountId = AccountId.fromUsername(BOB)
+    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(bobPath)
+    val message: Message = Fixture.createTestMessage
+    val flags: Flags = new Flags(Flags.Flag.ANSWERED)
+    val messageId: MessageId = server.getProbe(classOf[MailboxProbeImpl]).appendMessage(BOB.asString(), bobPath, AppendCommand.builder()
+      .withFlags(flags)
+      .build(message))
+      .getMessageId
+
+
+
+    Thread.sleep(100)
+
+    val response: Either[String, List[String]] =
+      authenticatedRequest(server)
+        .response(asWebSocket[Identity, List[String]] {
+          ws =>
+            ws.send(WebSocketFrame.text(
+              """{
+                |  "@type": "WebSocketPushEnable",
+                |  "dataTypes": ["Mailbox", "Email"]
+                |}""".stripMargin))
+
+            Thread.sleep(100)
+
+            ws.send(WebSocketFrame.text(
+              s"""{
+                 |  "@type": "Request",
+                 |  "requestId": "req-36",
+                 |  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+                 |  "methodCalls": [
+                 |    ["Email/set", {
+                 |      "accountId": "$ACCOUNT_ID",
+                 |      "update": {
+                 |        "${messageId.serialize()}":{
+                 |          "keywords": {
+                 |             "$$flagged": true
+                 |          }
+                 |        }
+                 |      }
+                 |    }, "c1"],
+                 |    ["Mailbox/set", {
+                 |      "accountId": "$ACCOUNT_ID",
+                 |      "create": {
+                 |        "C42": {
+                 |          "name": "myMailbox"
+                 |        }
+                 |      }
+                 |    }, "c1"]]
+                 |}""".stripMargin))
+
+            List(
+              ws.receive()
+                .map { case t: Text =>
+                  t.payload
+                },
+              ws.receive()
+                .map { case t: Text =>
+                  t.payload
+                })
+        })
+        .send(backend)
+        .body
+
+    Thread.sleep(100)
+
+    val jmapGuiceProbe: JmapGuiceProbe = server.getProbe(classOf[JmapGuiceProbe])
+    val emailState: State = jmapGuiceProbe.getLatestEmailState(accountId)
+    val mailboxState: State = jmapGuiceProbe.getLatestMailboxState(accountId)
+
+    val globalState1: String = PushState.fromOption(Some(mailboxState), None).get.value
+    val stateChange: String = s"""{"@type":"StateChange","changed":{"$ACCOUNT_ID":{"Mailbox":"${mailboxState.getValue}","Email":"${emailState.getValue}"}},"pushState":"$globalState1"}"""
+
+    assertThat(response.toOption.get.asJava)
+      .hasSize(2) // aggregated notification + API response
+      .contains(stateChange)
+  }
+
+  private def authenticatedRequest(server: GuiceJamesServer): RequestT[Identity, Either[String, String], Any] = {
+    val port = server.getProbe(classOf[JmapGuiceProbe])
+      .getJmapPort
+      .getValue
+
+    basicRequest.get(Uri.apply(new URI(s"ws://127.0.0.1:$port/jmap/ws")))
+      .header("Authorization", "Basic Ym9iQGRvbWFpbi50bGQ6Ym9icGFzc3dvcmQ=")
+      .header("Accept", ACCEPT_RFC8621_VERSION_HEADER)
+  }
+}

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryAggregateWebSocketTest.java
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryAggregateWebSocketTest.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.rfc8621.memory;
+
+import static org.apache.james.MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE;
+
+import java.time.Duration;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.jmap.core.JmapRfc8621Configuration;
+import org.apache.james.jmap.rfc8621.contract.WebSocketAggregateContract;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import scala.Option;
+
+public class MemoryAggregateWebSocketTest implements WebSocketAggregateContract {
+    @RegisterExtension
+    static JamesServerExtension testExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
+        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
+            .combineWith(IN_MEMORY_SERVER_AGGREGATE_MODULE)
+            .overrideWith(new TestJMAPServerModule())
+            .overrideWith(binder -> binder.bind(JmapRfc8621Configuration.class)
+                .toInstance(new JmapRfc8621Configuration(
+                    "http://127.0.0.1",
+                    JmapRfc8621Configuration.UPLOAD_LIMIT_30_MB(),
+                    Option.apply(Duration.ofSeconds(1))))))
+        .build();
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
@@ -21,13 +21,13 @@ package org.apache.james.jmap.change
 
 import org.apache.james.events.Event
 import org.apache.james.events.EventListener.ReactiveEventListener
-import org.apache.james.jmap.core.OutboundMessage
+import org.apache.james.jmap.core.StateChange
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Sinks
 import reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST
 import reactor.core.scala.publisher.SMono
 
-case class StateChangeListener(types: Set[TypeName], sink: Sinks.Many[OutboundMessage]) extends ReactiveEventListener {
+case class StateChangeListener(types: Set[TypeName], sink: Sinks.Many[StateChange]) extends ReactiveEventListener {
   override def reactiveEvent(event: Event): Publisher[Void] =
     event match {
       case stateChangeEvent: StateChangeEvent =>

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeListenerTest.scala
@@ -22,7 +22,7 @@ package org.apache.james.jmap.change
 import org.apache.james.core.Username
 import org.apache.james.events.Event.EventId
 import org.apache.james.jmap.api.change.{State => JavaState}
-import org.apache.james.jmap.core.{AccountId, OutboundMessage, PushState, State, StateChange}
+import org.apache.james.jmap.core.{AccountId, PushState, State, StateChange}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Sinks
@@ -37,7 +37,7 @@ class StateChangeListenerTest {
 
   @Test
   def reactiveEventShouldSendAnOutboundMessage(): Unit = {
-    val sink: Sinks.Many[OutboundMessage] = Sinks.many().unicast().onBackpressureBuffer()
+    val sink: Sinks.Many[StateChange] = Sinks.many().unicast().onBackpressureBuffer()
     val event = StateChangeEvent(eventId = eventId,
       username = Username.of("bob"),
       mailboxState = Some(mailboxState),
@@ -58,7 +58,7 @@ class StateChangeListenerTest {
 
   @Test
   def reactiveEventShouldOmitUnwantedTypes(): Unit = {
-    val sink: Sinks.Many[OutboundMessage] = Sinks.many().unicast().onBackpressureBuffer()
+    val sink: Sinks.Many[StateChange] = Sinks.many().unicast().onBackpressureBuffer()
     val event = StateChangeEvent(eventId = eventId,
       username = Username.of("bob"),
       mailboxState = Some(mailboxState),
@@ -78,7 +78,7 @@ class StateChangeListenerTest {
 
   @Test
   def reactiveEventShouldFilterOutUnwantedEvents(): Unit = {
-    val sink: Sinks.Many[OutboundMessage] = Sinks.many().unicast().onBackpressureBuffer()
+    val sink: Sinks.Many[StateChange] = Sinks.many().unicast().onBackpressureBuffer()
     val event = StateChangeEvent(eventId = eventId,
       username = Username.of("bob"),
       mailboxState = None,

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -75,6 +75,13 @@
                     <dd>Which version of the JMAP protocol should be served when none supplied in the Accept header.
                     Defaults to draft for legacy reasons (avoid breaking changes) but setting the value to
                     rfc-8621 allow compatibility with other third party apps.</dd>
+
+                    <dt><strong>push.aggregation.window.duration</strong></dt>
+                    <dd>Optional. Omitting this property leads to windowing being disables. James will then directly
+                        forward all StateChanges to the end user without attempting to buffer and aggregating them.</dd>
+                    <dd>If specified, James will delay stateChanges for that given amount of time and will attempt to
+                        aggregate subsequent state changes together before returning them to the client.
+                        Units: ms, s, min, h, d (default s)</dd>
                 </dl>
 
             </subsection>


### PR DESCRIPTION
## Why?

Today a JAMES action might trigger several events being dispatched on the event bus (eg moving 2 messages will end up firing 2 additions and 2 deletion) resulting in likely 4 StateChanges being pushed to the end user.

## How?

Using the reactor library, James can likely delay pushes for a given timewindow and merge the state changes together in order to supply the client with only one state change.

A likely time value might be 2 seconds.

 - Pros: avoid event storm and will lower re-synchronization request count (good for perf?)
 - Cons: delays of 2s for real time across devices.

We could of course make it configurable via a jmap.properties configuration.

```
# Optional. Omiting this property leads to windowing being disables. James will 
# then directly forward all StateChanges to the end user without attempting to 
# buffer and aggregating them.
# If specified, James will delay stateChanges for that given amout of time and will attempt 
# to aggregate subsequent state changes together before returning them to the client.
# Units: ms, s, min, h, d
push.aggregation.window.duration=2s
```