### PR TITLE
JAMES-3525 verifyIdentity should not fail on null sender

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -86,8 +86,10 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
     }
 
     private boolean belongsToLocalDomain(MaybeSender maybeSender) {
-        Preconditions.checkArgument(!maybeSender.isNullSender());
-        return isLocalDomain(maybeSender.get().getDomain());
+        return maybeSender.asOptional()
+            .map(MailAddress::getDomain)
+            .filter(this::isLocalDomain)
+            .isPresent();
     }
 
     /**

--- a/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
+++ b/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
@@ -126,6 +126,17 @@ public class SMTPMessageSender extends ExternalResource implements Closeable, Af
         return this;
     }
 
+    public SMTPMessageSender sendMessageNoSender(String recipient) throws IOException {
+        doHelo();
+        doSetSender("");
+        doAddRcpt(recipient);
+        doData("subject: test\r\n" +
+            "\r\n" +
+            "content\r\n" +
+            ".\r\n");
+        return this;
+    }
+
     public SMTPMessageSender sendMessage(Mail mail) throws MessagingException, IOException {
         String from = mail.getMaybeSender().asString();
         ImmutableList<String> recipients = mail.getRecipients().stream()


### PR DESCRIPTION
Before this patch an unchecked error was specified. SMTP error code 430.

```
java.lang.IllegalArgumentException: null
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:127)
	at org.apache.james.protocols.smtp.core.AbstractSenderAuthIdentifyVerificationRcptHook.belongsToLocalDomain(AbstractSenderAuthIdentifyVerificationRcptHook.java:89)
	at org.apache.james.protocols.smtp.core.AbstractSenderAuthIdentifyVerificationRcptHook.doRcpt(AbstractSenderAuthIdentifyVerificationRcptHook.java:66)
	at org.apache.james.smtpserver.SenderAuthIdentifyVerificationRcptHook.doRcpt(SenderAuthIdentifyVerificationRcptHook.java:59)
	at org.apache.james.protocols.smtp.hook.RcptHook.doRcpt(RcptHook.java:77)
```

After this patch the sender address is explicitly rejected. Error code 503 & no stacktrace.