### PR TITLE
JAMES-3567 Distributed server should not depend on ActiveMQ

### DIFF
--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -80,6 +80,16 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>4.1.58.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.58.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.1.58.Final</version>
         </dependency>

--- a/server/container/guice/cassandra-rabbitmq-guice/pom.xml
+++ b/server/container/guice/cassandra-rabbitmq-guice/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mailet-icalendar</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>blob-s3</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -113,10 +118,6 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-cassandra-guice</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-cassandra-guice</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -132,11 +133,19 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-data-ldap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-distributed</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-es-resporter</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -158,6 +167,26 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-lmtp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-mailbox</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-mailbox-plugin-spamassassin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-mailet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-managedsieve</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-pop</artifactId>
         </dependency>
         <dependency>
@@ -170,9 +199,45 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-webadmin-data</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-webadmin-jmap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-webadmin-mail-over-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-webadmin-mailbox</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-webadmin-mailqueue</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-webadmin-mailrepository</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-webadmin-swagger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-jmap-draft-integration-testing</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-mailbox-plugin-deleted-messages-vault-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-mailets</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -186,8 +251,6 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-util</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -201,12 +264,34 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-es-reporter-v7</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>queue-rabbitmq-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.linagora</groupId>
+            <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
@@ -217,6 +302,10 @@
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -19,33 +19,154 @@
 
 package org.apache.james;
 
-import static org.apache.james.CassandraJamesServerMain.REQUIRE_TASK_MANAGER_MODULE;
+import java.util.Set;
 
 import org.apache.james.data.UsersRepositoryModuleChooser;
+import org.apache.james.eventsourcing.eventstore.cassandra.EventNestedTypes;
+import org.apache.james.json.DTO;
+import org.apache.james.json.DTOModule;
+import org.apache.james.modules.BlobExportMechanismModule;
+import org.apache.james.modules.CassandraConsistencyTaskSerializationModule;
 import org.apache.james.modules.DistributedTaskManagerModule;
 import org.apache.james.modules.DistributedTaskSerializationModule;
+import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.blobstore.BlobStoreCacheModulesChooser;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.apache.james.modules.blobstore.BlobStoreModulesChooser;
+import org.apache.james.modules.data.CassandraDLPConfigurationStoreModule;
+import org.apache.james.modules.data.CassandraDomainListModule;
+import org.apache.james.modules.data.CassandraJmapModule;
+import org.apache.james.modules.data.CassandraRecipientRewriteTableModule;
+import org.apache.james.modules.data.CassandraSieveRepositoryModule;
 import org.apache.james.modules.data.CassandraUsersRepositoryModule;
 import org.apache.james.modules.event.JMAPEventBusModule;
 import org.apache.james.modules.event.RabbitMQEventBusModule;
+import org.apache.james.modules.eventstore.CassandraEventStoreModule;
+import org.apache.james.modules.mailbox.BlobStoreAPIModule;
+import org.apache.james.modules.mailbox.CassandraBlobStoreDependenciesModule;
+import org.apache.james.modules.mailbox.CassandraDeletedMessageVaultModule;
+import org.apache.james.modules.mailbox.CassandraMailboxModule;
+import org.apache.james.modules.mailbox.CassandraQuotaMailingModule;
+import org.apache.james.modules.mailbox.CassandraSessionModule;
+import org.apache.james.modules.mailbox.TikaMailboxModule;
+import org.apache.james.modules.mailrepository.CassandraMailRepositoryModule;
+import org.apache.james.modules.metrics.CassandraMetricsModule;
+import org.apache.james.modules.protocols.IMAPServerModule;
+import org.apache.james.modules.protocols.JMAPServerModule;
+import org.apache.james.modules.protocols.JmapEventBusModule;
+import org.apache.james.modules.protocols.LMTPServerModule;
+import org.apache.james.modules.protocols.ManageSieveServerModule;
+import org.apache.james.modules.protocols.POP3ServerModule;
+import org.apache.james.modules.protocols.ProtocolHandlerModule;
+import org.apache.james.modules.protocols.SMTPServerModule;
 import org.apache.james.modules.queue.rabbitmq.RabbitMQModule;
+import org.apache.james.modules.server.DKIMMailetModule;
+import org.apache.james.modules.server.DLPRoutesModule;
+import org.apache.james.modules.server.DataRoutesModules;
+import org.apache.james.modules.server.ElasticSearchMetricReporterModule;
+import org.apache.james.modules.server.InconsistencyQuotasSolvingRoutesModule;
 import org.apache.james.modules.server.JMXServerModule;
+import org.apache.james.modules.server.JmapTasksModule;
+import org.apache.james.modules.server.MailQueueRoutesModule;
+import org.apache.james.modules.server.MailRepositoriesRoutesModule;
+import org.apache.james.modules.server.MailboxRoutesModule;
+import org.apache.james.modules.server.MailboxesExportRoutesModule;
+import org.apache.james.modules.server.MessagesRoutesModule;
 import org.apache.james.modules.server.RabbitMailQueueRoutesModule;
+import org.apache.james.modules.server.SieveRoutesModule;
+import org.apache.james.modules.server.SwaggerRoutesModule;
+import org.apache.james.modules.server.WebAdminMailOverWebModule;
+import org.apache.james.modules.server.WebAdminReIndexingTaskSerializationModule;
+import org.apache.james.modules.server.WebAdminServerModule;
+import org.apache.james.modules.spamassassin.SpamAssassinListenerModule;
+import org.apache.james.modules.vault.DeletedMessageVaultRoutesModule;
+import org.apache.james.modules.webadmin.CassandraRoutesModule;
+import org.apache.james.modules.webadmin.InconsistencySolvingRoutesModule;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 
 public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
-    protected static final Module MODULES =
-        Modules
-            .override(Modules.combine(REQUIRE_TASK_MANAGER_MODULE, new DistributedTaskManagerModule()))
-            .with(new RabbitMQModule(),
-                new RabbitMailQueueRoutesModule(),
-                new JMAPEventBusModule(),
-                new RabbitMQEventBusModule(),
-                new DistributedTaskSerializationModule());
+    public static final Module WEBADMIN = Modules.combine(
+        new CassandraRoutesModule(),
+        new DataRoutesModules(),
+        new DeletedMessageVaultRoutesModule(),
+        new DLPRoutesModule(),
+        new InconsistencyQuotasSolvingRoutesModule(),
+        new InconsistencySolvingRoutesModule(),
+        new JmapTasksModule(),
+        new MailboxesExportRoutesModule(),
+        new MailboxRoutesModule(),
+        new MailQueueRoutesModule(),
+        new MailRepositoriesRoutesModule(),
+        new SieveRoutesModule(),
+        new SwaggerRoutesModule(),
+        new WebAdminServerModule(),
+        new WebAdminReIndexingTaskSerializationModule(),
+        new MessagesRoutesModule(),
+        new WebAdminMailOverWebModule());
+
+    public static final Module PROTOCOLS = Modules.combine(
+        new CassandraJmapModule(),
+        new IMAPServerModule(),
+        new LMTPServerModule(),
+        new ManageSieveServerModule(),
+        new POP3ServerModule(),
+        new ProtocolHandlerModule(),
+        new SMTPServerModule(),
+        new JMAPServerModule(),
+        new JmapEventBusModule(),
+        WEBADMIN);
+
+    public static final Module PLUGINS = Modules.combine(
+        new CassandraQuotaMailingModule());
+
+    private static final Module BLOB_MODULE = Modules.combine(
+        new BlobStoreAPIModule(),
+        new BlobExportMechanismModule());
+
+    private static final Module CASSANDRA_EVENT_STORE_JSON_SERIALIZATION_DEFAULT_MODULE = binder ->
+        binder.bind(new TypeLiteral<Set<DTOModule<?, ? extends DTO>>>() {}).annotatedWith(Names.named(EventNestedTypes.EVENT_NESTED_TYPES_INJECTION_NAME))
+            .toInstance(ImmutableSet.of());
+
+    public static final Module CASSANDRA_SERVER_CORE_MODULE = Modules.combine(
+        new CassandraBlobStoreDependenciesModule(),
+        new CassandraDomainListModule(),
+        new CassandraDLPConfigurationStoreModule(),
+        new CassandraEventStoreModule(),
+        new CassandraMailRepositoryModule(),
+        new CassandraMetricsModule(),
+        new CassandraRecipientRewriteTableModule(),
+        new CassandraSessionModule(),
+        new CassandraSieveRepositoryModule(),
+        new ElasticSearchMetricReporterModule(),
+        BLOB_MODULE,
+        CASSANDRA_EVENT_STORE_JSON_SERIALIZATION_DEFAULT_MODULE);
+
+    public static final Module CASSANDRA_MAILBOX_MODULE = Modules.combine(
+        new CassandraConsistencyTaskSerializationModule(),
+        new CassandraMailboxModule(),
+        new CassandraDeletedMessageVaultModule(),
+        new MailboxModule(),
+        new TikaMailboxModule(),
+        new SpamAssassinListenerModule());
+
+    public static Module REQUIRE_TASK_MANAGER_MODULE = Modules.combine(
+        CASSANDRA_SERVER_CORE_MODULE,
+        CASSANDRA_MAILBOX_MODULE,
+        PROTOCOLS,
+        PLUGINS,
+        new DKIMMailetModule());
+
+    protected static final Module MODULES = Modules.override(REQUIRE_TASK_MANAGER_MODULE, new DistributedTaskManagerModule())
+        .with(new RabbitMQModule(),
+            new RabbitMailQueueRoutesModule(),
+            new JMAPEventBusModule(),
+            new RabbitMQEventBusModule(),
+            new DistributedTaskSerializationModule());
 
     public static void main(String[] args) throws Exception {
         CassandraRabbitMQJamesConfiguration configuration = CassandraRabbitMQJamesConfiguration.builder()


### PR DESCRIPTION
Not required, this brings in the JGroup dependency, vulnerable prior version 4.0.

This is a simple dependency cleanup.