### PR TITLE
[Boyscout] trims DockerCassandra container logs

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
@@ -190,7 +190,7 @@ public class DockerCassandra {
     }
 
     private static void displayDockerLog(OutputFrame outputFrame) {
-        logger.info(outputFrame.getUtf8String());
+        logger.info(outputFrame.getUtf8String().trim());
     }
 
     public void start() {


### PR DESCRIPTION
I find it annoying when reading through tests log to have logs from the
container adding extra empty lines.

this is really just cosmetic but hopefully still interesting enough.