### PR TITLE
JAMES-3571 MimeMessageWrapper getSize was incorrect for empty messages

### DIFF
--- a/server/container/core/src/main/java/org/apache/james/server/core/MimeMessageWrapper.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MimeMessageWrapper.java
@@ -359,7 +359,7 @@ public class MimeMessageWrapper extends MimeMessage implements Disposable {
                     loadHeaders();
                 }
                 // 2 == CRLF
-                return (int) (fullSize - initialHeaderSize - HEADER_BODY_SEPARATOR_SIZE);
+                return Math.max(0, (int) (fullSize - initialHeaderSize - HEADER_BODY_SEPARATOR_SIZE));
 
             } catch (IOException e) {
                 throw new MessagingException("Unable to calculate message size");


### PR DESCRIPTION
 - Added the edge case tests
 - If the header delimiter is missing, then the size would be negative, then the body is as a zero size.