### PR TITLE
JAMES-3573 Allow specifying DC in Cassandra configuration

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/ClusterFactory.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/ClusterFactory.java
@@ -42,6 +42,8 @@ public class ClusterFactory {
             .addContactPoint(server.getHostName())
             .withPort(server.getPort()));
 
+        configuration.getLoadBalancingPolicy().ifPresent(clusterBuilder::withLoadBalancingPolicy);
+
         configuration.getUsername().ifPresent(username ->
             configuration.getPassword().ifPresent(password ->
                 clusterBuilder.withCredentials(username, password)));

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfigurationTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfigurationTest.java
@@ -1,0 +1,42 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.init.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.junit.jupiter.api.Test;
+
+class ClusterConfigurationTest {
+    @Test
+    void fromShouldParseLocalDC() {
+        PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+        propertiesConfiguration.addProperty("cassandra.local.dc", "DC2");
+
+        assertThat(ClusterConfiguration.from(propertiesConfiguration).getLocalDc()).contains("DC2");
+    }
+
+    @Test
+    void localDCShouldBeEmptyByDefault() {
+        PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+
+        assertThat(ClusterConfiguration.from(propertiesConfiguration).getLocalDc()).isEmpty();
+    }
+}

--- a/docs/modules/servers/pages/distributed/configure/cassandra.adoc
+++ b/docs/modules/servers/pages/distributed/configure/cassandra.adoc
@@ -73,6 +73,12 @@ Allowed values: https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/dml/dml
 |Optional. Allows specifying the driver serial consistency level. Defaults to SERIAL.
 Allowed values: https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/dml/dmlConfigConsistency.html[SERIAL or LOCAL_SERIAL]
 
+|cassandra.local.dc
+|Optional. Allows specifying the local DC as part of the load balancing policy. Specifying it
+would result in the use of `new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(value).build())` as a LoadBalancingPolicy.
+This value is useful in a multi-DC Cassandra setup. Be aware of xref:../architecture/consistency-model.html#_about_multi_data_center_setups[limitation of multi-DC setups for James]
+Not specifying this value results in the driver's default load balancing policy to be used.
+
 |===
 
 == Pooling options

--- a/src/site/xdoc/server/config-cassandra.xml
+++ b/src/site/xdoc/server/config-cassandra.xml
@@ -175,6 +175,11 @@
         <dd>Optional. Defaults to QUORUM.<br/> <a href="https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/dml/dmlConfigConsistency.html">QUORUM, LOCAL_QUORUM, or EACH_QUORUM</a>.</dd>
         <dt><strong>cassandra.consistency_level.lightweight_transaction</strong></dt>
         <dd>Optional. Defaults to SERIAL.<br/> <a href="https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/dml/dmlConfigConsistency.html">SERIAL or LOCAL_SERIAL</a>.</dd>
+        <dt><strong>cassandra.local.dc</strong></dt>
+        <dd>Optional. Allows specifying the local DC as part of the load balancing policy. Specifying it
+            would result in the use of <code>new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(value).build())</code> as a LoadBalancingPolicy.
+            This value is useful in a multi-DC Cassandra setup. Be aware of limitations of multi-DC setups for James.
+            Not specifying this value results in the driver's default load balancing policy to be used.</dd>
       </dl>
 
 


### PR DESCRIPTION
This makes sense for Multi-DC Cassandra setups,
especially given the use of LOCAL_QUORUM
consistency level.