### PR TITLE
[UPGRADE] Adopt Apache Tika 1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
  - JAMES-3524 Support symmetric encryption support on top of BlobStore
+ 
+### Third party software
+ - Upgrading to Apache Tika 1.26 is recommended
+     - 1.25 and before are subject to CVE-2021-28657 CVE-2021-27906 CVE-2021-27807
+     - 1.24 is subject to CVE-2020-9489
 
 ## [3.6.0] - 2021-03-16
 

--- a/README.adoc
+++ b/README.adoc
@@ -171,7 +171,7 @@ If you want to handle attachment text extraction before indexing in ElasticSearc
 and if you want to use all the JMAP search capabilities, you also need to start *Tika*.
 See http://james.apache.org/server/config-elasticsearch.html#Tika_Configuration[Tika configuration documentation] for more info.
 
-    $ docker run -d --name=tika apache/tika:1.24
+    $ docker run -d --name=tika apache/tika:1.26
 
 We need to provide the key we will use for TLS. For obvious reasons, this is not provided in this git.
 

--- a/dockerfiles/run/docker-compose.yml
+++ b/dockerfiles/run/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "9042:9042"
 
   tika:
-    image: apache/tika:1.24
+    image: apache/tika:1.26
 
   rabbitmq:
     image: rabbitmq:3.8.1-management

--- a/server/testing/src/main/java/org/apache/james/util/docker/Images.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/Images.java
@@ -26,7 +26,7 @@ public interface Images {
     String ELASTICSEARCH_6 = "docker.elastic.co/elasticsearch/elasticsearch:6.3.2";
     String ELASTICSEARCH_7 = "docker.elastic.co/elasticsearch/elasticsearch:7.10.2";
     String NGINX = "nginx:1.15.1";
-    String TIKA = "apache/tika:1.24";
+    String TIKA = "apache/tika:1.26";
     String SPAMASSASSIN = "dinkel/spamassassin:3.4.0";
     String MOCK_SMTP_SERVER = "linagora/mock-smtp-server:0.4";
 }


### PR DESCRIPTION
1.25 and before are subject to CVE-2021-28657
CVE-2021-27906 CVE-2021-27807

1.24 is subject to CVE-2020-9489