### PR TITLE
[REFACTORING] More reactive messageid manager

### DIFF
--- a/event-sourcing/event-sourcing-core/src/main/scala/org/apache/james/eventsourcing/EventBus.scala
+++ b/event-sourcing/event-sourcing-core/src/main/scala/org/apache/james/eventsourcing/EventBus.scala
@@ -36,7 +36,7 @@ class EventBus @Inject() (eventStore: EventStore, subscribers: Set[Subscriber]) 
 
   def runHandlers(events: Iterable[Event], subscribers: Set[Subscriber]): SMono[Void] =
     SFlux.fromIterable(events.flatMap((event: Event) => subscribers.map(subscriber => (event, subscriber))))
-      .flatMapSequential(infos => runHandler(infos._1, infos._2))
+      .concatMap(infos => runHandler(infos._1, infos._2))
       .`then`()
       .`then`(SMono.empty)
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -26,7 +26,7 @@ import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
+import org.apache.james.mailbox.cassandra.mail.ACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraAnnotationMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
@@ -92,7 +92,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     private final BlobStore blobStore;
     private final CassandraAttachmentMessageIdDAO attachmentMessageIdDAO;
     private final CassandraAttachmentOwnerDAO ownerDAO;
-    private final CassandraACLMapper aclMapper;
+    private final ACLMapper aclMapper;
     private final CassandraUserMailboxRightsDAO userMailboxRightsDAO;
     private final CassandraSchemaVersionManager versionManager;
     private final CassandraUtils cassandraUtils;
@@ -107,7 +107,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
                                                 CassandraMailboxPathDAOImpl mailboxPathDAO, CassandraMailboxPathV2DAO mailboxPathV2DAO, CassandraMailboxPathV3DAO mailboxPathV3DAO, CassandraFirstUnseenDAO firstUnseenDAO, CassandraApplicableFlagDAO applicableFlagDAO,
                                                 CassandraAttachmentDAOV2 attachmentDAOV2, CassandraDeletedMessageDAO deletedMessageDAO,
                                                 BlobStore blobStore, CassandraAttachmentMessageIdDAO attachmentMessageIdDAO,
-                                                CassandraAttachmentOwnerDAO ownerDAO, CassandraACLMapper aclMapper,
+                                                CassandraAttachmentOwnerDAO ownerDAO, ACLMapper aclMapper,
                                                 CassandraUserMailboxRightsDAO userMailboxRightsDAO,
                                                 CassandraSchemaVersionManager versionManager,
                                                 RecomputeMailboxCountersService recomputeMailboxCountersService,

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -50,7 +50,6 @@ import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider;
-import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
 import org.apache.james.mailbox.cassandra.mail.CassandraUserMailboxRightsDAO;
 import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersService;
 import org.apache.james.mailbox.cassandra.user.CassandraSubscriptionMapper;
@@ -73,8 +72,8 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     protected static final String ATTACHMENTMAPPER = "ATTACHMENTMAPPER";
 
     private final Session session;
-    private final CassandraUidProvider uidProvider;
-    private final CassandraModSeqProvider modSeqProvider;
+    private final UidProvider uidProvider;
+    private final ModSeqProvider modSeqProvider;
     private final CassandraMessageDAO messageDAO;
     private final CassandraMessageDAOV3 messageDAOV3;
     private final CassandraMessageIdDAO messageIdDAO;
@@ -101,7 +100,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     private final CassandraConfiguration cassandraConfiguration;
 
     @Inject
-    public CassandraMailboxSessionMapperFactory(CassandraUidProvider uidProvider, CassandraModSeqProvider modSeqProvider, Session session,
+    public CassandraMailboxSessionMapperFactory(UidProvider uidProvider, CassandraModSeqProvider modSeqProvider, Session session,
                                                 CassandraMessageDAO messageDAO,
                                                 CassandraMessageDAOV3 messageDAOV3, CassandraMessageIdDAO messageIdDAO, CassandraMessageIdToImapUidDAO imapUidDAO,
                                                 CassandraMailboxCounterDAO mailboxCounterDAO, CassandraMailboxRecentsDAO mailboxRecentsDAO, CassandraMailboxDAO mailboxDAO,

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -38,7 +38,7 @@ import org.apache.james.events.Group;
 import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
-import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
+import org.apache.james.mailbox.cassandra.mail.ACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
@@ -92,7 +92,7 @@ public class DeleteMessageListener implements EventListener.ReactiveGroupEventLi
     private final CassandraAttachmentDAOV2 attachmentDAO;
     private final CassandraAttachmentOwnerDAO ownerDAO;
     private final CassandraAttachmentMessageIdDAO attachmentMessageIdDAO;
-    private final CassandraACLMapper aclMapper;
+    private final ACLMapper aclMapper;
     private final CassandraUserMailboxRightsDAO rightsDAO;
     private final CassandraApplicableFlagDAO applicableFlagDAO;
     private final CassandraFirstUnseenDAO firstUnseenDAO;
@@ -105,7 +105,7 @@ public class DeleteMessageListener implements EventListener.ReactiveGroupEventLi
     @Inject
     public DeleteMessageListener(CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO, CassandraMessageDAO messageDAO,
                                  CassandraMessageDAOV3 messageDAOV3, CassandraAttachmentDAOV2 attachmentDAO, CassandraAttachmentOwnerDAO ownerDAO,
-                                 CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper,
+                                 CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, ACLMapper aclMapper,
                                  CassandraUserMailboxRightsDAO rightsDAO, CassandraApplicableFlagDAO applicableFlagDAO,
                                  CassandraFirstUnseenDAO firstUnseenDAO, CassandraDeletedMessageDAO deletedMessageDAO,
                                  CassandraMailboxCounterDAO counterDAO, CassandraMailboxRecentsDAO recentsDAO, BlobStore blobStore,

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/ACLMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/ACLMapper.java
@@ -1,0 +1,36 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import org.apache.james.mailbox.acl.ACLDiff;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.model.MailboxACL;
+
+import reactor.core.publisher.Mono;
+
+public interface ACLMapper {
+    Mono<MailboxACL> getACL(CassandraId cassandraId);
+
+    Mono<ACLDiff> updateACL(CassandraId cassandraId, MailboxACL.ACLCommand command);
+
+    Mono<ACLDiff> setACL(CassandraId cassandraId, MailboxACL mailboxACL);
+
+    Mono<Void> delete(CassandraId cassandraId);
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapper.java
@@ -46,7 +46,7 @@ import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Mono;
 
-public class CassandraACLMapper {
+public class CassandraACLMapper implements ACLMapper {
     public interface Store {
         Mono<MailboxACL> getACL(CassandraId cassandraId);
 
@@ -168,18 +168,22 @@ public class CassandraACLMapper {
             });
     }
 
+    @Override
     public Mono<MailboxACL> getACL(CassandraId cassandraId) {
         return store().flatMap(store -> store.getACL(cassandraId));
     }
 
+    @Override
     public Mono<ACLDiff> updateACL(CassandraId cassandraId, MailboxACL.ACLCommand command) {
         return store().flatMap(store -> store.updateACL(cassandraId, command));
     }
 
+    @Override
     public Mono<ACLDiff> setACL(CassandraId cassandraId, MailboxACL mailboxACL) {
         return store().flatMap(store -> store.setACL(cassandraId, mailboxACL));
     }
 
+    @Override
     public Mono<Void> delete(CassandraId cassandraId) {
         return store().flatMap(store -> store.delete(cassandraId));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapper.java
@@ -77,7 +77,7 @@ public class CassandraACLMapper {
             return cassandraACLDAOV1.updateACL(cassandraId, command)
                 .flatMap(aclDiff -> userMailboxRightsDAO.update(cassandraId, aclDiff)
                     .thenReturn(aclDiff))
-                .switchIfEmpty(Mono.error(new MailboxException("Unable to update ACL")));
+                .switchIfEmpty(Mono.error(() -> new MailboxException("Unable to update ACL")));
         }
 
         @Override
@@ -85,7 +85,7 @@ public class CassandraACLMapper {
             return cassandraACLDAOV1.setACL(cassandraId, mailboxACL)
                 .flatMap(aclDiff -> userMailboxRightsDAO.update(cassandraId, aclDiff)
                     .thenReturn(aclDiff))
-                .switchIfEmpty(Mono.defer(() -> Mono.error(new MailboxException("Unable to update ACL"))));
+                .switchIfEmpty(Mono.error(() -> new MailboxException("Unable to update ACL")));
         }
 
         public Mono<Void> delete(CassandraId cassandraId) {
@@ -125,7 +125,7 @@ public class CassandraACLMapper {
                 .map(ACLUpdated.class::cast)
                 .map(ACLUpdated::getAclDiff)
                 .next()
-                .switchIfEmpty(Mono.defer(() -> Mono.error(new MailboxException("Unable to update ACL"))));
+                .switchIfEmpty(Mono.error(() -> new MailboxException("Unable to update ACL")));
         }
 
         @Override
@@ -136,7 +136,7 @@ public class CassandraACLMapper {
                 .map(ACLUpdated.class::cast)
                 .map(ACLUpdated::getAclDiff)
                 .next()
-                .switchIfEmpty(Mono.defer(() -> Mono.error(new MailboxException("Unable to set ACL"))));
+                .switchIfEmpty(Mono.error(() -> new MailboxException("Unable to set ACL")));
         }
 
         @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -70,7 +70,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
     private final CassandraMailboxPathDAOImpl mailboxPathDAO;
     private final CassandraMailboxPathV2DAO mailboxPathV2DAO;
     private final CassandraMailboxPathV3DAO mailboxPathV3DAO;
-    private final CassandraACLMapper cassandraACLMapper;
+    private final ACLMapper aclMapper;
     private final CassandraUserMailboxRightsDAO userMailboxRightsDAO;
     private final CassandraSchemaVersionManager versionManager;
     private final CassandraConfiguration cassandraConfiguration;
@@ -82,7 +82,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
                                   CassandraMailboxPathV2DAO mailboxPathV2DAO,
                                   CassandraMailboxPathV3DAO mailboxPathV3DAO,
                                   CassandraUserMailboxRightsDAO userMailboxRightsDAO,
-                                  CassandraACLMapper aclMapper,
+                                  ACLMapper aclMapper,
                                   CassandraSchemaVersionManager versionManager,
                                   CassandraConfiguration cassandraConfiguration) {
         this.mailboxDAO = mailboxDAO;
@@ -90,7 +90,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
         this.mailboxPathV2DAO = mailboxPathV2DAO;
         this.mailboxPathV3DAO = mailboxPathV3DAO;
         this.userMailboxRightsDAO = userMailboxRightsDAO;
-        this.cassandraACLMapper = aclMapper;
+        this.aclMapper = aclMapper;
         this.versionManager = versionManager;
         this.cassandraConfiguration = cassandraConfiguration;
         this.secureRandom = new SecureRandom();
@@ -182,7 +182,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
 
     private Mono<Mailbox> addAcl(Mailbox mailbox) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
-        return cassandraACLMapper.getACL(mailboxId)
+        return aclMapper.getACL(mailboxId)
             .map(acl -> {
                 mailbox.setACL(acl);
                 return mailbox;
@@ -236,7 +236,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
     }
 
     private Mono<MailboxACL> retrieveAcl(CassandraId mailboxId) {
-        return cassandraACLMapper.getACL(mailboxId)
+        return aclMapper.getACL(mailboxId)
             .defaultIfEmpty(MailboxACL.EMPTY);
     }
 
@@ -341,13 +341,13 @@ public class CassandraMailboxMapper implements MailboxMapper {
     @Override
     public Mono<ACLDiff> updateACL(Mailbox mailbox, MailboxACL.ACLCommand mailboxACLCommand) {
         CassandraId cassandraId = (CassandraId) mailbox.getMailboxId();
-        return cassandraACLMapper.updateACL(cassandraId, mailboxACLCommand);
+        return aclMapper.updateACL(cassandraId, mailboxACLCommand);
     }
 
     @Override
     public Mono<ACLDiff> setACL(Mailbox mailbox, MailboxACL mailboxACL) {
         CassandraId cassandraId = (CassandraId) mailbox.getMailboxId();
-        return cassandraACLMapper.setACL(cassandraId, mailboxACL);
+        return aclMapper.setACL(cassandraId, mailboxACL);
     }
 
     private Mono<Mailbox> toMailboxWithAcl(Mailbox mailbox) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -263,7 +263,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
     }
 
     private Flux<Pair<MailboxId, UpdatedFlags>> flagsUpdateWithRetry(Flags newState, MessageManager.FlagsUpdateMode updateMode, MailboxId mailboxId, MessageId messageId) {
-        return Mono.defer(() -> updateFlags(mailboxId, messageId, newState, updateMode))
+        return updateFlags(mailboxId, messageId, newState, updateMode)
             .retry(cassandraConfiguration.getFlagsUpdateMessageIdMaxRetry())
             .onErrorResume(MailboxDeleteDuringUpdateException.class, e -> {
                 LOGGER.info("Mailbox {} was deleted during flag update", mailboxId);

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -49,6 +49,7 @@ import org.apache.james.mailbox.store.MailboxReactorUtils;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.MessageIdMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
+import org.apache.james.mailbox.store.mail.ModSeqProvider;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.util.FunctionalUtils;
 import org.apache.james.util.ReactorUtils;
@@ -79,14 +80,14 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
     private final CassandraMessageDAO messageDAO;
     private final CassandraMessageDAOV3 messageDAOV3;
     private final CassandraIndexTableHandler indexTableHandler;
-    private final CassandraModSeqProvider modSeqProvider;
+    private final ModSeqProvider modSeqProvider;
     private final AttachmentLoader attachmentLoader;
     private final CassandraConfiguration cassandraConfiguration;
 
     public CassandraMessageIdMapper(MailboxMapper mailboxMapper, CassandraMailboxDAO mailboxDAO, CassandraAttachmentMapper attachmentMapper,
                                     CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO,
                                     CassandraMessageDAO messageDAO, CassandraMessageDAOV3 messageDAOV3, CassandraIndexTableHandler indexTableHandler,
-                                    CassandraModSeqProvider modSeqProvider, CassandraConfiguration cassandraConfiguration) {
+                                    ModSeqProvider modSeqProvider, CassandraConfiguration cassandraConfiguration) {
 
         this.mailboxMapper = mailboxMapper;
         this.mailboxDAO = mailboxDAO;
@@ -308,7 +309,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
         if (identicalFlags(oldComposedId, newFlags)) {
             return Mono.just(Pair.of(oldComposedId.getFlags(), oldComposedId));
         } else {
-            return modSeqProvider.nextModSeq(cassandraId)
+            return modSeqProvider.nextModSeqReactive(cassandraId)
                 .map(modSeq -> new ComposedMessageIdWithMetaData(
                     oldComposedId.getComposedMessageId(),
                     newFlags,

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -172,9 +172,13 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
 
     @Override
     public void copyInMailbox(MailboxMessage mailboxMessage, Mailbox mailbox) throws MailboxException {
-        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
+        MailboxReactorUtils.block(copyInMailboxReactive(mailboxMessage, mailbox));
+    }
 
-        MailboxReactorUtils.block(saveMessageMetadata(mailboxMessage, mailboxId));
+    @Override
+    public Mono<Void> copyInMailboxReactive(MailboxMessage mailboxMessage, Mailbox mailbox) {
+        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
+        return saveMessageMetadata(mailboxMessage, mailboxId);
     }
 
     private Mono<Void> saveMessageMetadata(MailboxMessage mailboxMessage, CassandraId mailboxId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
@@ -105,12 +105,14 @@ public class CassandraUidProvider implements UidProvider {
     @Override
     public MessageUid nextUid(MailboxId mailboxId) throws MailboxException {
         CassandraId cassandraId = (CassandraId) mailboxId;
-        return nextUids(cassandraId)
+        return nextUidReactive(cassandraId)
             .blockOptional()
             .orElseThrow(() -> new MailboxException("Error during Uid update"));
     }
 
-    public Mono<MessageUid> nextUids(CassandraId cassandraId) {
+    @Override
+    public Mono<MessageUid> nextUidReactive(MailboxId mailboxId) {
+        CassandraId cassandraId = (CassandraId) mailboxId;
         Mono<MessageUid> updateUid = findHighestUid(cassandraId)
             .flatMap(messageUid -> tryUpdateUid(cassandraId, messageUid));
 
@@ -122,7 +124,10 @@ public class CassandraUidProvider implements UidProvider {
             .retryWhen(Retry.backoff(maxUidRetries, firstBackoff).scheduler(Schedulers.elastic()));
     }
 
-    public Mono<List<MessageUid>> nextUids(CassandraId cassandraId, int count) {
+    @Override
+    public Mono<List<MessageUid>> nextUids(MailboxId mailboxId, int count) {
+        CassandraId cassandraId = (CassandraId) mailboxId;
+
         Mono<List<MessageUid>> updateUid = findHighestUid(cassandraId)
             .flatMap(messageUid -> tryUpdateUid(cassandraId, messageUid, count)
                 .map(highest -> range(messageUid, highest)));

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProviderTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProviderTest.java
@@ -115,10 +115,10 @@ class CassandraModSeqProviderTest {
                     .times(1)
                     .whenQueryStartsWith("SELECT nextModseq FROM modseq WHERE mailboxId=:mailboxId;"));
 
-        CompletableFuture<ModSeq> operation1 = modSeqProvider.nextModSeq(CASSANDRA_ID)
+        CompletableFuture<ModSeq> operation1 = modSeqProvider.nextModSeqReactive(CASSANDRA_ID)
             .subscribeOn(Schedulers.elastic())
             .toFuture();
-        CompletableFuture<ModSeq> operation2 = modSeqProvider.nextModSeq(CASSANDRA_ID)
+        CompletableFuture<ModSeq> operation2 = modSeqProvider.nextModSeqReactive(CASSANDRA_ID)
             .subscribeOn(Schedulers.elastic())
             .toFuture();
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
@@ -38,6 +38,8 @@ import org.apache.james.eventsourcing.eventstore.cassandra.dto.EventDTOModule;
 import org.apache.james.json.DTO;
 import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.ACLMapper;
+import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
 import org.apache.james.mailbox.cassandra.mail.eventsourcing.acl.ACLModule;
 import org.apache.james.mailbox.model.MessageId;
@@ -76,6 +78,7 @@ public class GuiceUtils {
         return Modules.combine(
             binder -> binder.bind(MessageId.Factory.class).toInstance(messageIdFactory),
             binder -> binder.bind(UidProvider.class).to(CassandraUidProvider.class),
+            binder -> binder.bind(ACLMapper.class).to(CassandraACLMapper.class),
             binder -> binder.bind(BlobId.Factory.class).toInstance(new HashBlobId.Factory()),
             binder -> binder.bind(BlobStore.class).toProvider(() -> CassandraBlobStoreFactory.forTesting(session).passthrough()),
             binder -> binder.bind(Session.class).toInstance(session),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
@@ -38,8 +38,10 @@ import org.apache.james.eventsourcing.eventstore.cassandra.dto.EventDTOModule;
 import org.apache.james.json.DTO;
 import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
 import org.apache.james.mailbox.cassandra.mail.eventsourcing.acl.ACLModule;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.store.mail.UidProvider;
 
 import com.datastax.driver.core.Session;
 import com.google.common.collect.ImmutableSet;
@@ -73,6 +75,7 @@ public class GuiceUtils {
                                         CassandraConfiguration configuration) {
         return Modules.combine(
             binder -> binder.bind(MessageId.Factory.class).toInstance(messageIdFactory),
+            binder -> binder.bind(UidProvider.class).to(CassandraUidProvider.class),
             binder -> binder.bind(BlobId.Factory.class).toInstance(new HashBlobId.Factory()),
             binder -> binder.bind(BlobStore.class).toProvider(() -> CassandraBlobStoreFactory.forTesting(session).passthrough()),
             binder -> binder.bind(Session.class).toInstance(session),

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -95,7 +95,7 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
                 }
                 return true;
             })
-            .switchIfEmpty(Mono.error(new MailboxNotFoundException(mailbox.generateAssociatedPath())))
+            .switchIfEmpty(Mono.error(() -> new MailboxNotFoundException(mailbox.generateAssociatedPath())))
             .then();
     }
 
@@ -130,7 +130,7 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
         return list()
             .filter(mailbox -> mailbox.getMailboxId().equals(id))
             .next()
-            .switchIfEmpty(Mono.error(new MailboxNotFoundException(id)));
+            .switchIfEmpty(Mono.error(() -> new MailboxNotFoundException(id)));
     }
     
     @Override

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVaultHook.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVaultHook.java
@@ -123,7 +123,7 @@ public class DeletedMessageVaultHook implements PreDeletionHook {
         return mapperFactory.getMessageIdMapper(session)
             .findReactive(ImmutableList.of(deletedMessageMailboxContext.getMessageId()), MessageMapper.FetchType.Full)
             .next()
-            .switchIfEmpty(Mono.error(new RuntimeException("Cannot find " + deletedMessageMailboxContext.getMessageId())))
+            .switchIfEmpty(Mono.error(() -> new RuntimeException("Cannot find " + deletedMessageMailboxContext.getMessageId())))
             .flatMap(mailboxMessage -> Mono.fromCallable(() -> Pair.of(mailboxMessage,
                 deletedMessageConverter.convert(deletedMessageMailboxContext, mailboxMessage,
                     ZonedDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)))))

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -427,7 +427,7 @@ public class StoreMailboxManager implements MailboxManager {
 
         mailboxMapper.execute(() -> block(mailboxMapper.findMailboxByPath(mailboxPath)
             .flatMap(mailbox -> doDeleteMailbox(mailboxMapper, mailbox, session))
-            .switchIfEmpty(Mono.error(new MailboxNotFoundException(mailboxPath)))));
+            .switchIfEmpty(Mono.error(() -> new MailboxNotFoundException(mailboxPath)))));
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
@@ -151,6 +151,7 @@ public class StoreRightManager implements RightManager {
         return mailbox.getACL();
     }
 
+    @Override
     public MailboxACL listRights(MailboxId mailboxId, MailboxSession session) throws MailboxException {
         MailboxMapper mapper = mailboxSessionMapperFactory.getMailboxMapper(session);
         Mailbox mailbox = blockOptional(mapper.findMailboxById(mailboxId))

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageIdMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageIdMapper.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.reactivestreams.Publisher;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.Multimap;
 
 import reactor.core.publisher.Flux;
@@ -55,6 +56,10 @@ public interface MessageIdMapper {
     void save(MailboxMessage mailboxMessage) throws MailboxNotFoundException, MailboxException;
 
     void copyInMailbox(MailboxMessage mailboxMessage, Mailbox mailbox) throws MailboxException;
+
+    default Mono<Void> copyInMailboxReactive(MailboxMessage mailboxMessage, Mailbox mailbox) {
+        return Mono.fromRunnable(Throwing.runnable(() -> copyInMailboxReactive(mailboxMessage, mailbox)).sneakyThrow());
+    }
 
     void delete(MessageId messageId);
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageIdMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageIdMapper.java
@@ -58,7 +58,7 @@ public interface MessageIdMapper {
     void copyInMailbox(MailboxMessage mailboxMessage, Mailbox mailbox) throws MailboxException;
 
     default Mono<Void> copyInMailboxReactive(MailboxMessage mailboxMessage, Mailbox mailbox) {
-        return Mono.fromRunnable(Throwing.runnable(() -> copyInMailboxReactive(mailboxMessage, mailbox)).sneakyThrow());
+        return Mono.fromRunnable(Throwing.runnable(() -> copyInMailbox(mailboxMessage, mailbox)).sneakyThrow());
     }
 
     void delete(MessageId messageId);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/ModSeqProvider.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/ModSeqProvider.java
@@ -23,6 +23,8 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Take care of provide mod-seqences for a given {@link Mailbox}. Be aware that implementations
  * need to be thread-safe!
@@ -56,4 +58,8 @@ public interface ModSeqProvider {
      * Return the highest mod-sequence which were used for the {@link Mailbox}
      */
     ModSeq highestModSeq(MailboxId mailboxId) throws MailboxException;
+
+    default Mono<ModSeq> nextModSeqReactive(MailboxId mailboxId) {
+        return Mono.fromCallable(() -> nextModSeq(mailboxId));
+    }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
@@ -18,12 +18,18 @@
  ****************************************************************/
 package org.apache.james.mailbox.store.mail;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
+
+import com.github.steveash.guavate.Guavate;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Take care of provide uids for a given {@link Mailbox}. Be aware that implementations
@@ -44,4 +50,14 @@ public interface UidProvider {
     Optional<MessageUid> lastUid(Mailbox mailbox) throws MailboxException;
 
     MessageUid nextUid(MailboxId mailboxId) throws MailboxException;
+
+    default Mono<MessageUid> nextUidReactive(MailboxId mailboxId) {
+        return Mono.fromCallable(() -> nextUid(mailboxId));
+    }
+
+    default Mono<List<MessageUid>> nextUids(MailboxId mailboxId, int count) {
+        return Flux.range(0, count)
+            .flatMap(i -> nextUidReactive(mailboxId))
+            .collect(Guavate.toImmutableList());
+    }
 }

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
@@ -54,6 +54,7 @@ import org.apache.james.mailbox.cassandra.CassandraMailboxSessionMapperFactory;
 import org.apache.james.mailbox.cassandra.DeleteMessageListener;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.ACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLDAOV1;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
@@ -181,6 +182,7 @@ public class CassandraMailboxModule extends AbstractModule {
         bind(MailboxSessionMapperFactory.class).to(CassandraMailboxSessionMapperFactory.class);
         bind(SubscriptionMapperFactory.class).to(CassandraMailboxSessionMapperFactory.class);
 
+        bind(ACLMapper.class).to(CassandraACLMapper.class);
         bind(ModSeqProvider.class).to(CassandraModSeqProvider.class);
         bind(UidProvider.class).to(CassandraUidProvider.class);
         bind(SubscriptionManager.class).to(StoreSubscriptionManager.class);

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/access/CassandraAccessTokenRepository.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/access/CassandraAccessTokenRepository.java
@@ -59,6 +59,6 @@ public class CassandraAccessTokenRepository implements AccessTokenRepository {
         Preconditions.checkNotNull(accessToken);
 
         return cassandraAccessTokenDAO.getUsernameFromToken(accessToken)
-            .switchIfEmpty(Mono.error(new InvalidAccessToken(accessToken)));
+            .switchIfEmpty(Mono.error(() -> new InvalidAccessToken(accessToken)));
     }
 }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraEmailChangeRepository.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraEmailChangeRepository.java
@@ -67,7 +67,7 @@ public class CassandraEmailChangeRepository implements EmailChangeRepository {
         }
 
         return emailChangeRepositoryDAO.getChangesSince(accountId, state)
-            .switchIfEmpty(Flux.error(new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
+            .switchIfEmpty(Flux.error(() -> new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
             .filter(change -> !change.isDelegated())
             .filter(change -> !change.getState().equals(state))
             .collect(new EmailChanges.Builder.EmailChangeCollector(state, maxChanges.orElse(defaultLimit)));
@@ -85,7 +85,7 @@ public class CassandraEmailChangeRepository implements EmailChangeRepository {
         }
 
         return emailChangeRepositoryDAO.getChangesSince(accountId, state)
-            .switchIfEmpty(Flux.error(new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
+            .switchIfEmpty(Flux.error(() -> new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
             .filter(change -> !change.getState().equals(state))
             .collect(new EmailChanges.Builder.EmailChangeCollector(state, maxChanges.orElse(defaultLimit)));
     }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraMailboxChangeRepository.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraMailboxChangeRepository.java
@@ -67,7 +67,7 @@ public class CassandraMailboxChangeRepository implements MailboxChangeRepository
         }
 
         return mailboxChangeRepositoryDAO.getChangesSince(accountId, state)
-            .switchIfEmpty(Flux.error(new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
+            .switchIfEmpty(Flux.error(() -> new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
             .filter(change -> !change.isDelegated())
             .filter(change -> !change.getState().equals(state))
             .collect(new MailboxChanges.MailboxChangesBuilder.MailboxChangeCollector(state, maxChanges.orElse(defaultLimit)));
@@ -85,7 +85,7 @@ public class CassandraMailboxChangeRepository implements MailboxChangeRepository
         }
 
         return mailboxChangeRepositoryDAO.getChangesSince(accountId, state)
-            .switchIfEmpty(Flux.error(new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
+            .switchIfEmpty(Flux.error(() -> new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
             .filter(change -> !change.getState().equals(state))
             .collect(new MailboxChanges.MailboxChangesBuilder.MailboxChangeCollector(state, maxChanges.orElse(defaultLimit)));
     }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
@@ -130,14 +130,14 @@ public class MailboxChange implements JmapChange {
             this.stateFactory = stateFactory;
         }
 
-        public List<JmapChange> fromMailboxAdded(MailboxAdded mailboxAdded, ZonedDateTime now) {
-            return ImmutableList.of(MailboxChange.builder()
+        public JmapChange fromMailboxAdded(MailboxAdded mailboxAdded, ZonedDateTime now) {
+            return MailboxChange.builder()
                 .accountId(AccountId.fromUsername(mailboxAdded.getUsername()))
                 .state(stateFactory.generate())
                 .date(now)
                 .isCountChange(false)
                 .created(ImmutableList.of(mailboxAdded.getMailboxId()))
-                .build());
+                .build();
         }
 
         public List<JmapChange> fromMailboxRenamed(MailboxRenamed mailboxRenamed, ZonedDateTime now, List<AccountId> sharees) {

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepository.java
@@ -120,7 +120,7 @@ public class MemoryEmailChangeRepository implements EmailChangeRepository {
     private Mono<EmailChange> findByState(AccountId accountId, State state) {
         return Flux.fromIterable(emailChangeMap.get(accountId))
             .filter(change -> change.getState().equals(state))
-            .switchIfEmpty(Mono.error(new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
+            .switchIfEmpty(Mono.error(() -> new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
             .single();
     }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
@@ -101,7 +101,7 @@ public class MemoryMailboxChangeRepository implements MailboxChangeRepository {
     private Mono<MailboxChange> findByState(AccountId accountId, State state) {
         return Flux.fromIterable(mailboxChangeMap.get(accountId))
             .filter(change -> change.getState().equals(state))
-            .switchIfEmpty(Mono.error(new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
+            .switchIfEmpty(Mono.error(() -> new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
             .single();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AuthenticationRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AuthenticationRoutes.java
@@ -213,7 +213,7 @@ public class AuthenticationRoutes implements JMAPRoutes {
                     throw new BadRequestException("Request can't be deserialized", e);
                 }
             })
-            .switchIfEmpty(Mono.error(new BadRequestException("Empty body")));
+            .switchIfEmpty(Mono.error(() -> new BadRequestException("Empty body")));
     }
 
     private Mono<Void> handleContinuationTokenRequest(ContinuationTokenRequest request, HttpServerResponse resp) {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/MailboxesProvisioner.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/MailboxesProvisioner.scala
@@ -59,7 +59,7 @@ class MailboxesProvisioner @Inject() (mailboxManager: MailboxManager,
       SMono(mailboxManager.mailboxExists(mailboxPath, session))
         .map(exist => !exist)
     } catch {
-      case exception: MailboxException => SMono.raiseError(exception)
+      case exception: MailboxException => SMono.error(exception)
     }
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxFactory.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxFactory.scala
@@ -129,7 +129,7 @@ class MailboxFactory @Inject() (subscriptionManager: SubscriptionManager, mailbo
     val sanitizedCounters: MailboxCounters = mailboxMetaData.getCounters.sanitize()
 
     MailboxValidation.validate(mailboxMetaData.getPath, mailboxSession.getPathDelimiter, sanitizedCounters.getUnseen, sanitizedCounters.getUnseen, sanitizedCounters.getCount, sanitizedCounters.getCount) match {
-      case Left(error) => SMono.raiseError(error)
+      case Left(error) => SMono.error(error)
       case scala.Right(mailboxValidation) =>
         SMono.fromPublisher(quotaLoader.getQuotas(mailboxMetaData.getPath))
           .map(quotas => {
@@ -169,7 +169,7 @@ class MailboxFactory @Inject() (subscriptionManager: SubscriptionManager, mailbo
       val sanitizedCounters: MailboxCounters = messageManager.getMailboxCounters(mailboxSession).sanitize()
 
       MailboxValidation.validate(messageManager.getMailboxPath, mailboxSession.getPathDelimiter, sanitizedCounters.getUnseen, sanitizedCounters.getUnseen, sanitizedCounters.getCount, sanitizedCounters.getCount) match {
-        case Left(error) => SMono.raiseError(error)
+        case Left(error) => SMono.error(error)
         case scala.Right(mailboxValidation) =>
           SMono.fromPublisher(quotaLoader.getQuotas(messageManager.getMailboxPath))
             .map(quotas => {
@@ -206,7 +206,7 @@ class MailboxFactory @Inject() (subscriptionManager: SubscriptionManager, mailbo
                 isSubscribed = isSubscribed)})
       }
     } catch {
-      case error: Exception => SMono.raiseError(error)
+      case error: Exception => SMono.error(error)
     }
   }
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailQueryMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailQueryMethod.scala
@@ -42,7 +42,6 @@ import org.apache.james.metrics.api.MetricFactory
 import org.apache.james.util.streams.{Limit => JavaLimit}
 import play.api.libs.json.{JsError, JsSuccess}
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 import scala.jdk.CollectionConverters._
 
@@ -75,7 +74,7 @@ class EmailQueryMethod @Inject() (serializer: EmailQuerySerializer,
             arguments = Arguments(serializer.serialize(response)),
             methodCallId = invocation.methodCallId))
       }
-    validation.fold(SMono.raiseError, res => res)
+    validation.fold(SMono.error, res => res)
   }
 
   override def getRequest(mailboxSession: MailboxSession, invocation: Invocation): Either[Exception, EmailQueryRequest] =
@@ -115,7 +114,7 @@ class EmailQueryMethod @Inject() (serializer: EmailQuerySerializer,
         .collectSeq())
       .onErrorResume({
         case _: MailboxNotFoundException => SMono.just[Seq[MessageId]](Seq())
-        case e => SMono.raiseError[Seq[MessageId]](e)
+        case e => SMono.error[Seq[MessageId]](e)
       })
   }
 
@@ -129,7 +128,7 @@ class EmailQueryMethod @Inject() (serializer: EmailQuerySerializer,
         .collectSeq())
       .onErrorResume({
         case _: MailboxNotFoundException => SMono.just[Seq[MessageId]](Seq())
-        case e => SMono.raiseError[Seq[MessageId]](e)
+        case e => SMono.error[Seq[MessageId]](e)
       })
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MDNParseMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MDNParseMethod.scala
@@ -19,7 +19,10 @@
 
 package org.apache.james.jmap.method
 
+import java.io.InputStream
+
 import eu.timepit.refined.auto._
+import javax.inject.Inject
 import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JMAP_CORE, JMAP_MAIL, JMAP_MDN}
 import org.apache.james.jmap.core.Invocation
 import org.apache.james.jmap.core.Invocation._
@@ -36,8 +39,6 @@ import org.apache.james.mime4j.message.DefaultMessageBuilder
 import play.api.libs.json.{JsError, JsObject, JsSuccess, Json}
 import reactor.core.scala.publisher.{SFlux, SMono}
 
-import java.io.InputStream
-import javax.inject.Inject
 import scala.jdk.OptionConverters._
 import scala.util.Try
 
@@ -113,7 +114,7 @@ class MDNParseMethod @Inject()(serializer: MDNSerializer,
     } yield {
       (mdn, message)
     }
-    maybeMdn.fold(_ => SMono.raiseError(BlobUnParsableException(blobId)), result => SMono.just(result))
+    maybeMdn.fold(_ => SMono.error(BlobUnParsableException(blobId)), result => SMono.just(result))
   }
 }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MDNSendMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MDNSendMethod.scala
@@ -20,6 +20,9 @@
 package org.apache.james.jmap.method
 
 import eu.timepit.refined.auto._
+import javax.annotation.PreDestroy
+import javax.inject.Inject
+import javax.mail.internet.MimeMessage
 import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JMAP_CORE, JMAP_MAIL, JMAP_MDN}
 import org.apache.james.jmap.core.Invocation
 import org.apache.james.jmap.core.Invocation._
@@ -47,9 +50,6 @@ import play.api.libs.json.{JsError, JsObject, JsSuccess, Json}
 import reactor.core.scala.publisher.{SFlux, SMono}
 import reactor.core.scheduler.Schedulers
 
-import javax.annotation.PreDestroy
-import javax.inject.Inject
-import javax.mail.internet.MimeMessage
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 import scala.util.Try
@@ -78,7 +78,7 @@ class MDNSendMethod @Inject()(serializer: MDNSerializer,
                          request: MDNSendRequest): SFlux[InvocationWithContext] =
     identityResolver.resolveIdentityId(request.identityId, mailboxSession)
       .flatMap(maybeIdentity => maybeIdentity.map(identity => create(identity, request, mailboxSession, invocation.processingContext))
-        .getOrElse(SMono.raiseError(IdentityIdNotFoundException("The IdentityId cannot be found"))))
+        .getOrElse(SMono.error(IdentityIdNotFoundException("The IdentityId cannot be found"))))
       .flatMapMany(createdResults => {
         val explicitInvocation: InvocationWithContext = InvocationWithContext(
           invocation = Invocation(

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxGetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxGetMethod.scala
@@ -131,7 +131,7 @@ class MailboxGetMethod @Inject() (serializer: MailboxSerializer,
         .map(mailbox => filterShared(capabilities, mailbox))
         .onErrorResume {
           case _: MailboxNotFoundException => SMono.just(MailboxGetResults.notFound(mailboxId))
-          case error => SMono.raiseError(error)
+          case error => SMono.error(error)
         })
       .subscribeOn(Schedulers.elastic)
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxQueryMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxQueryMethod.scala
@@ -46,7 +46,7 @@ class MailboxQueryMethod @Inject()(systemMailboxesProvider: SystemMailboxesProvi
           errorCode = ErrorCode.InvalidArguments,
           description = e.getMessage,
           methodCallId = invocation.invocation.methodCallId))
-      case e: Throwable => SMono.raiseError(e)
+      case e: Throwable => SMono.error(e)
     }
       .map(invocationResult => InvocationWithContext(invocationResult, invocation.processingContext))
   }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetDeletePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetDeletePerformer.scala
@@ -74,7 +74,7 @@ class MailboxSetDeletePerformer @Inject()(mailboxManager: MailboxManager,
 
   private def delete(mailboxSession: MailboxSession, id: UnparsedMailboxId, onDestroy: RemoveEmailsOnDestroy): SMono[MailboxDeletionResult] = {
     MailboxGet.parse(mailboxIdFactory)(id)
-      .fold(e => SMono.raiseError(e),
+      .fold(e => SMono.error(e),
         id => SMono.fromCallable(() => doDelete(mailboxSession, id, onDestroy))
           .subscribeOn(Schedulers.elastic())
           .`then`(SMono.just[MailboxDeletionResult](MailboxDeletionSuccess(id))))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
@@ -102,7 +102,7 @@ class MailboxSetUpdatePerformer @Inject()(serializer: MailboxSerializer,
                             patch: MailboxPatchObject,
                             capabilities: Set[CapabilityIdentifier]): SMono[MailboxUpdateResult] = {
     patch.validate(mailboxIdFactory, serializer, capabilities, mailboxSession)
-      .fold(e => SMono.raiseError(e), validatedPatch =>
+      .fold(e => SMono.error(e), validatedPatch =>
         updateMailboxRights(mailboxId, validatedPatch, mailboxSession)
           .`then`(updateSubscription(mailboxId, validatedPatch, mailboxSession))
           .`then`(updateMailboxPath(mailboxId, unparsedMailboxId, validatedPatch, mailboxSession)))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/Method.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/Method.scala
@@ -61,7 +61,7 @@ trait MethodRequiringAccountId[REQUEST <: WithAccountId] extends Method {
       doProcess(capabilities, invocation, mailboxSession, request)
     }
 
-    val result: SFlux[InvocationWithContext] = SFlux.fromPublisher(either.fold(e => SFlux.raiseError[InvocationWithContext](e), r => r))
+    val result: SFlux[InvocationWithContext] = SFlux.fromPublisher(either.fold(e => SFlux.error[InvocationWithContext](e), r => r))
       .onErrorResume[InvocationWithContext] {
         case e: AccountNotFoundException => SFlux.just[InvocationWithContext] (InvocationWithContext(e.invocation, invocation.processingContext))
         case e: UnsupportedRequestParameterException => SFlux.just[InvocationWithContext] (InvocationWithContext(Invocation.error(
@@ -85,7 +85,7 @@ trait MethodRequiringAccountId[REQUEST <: WithAccountId] extends Method {
         case e: ChangeNotFoundException => SFlux.just[InvocationWithContext] (InvocationWithContext(Invocation.error(ErrorCode.CannotCalculateChanges, e.getMessage, invocation.invocation.methodCallId), invocation.processingContext))
         case e: RequestTooLargeException => SFlux.just[InvocationWithContext] (InvocationWithContext(Invocation.error(ErrorCode.RequestTooLarge, e.description, invocation.invocation.methodCallId), invocation.processingContext))
         case e: IdentityIdNotFoundException => SFlux.just[InvocationWithContext] (InvocationWithContext(Invocation.error(ErrorCode.InvalidArguments, e.description, invocation.invocation.methodCallId), invocation.processingContext))
-        case e: Throwable => SFlux.raiseError[InvocationWithContext] (e)
+        case e: Throwable => SFlux.error[InvocationWithContext] (e)
       }
 
     metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_RFC8621_PREFIX + methodName.value, result)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/JmapApi.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/JmapApi.scala
@@ -21,7 +21,7 @@ package org.apache.james.jmap.routes
 import javax.inject.Inject
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.Invocation.MethodName
-import org.apache.james.jmap.core.{Capability, DefaultCapabilities, ErrorCode, Invocation, MissingCapabilityException, RequestObject, ResponseObject}
+import org.apache.james.jmap.core.{Capability, ErrorCode, Invocation, MissingCapabilityException, RequestObject, ResponseObject}
 import org.apache.james.jmap.method.{InvocationWithContext, Method}
 import org.apache.james.mailbox.MailboxSession
 import org.slf4j.{Logger, LoggerFactory}
@@ -50,7 +50,7 @@ class JMAPApi (methods: Set[Method], defaultCapabilities: Set[Capability]) {
     val capabilities: Set[CapabilityIdentifier] = requestObject.using.toSet
 
     if (unsupportedCapabilities.nonEmpty) {
-      SMono.raiseError(UnsupportedCapabilitiesException(unsupportedCapabilities))
+      SMono.error(UnsupportedCapabilitiesException(unsupportedCapabilities))
     } else {
       processSequentiallyAndUpdateContext(requestObject, mailboxSession, processingContext, capabilities)
         .map(invocations => ResponseObject(ResponseObject.SESSION_STATE, invocations.map(_.invocation)))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
@@ -136,7 +136,7 @@ class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: A
         val targetAccountId: AccountId = AccountId(id)
         AccountId.from(session.getUser).map(accountId => accountId.equals(targetAccountId))
           .fold[SMono[Void]](
-            e => SMono.raiseError(e),
+            e => SMono.error(e),
             value => if (value) {
               SMono.fromCallable(() => ReactorUtils.toInputStream(request.receive
                 // Unwrapping to byte array needed to solve data races and buffer reordering when using .asByteBuffer()
@@ -144,10 +144,10 @@ class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: A
                 .map(array => ByteBuffer.wrap(array))))
               .flatMap(content => handle(targetAccountId, contentType, content, session, response))
             } else {
-              SMono.raiseError(ForbiddenException())
+              SMono.error(ForbiddenException())
             })
 
-      case Left(throwable: Throwable) => SMono.raiseError(throwable)
+      case Left(throwable: Throwable) => SMono.error(throwable)
     }
   }
 

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/JMAPApiRoutesTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/JMAPApiRoutesTest.scala
@@ -433,7 +433,7 @@ class JMAPApiRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
   "RFC-8621 with random error when processing request " should "return 200, with serverFail error, others method call proceed normally" in {
     val mockCoreEchoMethod = mock(classOf[CoreEchoMethod])
 
-    doReturn(SFlux.raiseError(new RuntimeException("Unexpected Exception occur, the others method may proceed normally")))
+    doReturn(SFlux.error(new RuntimeException("Unexpected Exception occur, the others method may proceed normally")))
       .doCallRealMethod()
       .when(mockCoreEchoMethod)
       .process(any[Set[CapabilityIdentifier]], any(), any())

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/Authenticator.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/Authenticator.java
@@ -56,7 +56,7 @@ public class Authenticator {
             Flux.fromIterable(authMethods)
                 .concatMap(auth -> auth.createMailboxSession(request))
                 .next()
-                .switchIfEmpty(Mono.error(noAuthSupplied()))));
+                .switchIfEmpty(Mono.error(this::noAuthSupplied))));
     }
 
     private NoAuthorizationSuppliedException noAuthSupplied() {


### PR DESCRIPTION
 - Solve some trivial deprecation warning linked to the use SMono.raiseError
 - Avoid filling up stacktraces when reactor do not encouter the error case
 - Fully reactive MessageIdManager::setInMailboxesReactive (Yes !!!)
 
Along the way I enforced the use of interfaces for UidProvider, ModSeqProvider and ACLMapper down in `mailbox/cassandra` meaning that implementors of tailor-made servers can trivially override it as need be....