### PR TITLE
JAMES-3107 Desactivate metrics p99 log

### DIFF
--- a/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/MetricFactory.java
+++ b/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/MetricFactory.java
@@ -40,6 +40,8 @@ public interface MetricFactory {
         }
     }
 
+    @Deprecated
+    // Underlying implementations implies a high overhead
     default <T> T decorateSupplierWithTimerMetricLogP99(String name, Supplier<T> operation) {
         TimeMetric timer = timer(name);
         try {
@@ -51,6 +53,8 @@ public interface MetricFactory {
 
     <T> Publisher<T> decoratePublisherWithTimerMetric(String name, Publisher<T> publisher);
 
+    @Deprecated
+    // Underlying implementations implies a high overhead
     <T> Publisher<T> decoratePublisherWithTimerMetricLogP99(String name, Publisher<T> publisher);
 
     default void runPublishingTimerMetric(String name, Runnable runnable) {

--- a/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
+++ b/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
@@ -27,6 +27,8 @@ public interface TimeMetric {
 
         Duration elasped();
 
+        @Deprecated
+        // Underlying implementations implies a high overhead
         ExecutionResult logWhenExceedP99(Duration thresholdInNanoSeconds);
     }
 

--- a/metrics/metrics-dropwizard/pom.xml
+++ b/metrics/metrics-dropwizard/pom.xml
@@ -73,6 +73,11 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mpierce.metrics.reservoir</groupId>
+            <artifactId>hdrhistogram-metrics-reservoir</artifactId>
+            <version>1.1.3</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardMetricFactory.java
+++ b/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardMetricFactory.java
@@ -28,11 +28,13 @@ import javax.inject.Inject;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.metrics.api.Metric;
 import org.apache.james.metrics.api.MetricFactory;
+import org.mpierce.metrics.reservoir.hdrhistogram.HdrHistogramReservoir;
 import org.reactivestreams.Publisher;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SlidingTimeWindowMovingAverages;
+import com.codahale.metrics.Timer;
 import com.codahale.metrics.jmx.JmxReporter;
 
 import reactor.core.publisher.Flux;
@@ -56,7 +58,8 @@ public class DropWizardMetricFactory implements MetricFactory, Startable {
 
     @Override
     public DropWizardTimeMetric timer(String name) {
-        return new DropWizardTimeMetric(name, metricRegistry.timer(name));
+        return new DropWizardTimeMetric(name, metricRegistry.timer(name,
+            () -> new Timer(new HdrHistogramReservoir())));
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -18,8 +18,6 @@
  ****************************************************************/
 package org.apache.james.imap.processor;
 
-import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -110,7 +108,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
             LOGGER.error("Unexpected error during IMAP processing", unexpectedException);
             no(acceptableMessage, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
         }
-        timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
+        timeMetric.stopAndPublish();
     }
 
     protected void flags(Responder responder, SelectedMailbox selected) {

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.mailetcontainer.impl;
 
-import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
-
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -98,7 +96,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
             TimeMetric timeMetric = metricFactory.timer(SPOOL_PROCESSING);
             return Mono.fromCallable(processingActive::incrementAndGet)
                 .flatMap(ignore -> processMail(queueItem))
-                .doOnSuccess(any -> timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD))
+                .doOnSuccess(any -> timeMetric.stopAndPublish())
                 .doOnTerminate(processingActive::decrementAndGet);
         }
 

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
@@ -18,8 +18,6 @@
  ****************************************************************/
 package org.apache.james.mailetcontainer.impl.camel;
 
-import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
-
 import java.io.Closeable;
 import java.util.List;
 import java.util.Locale;
@@ -99,7 +97,7 @@ public class CamelProcessor {
             }
 
         } finally {
-            timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
+            timeMetric.stopAndPublish();
             MailetPipelineLogging.logEndOfMailetProcess(mailet, mail);
             List<MailetProcessorListener> listeners = processor.getListeners();
             long complete = System.currentTimeMillis() - start;

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.mailetcontainer.impl.camel;
 
-import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
-
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -176,7 +174,7 @@ public class MatcherSplitter {
 
             return mails;
         } finally {
-            timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
+            timeMetric.stopAndPublish();
             long complete = System.currentTimeMillis() - start;
             List<MailetProcessorListener> listeners = container.getListeners();
             for (MailetProcessorListener listener : listeners) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.transport.mailets.remote.delivery;
 
-import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
 import static org.apache.james.transport.mailets.remote.delivery.Bouncer.IS_DELIVERY_PERMANENT_ERROR;
 
 import java.time.Duration;
@@ -98,7 +97,7 @@ public class DeliveryRunnable implements Disposable {
         TimeMetric timeMetric = metricFactory.timer(REMOTE_DELIVERY_TRIAL);
         try {
             return processMail(queueItem)
-                .doOnSuccess(any -> timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD));
+                .doOnSuccess(any -> timeMetric.stopAndPublish());
         } catch (Throwable e) {
             return Mono.error(e);
         }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetFilterMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetFilterMethod.java
@@ -74,7 +74,7 @@ public class GetFilterMethod implements Method {
 
         GetFilterRequest filterRequest = (GetFilterRequest) request;
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             process(methodCallId, mailboxSession, filterRequest)
                 .subscriberContext(context("GET_FILTER", MDCBuilder.of(MDCBuilder.ACTION, "GET_FILTER")))));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -97,7 +97,7 @@ public class GetMailboxesMethod implements Method {
         Preconditions.checkArgument(request instanceof GetMailboxesRequest);
         GetMailboxesRequest mailboxesRequest = (GetMailboxesRequest) request;
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             process(methodCallId, mailboxSession, mailboxesRequest)
                 .subscriberContext(context(ACTION, mdc(mailboxesRequest)))));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessageListMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessageListMethod.java
@@ -113,7 +113,7 @@ public class GetMessageListMethod implements Method {
 
         GetMessageListRequest messageListRequest = (GetMessageListRequest) request;
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             process(methodCallId, mailboxSession, messageListRequest)
                 .subscriberContext(context("GET_MESSAGE_LIST", mdc(messageListRequest)))));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
@@ -83,7 +83,7 @@ public class GetMessagesMethod implements Method {
         GetMessagesRequest getMessagesRequest = (GetMessagesRequest) request;
         MessageProperties outputProperties = getMessagesRequest.getProperties().toOutputProperties();
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             Flux.from(getMessagesResponse(mailboxSession, getMessagesRequest)
                 .map(response -> JmapResponse.builder().methodCallId(methodCallId)
                     .response(response)

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetVacationResponseMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetVacationResponseMethod.java
@@ -72,7 +72,7 @@ public class GetVacationResponseMethod implements Method {
         Preconditions.checkNotNull(mailboxSession);
         Preconditions.checkArgument(request instanceof GetVacationRequest);
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             process(mailboxSession)
                 .map(response -> JmapResponse.builder()
                     .methodCallId(methodCallId)

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
@@ -79,7 +79,7 @@ public class SendMDNProcessor implements SetMessagesProcessor {
 
     @Override
     public SetMessagesResponse process(SetMessagesRequest request, MailboxSession mailboxSession) {
-        return metricFactory.decorateSupplierWithTimerMetricLogP99(JMAP_PREFIX + "SendMDN",
+        return metricFactory.decorateSupplierWithTimerMetric(JMAP_PREFIX + "SendMDN",
             () -> handleMDNCreation(request, mailboxSession));
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
@@ -119,8 +119,8 @@ public class SetFilterMethod implements Method {
 
         SetFilterRequest setFilterRequest = (SetFilterRequest) request;
 
-        return Flux.from(metricFactory.decorateSupplierWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
-            () -> process(methodCallId, mailboxSession, setFilterRequest)
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
+            process(methodCallId, mailboxSession, setFilterRequest)
                 .subscriberContext(jmapAction("SET_FILTER"))
                 .subscriberContext(context("SET_FILTER", MDCBuilder.of("update", setFilterRequest.getSingleton())))));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMailboxesMethod.java
@@ -72,7 +72,7 @@ public class SetMailboxesMethod implements Method {
 
         SetMailboxesRequest setMailboxesRequest = (SetMailboxesRequest) request;
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             setMailboxesResponse(setMailboxesRequest, mailboxSession)
                 .map(response -> JmapResponse.builder().methodCallId(methodCallId)
                     .response(response)

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesDestructionProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesDestructionProcessor.java
@@ -57,7 +57,7 @@ public class SetMessagesDestructionProcessor implements SetMessagesProcessor {
 
     @Override
     public Mono<SetMessagesResponse> processReactive(SetMessagesRequest request, MailboxSession mailboxSession) {
-        return Mono.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + "SetMessageDestructionProcessor",
+        return Mono.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + "SetMessageDestructionProcessor",
             delete(request.getDestroy(), mailboxSession)));
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesMethod.java
@@ -68,7 +68,7 @@ public class SetMessagesMethod implements Method {
         Preconditions.checkArgument(request instanceof SetMessagesRequest);
         SetMessagesRequest setMessagesRequest = (SetMessagesRequest) request;
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             setMessagesResponse(setMessagesRequest, mailboxSession)
                 .map(responses ->
                     JmapResponse.builder().methodCallId(methodCallId)

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessor.java
@@ -120,7 +120,7 @@ public class SetMessagesUpdateProcessor implements SetMessagesProcessor {
 
     @Override
     public Mono<SetMessagesResponse> processReactive(SetMessagesRequest request, MailboxSession mailboxSession) {
-        return Mono.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + "SetMessagesUpdateProcessor",
+        return Mono.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + "SetMessagesUpdateProcessor",
             listMailboxIdsForRole(mailboxSession, Role.OUTBOX)
                 .flatMap(outboxIds -> prepareResponse(request, mailboxSession, outboxIds).map(SetMessagesResponse.Builder::build))
                 .onErrorResume(e ->

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetVacationResponseMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetVacationResponseMethod.java
@@ -80,7 +80,7 @@ public class SetVacationResponseMethod implements Method {
         Preconditions.checkArgument(request instanceof SetVacationRequest);
         SetVacationRequest setVacationRequest = (SetVacationRequest) request;
 
-        return Flux.from(metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+        return Flux.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
             process(methodCallId, mailboxSession, setVacationRequest)
                 .subscriberContext(jmapAction("SET_VACATION"))
                 .subscriberContext(context("set-vacation", MDCBuilder.of("update", setVacationRequest.getUpdate())))));

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AuthenticationRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AuthenticationRoutes.java
@@ -123,7 +123,7 @@ public class AuthenticationRoutes implements JMAPRoutes {
     }
 
     private Mono<Void> post(HttpServerRequest request, HttpServerResponse response) {
-        return Mono.from(metricFactory.decoratePublisherWithTimerMetricLogP99("JMAP-authentication-post",
+        return Mono.from(metricFactory.decoratePublisherWithTimerMetric("JMAP-authentication-post",
             Mono.just(request)
                 .map(this::assertJsonContentType)
                 .map(this::assertAcceptJsonOnly)

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
@@ -61,8 +61,8 @@ public class DefaultMailboxesProvisioner {
     }
 
     public Mono<Void> createMailboxesIfNeeded(MailboxSession session) {
-        return metricFactory.decorateSupplierWithTimerMetric("JMAP-mailboxes-provisioning",
-            () -> createDefaultMailboxes(session));
+        return Mono.from(metricFactory.decoratePublisherWithTimerMetric("JMAP-mailboxes-provisioning",
+            createDefaultMailboxes(session)));
     }
 
     private Mono<Void> createDefaultMailboxes(MailboxSession session) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UserProvisioner.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UserProvisioner.java
@@ -18,8 +18,6 @@
  ****************************************************************/
 package org.apache.james.jmap.http;
 
-import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
-
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -69,7 +67,7 @@ public class UserProvisioner {
         } catch (UsersRepositoryException e) {
             throw new RuntimeException(e);
         } finally {
-            timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
+            timeMetric.stopAndPublish();
         }
     }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/MailboxesProvisioner.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/MailboxesProvisioner.scala
@@ -39,8 +39,8 @@ class MailboxesProvisioner @Inject() (mailboxManager: MailboxManager,
   private val LOGGER: Logger = LoggerFactory.getLogger(classOf[MailboxesProvisioner])
 
   def createMailboxesIfNeeded(session: MailboxSession): SMono[Unit] =
-    metricFactory.decorateSupplierWithTimerMetric("JMAP-RFC-8621-mailboxes-provisioning", () =>
-      createDefaultMailboxes(session.getUser))
+    SMono(metricFactory.decoratePublisherWithTimerMetric("JMAP-RFC-8621-mailboxes-provisioning",
+      createDefaultMailboxes(session.getUser)))
 
 
   private def createDefaultMailboxes(username: Username): SMono[Unit] = {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/UserProvisioning.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/UserProvisioning.scala
@@ -50,7 +50,7 @@ class UserProvisioning @Inject() (usersRepository: UsersRepository, metricFactor
       case exception: AlreadyExistInUsersRepositoryException => // Ignore
       case exception: UsersRepositoryException => throw new RuntimeException(exception)
     } finally {
-      timeMetric.stopAndPublish.logWhenExceedP99(DEFAULT_100_MS_THRESHOLD)
+      timeMetric.stopAndPublish
     }
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/Method.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/Method.scala
@@ -88,7 +88,7 @@ trait MethodRequiringAccountId[REQUEST <: WithAccountId] extends Method {
         case e: Throwable => SFlux.error[InvocationWithContext] (e)
       }
 
-    metricFactory.decoratePublisherWithTimerMetricLogP99(JMAP_RFC8621_PREFIX + methodName.value, result)
+    metricFactory.decoratePublisherWithTimerMetric(JMAP_RFC8621_PREFIX + methodName.value, result)
   }
 
   private def validateAccountId(accountId: AccountId, mailboxSession: MailboxSession, sessionSupplier: SessionSupplier, invocation: Invocation): Either[IllegalArgumentException, Session] =


### PR DESCRIPTION
Using metrics to capture p99 lead to over-snapshoting, and incurs a 33% throughtput penalty on JMAP draft.

Other SLOW logging implementations do rely on manual time
measurements (eg Datastax Cassandra driver).

As such, due to the low benefits and high costs I propose
to deprecate the logP99 API and migrate away from it.

Tools like Glowroot are able to capture slow traces at a
 lighter cost and should rather be used.
 
 ## Performance
 
 I did run 2 benchmarks to evaluate the changes in terms of performance:
 
  - a. Run 1000 users doing a representative JMAP polling request with a pause of 2-4 seconds in between. This represents the regular usage.
  -b. Run 2000 users doing a representative JMAP polling request with a pause of 2-4 seconds in between. This adapts to system maximum throughtput (as high latencies would add up to the delays and acts as a feedback loop).
  
For each of these scenari we include:
 - Gatling overview
 - Glowroot average, that includes time spent executing Cassanra queries
 - Glowroot percentiles
 - Glowroot averages (1 min)
 - And finally Glowroot Cassandra queries breakdown
  
 Testing infrastructure:
   - 3 James, 3 CPU, 6GB memory
   - 3 Cassandra (SSD, 8 CPU, 32GB ram) - OVH B2-30)
   - OVH S3 object store

The instances are pre-provisionned with representative email corpus. Each account have a representative mailbox distribution 50 -> 1000 mailboxes (hence Mailbox/get dispersion)
   
### Before

#### a. LOG p99 and Regular scenario

![Screenshot from 2021-05-16 11-11-21](https://user-images.githubusercontent.com/6928740/118385236-85d94f80-b637-11eb-9b75-ae69100b538e.png)

![Screenshot from 2021-05-16 10-15-26](https://user-images.githubusercontent.com/6928740/118385251-b620ee00-b637-11eb-9354-43ab2ab3756c.png)

![Screenshot from 2021-05-16 10-15-18](https://user-images.githubusercontent.com/6928740/118385252-b7eab180-b637-11eb-9e36-3625cb6dd188.png)

![Screenshot from 2021-05-16 10-15-12](https://user-images.githubusercontent.com/6928740/118385253-b8834800-b637-11eb-8b06-512c82bd9c58.png)

![Screenshot from 2021-05-16 10-15-09](https://user-images.githubusercontent.com/6928740/118385254-b91bde80-b637-11eb-87b6-7a9e66663a0a.png)

#### b. LOG p99 and maximum throughtput

![Screenshot from 2021-05-16 11-14-04](https://user-images.githubusercontent.com/6928740/118385281-e2d50580-b637-11eb-93c6-a26623c31390.png)

![Screenshot from 2021-05-16 10-35-08](https://user-images.githubusercontent.com/6928740/118385320-14e66780-b638-11eb-8f85-cb134afdfc90.png)

![Screenshot from 2021-05-16 10-34-59](https://user-images.githubusercontent.com/6928740/118385322-16b02b00-b638-11eb-88af-7c72cabb486b.png)

![Screenshot from 2021-05-16 10-34-52](https://user-images.githubusercontent.com/6928740/118385323-1748c180-b638-11eb-86e7-9c43fa45945b.png)

![Screenshot from 2021-05-16 10-34-48](https://user-images.githubusercontent.com/6928740/118385327-1879ee80-b638-11eb-9ecb-a63fcd19d49e.png)

### After

#### a. LOG p99 and Regular scenario

![Screenshot from 2021-05-16 11-16-59](https://user-images.githubusercontent.com/6928740/118385355-4e1ed780-b638-11eb-82b6-3ec264307f27.png)

![Screenshot from 2021-05-16 09-19-57](https://user-images.githubusercontent.com/6928740/118385402-b1106e80-b638-11eb-864c-be0e9e7385d8.png)

![Screenshot from 2021-05-16 09-19-42](https://user-images.githubusercontent.com/6928740/118385405-b4a3f580-b638-11eb-9d58-0b35905e959b.png)

![Screenshot from 2021-05-16 09-19-50](https://user-images.githubusercontent.com/6928740/118385403-b2da3200-b638-11eb-8e7b-69cba36f587a.png)

![Screenshot from 2021-05-16 09-19-47](https://user-images.githubusercontent.com/6928740/118385404-b372c880-b638-11eb-8099-fe44876113e5.png)

#### b. LOG p99 and maximum throughtput

![Screenshot from 2021-05-16 11-21-00](https://user-images.githubusercontent.com/6928740/118385428-d9986880-b638-11eb-98ed-92c04496c784.png)

![Screenshot from 2021-05-16 09-31-21](https://user-images.githubusercontent.com/6928740/118385442-00ef3580-b639-11eb-89c9-572cc7ba7525.png)

![Screenshot from 2021-05-16 09-31-12](https://user-images.githubusercontent.com/6928740/118385443-02206280-b639-11eb-95d7-48e13161a0a0.png)

![Screenshot from 2021-05-16 09-31-10](https://user-images.githubusercontent.com/6928740/118385444-02b8f900-b639-11eb-800c-326479d5d93e.png)

![Screenshot from 2021-05-16 09-31-06](https://user-images.githubusercontent.com/6928740/118385445-03518f80-b639-11eb-94aa-70d1088ea025.png)

### Conclusion

 - Dramatic improvments of all KPIs at all levels of load. We can reach workloads with +50% higher
 - Surprisingly enough, Cassandra queries executed faster. I think because of CPU shortage Cassandra query execution lead to delays.

Side note: I tried many variations of the metrics, and oddly enough the final one behave even better than a "logging" metric implementation.

