### PR TITLE
[PERFORMANCE] Various small enhancements detected thanks to flame graphs

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
@@ -80,32 +80,32 @@ public class MessageResultImpl implements MessageResult {
 
     @Override
     public MessageUid getUid() {
-        return messageMetaData().getUid();
+        return message.getUid();
     }
 
     @Override
     public MessageId getMessageId() {
-        return messageMetaData().getMessageId();
+        return message.getMessageId();
     }
     
     @Override
     public Date getInternalDate() {
-        return messageMetaData().getInternalDate();
+        return message.getInternalDate();
     }
 
     @Override
     public Flags getFlags() {
-        return messageMetaData().getFlags();
+        return message.createFlags();
     }
 
     @Override
     public ModSeq getModSeq() {
-        return messageMetaData().getModSeq();
+        return message.getModSeq();
     }
 
     @Override
     public long getSize() {
-        return messageMetaData().getSize();
+        return message.getFullContentOctets();
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/FlagsFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/FlagsFactory.java
@@ -30,8 +30,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 public class FlagsFactory {
-
-    private static Flags asFlags(MailboxMessage mailboxMessage, String[] userFlags) {
+    public static Flags createFlags(MailboxMessage mailboxMessage, String[] userFlags) {
         final Flags flags = new Flags();
         if (mailboxMessage.isAnswered()) {
             flags.add(Flags.Flag.ANSWERED);
@@ -57,13 +56,6 @@ public class FlagsFactory {
             }
         }
         return flags;
-    }
-
-    public static Flags createFlags(MailboxMessage mailboxMessage, String[] userFlags) {
-        return builder()
-            .flags(asFlags(mailboxMessage, userFlags))
-            .addUserFlags(userFlags)
-            .build();
     }
 
     public static Builder builder() {

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/PeriodicalHealthChecksConfiguration.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/PeriodicalHealthChecksConfiguration.java
@@ -54,7 +54,7 @@ public class PeriodicalHealthChecksConfiguration {
 
             PeriodicalHealthChecksConfiguration build() {
                 Preconditions.checkArgument(period.compareTo(MINIMAL_HEALTH_CHECK_PERIOD) >= 0,
-                    "'period' must be equal or greater than " + MINIMAL_HEALTH_CHECK_PERIOD.toMillis() + "ms");
+                    "'period' must be equal or greater than %d ms", MINIMAL_HEALTH_CHECK_PERIOD.toMillis());
 
                 return new PeriodicalHealthChecksConfiguration(period);
             }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/model/Preview.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/model/Preview.java
@@ -103,7 +103,7 @@ public class Preview {
     Preview(String value) {
         Preconditions.checkNotNull(value);
         Preconditions.checkArgument(value.length() <= MAX_LENGTH,
-            String.format("the preview value '%s' has length longer than %d", value, MAX_LENGTH));
+            "the preview value '%s' has length longer than %s", value, MAX_LENGTH);
 
         this.value = value;
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponseWriterImpl.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponseWriterImpl.java
@@ -40,11 +40,11 @@ import reactor.core.publisher.Flux;
 public class JmapResponseWriterImpl implements JmapResponseWriter {
 
     public static final String PROPERTIES_FILTER = "propertiesFilter";
-    private final ObjectMapperFactory objectMapperFactory;
+    private final ObjectMapper objectMapper;
 
     @Inject
     public JmapResponseWriterImpl(ObjectMapperFactory objectMapperFactory) {
-        this.objectMapperFactory = objectMapperFactory;
+        this.objectMapper = objectMapperFactory.forWriting();
     }
 
     @Override
@@ -60,17 +60,13 @@ public class JmapResponseWriterImpl implements JmapResponseWriter {
     }
     
     private ObjectMapper newConfiguredObjectMapper(JmapResponse jmapResponse) {
-        ObjectMapper objectMapper = objectMapperFactory.forWriting();
-        
         FilterProvider filterProvider = jmapResponse
                 .getFilterProvider()
                 .orElseGet(SimpleFilterProvider::new)
                 .setDefaultFilter(SimpleBeanPropertyFilter.serializeAll())
                 .addFilter(PROPERTIES_FILTER, getPropertiesFilter(jmapResponse.getProperties()));
         
-        objectMapper.setFilterProvider(filterProvider);
-
-        return objectMapper;
+        return objectMapper.copy().setFilterProvider(filterProvider);
     }
     
     private PropertyFilter getPropertiesFilter(Optional<? extends Set<? extends Property>> properties) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageViewFactory.java
@@ -39,10 +39,11 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageResult;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.codec.DecoderUtil;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
-import org.apache.james.mime4j.util.MimeUtil;
 import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +112,7 @@ public interface MessageViewFactory<T extends MessageView> {
             Function<Map.Entry<String, Collection<Field>>, String> bodyConcatenator = fieldListEntry -> fieldListEntry.getValue()
                 .stream()
                 .map(Field::getBody)
-                .map(MimeUtil::unscrambleHeaderValue)
+                .map(body -> DecoderUtil.decodeEncodedWords(body, DecodeMonitor.SILENT))
                 .collect(Collectors.toList())
                 .stream()
                 .collect(Collectors.joining(JMAP_MULTIVALUED_FIELD_DELIMITER));

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/VersionParser.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/VersionParser.java
@@ -45,7 +45,7 @@ public class VersionParser {
     public VersionParser(Set<Version> supportedVersions, JMAPConfiguration jmapConfiguration) {
         this.jmapConfiguration = jmapConfiguration;
         Preconditions.checkArgument(supportedVersions.contains(jmapConfiguration.getDefaultVersion()),
-                jmapConfiguration + " is not a supported JMAP version");
+                "%s is not a supported JMAP version", jmapConfiguration);
 
         this.supportedVersions = supportedVersions;
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/VersionParser.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/VersionParser.java
@@ -50,6 +50,10 @@ public class VersionParser {
         this.supportedVersions = supportedVersions;
     }
 
+    public Set<Version> getSupportedVersions() {
+        return supportedVersions;
+    }
+
     @VisibleForTesting
     Version parse(String version) {
         Preconditions.checkNotNull(version);


### PR DESCRIPTION
![Screenshot from 2021-05-16 17-45-01](https://user-images.githubusercontent.com/6928740/118394413-cb653f00-b66e-11eb-9ee2-161407da0c6c.png)

Here we can see a call to `MessageResultImpl::getMessageId` responsible of `0.78%` of the total allocated memory... Rationals are that and intermediate (uneeded) on the fly messageMetadata is used, which includes an (innefficient) flag copy.

![Screenshot from 2021-05-16 17-51-05](https://user-images.githubusercontent.com/6928740/118394515-59412a00-b66f-11eb-86ae-6a40b240ebbc.png)

Here is a flame graph capture showing the costs of initializing JMAP routes for each requests.