### PR TITLE
[PERFORMANCE] Another (small) set of flame graphs improvments...

### DIFF
--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/GetMailboxesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/GetMailboxesMethodTest.java
@@ -343,7 +343,7 @@ public abstract class GetMailboxesMethodTest {
             .body(NAME, equalTo("error"))
             .body(ARGUMENTS + ".type", equalTo("invalidArguments"))
             .body(ARGUMENTS + ".description", containsString("Cannot deserialize value of type `java.util.ArrayList<org.apache.james.mailbox.model.MailboxId>` from Boolean value (token `JsonToken.VALUE_TRUE`)"))
-            .body(ARGUMENTS + ".description", containsString("{\"ids\":true}"));
+            .body(ARGUMENTS + ".description", containsString("(through reference chain: org.apache.james.jmap.draft.model.GetMailboxesRequest$Builder[\"ids\"])"));
     }
 
     @Category(BasicFeature.class)

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -889,7 +889,7 @@ public abstract class SetMessagesMethodTest {
             .body(NOT_UPDATED + "[\"" + messageId + "\"].type", equalTo("invalidProperties"))
             .body(NOT_UPDATED + "[\"" + messageId + "\"].properties[0]", equalTo("isUnread"))
             .body(NOT_UPDATED + "[\"" + messageId + "\"].description", containsString("isUnread: Cannot deserialize value of type `java.lang.Boolean` from String \"123\": only \"true\" or \"false\" recognized"))
-            .body(NOT_UPDATED + "[\"" + messageId + "\"].description", containsString("{\"isUnread\":\"123\"}"))
+            .body(NOT_UPDATED + "[\"" + messageId + "\"].description", containsString("(through reference chain: org.apache.james.jmap.draft.model.UpdateMessagePatch$Builder[\"isUnread\"])"))
             .body(ARGUMENTS + ".updated", hasSize(0));
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapRequestParserImpl.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapRequestParserImpl.java
@@ -29,6 +29,7 @@ import org.apache.james.jmap.draft.model.InvocationRequest;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 
 public class JmapRequestParserImpl implements JmapRequestParser {
 
@@ -42,6 +43,8 @@ public class JmapRequestParserImpl implements JmapRequestParser {
     @Override
     public <T extends JmapRequest> T extractJmapRequest(InvocationRequest request, Class<T> requestClass)
             throws IOException, JsonParseException, JsonMappingException {
-        return objectMapper.readValue(request.getParameters().toString(), requestClass);
+        Preconditions.checkNotNull(requestClass, "requestClass should not be null");
+
+        return objectMapper.treeToValue(request.getParameters(), requestClass);
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/UpdateMessagePatchValidator.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/UpdateMessagePatchValidator.java
@@ -53,7 +53,7 @@ public class UpdateMessagePatchValidator implements Validator<ObjectNode> {
     @Override
     public Set<ValidationResult> validate(ObjectNode json) {
         try {
-            parser.readValue(json.toString(), UpdateMessagePatch.class);
+            parser.treeToValue(json, UpdateMessagePatch.class);
         } catch (JsonMappingException e) {
             return ImmutableSet.of(ValidationResult.builder()
                     .property(firstFieldFrom(e.getPath()).orElse(ValidationResult.UNDEFINED_PROPERTY))

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/JsoupHtmlTextExtractor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/JsoupHtmlTextExtractor.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.draft.utils;
 
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
@@ -56,7 +57,7 @@ public class JsoupHtmlTextExtractor implements HtmlTextExtractor {
 
             return flatten(body, INITIAL_LIST_NESTED_LEVEL)
                 .map(this::convertNodeToText)
-                .reduce("", (s1, s2) -> s1 + s2);
+                .collect(Collectors.joining());
         } catch (Exception e) {
             LOGGER.warn("Failed extracting text from html", e);
             return html;

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/JmapRequestParserImplTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/JmapRequestParserImplTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.draft.methods;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.apache.james.jmap.draft.json.ObjectMapperFactory;
 import org.apache.james.jmap.draft.model.InvocationRequest;
 import org.apache.james.mailbox.inmemory.InMemoryId;
@@ -38,13 +40,14 @@ public class JmapRequestParserImplTest {
         testee = new JmapRequestParserImpl(new ObjectMapperFactory(new InMemoryId.Factory(), new InMemoryMessageId.Factory()));
     }
     
-    @Test(expected = IllegalArgumentException.class)
-    public void extractJmapRequestShouldThrowWhenNullRequestClass() throws Exception {
+    @Test
+    public void extractJmapRequestShouldThrowWhenNullRequestClass() {
         JsonNode[] nodes = new JsonNode[] { new ObjectNode(new JsonNodeFactory(false)).textNode("unknwonMethod"),
                 new ObjectNode(new JsonNodeFactory(false)).putObject("{\"id\": \"id\"}"),
                 new ObjectNode(new JsonNodeFactory(false)).textNode("#1")};
 
-        testee.extractJmapRequest(InvocationRequest.deserialize(nodes), null);
+        assertThatThrownBy(() -> testee.extractJmapRequest(InvocationRequest.deserialize(nodes), null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/UpdateMessagePatchValidatorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/UpdateMessagePatchValidatorTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.draft.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -82,7 +83,7 @@ public class UpdateMessagePatchValidatorTest {
 
         ObjectMapper mapper = mock(ObjectMapper.class);
         JsonGenerator jsonGenerator = null;
-        when(mapper.readValue(anyString(), eq(UpdateMessagePatch.class)))
+        when(mapper.treeToValue(any(), eq(UpdateMessagePatch.class)))
             .thenThrow(JsonMappingException.from(jsonGenerator, "Exception when parsing"));
 
         when(objectMapperFactory.forParsing())


### PR DESCRIPTION
![Screenshot from 2021-05-18 21-28-07](https://user-images.githubusercontent.com/6928740/118669541-09559500-b820-11eb-8959-ec82c9f5b6aa.png)

We can see over allocation, due to string concat at every stage of the pipeline, representing 2% of memory use in that production environment.

(We might benefit from some kind of tail recursion there too).

The other (JSON) one is trivial...