### PR TITLE
[PERFORMANCE] Cache and reuse Object mappers for writing JMAP responses

### DIFF
--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SendMDNMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SendMDNMethodTest.java
@@ -296,8 +296,8 @@ public abstract class SendMDNMethodTest {
                 "        \"type\":\"processed\"" +
                 "    }" +
                 "}" +
-                "}}, \"#0\"]]")
-            .post("/jmap");
+                "}}, \"#0\"]]").log().all()
+            .post("/jmap").prettyPeek();
 
         // BART should have received it
         calmlyAwait.atMost(TWO_MINUTES).until(() -> !listMessageIdsInMailbox(bartAccessToken, getInboxId(bartAccessToken)).isEmpty());
@@ -306,9 +306,9 @@ public abstract class SendMDNMethodTest {
         String firstMessage = ARGUMENTS + ".list[0]";
         given()
             .header("Authorization", bartAccessToken.asString())
-            .body("[[\"getMessages\", {\"ids\": [\"" + bartInboxMessageIds + "\"]}, \"#0\"]]")
+            .body("[[\"getMessages\", {\"ids\": [\"" + bartInboxMessageIds + "\"]}, \"#0\"]]").log().all()
         .when()
-            .post("/jmap")
+            .post("/jmap").prettyPeek()
         .then()
             .statusCode(200)
             .body(firstMessage + ".from.email", is(HOMER.asString()))
@@ -330,7 +330,7 @@ public abstract class SendMDNMethodTest {
         // USER sends a MDN back to BART
         String creationId = "creation-1";
         with()
-            .header("Authorization", homerAccessToken.asString())
+            .header("Authorization", homerAccessToken.asString()).log().all()
             .body("[[\"setMessages\", {\"sendMDN\": {" +
                 "\"" + creationId + "\":{" +
                 "    \"messageId\":\"" + messageIds.get(0) + "\"," +
@@ -344,16 +344,16 @@ public abstract class SendMDNMethodTest {
                 "    }" +
                 "}" +
                 "}}, \"#0\"]]")
-            .post("/jmap");
+            .post("/jmap").prettyPeek();
 
         // BART should have received it
         calmlyAwait.until(() -> !listMessageIdsInMailbox(bartAccessToken, getInboxId(bartAccessToken)).isEmpty());
         List<String> bobInboxMessageIds = listMessageIdsInMailbox(bartAccessToken, getInboxId(bartAccessToken));
 
-        String blobId = with()
+        String blobId = with().log().all()
             .header("Authorization", bartAccessToken.asString())
             .body("[[\"getMessages\", {\"ids\": [\"" + bobInboxMessageIds.get(0) + "\"]}, \"#0\"]]")
-            .post("/jmap")
+            .post("/jmap").prettyPeek()
         .then()
             .extract()
             .body()

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SendMDNMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SendMDNMethodTest.java
@@ -296,8 +296,8 @@ public abstract class SendMDNMethodTest {
                 "        \"type\":\"processed\"" +
                 "    }" +
                 "}" +
-                "}}, \"#0\"]]").log().all()
-            .post("/jmap").prettyPeek();
+                "}}, \"#0\"]]")
+            .post("/jmap");
 
         // BART should have received it
         calmlyAwait.atMost(TWO_MINUTES).until(() -> !listMessageIdsInMailbox(bartAccessToken, getInboxId(bartAccessToken)).isEmpty());
@@ -306,9 +306,9 @@ public abstract class SendMDNMethodTest {
         String firstMessage = ARGUMENTS + ".list[0]";
         given()
             .header("Authorization", bartAccessToken.asString())
-            .body("[[\"getMessages\", {\"ids\": [\"" + bartInboxMessageIds + "\"]}, \"#0\"]]").log().all()
+            .body("[[\"getMessages\", {\"ids\": [\"" + bartInboxMessageIds + "\"]}, \"#0\"]]")
         .when()
-            .post("/jmap").prettyPeek()
+            .post("/jmap")
         .then()
             .statusCode(200)
             .body(firstMessage + ".from.email", is(HOMER.asString()))
@@ -330,7 +330,7 @@ public abstract class SendMDNMethodTest {
         // USER sends a MDN back to BART
         String creationId = "creation-1";
         with()
-            .header("Authorization", homerAccessToken.asString()).log().all()
+            .header("Authorization", homerAccessToken.asString())
             .body("[[\"setMessages\", {\"sendMDN\": {" +
                 "\"" + creationId + "\":{" +
                 "    \"messageId\":\"" + messageIds.get(0) + "\"," +
@@ -344,16 +344,16 @@ public abstract class SendMDNMethodTest {
                 "    }" +
                 "}" +
                 "}}, \"#0\"]]")
-            .post("/jmap").prettyPeek();
+            .post("/jmap");
 
         // BART should have received it
         calmlyAwait.until(() -> !listMessageIdsInMailbox(bartAccessToken, getInboxId(bartAccessToken)).isEmpty());
         List<String> bobInboxMessageIds = listMessageIdsInMailbox(bartAccessToken, getInboxId(bartAccessToken));
 
-        String blobId = with().log().all()
+        String blobId = with()
             .header("Authorization", bartAccessToken.asString())
             .body("[[\"getMessages\", {\"ids\": [\"" + bobInboxMessageIds.get(0) + "\"]}, \"#0\"]]")
-            .post("/jmap").prettyPeek()
+            .post("/jmap")
         .then()
             .extract()
             .body()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponse.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponse.java
@@ -22,6 +22,7 @@ package org.apache.james.jmap.draft.methods;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.jmap.draft.model.MethodCallId;
 import org.apache.james.jmap.draft.model.Property;
 
@@ -43,7 +44,7 @@ public class JmapResponse {
         private MethodCallId methodCallId;
         private Method.Response response;
         private Optional<? extends Set<? extends Property>> properties = Optional.empty();
-        private Optional<SimpleFilterProvider> filterProvider = Optional.empty();
+        private Optional<Pair<? extends Set<? extends Property>, SimpleFilterProvider>> filterProvider = Optional.empty();
 
         private Builder() {
         }
@@ -72,7 +73,7 @@ public class JmapResponse {
             return properties(Optional.ofNullable(properties));
         }
         
-        public Builder filterProvider(Optional<SimpleFilterProvider> filterProvider) {
+        public Builder filterProvider(Optional<Pair<? extends Set<? extends Property>, SimpleFilterProvider>> filterProvider) {
             this.filterProvider = filterProvider;
             return this;
         }
@@ -102,9 +103,12 @@ public class JmapResponse {
     private final MethodCallId methodCallId;
     private final Method.Response response;
     private final Optional<? extends Set<? extends Property>> properties;
-    private final Optional<SimpleFilterProvider> filterProvider;
+    private final Optional<Pair<? extends Set<? extends Property>, SimpleFilterProvider>> filterProvider;
     
-    private JmapResponse(Method.Response.Name method, MethodCallId methodCallId, Method.Response response, Optional<? extends Set<? extends Property>> properties, Optional<SimpleFilterProvider> filterProvider) {
+    private JmapResponse(Method.Response.Name method, MethodCallId methodCallId,
+                         Method.Response response,
+                         Optional<? extends Set<? extends Property>> properties,
+                         Optional<Pair<? extends Set<? extends Property>, SimpleFilterProvider>> filterProvider) {
         this.method = method;
         this.methodCallId = methodCallId;
         this.response = response;
@@ -128,7 +132,7 @@ public class JmapResponse {
         return properties;
     }
 
-    public Optional<SimpleFilterProvider> getFilterProvider() {
+    public Optional<Pair<? extends Set<? extends Property>, SimpleFilterProvider>> getFilterProvider() {
         return filterProvider;
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponseWriterImpl.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponseWriterImpl.java
@@ -19,11 +19,14 @@
 
 package org.apache.james.jmap.draft.methods;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.jmap.draft.json.ObjectMapperFactory;
 import org.apache.james.jmap.draft.model.InvocationResponse;
 import org.apache.james.jmap.draft.model.Property;
@@ -33,40 +36,95 @@ import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import reactor.core.publisher.Flux;
 
 public class JmapResponseWriterImpl implements JmapResponseWriter {
-
     public static final String PROPERTIES_FILTER = "propertiesFilter";
+
+    private static class CachedObjectMapper {
+        private final ObjectMapper objectMapper;
+        private final Optional<? extends Set<? extends Property>> properties;
+        private final Optional<? extends Set<? extends Property>> subProperties;
+
+        private CachedObjectMapper(ObjectMapper objectMapper,
+                                   Optional<? extends Set<? extends Property>> properties,
+                                   Optional<? extends Set<? extends Property>> subProperties) {
+            this.objectMapper = objectMapper;
+            this.properties = properties;
+            this.subProperties = subProperties;
+        }
+
+        Optional<ObjectMapper> cachedMapperIfApplicable(JmapResponse jmapResponse) {
+            if (jmapResponse.getProperties().equals(properties)
+                && jmapResponse.getFilterProvider().map(Pair::getKey).equals(subProperties)) {
+
+                return Optional.of(objectMapper);
+            }
+            return Optional.empty();
+        }
+    }
+
+
     private final ObjectMapper objectMapper;
+    private final Cache<Long, CachedObjectMapper> writerCache;
 
     @Inject
     public JmapResponseWriterImpl(ObjectMapperFactory objectMapperFactory) {
         this.objectMapper = objectMapperFactory.forWriting();
+
+        writerCache = CacheBuilder.newBuilder()
+            .maximumSize(128)
+            .expireAfterAccess(Duration.ofMinutes(15))
+            .build();
     }
 
     @Override
     public Flux<InvocationResponse> formatMethodResponse(Flux<JmapResponse> jmapResponses) {
-        return jmapResponses.map(jmapResponse -> {
-            ObjectMapper objectMapper = newConfiguredObjectMapper(jmapResponse);
+        return jmapResponses.map(Throwing.function(jmapResponse -> {
+            ObjectMapper objectMapper = retrieveObjectMapperFromCache(jmapResponse)
+                .cachedMapperIfApplicable(jmapResponse)
+                .orElseGet(() -> newConfiguredObjectMapper(jmapResponse));
 
             return new InvocationResponse(
                     jmapResponse.getResponseName(),
                     objectMapper.valueToTree(jmapResponse.getResponse()),
                     jmapResponse.getMethodCallId());
-        });
+        }));
     }
-    
+
+    private CachedObjectMapper retrieveObjectMapperFromCache(JmapResponse jmapResponse) throws ExecutionException {
+        return writerCache.get(computeCachingKey(jmapResponse), () -> new CachedObjectMapper(
+            newConfiguredObjectMapper(jmapResponse),
+            jmapResponse.getProperties(),
+            jmapResponse.getFilterProvider().map(Pair::getKey)));
+    }
+
     private ObjectMapper newConfiguredObjectMapper(JmapResponse jmapResponse) {
         FilterProvider filterProvider = jmapResponse
-                .getFilterProvider()
-                .orElseGet(SimpleFilterProvider::new)
-                .setDefaultFilter(SimpleBeanPropertyFilter.serializeAll())
-                .addFilter(PROPERTIES_FILTER, getPropertiesFilter(jmapResponse.getProperties()));
-        
+            .getFilterProvider()
+            .map(Pair::getValue)
+            .orElseGet(SimpleFilterProvider::new)
+            .setDefaultFilter(SimpleBeanPropertyFilter.serializeAll())
+            .addFilter(PROPERTIES_FILTER, getPropertiesFilter(jmapResponse.getProperties()));
+
         return objectMapper.copy().setFilterProvider(filterProvider);
+
+    }
+
+    private long computeCachingKey(JmapResponse jmapResponse) {
+        long lowBits = jmapResponse.getProperties().hashCode();
+        long highBits = jmapResponse.getFilterProvider()
+            .map(Pair::getKey)
+            .map(Object::hashCode)
+            .map(i -> (long) i)
+            .orElse((long) jmapResponse.getResponseName().hashCode());
+
+        return lowBits + (highBits >> 32);
     }
     
     private PropertyFilter getPropertiesFilter(Optional<? extends Set<? extends Property>> properties) {

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMessagesMethodTest.java
@@ -453,7 +453,7 @@ public class GetMessagesMethodTest {
             .hasSize(1)
             .extracting(JmapResponse::getFilterProvider)
             .are(new Condition<>(Optional::isPresent, "present"));
-        SimpleFilterProvider actualFilterProvider = result.get(0).getFilterProvider().get();
+        SimpleFilterProvider actualFilterProvider = result.get(0).getFilterProvider().get().getRight();
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.setFilterProvider(actualFilterProvider.setDefaultFilter(SimpleBeanPropertyFilter.serializeAll()));


### PR DESCRIPTION
Clients use a close ensemble of properties combination in JMAP responses.
This enable reuse of jackson assemblies and achieve significant speedup
of JMAP responses serialisation.

## Before

~20% of James applicative CPU time is spent doing JMAP response serialization. This is because each request needs a dedicated property filter, which is implemented by always initializing a new ObjectMapper, which takes time and is sub-optimal as it is not warm.

![Screenshot from 2021-05-19 14-27-32](https://user-images.githubusercontent.com/6928740/118773118-b119a400-b8ae-11eb-8d53-dc0720d3193a.png)

Here are the associated gatling run:

![Screenshot from 2021-05-19 14-30-29](https://user-images.githubusercontent.com/6928740/118773240-d4445380-b8ae-11eb-9891-22a1efd210b9.png)

## After

![Screenshot from 2021-05-19 14-32-18](https://user-images.githubusercontent.com/6928740/118773465-11a8e100-b8af-11eb-8dcb-07d3531d612a.png)

By caching common serialization patterns we decreased 6 time CPU utilization for JMAP Draft response serialization.

Here are the associated gatling run:

![Screenshot from 2021-05-19 14-49-17](https://user-images.githubusercontent.com/6928740/118775757-76653b00-b8b1-11eb-8228-880ebdb4eb2b.png)



