### PR TITLE
JAMES-3586 Use LOCAL_ONE for optimistic consistency downgrades

### DIFF
--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBucketDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBucketDAO.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.blob.cassandra;
 
-import static com.datastax.driver.core.ConsistencyLevel.ONE;
+import static com.datastax.driver.core.ConsistencyLevel.LOCAL_ONE;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -151,7 +151,7 @@ public class CassandraBucketDAO {
             select.bind()
                 .setString(BUCKET, bucketName.asString())
                 .setString(ID, blobId.asString())
-                .setConsistencyLevel(ONE))
+                .setConsistencyLevel(LOCAL_ONE))
             .map(row -> row.getInt(NUMBER_OF_CHUNK));
     }
 
@@ -170,7 +170,7 @@ public class CassandraBucketDAO {
                 .setString(BucketBlobParts.BUCKET, bucketName.asString())
                 .setString(BucketBlobParts.ID, blobId.asString())
                 .setInt(BucketBlobParts.CHUNK_NUMBER, position)
-                .setConsistencyLevel(ONE))
+                .setConsistencyLevel(LOCAL_ONE))
             .map(this::rowToData);
     }
 

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraDefaultBucketDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraDefaultBucketDAO.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.blob.cassandra;
 
-import static com.datastax.driver.core.ConsistencyLevel.ONE;
+import static com.datastax.driver.core.ConsistencyLevel.LOCAL_ONE;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -128,7 +128,7 @@ public class CassandraDefaultBucketDAO {
         return cassandraAsyncExecutor.executeSingleRow(
             select.bind()
                 .setString(ID, blobId.asString())
-                .setConsistencyLevel(ONE))
+                .setConsistencyLevel(LOCAL_ONE))
             .map(row -> row.getInt(NUMBER_OF_CHUNK));
     }
 
@@ -145,7 +145,7 @@ public class CassandraDefaultBucketDAO {
             selectPart.bind()
                 .setString(DefaultBucketBlobParts.ID, blobId.asString())
                 .setInt(DefaultBucketBlobParts.CHUNK_NUMBER, position)
-                .setConsistencyLevel(ONE))
+                .setConsistencyLevel(LOCAL_ONE))
             .map(this::rowToData);
     }
 


### PR DESCRIPTION
This makes this more viable in a multi-DC setup
while not affecting the single DC use case.

Cc https://github.com/apache/james-project/pull/436

Sorry for having been slow on the review...