### PR TITLE
JAMES-3588 MailetContainer error handling: allow error propagation

### DIFF
--- a/dockerfiles/run/spring/destination/conf/mailetcontainer.xml
+++ b/dockerfiles/run/spring/destination/conf/mailetcontainer.xml
@@ -50,7 +50,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>file://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/docs/modules/servers/pages/distributed/configure/mailetcontainer.adoc
+++ b/docs/modules/servers/pages/distributed/configure/mailetcontainer.adoc
@@ -72,8 +72,14 @@ If an exception is encountered during the execution of a mailet or a matcher, th
 process the mail using the *error* processor.
 
 The *onMailetException* property allows you to override this behaviour. You can specify another
-processor than the *error* one for handling the errors of this mailet. The *ignore* special value also
-allows to continue processing and ignore the error.
+processor than the *error* one for handling the errors of this mailet.
+
+The *ignore* special value also allows to continue processing and ignore the error.
+
+The *propagate* special value causes the mailet container to rethrow the
+exception, propagating it to the execution context. In an SMTP execution context, the spooler will then requeue
+the item and automatic retries will be setted up - note that attempts will be done for each recipients. In LMTP
+(if LMTP is configured to execute the mailetContainer), the entire mail transaction is reported as failed to the caller.
 
 Moreover, the *onMatcherException* allows you to override matcher error handling. You can
 specify another processor than the *error* one for handling the errors of this mailet. The *matchall*

--- a/docs/modules/servers/pages/distributed/configure/smtp.adoc
+++ b/docs/modules/servers/pages/distributed/configure/smtp.adoc
@@ -181,7 +181,7 @@ to the default SMTP protocol. Here is how to achieve this:
 <lmtpservers>
     <lmtpserver enabled="true">
         <jmxName>lmtpserver</jmxName>
-        <bind>0.0.0.0:0</bind>
+        <bind>0.0.0.0:24</bind>
         <connectionBacklog>200</connectionBacklog>
         <connectiontimeout>1200</connectiontimeout>
         <connectionLimit>0</connectionLimit>
@@ -189,6 +189,30 @@ to the default SMTP protocol. Here is how to achieve this:
         <maxmessagesize>0</maxmessagesize>
         <handlerchain coreHandlersPackage="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader">
             <handler class="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader"/>
+        </handlerchain>
+    </lmtpserver>
+</lmtpservers>
+....
+
+Note that by default the mailet container is executed with all recipients at once and do not allow per recipient
+error reporting. An option <code>splitExecution</code> allow to execute the mailet container for each recipient separately and mitigate this
+limitation at the cost of performance.
+
+....
+<lmtpservers>
+    <lmtpserver enabled="true">
+        <jmxName>lmtpserver</jmxName>
+        <bind>0.0.0.0:24</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <connectiontimeout>1200</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <maxmessagesize>0</maxmessagesize>
+        <handlerchain coreHandlersPackage="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader">
+            <handler class="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader"/>
+            <handler class="org.apache.james.lmtpserver.MailetContainerHandler">
+                <splitExecution>true</splitExecution>
+            </handler>
         </handlerchain>
     </lmtpserver>
 </lmtpservers>

--- a/server/container/guice/cassandra-guice/sample-configuration/mailetcontainer.xml
+++ b/server/container/guice/cassandra-guice/sample-configuration/mailetcontainer.xml
@@ -52,7 +52,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>cassandra://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/cassandra-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/cassandra-guice/src/test/resources/mailetcontainer.xml
@@ -45,7 +45,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>cassandra://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/cassandra-rabbitmq-guice/sample-configuration/mailetcontainer.xml
+++ b/server/container/guice/cassandra-rabbitmq-guice/sample-configuration/mailetcontainer.xml
@@ -52,7 +52,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>cassandra://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/resources/mailetcontainer.xml
@@ -45,7 +45,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>cassandra://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
             <mailet match="All" class="Null"/>
         </processor>

--- a/server/container/guice/jpa-guice/sample-configuration/mailetcontainer.xml
+++ b/server/container/guice/jpa-guice/sample-configuration/mailetcontainer.xml
@@ -52,7 +52,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>file://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/jpa-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/jpa-guice/src/test/resources/mailetcontainer.xml
@@ -45,7 +45,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>file://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/jpa-smtp/sample-configuration/mailetcontainer.xml
+++ b/server/container/guice/jpa-smtp/sample-configuration/mailetcontainer.xml
@@ -49,7 +49,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>file://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/jpa-smtp/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/jpa-smtp/src/test/resources/mailetcontainer.xml
@@ -49,7 +49,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>file://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/memory-guice/sample-configuration/mailetcontainer.xml
+++ b/server/container/guice/memory-guice/sample-configuration/mailetcontainer.xml
@@ -52,7 +52,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>memory://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/ErrorMailet.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/ErrorMailet.java
@@ -1,0 +1,30 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class ErrorMailet extends GenericMailet {
+    @Override
+    public void service(Mail mail) {
+        throw new RuntimeException();
+    }
+}

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/LmtpIntegrationTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/LmtpIntegrationTest.java
@@ -1,0 +1,91 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.apache.james.jmap.JMAPTestingConstants.DOMAIN;
+import static org.apache.james.jmap.JMAPTestingConstants.LOCALHOST_IP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.modules.protocols.LmtpGuiceProbe;
+import org.apache.james.utils.DataProbeImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class LmtpIntegrationTest {
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
+        .server(configuration -> MemoryJamesServerMain.createServer(configuration)
+            .overrideWith(new TestJMAPServerModule()))
+        .build();
+
+    @BeforeEach
+    void setUp(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser("error@" + DOMAIN, "pass1")
+            .addUser("user@" + DOMAIN, "pass1");
+    }
+
+    @Test
+    void lmtpShouldBeConfigurableToReport(GuiceJamesServer guiceJamesServer) throws Exception {
+        SocketChannel server = SocketChannel.open();
+        server.connect(new InetSocketAddress(LOCALHOST_IP, guiceJamesServer.getProbe(LmtpGuiceProbe.class).getLmtpPort()));
+        readBytes(server);
+
+        server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+        readBytes(server);
+        server.write(ByteBuffer.wrap(("MAIL FROM: <user@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+        readBytes(server);
+        server.write(ByteBuffer.wrap(("RCPT TO: <user@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+        readBytes(server);
+        server.write(ByteBuffer.wrap(("RCPT TO: <error@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+        readBytes(server);
+        server.write(ByteBuffer.wrap(("DATA\r\n").getBytes(StandardCharsets.UTF_8)));
+        readBytes(server); // needed to synchronize
+        server.write(ByteBuffer.wrap(("header:value\r\n\r\nbody").getBytes(StandardCharsets.UTF_8)));
+        server.write(ByteBuffer.wrap(("\r\n").getBytes(StandardCharsets.UTF_8)));
+        server.write(ByteBuffer.wrap((".").getBytes(StandardCharsets.UTF_8)));
+        server.write(ByteBuffer.wrap(("\r\n").getBytes(StandardCharsets.UTF_8)));
+        byte[] dataResponse = readBytes(server);
+        server.write(ByteBuffer.wrap(("QUIT\r\n").getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(new String(dataResponse, StandardCharsets.UTF_8))
+            .contains("250 2.6.0 Message received <user@domain.tld>\r\n" +
+                "451 4.0.0 Temporary error deliver message <error@domain.tld>");
+    }
+
+
+    private byte[] readBytes(SocketChannel channel) throws IOException {
+        ByteBuffer line = ByteBuffer.allocate(1024);
+        channel.read(line);
+        line.rewind();
+        byte[] bline = new byte[line.remaining()];
+        line.get(bline);
+        return bline;
+    }
+}

--- a/server/container/guice/memory-guice/src/test/resources/lmtpserver.xml
+++ b/server/container/guice/memory-guice/src/test/resources/lmtpserver.xml
@@ -33,8 +33,11 @@
         <!--  This sets the maximum allowed message size (in kilobytes) for this -->
         <!--  LMTP service. If unspecified, the value defaults to 0, which means no limit. -->
         <maxmessagesize>0</maxmessagesize>
-        <handlerchain>
-            <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
+        <handlerchain coreHandlersPackage="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader">
+            <handler class="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader"/>
+            <handler class="org.apache.james.lmtpserver.MailetContainerHandler">
+                <splitExecution>true</splitExecution>
+            </handler>
         </handlerchain>
     </lmtpserver>
 

--- a/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
@@ -58,6 +58,9 @@
             <mailet match="All" class="RemoveMimeHeader">
                 <name>bcc</name>
             </mailet>
+            <mailet match="RecipientIs=error@domain.tld" class="org.apache.james.ErrorMailet">
+                <onMailetException>propagate</onMailetException>
+            </mailet>
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>rrt-error</errorProcessor>
             </mailet>

--- a/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
@@ -45,7 +45,7 @@
             </mailet>
             <mailet match="All" class="ToRepository">
                 <repositoryPath>memory://var/mail/error/</repositoryPath>
-                <onMailetException>ignore</onMailetException>
+                <onMailetException>propagate</onMailetException>
             </mailet>
         </processor>
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/OneRuntimeExceptionMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/OneRuntimeExceptionMailet.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.mail.MessagingException;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+public class OneRuntimeExceptionMailet extends GenericMailet {
+    private final AtomicInteger callCount = new AtomicInteger(0);
+
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        System.out.println("exection " + ImmutableList.copyOf(mail.getRecipients()));
+        if (callCount.getAndIncrement() == 0) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/OneRuntimeExceptionMatcher.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/OneRuntimeExceptionMatcher.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+public class OneRuntimeExceptionMatcher extends GenericMatcher {
+    private final AtomicInteger callCount = new AtomicInteger(0);
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) {
+        if (callCount.getAndIncrement() == 0) {
+            throw new RuntimeException();
+        }
+        return ImmutableList.of();
+    }
+}

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
@@ -92,6 +92,8 @@ public class CamelProcessor {
                 // changed by the mailet
                 LOGGER.warn("Encountered error while executing mailet {}. Ignoring it.", mailet, ex);
                 ProcessorUtil.verifyMailAddresses(mail.getRecipients());
+            } else if (onMailetException.equalsIgnoreCase("propagate")) {
+                throw me;
             } else {
                 ProcessorUtil.handleException(me, mail, mailet.getMailetConfig().getMailetName(), onMailetException, LOGGER);
             }

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
@@ -130,6 +130,8 @@ public class MatcherSplitter {
                     LOGGER.warn("Encountered error while executing matcher {}. matching all.", matcher, ex);
                     matchedRcpts = mail.getRecipients();
                     // no need to verify addresses
+                } else if (onMatchException.equalsIgnoreCase("propagate")) {
+                    throw new RuntimeException(me);
                 } else {
                     ProcessorUtil.handleException(me, mail, matcher.getMatcherConfig().getMatcherName(), onMatchException, LOGGER);
                 }

--- a/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
+++ b/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
@@ -102,6 +102,15 @@ public class SMTPMessageSender extends ExternalResource implements Closeable, Af
         return sendMessageWithHeaders(from, ImmutableList.of(recipient), message);
     }
 
+    public SMTPMessageSender sendMessage(String from, List<String> recipients) throws IOException {
+        String message = "FROM: " + from + "\r\n" +
+            "subject: test\r\n" +
+            "\r\n" +
+            "content\r\n" +
+            ".\r\n";
+        return sendMessageWithHeaders(from, recipients, message);
+    }
+
     public SMTPMessageSender sendMessageNoBracket(String from, String recipient) throws IOException {
         doHelo();
         doSetSender(from);

--- a/src/site/xdoc/server/config-mailetcontainer.xml
+++ b/src/site/xdoc/server/config-mailetcontainer.xml
@@ -88,8 +88,13 @@
       process the mail using the <strong>error</strong> processor.</p>
 
       <p>The <strong>onMailetException</strong> property allows you to override this behaviour. You can specify another
-          processor than the <strong>error</strong> one for handling the errors of this mailet. The <strong>ignore</strong> special value also
-      allows to continue processing and ignore the error.</p>
+          processor than the <strong>error</strong> one for handling the errors of this mailet. <br/>
+
+          The <strong>ignore</strong> special value also allows to continue processing and ignore the error. <br/>
+          The <strong>propagate</strong> special value causes the mailet container to rethrow the
+          exception, propagating it to the execution context. In an SMTP execution context, the spooler will then requeue
+          the item and automatic retries will be setted up - note that attempts will be done for each recipients. In LMTP
+          (if LMTP is configured to execute the mailetContainer), the entire mail transaction is reported as failed to the caller.</p>
 
       <p>Moreover, the <strong>onMatcherException</strong> allows you to override matcher error handling. You can
           specify another processor than the <strong>error</strong> one for handling the errors of this mailet. The <strong>matchall</strong>

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -229,6 +229,34 @@ Correct this.
           </code>
       </pre>
 
+      <p>Note that by default the mailet container is executed with all recipients at once and do not allow per recipient
+      error reporting. An option <code>splitExecution</code> allow to execute the mailet container for each recipient separately and mitigate this
+      limitation at the cost of performance.</p>
+
+      <pre>
+          <code>
+&lt;lmtpservers&gt;
+  &lt;lmtpserver enabled=&quot;true&quot;&gt;
+    &lt;jmxName&gt;lmtpserver&lt;/jmxName&gt;
+    &lt;bind&gt;0.0.0.0:0&lt;/bind&gt;
+    &lt;connectionBacklog&gt;200&lt;/connectionBacklog&gt;
+    &lt;connectiontimeout&gt;1200&lt;/connectiontimeout&gt;
+    &lt;connectionLimit&gt;0&lt;/connectionLimit&gt;
+    &lt;connectionLimitPerIP&gt;0&lt;/connectionLimitPerIP&gt;
+    &lt;maxmessagesize&gt;0&lt;/maxmessagesize&gt;
+    &lt;handlerchain coreHandlersPackage=&quot;org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader&quot;&gt;
+      &lt;handler class=&quot;org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader&quot;&gt;
+        &lt;splitExecution&gt;false&lt;/splitExecution&gt;
+      &lt;/handler&gt;
+      &lt;handler class=&quot;org.apache.james.lmtpserver.MailetContainerHandler&quot;&gt;
+        &lt;splitExecution>true&lt;/splitExecution&gt;
+      &lt;/handler&gt;
+    &lt;/handlerchain&gt;
+  &lt;/lmtpserver&gt;
+&lt;/lmtpservers&gt;
+          </code>
+      </pre>
+
   </section>
     
 </body>


### PR DESCRIPTION
Base use case: Executing the mailet container with LMTP I want to escalate some failures to the LMTP client

Nice bonus: It enables better error management eg by propagating exception upon mail processor we can trigger a nack and prevent message loss.