### PR TITLE
JAMES-3589 Matched mail resume processing from root

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/ExecutionCountTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/ExecutionCountTest.java
@@ -1,0 +1,108 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets;
+
+import static org.apache.james.MemoryJamesServerMain.SMTP_AND_IMAP_MODULE;
+import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
+import static org.apache.james.mailets.configuration.Constants.FROM;
+import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
+import static org.apache.james.mailets.configuration.Constants.PASSWORD;
+import static org.apache.james.mailets.configuration.Constants.RECIPIENT;
+import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMinute;
+import static org.apache.james.utils.TestIMAPClient.INBOX;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.apache.james.mailets.configuration.CommonProcessors;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.MailetContainer;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.transport.mailets.CountinExecutionMailet;
+import org.apache.james.transport.mailets.Null;
+import org.apache.james.transport.matchers.All;
+import org.apache.james.transport.matchers.RecipientIs;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.TestIMAPClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.common.collect.ImmutableList;
+
+public class ExecutionCountTest {
+    @RegisterExtension
+    public SMTPMessageSender smtpMessageSender = new SMTPMessageSender(DEFAULT_DOMAIN);
+    @RegisterExtension
+    public TestIMAPClient testIMAPClient = new TestIMAPClient();
+
+    private TemporaryJamesServer jamesServer;
+
+    @BeforeEach
+    public void test() {
+        CountinExecutionMailet.reset();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (jamesServer != null) {
+            jamesServer.shutdown();
+        }
+    }
+
+    @Test
+    public void partialMatchShouldLeadToSingleExecutionOfMailet(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(CountinExecutionMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountinExecutionMailet.executionCount()).isEqualTo(1);
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/ExecutionCountTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/ExecutionCountTest.java
@@ -37,9 +37,7 @@ import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
-import org.apache.james.transport.mailets.CountinExecutionMailet;
-import org.apache.james.transport.mailets.Null;
-import org.apache.james.transport.matchers.All;
+import org.apache.james.transport.mailets.CountingExecutionMailet;
 import org.apache.james.transport.matchers.RecipientIs;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.SMTPMessageSender;
@@ -62,7 +60,7 @@ public class ExecutionCountTest {
 
     @BeforeEach
     public void test() {
-        CountinExecutionMailet.reset();
+        CountingExecutionMailet.reset();
     }
 
     @AfterEach
@@ -82,7 +80,7 @@ public class ExecutionCountTest {
                         .addMailet(MailetConfiguration.builder()
                             .matcher(RecipientIs.class)
                             .matcherCondition(RECIPIENT)
-                            .mailet(CountinExecutionMailet.class)
+                            .mailet(CountingExecutionMailet.class)
                             .build())
                         .addMailet(MailetConfiguration.LOCAL_DELIVERY))
                 .putProcessor(CommonProcessors.error())
@@ -103,6 +101,6 @@ public class ExecutionCountTest {
             .login(RECIPIENT, PASSWORD)
             .select(INBOX)
             .awaitMessage(awaitAtMostOneMinute);
-        assertThat(CountinExecutionMailet.executionCount()).isEqualTo(1);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
     }
 }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/CountinExecutionMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/CountinExecutionMailet.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.mail.MessagingException;
+
+import org.apache.james.util.MimeMessageUtil;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class CountinExecutionMailet extends GenericMailet {
+    private static final AtomicLong executionCount = new AtomicLong();
+
+    public static void reset() {
+        executionCount.set(0L);
+    }
+
+    public static long executionCount() {
+        return executionCount.get();
+    }
+
+    @Override
+    public void service(Mail mail) {
+        executionCount.incrementAndGet();
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/CountingExecutionMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/CountingExecutionMailet.java
@@ -27,7 +27,7 @@ import org.apache.james.util.MimeMessageUtil;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
-public class CountinExecutionMailet extends GenericMailet {
+public class CountingExecutionMailet extends GenericMailet {
     private static final AtomicLong executionCount = new AtomicLong();
 
     public static void reset() {

--- a/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
+++ b/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
@@ -102,6 +102,15 @@ public class SMTPMessageSender extends ExternalResource implements Closeable, Af
         return sendMessageWithHeaders(from, ImmutableList.of(recipient), message);
     }
 
+    public SMTPMessageSender sendMessage(String from, List<String> recipients) throws IOException {
+        String message = "FROM: " + from + "\r\n" +
+            "subject: test\r\n" +
+            "\r\n" +
+            "content\r\n" +
+            ".\r\n";
+        return sendMessageWithHeaders(from, recipients, message);
+    }
+
     public SMTPMessageSender sendMessageNoBracket(String from, String recipient) throws IOException {
         doHelo();
         doSetSender(from);


### PR DESCRIPTION
## What

One of my customer reported me that a side effect was done two time upon MailetContainer execution.

What was not my surprise when writing integration tests counting executions, that they were right!

Tracking down the bug, I encountered that `MailImpl.duplicate` do not preserve state, hence processing resumes from ROOT processor (leaving the exchange).

## The fix

MatcherSplitter should preserve the state of the matched mail.

## The complications

Preserving several mails on the same exchange, we should not shut the exchange down before processing is finished. Doing so would result in following  I did set up reference counting for this.