### PR TITLE
JAMES-3516 Add threadId property to MessageResult POJO, MailboxMessage POJO

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageResult.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageResult.java
@@ -62,6 +62,8 @@ import org.apache.james.mailbox.exception.MailboxException;
 public interface MessageResult extends Comparable<MessageResult> {
     MessageId getMessageId();
 
+    ThreadId getThreadId();
+
     Date getInternalDate();
 
     Flags getFlags();

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/ThreadId.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/ThreadId.java
@@ -1,0 +1,58 @@
+/******************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one     *
+ * or more contributor license agreements.  See the NOTICE file   *
+ * distributed with this work for additional information          *
+ * regarding copyright ownership.  The ASF licenses this file     *
+ * to you under the Apache License, Version 2.0 (the              *
+ * "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at     *
+ *                                                                *
+ * http://www.apache.org/licenses/LICENSE-2.0                     *
+ *                                                                *
+ * Unless required by applicable law or agreed to in writing,     *
+ * software distributed under the License is distributed on an    *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY         *
+ * KIND, either express or implied.  See the License for the      *
+ * specific language governing permissions and limitations        *
+ * under the License.                                             *
+ ******************************************************************/
+
+package org.apache.james.mailbox.model;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+
+public class ThreadId {
+    private final MessageId baseMessageId;
+
+    public ThreadId(MessageId baseMessageId) {
+        this.baseMessageId = baseMessageId;
+    }
+
+    public MessageId getBaseMessageId() {
+        return baseMessageId;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof ThreadId) {
+            ThreadId that = (ThreadId) o;
+            return Objects.equals(this.baseMessageId, that.baseMessageId);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(baseMessageId);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("baseMessageId", baseMessageId)
+            .toString();
+    }
+}

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -2855,6 +2855,13 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                     .collectList().block())
                 .isEmpty();
         }
+
+        @Test
+        void shouldBeAbleToAccessThreadIdOfAMessageAndThatThreadIdShouldWrapsMessageId() throws Exception {
+            ComposedMessageId composeId1 = inboxManager.appendMessage(AppendCommand.builder().build(message), session).getId();
+            MessageResult messageResult = inboxManager.getMessages(MessageRange.one(composeId1.getUid()), FetchGroup.MINIMAL, session).next();
+            assertThat(messageResult.getThreadId().getBaseMessageId()).isInstanceOf(MessageId.class);
+        }
     }
 
     @Nested

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/ThreadIdTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/ThreadIdTest.java
@@ -1,0 +1,32 @@
+/******************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one     *
+ * or more contributor license agreements.  See the NOTICE file   *
+ * distributed with this work for additional information          *
+ * regarding copyright ownership.  The ASF licenses this file     *
+ * to you under the Apache License, Version 2.0 (the              *
+ * "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at     *
+ *                                                                *
+ * http://www.apache.org/licenses/LICENSE-2.0                     *
+ *                                                                *
+ * Unless required by applicable law or agreed to in writing,     *
+ * software distributed under the License is distributed on an    *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY         *
+ * KIND, either express or implied.  See the License for the      *
+ * specific language governing permissions and limitations        *
+ * under the License.                                             *
+ ******************************************************************/
+
+package org.apache.james.mailbox.model;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class ThreadIdTest {
+    @Test
+    void shouldMatchBeanContact() {
+        EqualsVerifier.forClass(ThreadId.class)
+            .verify();
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -55,6 +55,7 @@ import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.ParsedAttachment;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.DelegatingMailboxMessage;
 import org.apache.james.mailbox.store.mail.model.FlagsFactory;
@@ -491,6 +492,11 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
     @Override
     public MessageId getMessageId() {
         return new DefaultMessageId();
+    }
+
+    @Override
+    public ThreadId getThreadId() {
+        return new ThreadId(getMessageId());
     }
 
     public String toString() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
@@ -42,6 +42,7 @@ import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.MimeDescriptor;
 import org.apache.james.mailbox.model.MimePath;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.streaming.InputStreamContent;
 import org.apache.james.mailbox.store.streaming.InputStreamContent.Type;
@@ -87,7 +88,12 @@ public class MessageResultImpl implements MessageResult {
     public MessageId getMessageId() {
         return message.getMessageId();
     }
-    
+
+    @Override
+    public ThreadId getThreadId() {
+        return message.getThreadId();
+    }
+
     @Override
     public Date getInternalDate() {
         return message.getInternalDate();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageResultIterator.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageResultIterator.java
@@ -46,6 +46,7 @@ import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.MessageResultIterator;
 import org.apache.james.mailbox.model.MimeDescriptor;
 import org.apache.james.mailbox.model.MimePath;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
@@ -189,6 +190,11 @@ public class StoreMessageResultIterator implements MessageResultIterator {
         @Override
         public MessageId getMessageId() {
             return messageMetaData().getMessageId();
+        }
+
+        @Override
+        public ThreadId getThreadId() {
+            return new ThreadId(messageMetaData.getMessageId());
         }
 
         @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/DelegatingMailboxMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/DelegatingMailboxMessage.java
@@ -27,6 +27,7 @@ import javax.mail.Flags;
 
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.impl.Properties;
 
 public abstract class DelegatingMailboxMessage implements MailboxMessage {
@@ -110,6 +111,10 @@ public abstract class DelegatingMailboxMessage implements MailboxMessage {
     @Override
     public MessageId getMessageId() {
         return message.getMessageId();
+    }
+
+    public ThreadId getThreadId() {
+        return new ThreadId(message.getMessageId());
     }
 
     public Message getMessage() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/MailboxMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/MailboxMessage.java
@@ -25,6 +25,7 @@ import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
+import org.apache.james.mailbox.model.ThreadId;
 
 /**
  * A MIME message, consisting of meta-data (including MIME headers)
@@ -32,6 +33,8 @@ import org.apache.james.mailbox.model.MessageMetaData;
  * has internal structure described by the meta-data.
  */
 public interface MailboxMessage extends Message, Comparable<MailboxMessage> {
+
+    ThreadId getThreadId();
 
     ComposedMessageIdWithMetaData getComposedMessageIdWithMetaData();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
@@ -334,4 +334,9 @@ class SimpleMailboxMessageTest {
             .isInstanceOf(NullPointerException.class);
     }
 
+    @Test
+    void simpleMessageShouldReturnThreadIdWhichWrapsMessageId() {
+        assertThat(message.getThreadId().getBaseMessageId()).isEqualTo(message.getMessageId());
+    }
+
 }


### PR DESCRIPTION
We don't have threadId guessing algorithm yet, so now threadId property is naive implemented equals MessageId.
I think I should have put threadId property to some Implemented MailboxMessage constructor/ builder. However I not sure which Message model JMAP is using... 