### PR TITLE
JAMES-3589 Reasonable tests regarding mailet container execution

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/AddRecipient.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/AddRecipient.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import static org.apache.james.mailets.configuration.Constants.RECIPIENT2;
+
+import javax.mail.internet.AddressException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+import com.google.common.collect.ImmutableList;
+
+public class AddRecipient extends GenericMailet {
+    @Override
+    public void service(Mail mail) throws AddressException {
+        mail.setRecipients(ImmutableList.<MailAddress>builder()
+            .add(new MailAddress(RECIPIENT2))
+            .addAll(mail.getRecipients())
+            .build());
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/ClearRecipientsMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/ClearRecipientsMailet.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+import com.google.common.collect.ImmutableList;
+
+public class ClearRecipientsMailet extends GenericMailet {
+    @Override
+    public void service(Mail mail) {
+        mail.setRecipients(ImmutableList.of());
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CollectMailAttributeMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CollectMailAttributeMailet.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+public class CollectMailAttributeMailet extends GenericMailet {
+    public static final String MY_ATTRIBUTE = "myAttribute";
+    private static final ConcurrentLinkedDeque<String> encounteredAttributes = new ConcurrentLinkedDeque<>();
+
+    public static void reset() {
+        encounteredAttributes.clear();
+    }
+
+    public static List<String> encounteredAttributes() {
+        return ImmutableList.copyOf(encounteredAttributes);
+    }
+
+    @Override
+    public void service(Mail mail) {
+        mail.getAttribute(AttributeName.of(MY_ATTRIBUTE))
+            .ifPresent(attribute -> encounteredAttributes.add((String) attribute.getValue()
+                .value()));
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CollectingExecutionMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CollectingExecutionMailet.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class CollectingExecutionMailet extends GenericMailet {
+    private static final ConcurrentLinkedDeque<MailAddress> executedFor = new ConcurrentLinkedDeque<>();
+
+    public static void reset() {
+        executedFor.clear();
+    }
+
+    public static List<MailAddress> executionFor() {
+        return org.testcontainers.shaded.com.google.common.collect.ImmutableList.copyOf(executedFor);
+    }
+
+    @Override
+    public void service(Mail mail) {
+        executedFor.addAll(mail.getRecipients());
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CollectingExecutionMailetBis.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CollectingExecutionMailetBis.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class CollectingExecutionMailetBis extends GenericMailet {
+    private static final ConcurrentLinkedDeque<MailAddress> executedFor = new ConcurrentLinkedDeque<>();
+
+    public static void reset() {
+        executedFor.clear();
+    }
+
+    public static List<MailAddress> executionFor() {
+        return org.testcontainers.shaded.com.google.common.collect.ImmutableList.copyOf(executedFor);
+    }
+
+    @Override
+    public void service(Mail mail) {
+        executedFor.addAll(mail.getRecipients());
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CountingExecutionMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CountingExecutionMailet.java
@@ -1,0 +1,42 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class CountingExecutionMailet extends GenericMailet {
+    private static final AtomicLong executionCount = new AtomicLong();
+
+    public static void reset() {
+        executionCount.set(0L);
+    }
+
+    public static long executionCount() {
+        return executionCount.get();
+    }
+
+    @Override
+    public void service(Mail mail) {
+        executionCount.incrementAndGet();
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CountingExecutionMailetBis.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CountingExecutionMailetBis.java
@@ -1,0 +1,42 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class CountingExecutionMailetBis extends GenericMailet {
+    private static final AtomicLong executionCount = new AtomicLong();
+
+    public static void reset() {
+        executionCount.set(0L);
+    }
+
+    public static long executionCount() {
+        return executionCount.get();
+    }
+
+    @Override
+    public void service(Mail mail) {
+        executionCount.incrementAndGet();
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CountingExecutionTerminatingMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/CountingExecutionTerminatingMailet.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import static org.apache.mailet.Mail.GHOST;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class CountingExecutionTerminatingMailet extends GenericMailet {
+    private static final AtomicLong executionCount = new AtomicLong();
+
+    public static void reset() {
+        executionCount.set(0L);
+    }
+
+    public static long executionCount() {
+        return executionCount.get();
+    }
+
+    @Override
+    public void service(Mail mail) {
+        executionCount.incrementAndGet();
+        mail.setState(GHOST);
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/EnsureNotDisposed.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/EnsureNotDisposed.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.mail.MessagingException;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class EnsureNotDisposed extends GenericMailet {
+    private static final AtomicLong executionCount = new AtomicLong();
+
+    public static void reset() {
+        executionCount.set(0L);
+    }
+
+    public static long executionCount() {
+        return executionCount.get();
+    }
+
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        try {
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        assertThat(mail.getMessage()).isNotNull();
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/ExecutionFlowTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/ExecutionFlowTest.java
@@ -54,6 +54,7 @@ import org.apache.james.utils.SpoolerProbe;
 import org.apache.james.utils.TestIMAPClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -86,6 +87,8 @@ public class ExecutionFlowTest {
         }
     }
 
+    @Disabled("JAMES-3589 Mail.duplicate does not copy state, matched mail is sent back to `root` and mailet/matcher prior " +
+        "and at this stage are executed twice.")
     @Test
     public void partialMatchShouldLeadToSingleExecutionOfMailet(@TempDir File temporaryFolder) throws Exception {
         jamesServer = TemporaryJamesServer.builder()
@@ -120,6 +123,8 @@ public class ExecutionFlowTest {
         assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
     }
 
+    @Disabled("JAMES-3589 Mail.duplicate does not copy state, matched mail is sent back to `root` and mailet/matcher prior " +
+        "and at this stage are executed twice.")
     @Test
     public void partialMatchShouldLeadToSingleExecutionOfMatcher(@TempDir File temporaryFolder) throws Exception {
         jamesServer = TemporaryJamesServer.builder()
@@ -154,6 +159,8 @@ public class ExecutionFlowTest {
         assertThat(FirstRecipientCountingExecutions.executionCount()).isEqualTo(1);
     }
 
+    @Disabled("JAMES-3589 Mail.duplicate does not copy state, matched mail is sent back to `root` and mailet/matcher prior " +
+        "and at this stage are executed twice.")
     @Test
     public void partialMatchShouldLeadToSingleExecutionOfUpstreamMailet(@TempDir File temporaryFolder) throws Exception {
         jamesServer = TemporaryJamesServer.builder()
@@ -192,6 +199,8 @@ public class ExecutionFlowTest {
         assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
     }
 
+    @Disabled("JAMES-3589 Mail.duplicate does not copy state, matched mail is sent back to `root` and mailet/matcher prior " +
+        "and at this stage are executed twice.")
     @Test
     public void partialMatchShouldLeadToSingleExecutionOfUpstreamRootMailets(@TempDir File temporaryFolder) throws Exception {
         jamesServer = TemporaryJamesServer.builder()
@@ -277,6 +286,8 @@ public class ExecutionFlowTest {
         assertThat(CollectMailAttributeMailet.encounteredAttributes()).isEmpty();
     }
 
+    @Disabled("JAMES-3589 Mail.duplicate does not copy state, matched mail is sent back to `root`. As execution" +
+        "is resumed with mutations, mutations are visible to upstream stages.")
     @Test
     public void mutationsOfDownstreamMailetsShouldNotAffectUpStreamMailetsUponSplit(@TempDir File temporaryFolder) throws Exception {
         jamesServer = TemporaryJamesServer.builder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/ExecutionFlowTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/ExecutionFlowTest.java
@@ -1,0 +1,1077 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import static org.apache.james.MemoryJamesServerMain.SMTP_AND_IMAP_MODULE;
+import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
+import static org.apache.james.mailets.configuration.Constants.FROM;
+import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
+import static org.apache.james.mailets.configuration.Constants.PASSWORD;
+import static org.apache.james.mailets.configuration.Constants.RECIPIENT;
+import static org.apache.james.mailets.configuration.Constants.RECIPIENT2;
+import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMinute;
+import static org.apache.james.utils.TestIMAPClient.INBOX;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.mailets.TemporaryJamesServer;
+import org.apache.james.mailets.configuration.CommonProcessors;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.MailetContainer;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.transport.mailets.NoopMailet;
+import org.apache.james.transport.mailets.Null;
+import org.apache.james.transport.mailets.PostmasterAlias;
+import org.apache.james.transport.mailets.SetMailAttribute;
+import org.apache.james.transport.mailets.ToProcessor;
+import org.apache.james.transport.matchers.All;
+import org.apache.james.transport.matchers.RecipientIs;
+import org.apache.james.transport.matchers.RelayLimit;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.SpoolerProbe;
+import org.apache.james.utils.TestIMAPClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.common.collect.ImmutableList;
+
+public class ExecutionFlowTest {
+    @RegisterExtension
+    public SMTPMessageSender smtpMessageSender = new SMTPMessageSender(DEFAULT_DOMAIN);
+    @RegisterExtension
+    public TestIMAPClient testIMAPClient = new TestIMAPClient();
+
+    private TemporaryJamesServer jamesServer;
+
+    @BeforeEach
+    public void test() {
+        CountingExecutionMailet.reset();
+        CountingExecutionMailetBis.reset();
+        CountingExecutionTerminatingMailet.reset();
+        CollectingExecutionMailet.reset();
+        CollectingExecutionMailetBis.reset();
+        CollectMailAttributeMailet.reset();
+        FirstRecipientCountingExecutions.reset();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (jamesServer != null) {
+            jamesServer.shutdown();
+        }
+    }
+
+    @Test
+    public void partialMatchShouldLeadToSingleExecutionOfMailet(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(CountingExecutionMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void partialMatchShouldLeadToSingleExecutionOfMatcher(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(FirstRecipientCountingExecutions.class)
+                            .mailet(CountingExecutionMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(FirstRecipientCountingExecutions.executionCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void partialMatchShouldLeadToSingleExecutionOfUpstreamMailet(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(CountingExecutionMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(NoopMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void partialMatchShouldLeadToSingleExecutionOfUpstreamRootMailets(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(NoopMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor( ProcessorConfiguration.root()
+                    .enableJmx(false)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(PostmasterAlias.class))
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(RelayLimit.class)
+                        .matcherCondition("30")
+                        .mailet(Null.class))
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.TO_TRANSPORT)))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void mutationsOfDownstreamMailetsShouldNotAffectUpStreamMailets(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(CollectMailAttributeMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(SetMailAttribute.class)
+                            .addProperty(CollectMailAttributeMailet.MY_ATTRIBUTE, "value1")
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CollectMailAttributeMailet.encounteredAttributes()).isEmpty();
+    }
+
+    @Test
+    public void mutationsOfDownstreamMailetsShouldNotAffectUpStreamMailetsUponSplit(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(CollectMailAttributeMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(SetMailAttribute.class)
+                            .addProperty(CollectMailAttributeMailet.MY_ATTRIBUTE, "value1")
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(NoopMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CollectMailAttributeMailet.encounteredAttributes()).isEmpty();
+    }
+
+    @Test
+    public void totalMatchShouldNotSplitMail(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(2)
+            .containsOnly(new MailAddress(FROM), new MailAddress(RECIPIENT));
+    }
+
+    @Test
+    public void noMatchShouldNotExecuteMailet(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(None.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void noMatchWithNullShouldNotExecuteMailet(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(NoneWithNull.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void noMatchShouldNotSplitMailet(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(None.class)
+                        .mailet(NoopMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(2)
+            .containsOnly(new MailAddress(FROM), new MailAddress(RECIPIENT));
+    }
+
+    @Test
+    public void noMatchWithNullShouldNotSplitMailet(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(NoneWithNull.class)
+                        .mailet(NoopMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(2)
+            .containsOnly(new MailAddress(FROM), new MailAddress(RECIPIENT));
+    }
+
+    @Test
+    public void nullMailetShouldAbortProcessing(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(Null.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void nullMailetShouldAbortProcessingOnlOfMatchedEmails(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(RecipientIs.class)
+                        .matcherCondition(RECIPIENT)
+                        .mailet(Null.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(1)
+            .containsOnly(new MailAddress(FROM));
+    }
+
+    @Test
+    public void clearRecipientsMailetShouldAbortProcessing(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(ClearRecipientsMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void clearRecipientsMailetShouldAbortProcessingOnlOfMatchedEmails(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(RecipientIs.class)
+                        .matcherCondition(RECIPIENT)
+                        .mailet(ClearRecipientsMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(1);
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(1)
+            .containsOnly(new MailAddress(FROM));
+    }
+
+    @Test
+    public void mailetCanEditRecipients(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(AddRecipient.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(3)
+            .containsOnly(new MailAddress(FROM), new MailAddress(RECIPIENT), new MailAddress(RECIPIENT2));
+    }
+
+    @Test
+    public void toProcessorShouldSwitchExecutingProcessor(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(ToProcessor.class)
+                        .addProperty("processor", "custom")
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(ProcessorConfiguration.builder()
+                    .state("custom")
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailetBis.class)
+                        .build()))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionMailet.executionCount()).isEqualTo(0);
+        assertThat(CountingExecutionMailetBis.executionCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void toProcessorShouldSupportPartialMatches(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(RecipientIs.class)
+                        .matcherCondition(RECIPIENT)
+                        .mailet(ToProcessor.class)
+                        .addProperty("processor", "custom")
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(ProcessorConfiguration.builder()
+                    .state("custom")
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailetBis.class)
+                        .build()))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(1)
+            .containsOnly(new MailAddress(FROM));
+        assertThat(CollectingExecutionMailetBis.executionFor())
+            .hasSize(1)
+            .containsOnly(new MailAddress(RECIPIENT));
+    }
+
+    @Test
+    public void toProcessorSplitShouldNotDisposeContent(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(RecipientIs.class)
+                        .matcherCondition(RECIPIENT)
+                        .mailet(ToProcessor.class)
+                        .addProperty("processor", "custom")
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(EnsureNotDisposed.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(ProcessorConfiguration.builder()
+                    .state("custom")
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(EnsureNotDisposed.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CollectingExecutionMailetBis.class)
+                        .build()))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(1)
+            .containsOnly(new MailAddress(FROM));
+        assertThat(CollectingExecutionMailetBis.executionFor())
+            .hasSize(1)
+            .containsOnly(new MailAddress(RECIPIENT));
+    }
+
+    @Test
+    public void toProcessorShouldSendToErrorWhenNotFound(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(RecipientIs.class)
+                        .matcherCondition(RECIPIENT)
+                        .mailet(ToProcessor.class)
+                        .addProperty("processor", "custom")
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(ProcessorConfiguration.error()
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)))
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionMailet.executionCount())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void splitShouldNotDisposeContent(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(RecipientIs.class)
+                        .matcherCondition(RECIPIENT)
+                        .mailet(NoopMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(EnsureNotDisposed.class)
+                        .build())
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(CountingExecutionMailet.class)
+                        .build())
+                    .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+            jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionMailet.executionCount())
+            .isEqualTo(2);
+    }
+
+    @Test
+    public void partialMatchShouldLeadToExecutionOfDownStreamMailetsForEachSplitedMails(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(NoopMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(CountingExecutionTerminatingMailet.class)
+                            .build()))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+                jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CountingExecutionTerminatingMailet.executionCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void emailModificationsShouldBePreservedOnPartialMatch(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(SetMailAttribute.class)
+                            .addProperty(CollectMailAttributeMailet.MY_ATTRIBUTE, "value1")
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(SetMailAttribute.class)
+                            .addProperty(CollectMailAttributeMailet.MY_ATTRIBUTE, "value2")
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(CollectMailAttributeMailet.class)
+                            .build()))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        Thread.sleep(100); // queue delays might cause the processing not to start straight at the end of the SMTP session
+        awaitAtMostOneMinute.untilAsserted(() -> assertThat(
+                jamesServer.getProbe(SpoolerProbe.class).processingFinished())
+            .isTrue());
+        assertThat(CollectMailAttributeMailet.encounteredAttributes())
+            .hasSize(2)
+            .containsOnly("value1", "value2");
+    }
+
+    @Test
+    public void matcherSplitShouldNotDuplicateRecipients(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(SMTP_AND_IMAP_MODULE)
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.transport()
+                        .addMailet(MailetConfiguration.BCC_STRIPPER)
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(RecipientIs.class)
+                            .matcherCondition(RECIPIENT)
+                            .mailet(NoopMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.builder()
+                            .matcher(All.class)
+                            .mailet(CollectingExecutionMailet.class)
+                            .build())
+                        .addMailet(MailetConfiguration.LOCAL_DELIVERY))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.root()))
+            .build(temporaryFolder);
+        jamesServer.start();
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD);
+
+        smtpMessageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, ImmutableList.of(FROM, RECIPIENT));
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(RECIPIENT, PASSWORD)
+            .select(INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(CollectingExecutionMailet.executionFor())
+            .hasSize(2)
+            .containsOnly(new MailAddress(FROM), new MailAddress(RECIPIENT));
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/FirstRecipientCountingExecutions.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/FirstRecipientCountingExecutions.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+public class FirstRecipientCountingExecutions extends GenericMatcher {
+    private static final AtomicLong executionCount = new AtomicLong();
+
+    public static void reset() {
+        executionCount.set(0L);
+    }
+
+    public static long executionCount() {
+        return executionCount.get();
+    }
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) {
+        executionCount.incrementAndGet();
+        return mail.getRecipients().stream()
+            .findFirst()
+            .map(ImmutableList::of)
+            .orElse(ImmutableList.<MailAddress>of());
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/None.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/None.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.Collection;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+public class None extends GenericMatcher {
+    @Override
+    public Collection<MailAddress> match(Mail mail) {
+        return ImmutableList.of();
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/NoneWithNull.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/flow/NoneWithNull.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets.flow;
+
+import java.util.Collection;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+
+public class NoneWithNull extends GenericMatcher {
+    @Override
+    public Collection<MailAddress> match(Mail mail) {
+        return null;
+    }
+}


### PR DESCRIPTION
We expect:
 - A mailet to be executed once for each recipients upon partial match and not several time
 - A terminating mailet should not abort processing of previously split mails
 - Mail modifications upon partial match should be retained
 - After a partial match, downstream recipients should not be executed twice for a given recipient

 The tests pass b replacing Camel logic by simple Java code:

```
 public class CamelMailetProcessor extends AbstractStateMailetProcessor implements CamelContextAware {
     private static final Logger LOGGER = LoggerFactory.getLogger(CamelMailetProcessor.class);

     private final MetricFactory metricFactory;
     private List<MatcherMailetPair> pairs;

     public CamelMailetProcessor(MetricFactory metricFactory) {
         this.metricFactory = metricFactory;
     }

     @override
     public void service(Mail mail) throws MessagingException {
         pairs.stream()
             .reduce(ImmutableList.of(mail), (mails, pair) -> {
                 if (mails.size() > 0) {
                     return executePair(mails, pair);
                 }
                 return ImmutableList.of();
             }, (a, b) -> {
                 throw new NotImplementedException("Fold left implementation. Should never be called.");
             });
     }

     private ImmutableList<Mail> executePair(ImmutableList<Mail> mails, MatcherMailetPair pair) {
         MatcherSplitter matcherSplitter = new MatcherSplitter(metricFactory, this, pair);
         ImmutableList<Mail> afterMatching = mails.stream()
             .flatMap(Throwing.<Mail, Stream<Mail>>function(mail -> matcherSplitter.split(mail).stream()).sneakyThrow())
             .collect(Guavate.toImmutableList());
         afterMatching
             .stream().filter(mail -> mail.removeAttribute(MATCHER_MATCHED_ATTRIBUTE).isPresent())
             .forEach(Throwing.<Mail>consumer(mail -> new CamelProcessor(metricFactory, this, pair.getMailet())
                 .processMail(mail)).sneakyThrow());

         afterMatching.stream()
             .filter(mail -> !mail.getState().equals(getState()))
             .filter(mail -> !mail.getState().equals(Mail.GHOST))
             .forEach(Throwing.consumer(this::toProcessor).sneakyThrow());

         return afterMatching.stream()
             .filter(mail -> mail.getState().equals(getState()))
             .collect(Guavate.toImmutableList());
     }

     // Few boiler plate methods
 }
```

Mail.duplicate does not copy state, matched mail is sent back to `root`
and mailet/matcher prior and at this stage are executed twice. Which feels
like 'unexpected'. This bug is present since at least 2015.

Preserving the state leads to other Camel related issues like lifecycle
management of the exchange, routing issues, etc... It looks like having two Mail flowing the same exchange had never been thought off. I did not win that battle.

To be fairly honnest my feeling is that:
 - Camel had been used for some complicated integrations, via some tweaks of `spring configuration` to output emails to some tierce system and benefit for that of Camel ecosystem.
 - The right way to do that would be to just write a Mailet.
 - Camel brings in complexity, dependencies, the project apparently have an untested legacy regarding it, and do not have the knowledge.
 - Camel is a blocker on the road to **reactive** mailets / matchers.
 - I truly think we will be better off without it. And have a plain Java implementation of it.

Tomorrow... 

  - [x] I will set up  a Proof Of Concept PR for a plain Java mailetContainer
  - [ ] I will continue to scratch my head at this Camel hell.
  - [ ] I will probably contact Camel PMC

Cc @mbaechler  @jeantil @rouazana 