### PR TITLE
JAMES-3589 Allow tailor-made servers to customize their mailet container

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -27,6 +27,7 @@ import org.apache.james.json.DTOModule;
 import org.apache.james.modules.BlobExportMechanismModule;
 import org.apache.james.modules.CassandraConsistencyTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
+import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.data.CassandraDLPConfigurationStoreModule;
 import org.apache.james.modules.data.CassandraDomainListModule;
 import org.apache.james.modules.data.CassandraJmapModule;
@@ -158,6 +159,7 @@ public class CassandraJamesServerMain implements JamesServerMain {
         new DKIMMailetModule());
 
     protected static Module ALL_BUT_JMX_CASSANDRA_MODULE = Modules.combine(
+        new MailetProcessingModule(),
         new CassandraBucketModule(),
         new CassandraBlobStoreModule(),
         REQUIRE_TASK_MANAGER_MODULE,

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -30,6 +30,7 @@ import org.apache.james.modules.CassandraConsistencyTaskSerializationModule;
 import org.apache.james.modules.DistributedTaskManagerModule;
 import org.apache.james.modules.DistributedTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
+import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.blobstore.BlobStoreCacheModulesChooser;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.apache.james.modules.blobstore.BlobStoreModulesChooser;
@@ -155,6 +156,7 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
         new SpamAssassinListenerModule());
 
     public static Module REQUIRE_TASK_MANAGER_MODULE = Modules.combine(
+        new MailetProcessingModule(),
         CASSANDRA_SERVER_CORE_MODULE,
         CASSANDRA_MAILBOX_MODULE,
         PROTOCOLS,

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/GuiceJamesServer.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/GuiceJamesServer.java
@@ -26,7 +26,6 @@ import javax.annotation.PreDestroy;
 
 import org.apache.james.modules.CommonServicesModule;
 import org.apache.james.modules.IsStartedProbeModule;
-import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.onami.lifecycle.Stager;
 import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.utils.GuiceProbe;
@@ -58,8 +57,7 @@ public class GuiceJamesServer {
             isStartedProbe,
             Modules.combine(
                 new IsStartedProbeModule(isStartedProbe),
-                new CommonServicesModule(configuration),
-                new MailetProcessingModule()));
+                new CommonServicesModule(configuration)));
     }
 
     protected GuiceJamesServer(IsStartedProbe isStartedProbe, Module module) {

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
@@ -60,7 +60,7 @@ import com.google.common.io.Resources;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-interface MailsShouldBeWellReceived {
+public interface MailsShouldBeWellReceived {
 
     String JAMES_SERVER_HOST = "127.0.0.1";
     String DOMAIN = "apache.org";

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -20,6 +20,7 @@
 package org.apache.james;
 
 import org.apache.james.modules.MailboxModule;
+import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.data.JPADataModule;
 import org.apache.james.modules.data.SieveJPARepositoryModules;
 import org.apache.james.modules.mailbox.DefaultEventModule;
@@ -94,7 +95,8 @@ public class JPAJamesServerMain implements JamesServerMain {
         new MemoryDeadLetterModule(),
         new SpamAssassinListenerModule());
 
-    private static final Module JPA_MODULE_AGGREGATE = Modules.combine(JPA_SERVER_MODULE, PROTOCOLS);
+    private static final Module JPA_MODULE_AGGREGATE = Modules.combine(
+        new MailetProcessingModule(), JPA_SERVER_MODULE, PROTOCOLS);
 
     public static void main(String[] args) throws Exception {
         Configuration configuration = Configuration.builder()

--- a/server/container/guice/jpa-smtp-common/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-smtp-common/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -19,6 +19,7 @@
 
 package org.apache.james;
 
+import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.data.JPADataModule;
 import org.apache.james.modules.data.JPAEntityManagerModule;
 import org.apache.james.modules.protocols.ProtocolHandlerModule;
@@ -53,6 +54,7 @@ public class JPAJamesServerMain implements JamesServerMain {
         new TaskManagerModule());
     
     private static final Module JPA_SERVER_MODULE = Modules.combine(
+        new MailetProcessingModule(),
         new JPAEntityManagerModule(),
         new JPADataModule(),
         new ActiveMQQueueModule(),

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -26,6 +26,7 @@ import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.modules.BlobExportMechanismModule;
 import org.apache.james.modules.BlobMemoryModule;
 import org.apache.james.modules.MailboxModule;
+import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.data.MemoryDataJmapModule;
 import org.apache.james.modules.data.MemoryDataModule;
 import org.apache.james.modules.eventstore.MemoryEventStoreModule;
@@ -106,6 +107,7 @@ public class MemoryJamesServerMain implements JamesServerMain {
         new JMAPServerModule());
 
     public static final Module IN_MEMORY_SERVER_MODULE = Modules.combine(
+        new MailetProcessingModule(),
         new BlobMemoryModule(),
         new DeletedMessageVaultModule(),
         new BlobExportMechanismModule(),


### PR DESCRIPTION
This enables those who want to adopt alternatives to the existing `CamelMailetContainer`, allowing to bypass existing bugs like `JAMES-3589`.

The issue is that Mailet container is pre-bundled in GuiceJamesServer thus do not allow overrides.