### PR TITLE
[PERFORMANCE] Fasten MessageProperties lookup

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
@@ -22,11 +22,13 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -190,10 +192,13 @@ public class MessageProperties {
         public ReadProfile getReadProfile() {
             return readProfile;
         }
+
+        private static final ImmutableMap<String, MessageProperty> LOOKUP_MAP = Arrays.stream(values())
+            .collect(Guavate.toImmutableMap(v -> v.property, Function.identity()));
     
         public static Stream<MessageProperty> find(String property) {
             Preconditions.checkNotNull(property);
-            return Arrays.stream(values()).filter(entry -> entry.property.equals(property));
+            return Optional.ofNullable(LOOKUP_MAP.get(property)).stream();
         }
 
         public static ImmutableSet<MessageProperty> allOutputProperties() {


### PR DESCRIPTION
Read a Map instead of iterating values. This is done for each
getMessage requests hence is on the critical path.

With 27 properties to iterate for each 19 properties specified in the gatling tests, at a rate of 425 req/s makes this lookup noticeable...

![Screenshot from 2021-05-23 09-02-25](https://user-images.githubusercontent.com/6928740/119245743-ac523a00-bba5-11eb-8c2d-702da427df70.png)

(Note this pattern is repeated in ~3 places)