### PR TITLE
[PERFORMANCE] Use static TypeToken for complex CQL types

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
@@ -78,10 +78,12 @@ import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.TypeTokens;
 import com.datastax.driver.core.UDTValue;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
@@ -98,7 +100,9 @@ public class CassandraMessageDAOV3 {
     public static final long DEFAULT_LONG_VALUE = 0L;
     private static final byte[] EMPTY_BYTE_ARRAY = {};
     private static final TypeToken<Map<String, String>> MAP_OF_STRING = TypeTokens.mapOf(String.class, String.class);
+    private static final TypeCodec<Map<String, String>> MAP_OF_STRINGS_CODEC = CodecRegistry.DEFAULT_INSTANCE.codecFor(DataType.frozenMap(DataType.text(), DataType.text()), MAP_OF_STRING);
     private static final TypeToken<List<String>> LIST_OF_STRINGS = TypeTokens.listOf(String.class);
+    private static final TypeCodec<List<String>> LIST_OF_STRINGS_CODEC = CodecRegistry.DEFAULT_INSTANCE.codecFor(DataType.frozenList(DataType.text()), LIST_OF_STRINGS);
     private static final TypeToken<List<UDTValue>> LIST_OF_UDT = TypeTokens.listOf(UDTValue.class);
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
@@ -333,9 +337,9 @@ public class CassandraMessageDAOV3 {
         property.setContentMD5(row.getString(CONTENT_MD5));
         property.setContentTransferEncoding(row.getString(CONTENT_TRANSFER_ENCODING));
         property.setContentLocation(row.getString(CONTENT_LOCATION));
-        property.setContentLanguage(row.get(CONTENT_LANGUAGE, LIST_OF_STRINGS));
-        property.setContentDispositionParameters(row.get(CONTENT_DISPOSITION_PARAMETERS, MAP_OF_STRING));
-        property.setContentTypeParameters(row.get(CONTENT_TYPE_PARAMETERS, MAP_OF_STRING));
+        property.setContentLanguage(row.get(CONTENT_LANGUAGE, LIST_OF_STRINGS_CODEC));
+        property.setContentDispositionParameters(row.get(CONTENT_DISPOSITION_PARAMETERS, MAP_OF_STRINGS_CODEC));
+        property.setContentTypeParameters(row.get(CONTENT_TYPE_PARAMETERS, MAP_OF_STRINGS_CODEC));
         property.setTextualLineCount(row.getLong(TEXTUAL_LINE_COUNT));
         return property.build();
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/FlagsExtractor.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/FlagsExtractor.java
@@ -24,12 +24,16 @@ import javax.mail.Flags;
 
 import org.apache.james.mailbox.cassandra.table.Flag;
 
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Row;
+import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.TypeTokens;
 import com.google.common.reflect.TypeToken;
 
 public class FlagsExtractor {
     public static final TypeToken<Set<String>> STRING_SET = TypeTokens.setOf(String.class);
+    public static final TypeCodec<Set<String>> SET_OF_STRINGS_CODEC = CodecRegistry.DEFAULT_INSTANCE.codecFor(DataType.set(DataType.text()), STRING_SET);
 
     public static Flags getFlags(Row row) {
         Flags flags = new Flags();
@@ -38,14 +42,14 @@ public class FlagsExtractor {
                 flags.add(Flag.JAVAX_MAIL_FLAG.get(flag));
             }
         }
-        row.get(Flag.USER_FLAGS, STRING_SET)
+        row.get(Flag.USER_FLAGS, SET_OF_STRINGS_CODEC)
             .forEach(flags::add);
         return flags;
     }
 
     public static Flags getApplicableFlags(Row row) {
         Flags flags = new Flags();
-        row.get(Flag.USER_FLAGS, STRING_SET)
+        row.get(Flag.USER_FLAGS, SET_OF_STRINGS_CODEC)
             .forEach(flags::add);
         return flags;
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/FlagsExtractor.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/FlagsExtractor.java
@@ -18,13 +18,19 @@
  ****************************************************************/
 package org.apache.james.mailbox.cassandra.mail;
 
+import java.util.Set;
+
 import javax.mail.Flags;
 
 import org.apache.james.mailbox.cassandra.table.Flag;
 
 import com.datastax.driver.core.Row;
+import com.datastax.driver.core.TypeTokens;
+import com.google.common.reflect.TypeToken;
 
 public class FlagsExtractor {
+    public static final TypeToken<Set<String>> STRING_SET = TypeTokens.setOf(String.class);
+
     public static Flags getFlags(Row row) {
         Flags flags = new Flags();
         for (String flag : Flag.ALL) {
@@ -32,14 +38,14 @@ public class FlagsExtractor {
                 flags.add(Flag.JAVAX_MAIL_FLAG.get(flag));
             }
         }
-        row.getSet(Flag.USER_FLAGS, String.class)
+        row.get(Flag.USER_FLAGS, STRING_SET)
             .forEach(flags::add);
         return flags;
     }
 
     public static Flags getApplicableFlags(Row row) {
         Flags flags = new Flags();
-        row.getSet(Flag.USER_FLAGS, String.class)
+        row.get(Flag.USER_FLAGS, STRING_SET)
             .forEach(flags::add);
         return flags;
     }


### PR DESCRIPTION
There computing take up to 1,3% of CPU time, doing reflection
over and over again to build them.

See the following flame graphs:

![Screenshot from 2021-05-23 23-39-48](https://user-images.githubusercontent.com/6928740/119269823-da765f00-bc23-11eb-94f1-f83218881888.png)

![Screenshot from 2021-05-23 23-38-00](https://user-images.githubusercontent.com/6928740/119269824-dc402280-bc23-11eb-946c-9f756f7c3c18.png)
