### PR TITLE
JAMES-2157 HasMimeType only look at the top level mime type

### DIFF
--- a/docs/modules/servers/partials/HasMimeType.adoc
+++ b/docs/modules/servers/partials/HasMimeType.adoc
@@ -2,7 +2,7 @@
 
 This matcher checks if the content type matches.
 
-This matcher do not walk down the mime tree and stops at the top level mime part.
+This matcher does not walk down the mime tree and stops at the top level mime part.
 
 use:
 

--- a/docs/modules/servers/partials/HasMimeType.adoc
+++ b/docs/modules/servers/partials/HasMimeType.adoc
@@ -2,6 +2,8 @@
 
 This matcher checks if the content type matches.
 
+This matcher do not walk down the mime tree and stops at the top level mime part.
+
 use:
 
 ....

--- a/docs/modules/servers/partials/HasMimeTypeAnySubPart.adoc
+++ b/docs/modules/servers/partials/HasMimeTypeAnySubPart.adoc
@@ -1,0 +1,11 @@
+=== HasMimeTypeAnySubPart
+
+This matcher checks if the content type matches.
+
+This matcher walks down the mime tree and will look up at all the mime parts of this message.
+
+use:
+
+....
+<mailet match="HasMimeTypeAnySubPart=text/plain,text/html" class="..." />
+....

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasMimeType.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasMimeType.java
@@ -42,6 +42,8 @@ import com.google.common.collect.ImmutableSet;
 /**
  * <p>This matcher checks if the content type matches.</p>
  *
+ * <p>This matcher do not walk down the mime tree and stops at the top level mime part.</p>
+ *
  * use: <pre><code><mailet match="HasMimeType=text/plain,text/html" class="..." /></code></pre>
  */
 public class HasMimeType extends GenericMatcher {

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasMimeTypeAnySubPart.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasMimeTypeAnySubPart.java
@@ -17,23 +17,30 @@
  * under the License.                                           *
  ****************************************************************/
 
-
 package org.apache.james.transport.matchers;
 
 import static org.apache.mailet.base.RFC2822Headers.CONTENT_TYPE;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.Part;
+
 import org.apache.james.core.MailAddress;
+import org.apache.james.javax.MultipartUtil;
 import org.apache.james.mime4j.field.Fields;
 import org.apache.james.util.StreamUtils;
 import org.apache.mailet.Mail;
+import org.apache.mailet.MailetException;
 import org.apache.mailet.base.GenericMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -42,29 +49,61 @@ import com.google.common.collect.ImmutableSet;
 /**
  * <p>This matcher checks if the content type matches.</p>
  *
- * <p>This matcher does not walk down the mime tree and stops at the top level mime part.</p>
+ * <p>This matcher walks down the mime tree and will try to match any of the mime parts of this message.</p>
  *
- * use: <pre><code><mailet match="HasMimeType=text/plain,text/html" class="..." /></code></pre>
+ * use: <pre><code><mailet match="HasMimeTypeAnySubPart=text/plain,text/html" class="..." /></code></pre>
  */
-public class HasMimeType extends GenericMatcher {
+public class HasMimeTypeAnySubPart extends GenericMatcher {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HasMimeType.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HasMimeTypeAnySubPart.class);
+    private static final String MULTIPART_MIME_TYPE = "multipart/*";
 
     private Set<String> acceptedContentTypes;
 
     @Override
-    public void init() throws javax.mail.MessagingException {
+    public void init() throws MessagingException {
         acceptedContentTypes = ImmutableSet.copyOf(Splitter.on(",").trimResults().split(getCondition()));
     }
 
     @Override
-    public Collection<MailAddress> match(Mail mail) throws javax.mail.MessagingException {
-        return StreamUtils.ofNullable(mail.getMessage().getHeader(CONTENT_TYPE))
-            .flatMap(this::getMimeType)
-            .filter(acceptedContentTypes::contains)
+    public Collection<MailAddress> match(Mail mail) throws MessagingException {
+        return detectMatchingMimeTypes(mail.getMessage())
             .findAny()
             .map(any -> mail.getRecipients())
             .orElse(ImmutableList.of());
+    }
+
+
+    private boolean isMultipart(Part part) throws MailetException {
+        try {
+            return part.isMimeType(MULTIPART_MIME_TYPE);
+        } catch (MessagingException e) {
+            throw new MailetException("Could not retrieve contenttype of MimePart.", e);
+        }
+    }
+
+    private Stream<String> detectMatchingMimeTypes(Part part) throws MailetException {
+        try {
+            if (isMultipart(part)) {
+                Multipart multipart = (Multipart) part.getContent();
+
+                return Stream.concat(
+                    MultipartUtil.retrieveBodyParts(multipart)
+                        .stream()
+                        .flatMap(Throwing.function(this::detectMatchingMimeTypes).sneakyThrow()),
+                    detectMatchingMimeTypesNoRecursion(part));
+            }
+
+            return detectMatchingMimeTypesNoRecursion(part);
+        } catch (MessagingException | IOException e) {
+            throw new MailetException("Could not retrieve contenttype of MimePart.", e);
+        }
+    }
+
+    private Stream<String> detectMatchingMimeTypesNoRecursion(Part part) throws MessagingException {
+        return StreamUtils.ofNullable(part.getHeader(CONTENT_TYPE))
+            .flatMap(this::getMimeType)
+            .filter(acceptedContentTypes::contains);
     }
 
     private Stream<String> getMimeType(String rawValue) {

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/HasMimeTypeAnySubPartTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/HasMimeTypeAnySubPartTest.java
@@ -1,0 +1,181 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.matchers;
+
+import static org.apache.mailet.base.RFC2822Headers.CONTENT_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.mail.internet.MimeMessage;
+
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMatcherConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HasMimeTypeAnySubPartTest {
+    private static final String RECIPIENT = "test@james.apache.org";
+    private static final String FROM = "test@james.apache.org";
+    private static final String MIME_TYPES = "multipart/mixed";
+
+    private HasMimeTypeAnySubPart matcher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        matcher = new HasMimeTypeAnySubPart();
+    }
+
+    @Test
+    void shouldMatchWhenHasMimeTypeTopLevel() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+            .matcherName("HasMimeType")
+            .condition(MIME_TYPES)
+            .build());
+
+        MimeMessageBuilder message = MimeMessageBuilder.mimeMessageBuilder()
+            .setMultipartWithBodyParts(
+                MimeMessageBuilder.bodyPartBuilder()
+                    .data("simple text")
+                    .disposition("text"),
+                MimeMessageBuilder.bodyPartBuilder()
+                    .filename("text_file.txt")
+                    .disposition("attachment"),
+                MimeMessageBuilder.bodyPartBuilder()
+                    .type("application/zip")
+                    .filename("zip_file.zip")
+                    .disposition("attachment"))
+            .setSubject("test");
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .mimeMessage(message)
+            .sender(FROM)
+            .recipient(RECIPIENT)
+            .build();
+
+        assertThat(matcher.match(mail)).containsAll(mail.getRecipients());
+    }
+
+    @Test
+    void shouldNotMatchWhenTypeDoNotAppearInParts() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+            .matcherName("HasMimeType")
+            .condition("application/zip")
+            .build());
+
+        MimeMessageBuilder message = MimeMessageBuilder.mimeMessageBuilder()
+            .setMultipartWithBodyParts(
+                MimeMessageBuilder.bodyPartBuilder()
+                    .data("simple text")
+                    .disposition("text"),
+                MimeMessageBuilder.bodyPartBuilder()
+                    .filename("text_file.txt")
+                    .disposition("attachment"),
+                MimeMessageBuilder.bodyPartBuilder()
+                    .type("image/png")
+                    .filename("file.png")
+                    .disposition("attachment"))
+            .setSubject("test");
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .mimeMessage(message)
+            .sender(FROM)
+            .recipient(RECIPIENT)
+            .build();
+
+        assertThat(matcher.match(mail)).isEmpty();
+    }
+
+    @Test
+    void shouldMatchWhenTypeDoAppearInParts() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+            .matcherName("HasMimeType")
+            .condition("text/plain, application/zip")
+            .build());
+
+        MimeMessageBuilder message = MimeMessageBuilder.mimeMessageBuilder()
+            .setMultipartWithBodyParts(
+                MimeMessageBuilder.bodyPartBuilder()
+                    .data("simple text")
+                    .disposition("text"),
+                MimeMessageBuilder.bodyPartBuilder()
+                    .filename("text_file.txt")
+                    .disposition("attachment"),
+                MimeMessageBuilder.bodyPartBuilder()
+                    .type("application/zip")
+                    .filename("zip_file.zip")
+                    .disposition("attachment"))
+            .setSubject("test");
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .mimeMessage(message)
+            .sender(FROM)
+            .recipient(RECIPIENT)
+            .build();
+
+        assertThat(matcher.match(mail)).containsAll(mail.getRecipients());
+    }
+
+    @Test
+    void matchShouldReturnRecipientsWhenAtLeastOneMimeTypeMatch() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+            .matcherName("HasMimeType")
+            .condition("text/md, text/html")
+            .build());
+
+        MimeMessageBuilder message = MimeMessageBuilder.mimeMessageBuilder()
+            .setText("content <b>in</b> <i>HTML</i>", "text/html")
+            .setSubject("test");
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .mimeMessage(message)
+            .sender(FROM)
+            .recipient(RECIPIENT)
+            .build();
+
+        assertThat(matcher.match(mail)).containsExactlyElementsOf(mail.getRecipients());
+    }
+
+    @Test
+    void matchShouldNotFailOnEmptyCharset() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+            .matcherName("HasMimeType")
+            .condition("text/html")
+            .build());
+
+        MimeMessage message = mock(MimeMessage.class);
+        when(message.getHeader(CONTENT_TYPE)).thenReturn(new String[] {"text/html; charset="});
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .mimeMessage(message)
+            .sender(FROM)
+            .recipient(RECIPIENT)
+            .build();
+
+        assertThat(matcher.match(mail)).containsExactlyElementsOf(mail.getRecipients());
+    }
+}

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/HasMimeTypeTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/HasMimeTypeTest.java
@@ -94,6 +94,37 @@ class HasMimeTypeTest {
                     .filename("text_file.txt")
                     .disposition("attachment"),
                 MimeMessageBuilder.bodyPartBuilder()
+                    .type("image/png")
+                    .filename("file.png")
+                    .disposition("attachment"))
+            .setSubject("test");
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .mimeMessage(message)
+            .sender(FROM)
+            .recipient(RECIPIENT)
+            .build();
+
+        assertThat(matcher.match(mail)).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchSubParts() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("HasMimeType")
+                .condition("application/zip")
+                .build());
+
+        MimeMessageBuilder message = MimeMessageBuilder.mimeMessageBuilder()
+            .setMultipartWithBodyParts(
+                MimeMessageBuilder.bodyPartBuilder()
+                    .data("simple text")
+                    .disposition("text"),
+                MimeMessageBuilder.bodyPartBuilder()
+                    .filename("text_file.txt")
+                    .disposition("attachment"),
+                MimeMessageBuilder.bodyPartBuilder()
                     .type("application/zip")
                     .filename("zip_file.zip")
                     .disposition("attachment"))


### PR DESCRIPTION
It do not try to go down the mime tree which makes it impractical for some use cases like `no subpart should have the content type application/zip`.

I understand that some use case do not need to walk down the entire mime tree (eg when categorizing MDN reports only top level content type is enough) however some over generic use cases implies checking the wall mime tree.

Thus I propose to add a `HasMimeTypeAnySubPart` mailet that complement HasMimeType and does just this.