### PR TITLE
[DOCUMENTATION] Ship master branch Antora doc as 3.7.0-SNAPSHOT

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: james-project
 title: Apache James Server
-version: '3.6.0'
+version: '3.7.0-SNAPSHOT'
 prerelease: Snapshot
 nav:
 - modules/concepts/nav.adoc


### PR DESCRIPTION
Trying to introduce a build for https://github.com/apache/james-site/pull/15 I have the following error:

```
Error: Duplicate nav in 3.6.0@james-project: modules/community/nav.adoc
```