### PR TITLE
Limit the heap size of Cassandra and ES docker containers for tests

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
@@ -129,7 +129,7 @@ public class DockerCassandra {
     }
 
     private static final int CASSANDRA_PORT = 9042;
-    private static final int CASSANDRA_MEMORY = 650;
+    private static final int CASSANDRA_MEMORY = 750;
 
     private static final String CASSANDRA_CONFIG_DIR = "$CASSANDRA_CONFIG";
     private static final String JVM_OPTIONS = CASSANDRA_CONFIG_DIR + "/jvm.options";
@@ -175,7 +175,7 @@ public class DockerCassandra {
                 .withDockerfileFromBuilder(builder ->
                     additionalSteps.applyStep(builder
                         .from("cassandra:3.11.10")
-                        .env("ENV CASSANDRA_CONFIG", "/etc/cassandra")
+                        .env("CASSANDRA_CONFIG", "/etc/cassandra")
                         .run("echo \"-Xms" + CASSANDRA_MEMORY + "M\" >> " + JVM_OPTIONS)
                         .run("echo \"-Xmx" + CASSANDRA_MEMORY + "M\" >> " + JVM_OPTIONS)
                         .run("sed", "-i", "s/auto_snapshot: true/auto_snapshot: false/g", "/etc/cassandra/cassandra.yaml")

--- a/backends-common/elasticsearch-v7/src/test/java/org/apache/james/backends/es/v7/DockerElasticSearch.java
+++ b/backends-common/elasticsearch-v7/src/test/java/org/apache/james/backends/es/v7/DockerElasticSearch.java
@@ -20,6 +20,7 @@
 package org.apache.james.backends.es.v7;
 
 import static org.apache.james.backends.es.v7.DockerElasticSearch.Fixture.ES_HTTP_PORT;
+import static org.apache.james.backends.es.v7.DockerElasticSearch.Fixture.ES_MEMORY;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -124,6 +125,7 @@ public interface DockerElasticSearch {
 
     interface Fixture {
         int ES_HTTP_PORT = 9200;
+        int ES_MEMORY = 620;
     }
 
     class NoAuth implements DockerElasticSearch {
@@ -133,6 +135,7 @@ public interface DockerElasticSearch {
                 .withTmpFs(ImmutableMap.of("/usr/share/elasticsearch/data", "rw,size=200m"))
                 .withExposedPorts(ES_HTTP_PORT)
                 .withEnv("discovery.type", "single-node")
+                .withEnv("ES_JAVA_OPTS", "-Xms" + ES_MEMORY + "m -Xmx" + ES_MEMORY + "m")
                 .withAffinityToContainer()
                 .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND));
         }


### PR DESCRIPTION
Well as I'm getting tired of having the RAM of my laptop burning to the ground half of the time I run integration tests on James, I decided to take a closer look.

Cassandra by default is deployed with 4Go RAM of heap. ES is deployed with 1Go (well I observed those when running locally)

Now the interesting thing is that some work has been done a while ago to limit the size of Cassandra to 650M for the tests, but the env variable setup was wrong. Thus we were still living with a 4Go memory eater Cassandra. 

I fixed that, and while I was at it, I'm taking a shot at ES too (half, from 1Go to 512M). The rational being, if it passes with Cassandra limited like this, might be as well with ES.

I would like to have a good bunch of CI runs though first to be sure it does not bring instability to the build. If it does, I will change those values and go up gradually until we got a stable build.

If any feedback on this or proposition, don't hesitate :)