### PR TITLE
JAMES-2813 Long tasks on the MemoryTaskManager generates stactraces

### DIFF
--- a/server/task/task-memory/src/main/java/org/apache/james/task/MemoryTaskManager.java
+++ b/server/task/task-memory/src/main/java/org/apache/james/task/MemoryTaskManager.java
@@ -92,8 +92,8 @@ public class MemoryTaskManager implements TaskManager {
 
         @Override
         public Publisher<Void> updated(TaskId taskId, TaskExecutionDetails.AdditionalInformation additionalInformation) {
-            //The memory task manager doesn't use polling to update its additionalInformation.
-            throw new IllegalStateException();
+            //The memory task manager doesn't need polling to update its additionalInformation.
+            return Mono.empty();
         }
     }
 


### PR DESCRIPTION
```
13:55:34.375 [ERROR] r.c.p.Operators - Operator called default onErrorDropped
java.lang.IllegalStateException: null
	at org.apache.james.task.MemoryTaskManager$DetailsUpdater.updated(MemoryTaskManager.java:97)
	at org.apache.james.task.SerialTaskManagerWorker.lambda$pollAdditionalInformation$5(SerialTaskManagerWorker.java:105)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:385)
	at reactor.core.publisher.FluxHandle$HandleSubscriber.onNext(FluxHandle.java:118)
	at reactor.core.publisher.FluxRepeatPredicate$RepeatPredicateSubscriber.onNext(FluxRepeatPredicate.java:85)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoDelayElement$DelayElementSubscriber.lambda$onNext$0(MonoDelayElement.java:125)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Is triggered after 5 seconds of execution. To be triggered you need additional informations.

The errors are benign though (stops an asynchronous subscription that is anyway not needed for the MemoryTaskManager)...