### PR TITLE
JAMES-2683 SimpleConnectionPool should be a guice singleton

### DIFF
--- a/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
+++ b/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
@@ -83,6 +83,7 @@ public class RabbitMQModule extends AbstractModule {
         bind(CassandraMailQueueBrowser.class).in(Scopes.SINGLETON);
         bind(CassandraMailQueueMailDelete.class).in(Scopes.SINGLETON);
         bind(CassandraMailQueueMailStore.class).in(Scopes.SINGLETON);
+        bind(SimpleConnectionPool.class).in(Scopes.SINGLETON);
 
         Multibinder<CassandraModule> cassandraModuleBinder = Multibinder.newSetBinder(binder(), CassandraModule.class);
         cassandraModuleBinder.addBinding().toInstance(CassandraMailQueueViewModule.MODULE);


### PR DESCRIPTION
Not doing so results in opening too many connections...

 - Two connections were opened for the Health checks
 - One connection for ReactorRabbitMQChannelPool
 - One connection for ReceiverProvider

![Screenshot from 2021-06-04 10-34-04](https://user-images.githubusercontent.com/6928740/120742069-78213680-c520-11eb-9422-fc7150f9f573.png)

With the proposed fix we are down to one.
