### PR TITLE
JAMES-3593 Recommend upgrade of RabbitMQ to 3.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
  - Upgrading to Apache Tika 1.26 is recommended
      - 1.25 and before are subject to CVE-2021-28657 CVE-2021-27906 CVE-2021-27807
      - 1.24 is subject to CVE-2020-9489
+ - Upgrading to RabbitMQ 3.8.16 is recommended. According to [the changelog](https://www.rabbitmq.com/changelog.html) RabbitMQ prior this version is subject to several CVE:
+     - https://tanzu.vmware.com/security/cve-2020-5419
+     - https://tanzu.vmware.com/security/cve-2021-22117
+     - https://tanzu.vmware.com/security/cve-2021-22116
 
 ## [3.6.0] - 2021-03-16
 

--- a/dockerfiles/run/docker-compose.yml
+++ b/dockerfiles/run/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     image: apache/tika:1.26
 
   rabbitmq:
-    image: rabbitmq:3.8.1-management
+    image: rabbitmq:3.8.16-management
     ports:
       - "5672:5672"
       - "15672:15672"

--- a/docs/modules/servers/pages/distributed/run-docker.adoc
+++ b/docs/modules/servers/pages/distributed/run-docker.adoc
@@ -54,7 +54,7 @@ You need a running *cassandra* in docker. To achieve this run:
 
 You need a running *rabbitmq* in docker. To achieve this run:
 
-    $ docker run -d --name=rabbitmq rabbitmq:3.8.1-management
+    $ docker run -d --name=rabbitmq rabbitmq:3.8.16-management
 
 You need a running *Zenko Cloudserver* objectstorage in docker. To achieve this run:
 

--- a/docs/modules/servers/pages/distributed/run.adoc
+++ b/docs/modules/servers/pages/distributed/run.adoc
@@ -6,7 +6,7 @@
 === Requirements
 
 * Java 11 SDK
-* Docker ∕ ElasticSearch 7.10.2, RabbitMQ Management 3.3.7, S3 compatible
+* Docker ∕ ElasticSearch 7.10.2, RabbitMQ Management 3.8.16, S3 compatible
 ObjectStorage and Cassandra 3.11.10
 * Maven 3
 
@@ -31,7 +31,7 @@ mvn clean install
 
 * Cassandra 3.11.10
 * ElasticSearch 7.10.2
-* RabbitMQ-Management 3.8.1
+* RabbitMQ-Management 3.8.16
 * Swift ObjectStorage 2.15.1 or Zenko Cloudserver or AWS S3
 
 === James Launch
@@ -60,7 +60,7 @@ running. You can either install the servers or launch them via docker:
 ----
 $ docker run -d -p 9042:9042 --name=cassandra cassandra:3.11.10
 $ docker run -d -p 9200:9200 --name=elasticsearch --env 'discovery.type=single-node' docker.elastic.co/elasticsearch/elasticsearch:7.10.2
-$ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.8.1-management
+$ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.8.16-management
 $ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 zenko/cloudserver:8.2.6
 ----
 

--- a/server/container/guice/cassandra-rabbitmq-guice/README.adoc
+++ b/server/container/guice/cassandra-rabbitmq-guice/README.adoc
@@ -8,14 +8,14 @@ Third party compulsory dependencies:
 
  * Cassandra 3.11.10
  * ElasticSearch 7.10.2
- * RabbitMQ-Management 3.8.1
+ * RabbitMQ-Management 3.8.16
  * Zenko Cloudserver or AWS S3
 
 [source]
 ----
 $ docker run -d -p 9042:9042 --name=cassandra cassandra:3.11.10
 $ docker run -d -p 9200:9200 --name=elasticsearch --env 'discovery.type=single-node' docker.elastic.co/elasticsearch/elasticsearch:7.10.2
-$ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.8.1-management
+$ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.8.16-management
 $ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 zenko/cloudserver:8.2.6
 ----
 

--- a/server/testing/src/main/java/org/apache/james/util/docker/Images.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/Images.java
@@ -21,7 +21,7 @@ package org.apache.james.util.docker;
 
 public interface Images {
     String FAKE_SMTP = "weave/rest-smtp-sink:latest";
-    String RABBITMQ = "rabbitmq:3.8.1-management";
+    String RABBITMQ = "rabbitmq:3.8.16-management";
     String ELASTICSEARCH_2 = "elasticsearch:2.4.6";
     String ELASTICSEARCH_6 = "docker.elastic.co/elasticsearch/elasticsearch:6.3.2";
     String ELASTICSEARCH_7 = "docker.elastic.co/elasticsearch/elasticsearch:7.10.2";

--- a/src/site/markdown/server/install/guice-cassandra-rabbitmq-s3.md
+++ b/src/site/markdown/server/install/guice-cassandra-rabbitmq-s3.md
@@ -5,7 +5,7 @@
 ### Requirements
 
  - Java 11 SDK
- - Docker ∕ ElasticSearch 7.10.2, RabbitMQ Management 3.8.1, compatible S3 ObjectStorage and Cassandra 3.11.10
+ - Docker ∕ ElasticSearch 7.10.2, RabbitMQ Management 3.8.16, compatible S3 ObjectStorage and Cassandra 3.11.10
  - Maven 3
 
 ### Building the artifacts
@@ -27,7 +27,7 @@ mvn clean install
 
  * Cassandra 3.11.10
  * ElasticSearch 7.10.2
- * RabbitMQ-Management 3.8.1
+ * RabbitMQ-Management 3.8.16
  * Zenko Cloudserver or AWS S3 compatible API
 
 ### James Launch
@@ -49,7 +49,7 @@ You need to have a Cassandra, ElasticSearch, S3 and RabbitMQ instance running. Y
 ```bash
 $ docker run -d -p 9042:9042 --name=cassandra cassandra:3.11.10
 $ docker run -d -p 9200:9200 --name=elasticsearch --env 'discovery.type=single-node' docker.elastic.co/elasticsearch/elasticsearch:7.10.2
-$ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.8.1-management
+$ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.8.16-management
 $ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 zenko/cloudserver:8.2.6
 ```
 


### PR DESCRIPTION
According to https://www.rabbitmq.com/changelog.html RabbitMQ prior this version is subject to several CVE:

 - https://tanzu.vmware.com/security/cve-2020-5419
 - https://tanzu.vmware.com/security/cve-2021-22117
 - https://tanzu.vmware.com/security/cve-2021-22116

We currently run on `3.8.3`...