### PR TITLE
[PERFORMANCE] Reduce Cassandra chunk length for some read intensive t…

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMailboxModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMailboxModule.java
@@ -42,7 +42,8 @@ public interface CassandraMailboxModule {
         .comment("Holds the mailboxes information.")
         .options(options -> options
             .caching(SchemaBuilder.KeyCaching.ALL,
-                SchemaBuilder.rows(CassandraConstants.DEFAULT_CACHED_ROW_PER_PARTITION)))
+                SchemaBuilder.rows(CassandraConstants.DEFAULT_CACHED_ROW_PER_PARTITION))
+            .compressionOptions(SchemaBuilder.lz4().withChunkLengthInKb(8)))
         .statement(statement -> statement
             .addPartitionKey(CassandraMailboxTable.ID, timeuuid())
             .addUDTColumn(CassandraMailboxTable.MAILBOX_BASE, SchemaBuilder.frozen(CassandraMailboxTable.MAILBOX_BASE))

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMessageModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMessageModule.java
@@ -68,6 +68,7 @@ public interface CassandraMessageModule {
         .comment("Holds mailbox and flags for each message, lookup by message ID")
         .options(options -> options
             .compactionOptions(SchemaBuilder.sizedTieredStategy())
+            .compressionOptions(SchemaBuilder.lz4().withChunkLengthInKb(8))
             .caching(SchemaBuilder.KeyCaching.ALL,
                 SchemaBuilder.rows(CACHED_IMAP_UID_ROWS)))
         .statement(statement -> statement

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CassandraBlobCacheModule.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CassandraBlobCacheModule.java
@@ -40,6 +40,7 @@ public interface CassandraBlobCacheModule {
             .compactionOptions(SchemaBuilder.timeWindowCompactionStrategy()
                 .compactionWindowSize(1)
                 .compactionWindowUnit(HOURS))
+            .compressionOptions(SchemaBuilder.lz4().withChunkLengthInKb(8))
             .readRepairChance(NO_READ_REPAIR))
         .comment("Write through cache for small blobs stored in a slower blob store implementation.")
         .statement(statement -> statement

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/projections/CassandraMessageFastViewProjectionModule.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/projections/CassandraMessageFastViewProjectionModule.java
@@ -36,7 +36,8 @@ public interface CassandraMessageFastViewProjectionModule {
     CassandraModule MODULE = CassandraModule.table(TABLE_NAME)
         .comment("Storing the JMAP projections for MessageFastView, an aggregation of JMAP properties expected to be fast to fetch.")
         .options(options -> options
-            .caching(SchemaBuilder.KeyCaching.ALL, SchemaBuilder.rows(DEFAULT_CACHED_ROW_PER_PARTITION)))
+            .caching(SchemaBuilder.KeyCaching.ALL, SchemaBuilder.rows(DEFAULT_CACHED_ROW_PER_PARTITION))
+            .compressionOptions(SchemaBuilder.lz4().withChunkLengthInKb(8)))
         .statement(statement -> statement
             .addPartitionKey(MESSAGE_ID, uuid())
             .addColumn(PREVIEW, text())


### PR DESCRIPTION
…ables

 - The table should be read heavy
 - Have a small PARTITION size

Reducing the compression chunk size reduces the amount of data Cassandra have to
pull and deflate, at the expense of a lower compression and of more object creation.

The proposed values lead to a net performance improvement both for mean and p99
response time (106 ms mean time for JMAP queries to 85ms)

Testing infrastructure: 2*2 CPU James with 4GB RAM, 3 Cassandra being OVH B2-30,
 ~900 requests per second

## Before

![Screenshot from 2021-06-05 19-16-51](https://user-images.githubusercontent.com/6928740/120891393-a68f3680-c632-11eb-9091-f249edd90f5c.png)

## After

![Screenshot from 2021-06-05 19-17-45](https://user-images.githubusercontent.com/6928740/120891418-c292d800-c632-11eb-93c6-a5d4b12c227d.png)
