### PR TITLE
[PERFORMANCE] Use buffer output stream upon MessageManager::append

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -382,8 +382,9 @@ public class StoreMessageManager implements MessageManager {
                 throw new ReadOnlyException(getMailboxPath());
             }
 
-            try (InputStream contentStreamStream = msgIn.getInputStream()) {
-                BodyOffsetInputStream bIn = new BodyOffsetInputStream(contentStreamStream);
+            try (InputStream contentStream = msgIn.getInputStream();
+                    BufferedInputStream bufferedContentStream = new BufferedInputStream(contentStream);
+                    BodyOffsetInputStream bIn = new BodyOffsetInputStream(bufferedContentStream)) {
                 PropertyBuilder propertyBuilder = parseProperties(bIn);
                 int bodyStartOctet = getBodyStartOctet(bIn);
 


### PR DESCRIPTION
This lead to many calls to FileInputStream::read that
triggers to much blocking calls.

Before:

![file_input_stream_before](https://user-images.githubusercontent.com/6928740/120898012-507ebb00-c653-11eb-89e2-710b11baaced.png)

After:

![file_input_stream_after](https://user-images.githubusercontent.com/6928740/120898047-77d58800-c653-11eb-914d-01cd4155b9ba.png)
