### PR TITLE
JAMES-2989 Preview should not normalize spaces of the entire body

### DIFF
--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/model/Preview.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/model/Preview.java
@@ -101,16 +101,15 @@ public class Preview {
     }
 
     private static int estimatePreviewOffset(String body, int charCount) {
-        AtomicInteger position = new AtomicInteger(0);
-
-        body.chars()
-            .mapToObj(i -> (char) i)
-            .peek(any -> position.incrementAndGet())
-            .filter(Character::isLetterOrDigit)
-            .limit(charCount)
-            .forEach(any -> { });
-
-        return position.get();
+        int position = 0;
+        int nonWhitespace = 0;
+        while (position < body.length() && nonWhitespace < charCount) {
+            if (Character.isLetterOrDigit(body.charAt(position))) {
+                nonWhitespace++;
+            }
+            position++;
+        }
+        return position;
     }
 
     private final String value;

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/model/Preview.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/model/Preview.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.inject.Inject;
 


### PR DESCRIPTION
Doing so is inefficient as bodies can be very large...

However we should truncate the preview after normalizing
spaces. So we try to estimate (being defensive) the
offset of the preview within the original string, to
only normalize spaces on the portion of the body that
interest us.

On some IMAP benchmarks, this space normalization occupied
2% of the CPU, as much as the mime parsing...

Proof:

## Before

![preview-before](https://user-images.githubusercontent.com/6928740/120915843-359e5c00-c6d0-11eb-8edf-14ae983d8c10.png)

## After

![preview-after](https://user-images.githubusercontent.com/6928740/120915853-3afba680-c6d0-11eb-874d-df08201111f1.png)
