### PR TITLE
JAMES-2597  [FIX]  Remove the invoke LDAP testContainer when unnecessary

### DIFF
--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/DockerLdapSingleton.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/DockerLdapSingleton.java
@@ -34,7 +34,4 @@ public class DockerLdapSingleton {
         .password(ADMIN_PASSWORD)
         .build();
 
-    static {
-        ldapContainer.start();
-    }
 }

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/DockerLdapSingleton.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/DockerLdapSingleton.java
@@ -34,4 +34,7 @@ public class DockerLdapSingleton {
         .password(ADMIN_PASSWORD)
         .build();
 
+    static {
+        ldapContainer.start();
+    }
 }

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
@@ -18,16 +18,16 @@
  ****************************************************************/
 package org.apache.james.user.ldap;
 
-import java.util.Optional;
-
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import org.apache.james.util.docker.DockerContainer;
 import org.apache.james.util.docker.RateLimiters;
 import org.junit.rules.ExternalResource;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import java.util.Optional;
+import java.util.UUID;
 
 public class LdapGenericContainer extends ExternalResource {
 
@@ -68,7 +68,7 @@ public class LdapGenericContainer extends ExternalResource {
 
         private DockerContainer createContainer() {
             return DockerContainer.fromDockerfile(
-                new ImageFromDockerfile()
+                new ImageFromDockerfile("openldap_" + UUID.randomUUID())
                     .withFileFromClasspath("populate.ldif", dockerFilePrefix.orElse("") + "ldif-files/populate.ldif")
                     .withFileFromClasspath("Dockerfile", dockerFilePrefix.orElse("") + "ldif-files/Dockerfile"))
                 .withAffinityToContainer()

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
@@ -97,7 +97,9 @@ public class LdapGenericContainer extends ExternalResource {
     }
 
     public void start() {
-        container.start();
+        if (!container.isRunning()) {
+            container.start();
+        }
     }
 
     public void stop() {


### PR DESCRIPTION
When I run the test `ReadOnlyUsersLDAPRepositoryTest,` I realized two containers about OpenLDAP had been started. 
![image](https://user-images.githubusercontent.com/81145350/121111436-0f480000-c839-11eb-92dc-81c4511de1b8.png)

One in it is unnecessary.
The reason is `ldapContainer.start()` was called twice. 

The use `static called` make docker container start whenever `DockerLdapSingleton` class be called. (Some of them don't even use it)

**Solution**
Remove the start called in static -> Let start manual.