### PR TITLE
JAMES-3595 Spooler processing starts before mailetContainer initialis…

### DIFF
--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
@@ -131,16 +131,6 @@ public class CamelMailetContainerModule extends AbstractModule {
         return JamesMailSpooler.Configuration.from(mailRepositoryStore, conf);
     }
 
-    @ProvidesIntoSet
-    InitializationOperation startSpooler(JamesMailSpooler jamesMailSpooler, JamesMailSpooler.Configuration configuration) {
-        return InitilizationOperationBuilder
-            .forClass(JamesMailSpooler.class)
-            .init(() -> {
-                jamesMailSpooler.configure(configuration);
-                jamesMailSpooler.init();
-            });
-    }
-
     private HierarchicalConfiguration<ImmutableNode> getJamesSpoolerConfiguration(ConfigurationProvider configurationProvider) {
         try {
             return configurationProvider.getConfiguration("mailetcontainer")
@@ -176,18 +166,23 @@ public class CamelMailetContainerModule extends AbstractModule {
         private final DefaultProcessorsConfigurationSupplier defaultProcessorsConfigurationSupplier;
         private final Set<ProcessorsCheck> processorsCheckSet;
         private final DefaultCamelContext camelContext;
+        private final JamesMailSpooler jamesMailSpooler;
+        private final JamesMailSpooler.Configuration spoolerConfiguration;
+
 
         @Inject
         public MailetModuleInitializationOperation(ConfigurationProvider configurationProvider,
                                                    CamelCompositeProcessor camelCompositeProcessor,
                                                    Set<ProcessorsCheck> processorsCheckSet,
                                                    DefaultProcessorsConfigurationSupplier defaultProcessorsConfigurationSupplier,
-                                                   DefaultCamelContext camelContext) {
+                                                   DefaultCamelContext camelContext, JamesMailSpooler jamesMailSpooler, JamesMailSpooler.Configuration spoolerConfiguration) {
             this.configurationProvider = configurationProvider;
             this.camelCompositeProcessor = camelCompositeProcessor;
             this.processorsCheckSet = processorsCheckSet;
             this.defaultProcessorsConfigurationSupplier = defaultProcessorsConfigurationSupplier;
             this.camelContext = camelContext;
+            this.jamesMailSpooler = jamesMailSpooler;
+            this.spoolerConfiguration = spoolerConfiguration;
         }
 
         @Override
@@ -200,6 +195,9 @@ public class CamelMailetContainerModule extends AbstractModule {
             camelCompositeProcessor.setCamelContext(camelContext);
             camelCompositeProcessor.configure(getProcessorConfiguration());
             camelCompositeProcessor.init();
+
+            jamesMailSpooler.configure(spoolerConfiguration);
+            jamesMailSpooler.init();
         }
 
         @VisibleForTesting

--- a/server/container/guice/mailet/src/test/java/org/apache/james/modules/server/CamelMailetContainerModuleTest.java
+++ b/server/container/guice/mailet/src/test/java/org/apache/james/modules/server/CamelMailetContainerModuleTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.XMLConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationRuntimeException;
 import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.mailetcontainer.impl.JamesMailSpooler;
 import org.apache.james.mailetcontainer.impl.camel.CamelCompositeProcessor;
 import org.apache.james.modules.server.CamelMailetContainerModule.MailetModuleInitializationOperation;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
@@ -103,7 +104,9 @@ class CamelMailetContainerModuleTest {
             mock(CamelCompositeProcessor.class),
             NO_TRANSPORT_CHECKS,
             () -> defaultConfiguration,
-            mock(DefaultCamelContext.class));
+            mock(DefaultCamelContext.class),
+            mock(JamesMailSpooler.class),
+            mock(JamesMailSpooler.Configuration.class));
 
         assertThat(testee.getProcessorConfiguration())
             .isEqualTo(defaultConfiguration);
@@ -119,7 +122,9 @@ class CamelMailetContainerModuleTest {
             mock(CamelCompositeProcessor.class),
             NO_TRANSPORT_CHECKS,
             mock(CamelMailetContainerModule.DefaultProcessorsConfigurationSupplier.class),
-            mock(DefaultCamelContext.class));
+            mock(DefaultCamelContext.class),
+            mock(JamesMailSpooler.class),
+            mock(JamesMailSpooler.Configuration.class));
 
         assertThatThrownBy(testee::getProcessorConfiguration)
             .isInstanceOf(ConfigurationRuntimeException.class);
@@ -141,7 +146,9 @@ class CamelMailetContainerModuleTest {
             mock(CamelCompositeProcessor.class),
             NO_TRANSPORT_CHECKS,
             mock(CamelMailetContainerModule.DefaultProcessorsConfigurationSupplier.class),
-            mock(DefaultCamelContext.class));
+            mock(DefaultCamelContext.class),
+            mock(JamesMailSpooler.class),
+            mock(JamesMailSpooler.Configuration.class));
 
         HierarchicalConfiguration<ImmutableNode> mailetContextConfiguration = testee.getProcessorConfiguration();
         assertThat(mailetContextConfiguration.getString("key"))


### PR DESCRIPTION
…ation

Proof of evidence:

`MailProcessor 'transport' could not be found. Processing 7d01c8f0-c82b-11eb-aa8a-9fabe7587cf3 to 'error' instead`

This could only happen if a mail is processed before the mailet container is initialized....