### PR TITLE
JAMES-3599 Group execution: execute listeners together

### DIFF
--- a/event-bus/api/src/test/java/org/apache/james/events/GroupContract.java
+++ b/event-bus/api/src/test/java/org/apache/james/events/GroupContract.java
@@ -174,6 +174,7 @@ public interface GroupContract {
             EventListener listener = EventBusTestFixture.newListener();
 
             eventBus().dispatch(EVENT, NO_KEYS).block();
+            Thread.sleep(100);
 
             eventBus().register(listener, GROUP_A);
 

--- a/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
@@ -19,16 +19,51 @@
 
 package org.apache.james.events;
 
+import static org.apache.james.backends.rabbitmq.Constants.AUTO_DELETE;
+import static org.apache.james.backends.rabbitmq.Constants.DURABLE;
+import static org.apache.james.backends.rabbitmq.Constants.EMPTY_ROUTING_KEY;
+import static org.apache.james.backends.rabbitmq.Constants.EXCLUSIVE;
+import static org.apache.james.backends.rabbitmq.Constants.REQUEUE;
+import static org.apache.james.backends.rabbitmq.Constants.deadLetterQueue;
+import static org.apache.james.events.GroupRegistration.DEFAULT_RETRY_COUNT;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
 import org.apache.james.backends.rabbitmq.ReceiverProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.github.steveash.guavate.Guavate;
+import com.google.common.base.Preconditions;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.rabbitmq.AcknowledgableDelivery;
+import reactor.rabbitmq.BindingSpecification;
+import reactor.rabbitmq.ConsumeOptions;
+import reactor.rabbitmq.QueueSpecification;
+import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.Sender;
+import reactor.util.retry.Retry;
 
 class GroupRegistrationHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GroupRegistrationHandler.class);
+
+    private final GroupRegistration.WorkQueueName queueName;
+
+    public static class GroupRegistrationHandlerGroup extends Group {
+
+    }
+
+    static final Group GROUP = new GroupRegistrationHandlerGroup();
+
     private final NamingStrategy namingStrategy;
     private final Map<Group, GroupRegistration> groupRegistrations;
     private final EventSerializer eventSerializer;
@@ -38,10 +73,13 @@ class GroupRegistrationHandler {
     private final RetryBackoffConfiguration retryBackoff;
     private final EventDeadLetters eventDeadLetters;
     private final ListenerExecutor listenerExecutor;
+    private final EventBusId eventBusId;
+    private Optional<Receiver> receiver;
+    private Optional<Disposable> consumer;
 
     GroupRegistrationHandler(NamingStrategy namingStrategy, EventSerializer eventSerializer, ReactorRabbitMQChannelPool channelPool, Sender sender, ReceiverProvider receiverProvider,
                              RetryBackoffConfiguration retryBackoff,
-                             EventDeadLetters eventDeadLetters, ListenerExecutor listenerExecutor) {
+                             EventDeadLetters eventDeadLetters, ListenerExecutor listenerExecutor, EventBusId eventBusId) {
         this.namingStrategy = namingStrategy;
         this.eventSerializer = eventSerializer;
         this.channelPool = channelPool;
@@ -50,7 +88,11 @@ class GroupRegistrationHandler {
         this.retryBackoff = retryBackoff;
         this.eventDeadLetters = eventDeadLetters;
         this.listenerExecutor = listenerExecutor;
+        this.eventBusId = eventBusId;
         this.groupRegistrations = new ConcurrentHashMap<>();
+        this.queueName = namingStrategy.workQueue(GROUP);
+        this.consumer = Optional.empty();
+        this.receiver = Optional.empty();
     }
 
     GroupRegistration retrieveGroupRegistration(Group group) {
@@ -58,11 +100,68 @@ class GroupRegistrationHandler {
             .orElseThrow(() -> new GroupRegistrationNotFound(group));
     }
 
+    public void start() {
+        channelPool.createWorkQueue(
+            QueueSpecification.queue(queueName.asString())
+                .durable(DURABLE)
+                .exclusive(!EXCLUSIVE)
+                .autoDelete(!AUTO_DELETE)
+                .arguments(deadLetterQueue(namingStrategy.deadLetterExchange())),
+            BindingSpecification.binding()
+                .exchange(namingStrategy.exchange())
+                .queue(queueName.asString())
+                .routingKey(EMPTY_ROUTING_KEY))
+            .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.elastic()))
+            .block();
+
+        this.receiver = Optional.of(receiverProvider.createReceiver());
+        this.consumer = Optional.of(consumeWorkQueue());
+    }
+
+    private Disposable consumeWorkQueue() {
+        Preconditions.checkState(receiver.isPresent());
+        return receiver.get().consumeManualAck(queueName.asString(), new ConsumeOptions().qos(EventBus.EXECUTION_RATE))
+            .publishOn(Schedulers.parallel())
+            .filter(delivery -> Objects.nonNull(delivery.getBody()))
+            .flatMap(this::deliver, EventBus.EXECUTION_RATE)
+            .subscribeOn(Schedulers.elastic())
+            .subscribe();
+    }
+
+    private Mono<Void> deliver(AcknowledgableDelivery acknowledgableDelivery) {
+        byte[] eventAsBytes = acknowledgableDelivery.getBody();
+
+        return deserializeEvent(eventAsBytes)
+            .flatMapIterable(aa -> groupRegistrations.values()
+                .stream()
+                .map(group -> Pair.of(group, aa))
+                .collect(Guavate.toImmutableList()))
+            .flatMap(event -> event.getLeft().runListenerReliably(DEFAULT_RETRY_COUNT, event.getRight()))
+                .then(Mono.<Void>fromRunnable(acknowledgableDelivery::ack).subscribeOn(Schedulers.elastic()))
+            .then()
+            .onErrorResume(e -> {
+                LOGGER.error("Unable to process delivery for group {}", GROUP, e);
+                return Mono.fromRunnable(() -> acknowledgableDelivery.nack(!REQUEUE))
+                    .subscribeOn(Schedulers.elastic())
+                    .then();
+            });
+    }
+
+    private Mono<Event> deserializeEvent(byte[] eventAsBytes) {
+        return Mono.fromCallable(() -> eventSerializer.asEvent(new String(eventAsBytes, StandardCharsets.UTF_8)))
+            .subscribeOn(Schedulers.parallel());
+    }
+
     void stop() {
         groupRegistrations.values().forEach(GroupRegistration::unregister);
+        consumer.ifPresent(Disposable::dispose);
+        receiver.ifPresent(Receiver::close);
     }
 
     Registration register(EventListener.ReactiveEventListener listener, Group group) {
+        if (groupRegistrations.isEmpty()) {
+            start();
+        }
         return groupRegistrations
             .compute(group, (groupToRegister, oldGroupRegistration) -> {
                 if (oldGroupRegistration != null) {

--- a/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
@@ -83,7 +83,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
 
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
             keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff);
-            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor);
+            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId);
             eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters);
 
             eventDispatcher.start();
@@ -98,7 +98,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
 
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
             keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff);
-            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor);
+            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId);
             eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters);
 
             keyRegistrationHandler.declareQueue();

--- a/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusTest.java
+++ b/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusTest.java
@@ -138,7 +138,9 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
         eventBus2.stop();
         eventBus3.stop();
         eventBusWithKeyHandlerNotStarted.stop();
-        ALL_GROUPS.stream()
+        Stream.concat(
+            ALL_GROUPS.stream(),
+            Stream.of(GroupRegistrationHandler.GROUP))
             .map(TEST_NAMING_STRATEGY::workQueue)
             .forEach(queueName -> rabbitMQExtension.getSender().delete(QueueSpecification.queue(queueName.asString())).block());
         rabbitMQExtension.getSender()

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -17,7 +17,27 @@ Changes to apply between 3.5.x and 3.6.x will be reported here.
 Change list:
 
  - [Drop Cassandra schema version prior version 8](#drop-cassandra-schema-version-prior-version-8)
- - [Adopt UnboundID as a LDAP library](#drop-cassandra-schema-version-prior-version-8)
+ - [Adopt UnboundID as a LDAP library](#adopt-unboundid-as-a-ldap-library)
+ - [Review the architecture of the RabbitMQ event bus](#review-the-architecture-of-the-rabbitmq-event-bus)
+ 
+### Review the architecture of the RabbitMQ event bus
+
+Date 14/06/2021
+
+JIRA: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3599
+
+Impacted products: Distributed James server
+
+We now group listeners execution whenever possible. This minimizes:
+                                                    
+ - The count of events to deserialize (one for all groups)
+ - The count of ACKs to perform
+
+Note that retries are still performed on a per-group basis.
+
+One need, after a rolling upgrade to unbind group queues from the primary exchange. Group queues can be identified by
+their `mailboxEvent-workQueue-` prefix, and the primary exchange is named `mailboxEvent-exchange`. These operations can
+easily be performed via the rabbitMQ management web interface.
  
 ### Adopt UnboundID as a LDAP library
 


### PR DESCRIPTION
## Why

Every groups deserializes the event, which uses CPU and puts pressure on RabbitMQ.

![rabbitmq-management](https://user-images.githubusercontent.com/6928740/121860903-83940f00-cd23-11eb-997a-b734400af2b9.png)

We can likely mutualize group executions to minimize deserialization, acks, and reduce pressure on RabbitMQ.

Note that we should try to preserve per-groups retries.

## How

![design_before](https://user-images.githubusercontent.com/6928740/121861039-a9211880-cd23-11eb-9790-ed71fa2cf63f.png)

![design_after](https://user-images.githubusercontent.com/6928740/121861051-ac1c0900-cd23-11eb-819d-14e333bda714.png)

## Results

Single queue with consumer rate equals publish rate

![Screenshot from 2021-06-14 19-51-30](https://user-images.githubusercontent.com/6928740/121895125-15167780-cd4a-11eb-973c-ca3376109f9f.png)

And perf definitl improved!

![Screenshot from 2021-06-14 20-22-28](https://user-images.githubusercontent.com/6928740/121899188-60cb2000-cd4e-11eb-998c-c574747f2051.png)
