### PR TITLE
Upgrade pdfbox to 2.0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2533,7 +2533,7 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
-                <version>2.0.22</version>
+                <version>2.0.24</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>


### PR DESCRIPTION
2 CVEs for versions anterior to 2.0.24 regarding pdfbox dependency have been reported:
- https://nvd.nist.gov/vuln/detail/CVE-2021-31812
- https://nvd.nist.gov/vuln/detail/CVE-2021-31811

This upgrade should solve them.