### PR TITLE
JAMES-3604 Use publish confirm

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -22,8 +22,12 @@ package org.apache.james.backends.rabbitmq;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 import javax.annotation.PreDestroy;
@@ -39,8 +43,22 @@ import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.CancelCallback;
 import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Command;
+import com.rabbitmq.client.ConfirmCallback;
+import com.rabbitmq.client.ConfirmListener;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.ConsumerShutdownSignalCallback;
+import com.rabbitmq.client.DeliverCallback;
+import com.rabbitmq.client.GetResponse;
+import com.rabbitmq.client.Method;
+import com.rabbitmq.client.ReturnCallback;
+import com.rabbitmq.client.ReturnListener;
+import com.rabbitmq.client.ShutdownListener;
 import com.rabbitmq.client.ShutdownSignalException;
 
 import reactor.core.publisher.Flux;
@@ -59,6 +77,524 @@ import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
 public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
+
+    private static class SelectOnceChannel implements Channel {
+        private final Channel delegate;
+        private final AtomicBoolean confirmSelected = new AtomicBoolean(false);
+
+        private SelectOnceChannel(Channel delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public AMQP.Confirm.SelectOk confirmSelect() throws IOException {
+            if (!confirmSelected.getAndSet(true)) {
+                return delegate.confirmSelect();
+            }
+            return new AMQP.Confirm.SelectOk.Builder().build();
+        }
+
+        @Override
+        public int getChannelNumber() {
+            return delegate.getChannelNumber();
+        }
+
+        @Override
+        public Connection getConnection() {
+            return delegate.getConnection();
+        }
+
+        @Override
+        public void close() throws IOException, TimeoutException {
+            delegate.close();
+        }
+
+        @Override
+        public void close(int closeCode, String closeMessage) throws IOException, TimeoutException {
+            delegate.close(closeCode, closeMessage);
+        }
+
+        @Override
+        public void abort() throws IOException {
+            delegate.abort();
+        }
+
+        @Override
+        public void abort(int closeCode, String closeMessage) throws IOException {
+            delegate.abort(closeCode, closeMessage);
+        }
+
+        @Override
+        public void addReturnListener(ReturnListener listener) {
+            delegate.removeReturnListener(listener);
+        }
+
+        @Override
+        public ReturnListener addReturnListener(ReturnCallback returnCallback) {
+            return delegate.addReturnListener(returnCallback);
+        }
+
+        @Override
+        public boolean removeReturnListener(ReturnListener listener) {
+            return delegate.removeReturnListener(listener);
+        }
+
+        @Override
+        public void clearReturnListeners() {
+            delegate.clearReturnListeners();
+        }
+
+        @Override
+        public void addConfirmListener(ConfirmListener listener) {
+            delegate.addConfirmListener(listener);
+        }
+
+        @Override
+        public ConfirmListener addConfirmListener(ConfirmCallback ackCallback, ConfirmCallback nackCallback) {
+            return delegate.addConfirmListener(ackCallback, nackCallback);
+        }
+
+        @Override
+        public boolean removeConfirmListener(ConfirmListener listener) {
+            return delegate.removeConfirmListener(listener);
+        }
+
+        @Override
+        public void clearConfirmListeners() {
+            delegate.clearConfirmListeners();
+        }
+
+        @Override
+        public Consumer getDefaultConsumer() {
+            return delegate.getDefaultConsumer();
+        }
+
+        @Override
+        public void setDefaultConsumer(Consumer consumer) {
+            delegate.setDefaultConsumer(consumer);
+        }
+
+        @Override
+        public void basicQos(int prefetchSize, int prefetchCount, boolean global) throws IOException {
+            delegate.basicQos(prefetchSize, prefetchCount, global);
+        }
+
+        @Override
+        public void basicQos(int prefetchCount, boolean global) throws IOException {
+            delegate.basicQos(prefetchCount, global);
+        }
+
+        @Override
+        public void basicQos(int prefetchCount) throws IOException {
+            delegate.basicQos(prefetchCount);
+        }
+
+        @Override
+        public void basicPublish(String exchange, String routingKey, AMQP.BasicProperties props, byte[] body) throws IOException {
+            delegate.basicPublish(exchange, routingKey, props, body);
+        }
+
+        @Override
+        public void basicPublish(String exchange, String routingKey, boolean mandatory, AMQP.BasicProperties props, byte[] body) throws IOException {
+            delegate.basicPublish(exchange, routingKey, mandatory, props, body);
+
+        }
+
+        @Override
+        public void basicPublish(String exchange, String routingKey, boolean mandatory, boolean immediate, AMQP.BasicProperties props, byte[] body) throws IOException {
+            delegate.basicPublish(exchange, routingKey, mandatory, immediate, props, body);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type) throws IOException {
+            return delegate.exchangeDeclare(exchange, type);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type) throws IOException {
+            return delegate.exchangeDeclare(exchange, type);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type, boolean durable) throws IOException {
+            return delegate.exchangeDeclare(exchange, type, durable);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type, boolean durable) throws IOException {
+            return delegate.exchangeDeclare(exchange, type, durable);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, Map<String, Object> arguments) throws IOException {
+            return delegate.exchangeDeclare(exchange, type, durable, autoDelete, arguments);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type, boolean durable, boolean autoDelete, Map<String, Object> arguments) throws IOException {
+            return delegate.exchangeDeclare(exchange, type, durable, autoDelete, arguments);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, boolean internal, Map<String, Object> arguments) throws IOException {
+            return delegate.exchangeDeclare(exchange, type, durable, autoDelete, internal, arguments);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type, boolean durable, boolean autoDelete, boolean internal, Map<String, Object> arguments) throws IOException {
+            return delegate.exchangeDeclare(exchange, type, durable, autoDelete, internal, arguments);
+        }
+
+        @Override
+        public void exchangeDeclareNoWait(String exchange, String type, boolean durable, boolean autoDelete, boolean internal, Map<String, Object> arguments) throws IOException {
+            delegate.exchangeDeclareNoWait(exchange, type, durable, autoDelete, internal, arguments);
+        }
+
+        @Override
+        public void exchangeDeclareNoWait(String exchange, BuiltinExchangeType type, boolean durable, boolean autoDelete, boolean internal, Map<String, Object> arguments) throws IOException {
+            delegate.exchangeDeclare(exchange, type, durable, autoDelete, internal, arguments);
+        }
+
+        @Override
+        public AMQP.Exchange.DeclareOk exchangeDeclarePassive(String name) throws IOException {
+            return delegate.exchangeDeclarePassive(name);
+        }
+
+        @Override
+        public AMQP.Exchange.DeleteOk exchangeDelete(String exchange, boolean ifUnused) throws IOException {
+            return delegate.exchangeDelete(exchange, ifUnused);
+        }
+
+        @Override
+        public void exchangeDeleteNoWait(String exchange, boolean ifUnused) throws IOException {
+            delegate.exchangeDeleteNoWait(exchange, ifUnused);
+        }
+
+        @Override
+        public AMQP.Exchange.DeleteOk exchangeDelete(String exchange) throws IOException {
+            return  delegate.exchangeDelete(exchange);
+        }
+
+        @Override
+        public AMQP.Exchange.BindOk exchangeBind(String destination, String source, String routingKey) throws IOException {
+            return delegate.exchangeBind(destination, source, routingKey);
+        }
+
+        @Override
+        public AMQP.Exchange.BindOk exchangeBind(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
+            return delegate.exchangeBind(destination, source, routingKey, arguments);
+        }
+
+        @Override
+        public void exchangeBindNoWait(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
+            delegate.exchangeBindNoWait(destination, source, routingKey, arguments);
+        }
+
+        @Override
+        public AMQP.Exchange.UnbindOk exchangeUnbind(String destination, String source, String routingKey) throws IOException {
+            return delegate.exchangeUnbind(destination, source, routingKey);
+        }
+
+        @Override
+        public AMQP.Exchange.UnbindOk exchangeUnbind(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
+            return delegate.exchangeUnbind(destination, source, routingKey, arguments);
+        }
+
+        @Override
+        public void exchangeUnbindNoWait(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
+            delegate.exchangeBindNoWait(destination, source, routingKey, arguments);
+        }
+
+        @Override
+        public AMQP.Queue.DeclareOk queueDeclare() throws IOException {
+            return delegate.queueDeclare();
+        }
+
+        @Override
+        public AMQP.Queue.DeclareOk queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments) throws IOException {
+            return delegate.queueDeclare(queue, durable, exclusive, autoDelete, arguments);
+        }
+
+        @Override
+        public void queueDeclareNoWait(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments) throws IOException {
+            delegate.queueDeclareNoWait(queue, durable, exclusive, autoDelete, arguments);
+        }
+
+        @Override
+        public AMQP.Queue.DeclareOk queueDeclarePassive(String queue) throws IOException {
+            return delegate.queueDeclarePassive(queue);
+        }
+
+        @Override
+        public AMQP.Queue.DeleteOk queueDelete(String queue) throws IOException {
+            return delegate.queueDelete(queue);
+        }
+
+        @Override
+        public AMQP.Queue.DeleteOk queueDelete(String queue, boolean ifUnused, boolean ifEmpty) throws IOException {
+            return delegate.queueDelete(queue, ifUnused, ifEmpty);
+        }
+
+        @Override
+        public void queueDeleteNoWait(String queue, boolean ifUnused, boolean ifEmpty) throws IOException {
+            delegate.queueDeleteNoWait(queue, ifUnused, ifEmpty);
+        }
+
+        @Override
+        public AMQP.Queue.BindOk queueBind(String queue, String exchange, String routingKey) throws IOException {
+            return delegate.queueBind(queue, exchange, routingKey);
+        }
+
+        @Override
+        public AMQP.Queue.BindOk queueBind(String queue, String exchange, String routingKey, Map<String, Object> arguments) throws IOException {
+            return delegate.queueBind(queue, exchange, routingKey, arguments);
+        }
+
+        @Override
+        public void queueBindNoWait(String queue, String exchange, String routingKey, Map<String, Object> arguments) throws IOException {
+            delegate.queueBindNoWait(queue, exchange, routingKey, arguments);
+        }
+
+        @Override
+        public AMQP.Queue.UnbindOk queueUnbind(String queue, String exchange, String routingKey) throws IOException {
+            return delegate.queueUnbind(queue, exchange, routingKey);
+        }
+
+        @Override
+        public AMQP.Queue.UnbindOk queueUnbind(String queue, String exchange, String routingKey, Map<String, Object> arguments) throws IOException {
+            return delegate.queueUnbind(queue, exchange, routingKey, arguments);
+        }
+
+        @Override
+        public AMQP.Queue.PurgeOk queuePurge(String queue) throws IOException {
+            return delegate.queuePurge(queue);
+        }
+
+        @Override
+        public GetResponse basicGet(String queue, boolean autoAck) throws IOException {
+            return delegate.basicGet(queue, autoAck);
+        }
+
+        @Override
+        public void basicAck(long deliveryTag, boolean multiple) throws IOException {
+            delegate.basicAck(deliveryTag, multiple);
+        }
+
+        @Override
+        public void basicNack(long deliveryTag, boolean multiple, boolean requeue) throws IOException {
+            delegate.basicNack(deliveryTag, multiple, requeue);
+        }
+
+        @Override
+        public void basicReject(long deliveryTag, boolean requeue) throws IOException {
+            delegate.basicReject(deliveryTag, requeue);
+        }
+
+        @Override
+        public String basicConsume(String queue, Consumer callback) throws IOException {
+            return delegate.basicConsume(queue, callback);
+        }
+
+        @Override
+        public String basicConsume(String queue, DeliverCallback deliverCallback, CancelCallback cancelCallback) throws IOException {
+            return delegate.basicConsume(queue, deliverCallback, cancelCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, DeliverCallback deliverCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, deliverCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, DeliverCallback deliverCallback, CancelCallback cancelCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, deliverCallback, cancelCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, Consumer callback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, callback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, DeliverCallback deliverCallback, CancelCallback cancelCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, deliverCallback, cancelCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, DeliverCallback deliverCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, deliverCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, DeliverCallback deliverCallback, CancelCallback cancelCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, deliverCallback, cancelCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, Map<String, Object> arguments, Consumer callback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, arguments, callback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, Map<String, Object> arguments, DeliverCallback deliverCallback, CancelCallback cancelCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, arguments, deliverCallback, cancelCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, Map<String, Object> arguments, DeliverCallback deliverCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, arguments, deliverCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, Map<String, Object> arguments, DeliverCallback deliverCallback, CancelCallback cancelCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, arguments, deliverCallback, cancelCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, Consumer callback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, callback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, DeliverCallback deliverCallback, CancelCallback cancelCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, deliverCallback, cancelCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, DeliverCallback deliverCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, deliverCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, DeliverCallback deliverCallback, CancelCallback cancelCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, deliverCallback, cancelCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, Consumer callback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, callback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, DeliverCallback deliverCallback, CancelCallback cancelCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, deliverCallback, cancelCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, DeliverCallback deliverCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, deliverCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public String basicConsume(String queue, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, DeliverCallback deliverCallback, CancelCallback cancelCallback, ConsumerShutdownSignalCallback shutdownSignalCallback) throws IOException {
+            return delegate.basicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, deliverCallback, cancelCallback, shutdownSignalCallback);
+        }
+
+        @Override
+        public void basicCancel(String consumerTag) throws IOException {
+            delegate.basicCancel(consumerTag);
+        }
+
+        @Override
+        public AMQP.Basic.RecoverOk basicRecover() throws IOException {
+            return delegate.basicRecover();
+        }
+
+        @Override
+        public AMQP.Basic.RecoverOk basicRecover(boolean requeue) throws IOException {
+            return delegate.basicRecover(requeue);
+        }
+
+        @Override
+        public AMQP.Tx.SelectOk txSelect() throws IOException {
+            return delegate.txSelect();
+        }
+
+        @Override
+        public AMQP.Tx.CommitOk txCommit() throws IOException {
+            return delegate.txCommit();
+        }
+
+        @Override
+        public AMQP.Tx.RollbackOk txRollback() throws IOException {
+            return delegate.txRollback();
+        }
+
+        @Override
+        public long getNextPublishSeqNo() {
+            return delegate.getNextPublishSeqNo();
+        }
+
+        @Override
+        public boolean waitForConfirms() throws InterruptedException {
+            return delegate.waitForConfirms();
+        }
+
+        @Override
+        public boolean waitForConfirms(long timeout) throws InterruptedException, TimeoutException {
+            return delegate.waitForConfirms(timeout);
+        }
+
+        @Override
+        public void waitForConfirmsOrDie() throws IOException, InterruptedException {
+            delegate.waitForConfirmsOrDie();
+        }
+
+        @Override
+        public void waitForConfirmsOrDie(long timeout) throws IOException, InterruptedException, TimeoutException {
+            delegate.waitForConfirms(timeout);
+        }
+
+        @Override
+        public void asyncRpc(Method method) throws IOException {
+            delegate.asyncRpc(method);
+        }
+
+        @Override
+        public Command rpc(Method method) throws IOException {
+            return delegate.rpc(method);
+        }
+
+        @Override
+        public long messageCount(String queue) throws IOException {
+            return delegate.messageCount(queue);
+        }
+
+        @Override
+        public long consumerCount(String queue) throws IOException {
+            return delegate.consumerCount(queue);
+        }
+
+        @Override
+        public CompletableFuture<Command> asyncCompletableRpc(Method method) throws IOException {
+            return delegate.asyncCompletableRpc(method);
+        }
+
+        @Override
+        public void addShutdownListener(ShutdownListener listener) {
+            delegate.addShutdownListener(listener);
+        }
+
+        @Override
+        public void removeShutdownListener(ShutdownListener listener) {
+            delegate.removeShutdownListener(listener);
+        }
+
+        @Override
+        public ShutdownSignalException getCloseReason() {
+            return delegate.getCloseReason();
+        }
+
+        @Override
+        public void notifyListeners() {
+            delegate.notifyListeners();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return delegate.isOpen();
+        }
+    }
 
     private static class ChannelClosedException extends IOException {
         ChannelClosedException(String message) {
@@ -85,10 +621,11 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
                 .block();
         }
 
-        private Mono<Channel> openChannel(Connection connection) {
+        private Mono<? extends Channel> openChannel(Connection connection) {
             return Mono.fromCallable(connection::openChannel)
                 .map(maybeChannel ->
                     maybeChannel.orElseThrow(() -> new RuntimeException("RabbitMQ reached to maximum opened channels, cannot get more channels")))
+                .map(SelectOnceChannel::new)
                 .retryWhen(configuration.backoffSpec().scheduler(Schedulers.elastic()))
                 .doOnError(throwable -> LOGGER.error("error when creating new channel", throwable));
         }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -384,9 +384,13 @@ class RabbitMQMailQueueTest {
             rabbitMQExtension.getRabbitMQ().pause();
             Thread.sleep(2000);
 
-            getMailQueue().enQueue(defaultMail()
-                .name(name2)
-                .build());
+            try {
+                getMailQueue().enQueue(defaultMail()
+                    .name(name2)
+                    .build());
+            } catch (Exception e) {
+                // Expected
+            }
 
             rabbitMQExtension.getRabbitMQ().unpause();
             Thread.sleep(100);
@@ -395,11 +399,11 @@ class RabbitMQMailQueueTest {
                 .name(name3)
                 .build());
 
-            List<MailQueue.MailQueueItem> items = dequeueFlux.take(3).collectList().block(Duration.ofSeconds(10));
+            List<MailQueue.MailQueueItem> items = dequeueFlux.take(2).collectList().block(Duration.ofSeconds(10));
 
             assertThat(items)
                 .extracting(item -> item.getMail().getName())
-                .containsExactly(name1, name2, name3);
+                .containsExactly(name1, name3);
         }
 
         @Test

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -390,20 +390,20 @@ class RabbitMQMailQueueTest {
                     .build());
             } catch (Exception e) {
                 // Expected
+            } finally {
+                rabbitMQExtension.getRabbitMQ().unpause();
+                Thread.sleep(100);
             }
-
-            rabbitMQExtension.getRabbitMQ().unpause();
-            Thread.sleep(100);
 
             getMailQueue().enQueue(defaultMail()
                 .name(name3)
                 .build());
 
-            List<MailQueue.MailQueueItem> items = dequeueFlux.take(2).collectList().block(Duration.ofSeconds(10));
+            List<MailQueue.MailQueueItem> items = dequeueFlux.take(3).collectList().block(Duration.ofSeconds(10));
 
             assertThat(items)
                 .extracting(item -> item.getMail().getName())
-                .containsExactly(name1, name3);
+                .contains(name1, name3);
         }
 
         @Test


### PR DESCRIPTION
CPU utilisation related to RabbitMQ as expected increased (1.30 % -> 2.6%) however latencies went from 67ms to 90+ ms at ~800 req/s.

RPC related to `Channel::confirmSelect` done repeatedly are rather expensive, and I notice some active creation of channels.

As such, I feel unconfident with the publish / confirm part of the work and would split it to another pull request...

https://www.rabbitmq.com/tutorials/tutorial-seven-java.html

```
Confirms should be enabled just once, not for every message published.
```

Not the case given my implementation.

For now I see several solutions:

  - rely on a sink to pass all messages as part of a single Flux. Thus init is done once. The done side is that the result is asynchronous to the caller (error handling would not be propagated)
  - enable publish confirms globally in ReactorRabbitMQChannelPool and re-implement send operation to skip confirmSelect activation...
  - Wrap channel in a super-class that activated `confirmSelect` only once (AtomicBoolean?)
  - ...
  
See https://github.com/apache/james-project/pull/508#issuecomment-869131638