### PR TITLE
JAMES-3516 Allow setting threadId through MessageFactory::createMessage params

### DIFF
--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
@@ -124,6 +125,7 @@ public interface MailboxMessageFixture {
 
     SimpleMailboxMessage MESSAGE_1 = SimpleMailboxMessage.builder()
         .messageId(MESSAGE_ID_1)
+        .threadId(ThreadId.fromBaseMessageId(MESSAGE_ID_1))
         .uid(MESSAGE_UID_1)
         .content(CONTENT_STREAM_1)
         .size(SIZE_1)
@@ -136,6 +138,7 @@ public interface MailboxMessageFixture {
 
     SimpleMailboxMessage MESSAGE_1_OTHER_USER = SimpleMailboxMessage.builder()
         .messageId(MESSAGE_ID_OTHER_USER_1)
+        .threadId(ThreadId.fromBaseMessageId(MESSAGE_ID_OTHER_USER_1))
         .uid(MESSAGE_UID_OTHER_USER_1)
         .content(CONTENT_STREAM_1)
         .size(SIZE_1)
@@ -148,6 +151,7 @@ public interface MailboxMessageFixture {
 
     SimpleMailboxMessage MESSAGE_2 = SimpleMailboxMessage.builder()
         .messageId(MESSAGE_ID_2)
+        .threadId(ThreadId.fromBaseMessageId(MESSAGE_ID_2))
         .uid(MESSAGE_UID_2)
         .content(CONTENT_STREAM_2)
         .size(SIZE_2)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMetadata.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMetadata.java
@@ -329,6 +329,7 @@ public class CassandraMessageMetadata {
             SimpleMailboxMessage.builder()
                 .mailboxId(composedMessageId.getComposedMessageId().getMailboxId())
                 .messageId(composedMessageId.getComposedMessageId().getMessageId())
+                .threadId(composedMessageId.getThreadId())
                 .uid(composedMessageId.getComposedMessageId().getUid())
                 .modseq(composedMessageId.getModSeq())
                 .flags(composedMessageId.getFlags())

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
@@ -57,6 +57,7 @@ public class MessageRepresentation {
     public SimpleMailboxMessage toMailboxMessage(ComposedMessageIdWithMetaData metadata, List<MessageAttachmentMetadata> attachments) {
         return SimpleMailboxMessage.builder()
             .messageId(messageId)
+            .threadId(metadata.getThreadId())
             .mailboxId(metadata.getComposedMessageId().getMailboxId())
             .uid(metadata.getComposedMessageId().getUid())
             .modseq(metadata.getModSeq())

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTest.java
@@ -45,6 +45,7 @@ import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
 import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
@@ -97,7 +98,7 @@ class MessageV3MigrationTest {
     }
 
     @Test
-    void migrationTaskShouldMoveDataToMostRecentDao() throws Exception{
+    void migrationTaskShouldMoveDataToMostRecentDao() throws Exception {
         SimpleMailboxMessage message1 = createMessage(messageIdFactory.generate());
         SimpleMailboxMessage message2 = createMessage(messageIdFactory.generate());
         SimpleMailboxMessage message3 = createMessage(messageIdFactory.generate());
@@ -125,7 +126,7 @@ class MessageV3MigrationTest {
     }
 
     @Test
-    void migrationTaskShouldPreserveMessageContent() throws Exception{
+    void migrationTaskShouldPreserveMessageContent() throws Exception {
         SimpleMailboxMessage message1 = createMessage(messageIdFactory.generate());
         daoV2.save(message1).block();
         MessageRepresentation original = daoV2.retrieveMessage((CassandraMessageId) message1.getMessageId(), MessageMapper.FetchType.Metadata).block();
@@ -142,6 +143,7 @@ class MessageV3MigrationTest {
     private SimpleMailboxMessage createMessage(MessageId messageId) {
         return SimpleMailboxMessage.builder()
             .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
             .mailboxId(MAILBOX_ID)
             .uid(messageUid)
             .internalDate(new Date())

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -30,7 +30,6 @@ import java.time.ZoneId;
 import java.util.Date;
 
 import javax.mail.Flags;
-import javax.mail.util.SharedByteArrayInputStream;
 
 import org.apache.james.backends.es.v7.DockerElasticSearchExtension;
 import org.apache.james.backends.es.v7.ElasticSearchIndexer;
@@ -50,7 +49,6 @@ import org.apache.james.mailbox.elasticsearch.v7.json.MessageToElasticSearchJson
 import org.apache.james.mailbox.elasticsearch.v7.query.CriterionConverter;
 import org.apache.james.mailbox.elasticsearch.v7.query.QueryConverter;
 import org.apache.james.mailbox.elasticsearch.v7.search.ElasticSearchSearcher;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.inmemory.InMemoryId;
@@ -68,6 +66,7 @@ import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.FakeAuthenticator;
@@ -88,7 +87,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -127,10 +125,12 @@ class ElasticSearchListeningMessageSearchIndexTest {
         .modseq(MOD_SEQ);
 
     static final SimpleMailboxMessage MESSAGE_1 = MESSAGE_BUILDER.messageId(MESSAGE_ID_1)
+        .threadId(ThreadId.fromBaseMessageId(MESSAGE_ID_1))
         .uid(MESSAGE_UID_1)
         .build();
 
     static final SimpleMailboxMessage MESSAGE_2 = MESSAGE_BUILDER.messageId(MESSAGE_ID_2)
+        .threadId(ThreadId.fromBaseMessageId(MESSAGE_ID_2))
         .uid(MESSAGE_UID_2)
         .build();
 
@@ -145,6 +145,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
         .build();
 
     static final SimpleMailboxMessage MESSAGE_WITH_ATTACHMENT = MESSAGE_BUILDER.messageId(MESSAGE_ID_3)
+        .threadId(ThreadId.fromBaseMessageId(MESSAGE_ID_3))
         .uid(MESSAGE_UID_3)
         .addAttachments(ImmutableList.of(MESSAGE_ATTACHMENT))
         .build();

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MessageToElasticSearchJsonTest.java
@@ -42,6 +42,7 @@ import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
 import org.apache.james.mailbox.store.extractor.JsoupTextExtractor;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
@@ -64,6 +65,7 @@ class MessageToElasticSearchJsonTest {
     static final int BODY_START_OCTET = 100;
     static final TestId MAILBOX_ID = TestId.of(18L);
     static final MessageId MESSAGE_ID = TestMessageId.of(184L);
+    static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
     static final ModSeq MOD_SEQ = ModSeq.of(42L);
     static final MessageUid UID = MessageUid.of(25);
     static final Username USERNAME = Username.of("username");
@@ -97,6 +99,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
         MailboxMessage spamMail = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 date,
                 SIZE,
                 BODY_START_OCTET,
@@ -117,6 +120,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
         MailboxMessage spamMail = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 date,
                 SIZE,
                 BODY_START_OCTET,
@@ -139,6 +143,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
         MailboxMessage htmlMail = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 date,
                 SIZE,
                 BODY_START_OCTET,
@@ -159,6 +164,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
         MailboxMessage pgpSignedMail = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 date,
                 SIZE,
                 BODY_START_OCTET,
@@ -179,6 +185,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
         MailboxMessage mail = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 date,
                 SIZE,
                 BODY_START_OCTET,
@@ -199,7 +206,8 @@ class MessageToElasticSearchJsonTest {
         MessageToElasticSearchJson messageToElasticSearchJson = new MessageToElasticSearchJson(
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
-        MailboxMessage recursiveMail = new SimpleMailboxMessage(MESSAGE_ID, 
+        MailboxMessage recursiveMail = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 date,
                 SIZE,
                 BODY_START_OCTET,
@@ -220,6 +228,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
         MailboxMessage mailWithNoInternalDate = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 null,
                 SIZE,
                 BODY_START_OCTET,
@@ -239,6 +248,7 @@ class MessageToElasticSearchJsonTest {
     void emailWithAttachmentsShouldConvertAttachmentsWhenIndexAttachmentsIsTrue() throws IOException {
         // Given
         MailboxMessage mailWithNoInternalDate = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 null,
                 SIZE,
                 BODY_START_OCTET,
@@ -267,6 +277,7 @@ class MessageToElasticSearchJsonTest {
     void emailWithAttachmentsShouldNotConvertAttachmentsWhenIndexAttachmentsIsFalse() throws IOException {
         // Given
         MailboxMessage mailWithNoInternalDate = new SimpleMailboxMessage(MESSAGE_ID,
+                THREAD_ID,
                 null,
                 SIZE,
                 BODY_START_OCTET,
@@ -296,7 +307,7 @@ class MessageToElasticSearchJsonTest {
         MessageToElasticSearchJson messageToElasticSearchJson = new MessageToElasticSearchJson(
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"), IndexAttachments.YES);
-        MailboxMessage mailWithNoMailboxId = new SimpleMailboxMessage(MESSAGE_ID, date,
+        MailboxMessage mailWithNoMailboxId = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date,
             SIZE,
             BODY_START_OCTET,
             new ByteContent(IOUtils.toByteArray(ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"))),
@@ -348,7 +359,7 @@ class MessageToElasticSearchJsonTest {
             textExtractor,
             ZoneId.of("Europe/Paris"),
             IndexAttachments.YES);
-        MailboxMessage spamMail = new SimpleMailboxMessage(MESSAGE_ID, date,
+        MailboxMessage spamMail = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date,
             SIZE,
             BODY_START_OCTET,
             new ByteContent(IOUtils.toByteArray(ClassLoaderUtils.getSystemResourceAsSharedStream("eml/nonTextual.eml"))),
@@ -368,6 +379,7 @@ class MessageToElasticSearchJsonTest {
     void convertToJsonWithoutAttachmentShouldConvertEmailBoby() throws IOException {
         // Given
         MailboxMessage message = new SimpleMailboxMessage(MESSAGE_ID,
+            THREAD_ID,
             null,
             SIZE,
             BODY_START_OCTET,
@@ -396,6 +408,7 @@ class MessageToElasticSearchJsonTest {
     void convertToJsonShouldExtractHtmlText() throws IOException {
         // Given
         MailboxMessage message = new SimpleMailboxMessage(MESSAGE_ID,
+            THREAD_ID,
             date,
             SIZE,
             BODY_START_OCTET,

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/openjpa/OpenJPAMessageFactory.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/openjpa/OpenJPAMessageFactory.java
@@ -34,6 +34,7 @@ import org.apache.james.mailbox.model.Content;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.MessageFactory;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 
@@ -51,7 +52,7 @@ public class OpenJPAMessageFactory implements MessageFactory<AbstractJPAMailboxM
     }
 
     @Override
-    public AbstractJPAMailboxMessage createMessage(MessageId messageId, Mailbox mailbox, Date internalDate, int size, int bodyStartOctet, Content content, Flags flags, PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) throws MailboxException {
+    public AbstractJPAMailboxMessage createMessage(MessageId messageId, ThreadId threadId, Mailbox mailbox, Date internalDate, int size, int bodyStartOctet, Content content, Flags flags, PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) throws MailboxException {
         switch (feature) {
             case Streaming:
                 return new JPAStreamingMailboxMessage(JPAMailbox.from(mailbox), internalDate, size, flags, content,

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/MessageUtilsTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/MessageUtilsTest.java
@@ -34,6 +34,7 @@ import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.ModSeqProvider;
 import org.apache.james.mailbox.store.mail.UidProvider;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
@@ -48,6 +49,7 @@ import org.mockito.MockitoAnnotations;
 class MessageUtilsTest {
     static final MessageUid MESSAGE_UID = MessageUid.of(1);
     static final MessageId MESSAGE_ID = new DefaultMessageId();
+    static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
     static final int BODY_START = 16;
     static final String CONTENT = "anycontent";
     
@@ -62,7 +64,7 @@ class MessageUtilsTest {
     void setUp() {
         MockitoAnnotations.initMocks(this);
         messageUtils = new MessageUtils(uidProvider, modSeqProvider);
-        message = new SimpleMailboxMessage(MESSAGE_ID, new Date(), CONTENT.length(), BODY_START,
+        message = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, new Date(), CONTENT.length(), BODY_START,
             new ByteContent(CONTENT.getBytes()), new Flags(), new PropertyBuilder().build(), mailbox.getMailboxId());
     }
     

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -48,6 +48,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageMoves;
 import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.StoreMailboxManager;
@@ -64,6 +65,7 @@ class SpamAssassinListenerTest {
     static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
     static final UidValidity UID_VALIDITY = UidValidity.of(43);
     static final TestMessageId MESSAGE_ID = TestMessageId.of(45);
+    static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
 
     SpamAssassin spamAssassin;
     SpamAssassinListener listener;
@@ -271,7 +273,7 @@ class SpamAssassinListenerTest {
         int size = 45;
         int bodyStartOctet = 25;
         byte[] content = "Subject: test\r\n\r\nBody\r\n".getBytes(StandardCharsets.UTF_8);
-        SimpleMailboxMessage message = new SimpleMailboxMessage(MESSAGE_ID, new Date(),
+        SimpleMailboxMessage message = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, new Date(),
             size, bodyStartOctet, new ByteContent(content), new Flags(), new PropertyBuilder().build(),
             mailbox.getMailboxId());
         MessageMetaData messageMetaData = mapperFactory.createMessageMapper(null).add(mailbox, message);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
@@ -44,7 +44,7 @@ public interface MessageFactory<T extends MailboxMessage> {
         public SimpleMailboxMessage createMessage(MessageId messageId, ThreadId threadId, Mailbox mailbox, Date internalDate, int size,
                                                   int bodyStartOctet, Content content, Flags flags,
                                                   PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
-            return new SimpleMailboxMessage(messageId, internalDate, size, bodyStartOctet, content, flags, propertyBuilder.build(),
+            return new SimpleMailboxMessage(messageId, threadId, internalDate, size, bodyStartOctet, content, flags, propertyBuilder.build(),
                 mailbox.getMailboxId(), attachments);
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
@@ -29,18 +29,19 @@ import org.apache.james.mailbox.model.Content;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 
 public interface MessageFactory<T extends MailboxMessage> {
-    T createMessage(MessageId messageId, Mailbox mailbox, Date internalDate, int size, int bodyStartOctet,
+    T createMessage(MessageId messageId, ThreadId threadId, Mailbox mailbox, Date internalDate, int size, int bodyStartOctet,
                     Content content, Flags flags, PropertyBuilder propertyBuilder,
                     List<MessageAttachmentMetadata> attachments) throws MailboxException;
 
     class StoreMessageFactory implements MessageFactory<SimpleMailboxMessage> {
         @Override
-        public SimpleMailboxMessage createMessage(MessageId messageId, Mailbox mailbox, Date internalDate, int size,
+        public SimpleMailboxMessage createMessage(MessageId messageId, ThreadId threadId, Mailbox mailbox, Date internalDate, int size,
                                                   int bodyStartOctet, Content content, Flags flags,
                                                   PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
             return new SimpleMailboxMessage(messageId, internalDate, size, bodyStartOctet, content, flags, propertyBuilder.build(),

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageBuilder.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageBuilder.java
@@ -34,6 +34,7 @@ import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -80,7 +81,8 @@ public class MessageBuilder {
 
     public MailboxMessage build(MessageId messageId) throws Exception {
         byte[] headerContent = getHeaderContent();
-        SimpleMailboxMessage mailboxMessage = new SimpleMailboxMessage(messageId, internalDate, size, headerContent.length,
+        ThreadId threadId = ThreadId.fromBaseMessageId(messageId);
+        SimpleMailboxMessage mailboxMessage = new SimpleMailboxMessage(messageId, threadId, internalDate, size, headerContent.length,
             new ByteContent(Bytes.concat(headerContent, body)), flags, new PropertyBuilder().build(), mailboxId, NO_ATTACHMENTS);
         mailboxMessage.setUid(uid);
         return mailboxMessage;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
@@ -36,6 +36,7 @@ import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -82,8 +83,9 @@ public class MessageIdManagerTestSystem {
     public MessageId persist(MailboxId mailboxId, MessageUid uid, Flags flags, MailboxSession mailboxSession) {
         try {
             MessageId messageId = messageIdFactory.generate();
+            ThreadId threadId = ThreadId.fromBaseMessageId(messageId);
             Mailbox mailbox = mapperFactory.getMailboxMapper(mailboxSession).findMailboxById(mailboxId).block();
-            MailboxMessage message = createMessage(mailboxId, flags, messageId, uid);
+            MailboxMessage message = createMessage(mailboxId, flags, messageId, threadId, uid);
             mapperFactory.getMessageMapper(mailboxSession).add(mailbox, message);
             mailboxManager.getEventBus().dispatch(EventFactory.added()
                 .randomEventId()
@@ -112,8 +114,8 @@ public class MessageIdManagerTestSystem {
         }
     }
 
-    private static MailboxMessage createMessage(MailboxId mailboxId, Flags flags, MessageId messageId, MessageUid uid) {
-        MailboxMessage mailboxMessage = new SimpleMailboxMessage(messageId, new Date(), MESSAGE_CONTENT.length, 1256,
+    private static MailboxMessage createMessage(MailboxId mailboxId, Flags flags, MessageId messageId, ThreadId threadId, MessageUid uid) {
+        MailboxMessage mailboxMessage = new SimpleMailboxMessage(messageId, threadId, new Date(), MESSAGE_CONTENT.length, 1256,
             new ByteContent(MESSAGE_CONTENT), flags, new PropertyBuilder().build(), mailboxId);
         mailboxMessage.setModSeq(MOD_SEQ);
         mailboxMessage.setUid(uid);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
@@ -84,7 +85,7 @@ class StoreMailboxMessageResultIteratorTest {
         }
 
         private SimpleMailboxMessage createMessage(MessageUid uid) {
-            SimpleMailboxMessage message = new SimpleMailboxMessage(new DefaultMessageId(), null, 0, 0, new ByteContent(
+            SimpleMailboxMessage message = new SimpleMailboxMessage(new DefaultMessageId(), ThreadId.fromBaseMessageId(new DefaultMessageId()), null, 0, 0, new ByteContent(
                     "".getBytes()), new Flags(), new PropertyBuilder().build(), TestId.of(1L));
             message.setUid(uid);
             return message;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssertTest.java
@@ -38,6 +38,7 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
@@ -54,6 +55,7 @@ class ListMessageAssertTest {
     static final MailboxId MAILBOX_ID = TestId.of(1);
     static final MessageUid MESSAGE_UID = MessageUid.of(2);
     static final MessageId MESSAGE_ID = new DefaultMessageId();
+    static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
     static final Date INTERNAL_DATE = new Date();
 
     Mailbox benwaInboxMailbox;
@@ -65,8 +67,8 @@ class ListMessageAssertTest {
     void setUp() {
         benwaInboxMailbox = createMailbox(MailboxPath.inbox(Username.of("user")));
 
-        message1 = createMessage(benwaInboxMailbox, MESSAGE_ID, BODY_CONTENT1, BODY_START, new PropertyBuilder());
-        message2 = createMessage(benwaInboxMailbox, MESSAGE_ID, BODY_CONTENT2, BODY_START, new PropertyBuilder());
+        message1 = createMessage(benwaInboxMailbox, MESSAGE_ID, THREAD_ID, BODY_CONTENT1, BODY_START, new PropertyBuilder());
+        message2 = createMessage(benwaInboxMailbox, MESSAGE_ID, THREAD_ID, BODY_CONTENT2, BODY_START, new PropertyBuilder());
     }
 
     @Test
@@ -74,8 +76,8 @@ class ListMessageAssertTest {
         List<MailboxMessage> actual = ImmutableList.of(message1, message2);
 
         assertMessages(actual).containOnly(
-                createMailboxMessage(MAILBOX_ID, MESSAGE_ID, MESSAGE_UID, INTERNAL_DATE, BODY_CONTENT1, BODY_START, new PropertyBuilder()),
-                createMailboxMessage(MAILBOX_ID, MESSAGE_ID, MESSAGE_UID, INTERNAL_DATE, BODY_CONTENT2, BODY_START, new PropertyBuilder()));
+                createMailboxMessage(MAILBOX_ID, MESSAGE_ID, THREAD_ID, MESSAGE_UID, INTERNAL_DATE, BODY_CONTENT1, BODY_START, new PropertyBuilder()),
+                createMailboxMessage(MAILBOX_ID, MESSAGE_ID, THREAD_ID, MESSAGE_UID, INTERNAL_DATE, BODY_CONTENT2, BODY_START, new PropertyBuilder()));
     }
 
     @Test
@@ -83,13 +85,13 @@ class ListMessageAssertTest {
         List<MailboxMessage> actual = ImmutableList.of(message1);
 
         assertThatThrownBy(() -> assertMessages(actual).containOnly(
-                createMailboxMessage(MAILBOX_ID, MESSAGE_ID, MESSAGE_UID, INTERNAL_DATE, BODY_CONTENT2, BODY_START, new PropertyBuilder())))
+                createMailboxMessage(MAILBOX_ID, MESSAGE_ID, THREAD_ID, MESSAGE_UID, INTERNAL_DATE, BODY_CONTENT2, BODY_START, new PropertyBuilder())))
             .isInstanceOf(AssertionError.class);
     }
 
-    private MailboxMessage createMailboxMessage(MailboxId mailboxId, MessageId messageId, MessageUid uid, Date internalDate,
+    private MailboxMessage createMailboxMessage(MailboxId mailboxId, MessageId messageId, ThreadId threadId, MessageUid uid, Date internalDate,
                                                 String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        SimpleMailboxMessage simpleMailboxMessage = new SimpleMailboxMessage(messageId, internalDate, content.length(),
+        SimpleMailboxMessage simpleMailboxMessage = new SimpleMailboxMessage(messageId, threadId, internalDate, content.length(),
             bodyStart, new ByteContent(content.getBytes(StandardCharsets.UTF_8)), new Flags(), propertyBuilder.build(), mailboxId);
 
         simpleMailboxMessage.setUid(uid);
@@ -101,8 +103,8 @@ class ListMessageAssertTest {
         return new Mailbox(mailboxPath, UID_VALIDITY, MAILBOX_ID);
     }
 
-    private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        SimpleMailboxMessage simpleMailboxMessage = new SimpleMailboxMessage(messageId, INTERNAL_DATE, content.length(),
+    private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, ThreadId threadId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
+        SimpleMailboxMessage simpleMailboxMessage = new SimpleMailboxMessage(messageId, threadId, INTERNAL_DATE, content.length(),
             bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
 
         simpleMailboxMessage.setUid(MESSAGE_UID);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMessageAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMessageAssertTest.java
@@ -30,6 +30,7 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
@@ -40,6 +41,7 @@ class MailboxMessageAssertTest {
     static final TestId MAILBOX_ID = TestId.of(42L);
     static final MessageUid UID = MessageUid.of(24);
     static final MessageId MESSAGE_ID = new DefaultMessageId();
+    static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
 
     @Test
     void messageAssertShouldSucceedWithTwoEqualsMessages() throws IOException {
@@ -47,11 +49,11 @@ class MailboxMessageAssertTest {
         String bodyString = "body\n.\n";
         Date date = new Date();
 
-        SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
+        SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date, headerString.length() + bodyString.length(),
             headerString.length(), new ByteContent((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
 
-        SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
+        SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date, headerString.length() + bodyString.length(),
             headerString.length(), new ByteContent((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message2.setUid(UID);
 
@@ -64,12 +66,12 @@ class MailboxMessageAssertTest {
         String bodyString = "body\n.\n";
         Date date = new Date();
 
-        SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
+        SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date, headerString.length() + bodyString.length(),
             headerString.length(), new ByteContent((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
 
         bodyString = "work\n.\n";
-        SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
+        SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date, headerString.length() + bodyString.length(),
             headerString.length(), new ByteContent((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message2.setUid(UID);
 
@@ -82,12 +84,12 @@ class MailboxMessageAssertTest {
         String bodyString = "body\n.\n";
         Date date = new Date();
 
-        SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
+        SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date, headerString.length() + bodyString.length(),
             headerString.length(), new ByteContent((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
 
         bodyString = "work\n.\n";
-        SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
+        SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, date, headerString.length() + bodyString.length(),
             headerString.length(), new ByteContent((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message2.setUid(UID);
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -42,6 +42,7 @@ import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
@@ -1001,7 +1002,10 @@ public abstract class MessageIdMapperTest {
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        return new SimpleMailboxMessage(mapperProvider.generateMessageId(), 
+        MessageId messageId = mapperProvider.generateMessageId();
+        ThreadId threadId = ThreadId.fromBaseMessageId(messageId);
+        return new SimpleMailboxMessage(messageId,
+                threadId,
                 new Date(), 
                 content.length(), 
                 bodyStart, 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -48,6 +48,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.FlagsUpdateCalculator;
@@ -1265,6 +1266,6 @@ public abstract class MessageMapperTest {
     }
     
     private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
+        return new SimpleMailboxMessage(messageId, ThreadId.fromBaseMessageId(messageId), new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
@@ -33,6 +33,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
@@ -148,6 +149,6 @@ public abstract class MessageMoveTest {
     }
     
     private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
+        return new SimpleMailboxMessage(messageId, ThreadId.fromBaseMessageId(messageId),new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.ParsedAttachment;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
@@ -101,15 +102,19 @@ public abstract class MessageWithAttachmentMapperTest {
             .inline(false);
 
         MessageId messageId1 = mapperProvider.generateMessageId();
+        ThreadId threadId1 = ThreadId.fromBaseMessageId(messageId1);
         MessageId messageId2 = mapperProvider.generateMessageId();
+        ThreadId threadId2 = ThreadId.fromBaseMessageId(messageId2);
+        MessageId messageId3 = mapperProvider.generateMessageId();
+        ThreadId threadId3 = ThreadId.fromBaseMessageId(messageId3);
         List<MessageAttachmentMetadata> message1Attachments = attachmentMapper.storeAttachmentsForMessage(ImmutableList.of(attachment1), messageId1);
         List<MessageAttachmentMetadata> message2Attachments = attachmentMapper.storeAttachmentsForMessage(ImmutableList.of(attachment2, attachment3), messageId2);
 
-        messageWith1Attachment = createMessage(attachmentsMailbox, messageId1, "Subject: Test7 \n\nBody7\n.\n", BODY_START, new PropertyBuilder(),
+        messageWith1Attachment = createMessage(attachmentsMailbox, messageId1, threadId1, "Subject: Test7 \n\nBody7\n.\n", BODY_START, new PropertyBuilder(),
                 message1Attachments);
-        messageWith2Attachments = createMessage(attachmentsMailbox, messageId2, "Subject: Test8 \n\nBody8\n.\n", BODY_START, new PropertyBuilder(),
+        messageWith2Attachments = createMessage(attachmentsMailbox, messageId2, threadId2, "Subject: Test8 \n\nBody8\n.\n", BODY_START, new PropertyBuilder(),
                 message2Attachments);
-        messageWithoutAttachment = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test1 \n\nBody1\n.\n", BODY_START, new PropertyBuilder());
+        messageWithoutAttachment = createMessage(attachmentsMailbox, messageId3, threadId3, "Subject: Test1 \n\nBody1\n.\n", BODY_START, new PropertyBuilder());
     }
 
     @Test
@@ -193,11 +198,11 @@ public abstract class MessageWithAttachmentMapperTest {
         messageWith2Attachments.setModSeq(messageMapper.getHighestModSeq(attachmentsMailbox));
     }
 
-    private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId(), attachments);
+    private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, ThreadId threadId, String content, int bodyStart, PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
+        return new SimpleMailboxMessage(messageId, threadId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId(), attachments);
     }
 
-    private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
+    private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, ThreadId threadId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
+        return new SimpleMailboxMessage(messageId, threadId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MetadataMapAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MetadataMapAssertTest.java
@@ -43,6 +43,7 @@ class MetadataMapAssertTest {
 
     static final MessageUid UID = MessageUid.of(18);
     static final MessageId MESSAGE_ID = new DefaultMessageId();
+    static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
     static final ModSeq MODSEQ = ModSeq.of(24L);
     static final Date DATE = new Date();
     static final String HEADER_STRING = "name: headerName\n\n";
@@ -53,7 +54,7 @@ class MetadataMapAssertTest {
 
     @BeforeEach
     void setUp() {
-        message1 = new SimpleMailboxMessage(MESSAGE_ID, DATE, HEADER_STRING.length() + BODY_STRING.length(),
+        message1 = new SimpleMailboxMessage(MESSAGE_ID, THREAD_ID, DATE, HEADER_STRING.length() + BODY_STRING.length(),
             HEADER_STRING.length(), new ByteContent((HEADER_STRING + BODY_STRING).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
         message1.setModSeq(MODSEQ);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,7 @@ class SimpleMailboxMessageTest {
     static final TestId TEST_ID = TestId.of(1L);
     static final int BODY_START_OCTET = 0;
     static final MessageId MESSAGE_ID = new TestMessageId.Factory().generate();
+    static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
     static final int SIZE = 1000;
 
     SimpleMailboxMessage message;
@@ -109,7 +111,9 @@ class SimpleMailboxMessageTest {
         propertyBuilder.setTextualLineCount(textualLineCount);
         propertyBuilder.setMediaType(text);
         propertyBuilder.setSubType(plain);
-        SimpleMailboxMessage original = new SimpleMailboxMessage(new TestMessageId.Factory().generate(), new Date(),
+        MessageId messageId = new TestMessageId.Factory().generate();
+        ThreadId threadId = ThreadId.fromBaseMessageId(messageId);
+        SimpleMailboxMessage original = new SimpleMailboxMessage(messageId, threadId, new Date(),
             MESSAGE_CONTENT.length(),
             BODY_START_OCTET,
             CONTENT_STREAM,
@@ -132,7 +136,7 @@ class SimpleMailboxMessageTest {
     }
 
     private static SimpleMailboxMessage buildMessage(String content) {
-        return new SimpleMailboxMessage(new DefaultMessageId(), Calendar.getInstance().getTime(),
+        return new SimpleMailboxMessage(new DefaultMessageId(), ThreadId.fromBaseMessageId(new DefaultMessageId()), Calendar.getInstance().getTime(),
             content.length(), BODY_START_OCTET, new ByteContent(
                     content.getBytes(MESSAGE_CHARSET)), new Flags(),
             new PropertyBuilder().build(), TEST_ID);
@@ -157,6 +161,7 @@ class SimpleMailboxMessageTest {
         Date internalDate = new Date();
         SimpleMailboxMessage.builder()
             .messageId(MESSAGE_ID)
+            .threadId(THREAD_ID)
             .mailboxId(TEST_ID)
             .internalDate(internalDate)
             .bodyStartOctet(BODY_START_OCTET)
@@ -187,6 +192,7 @@ class SimpleMailboxMessageTest {
             .build();
         SimpleMailboxMessage message = SimpleMailboxMessage.builder()
             .messageId(MESSAGE_ID)
+            .threadId(THREAD_ID)
             .mailboxId(TEST_ID)
             .modseq(modseq)
             .uid(uid)
@@ -219,6 +225,7 @@ class SimpleMailboxMessageTest {
     void buildShouldThrowOnMissingMessageId() {
         Date internalDate = new Date();
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
+                .threadId(THREAD_ID)
                 .mailboxId(TEST_ID)
                 .internalDate(internalDate)
                 .bodyStartOctet(BODY_START_OCTET)
@@ -231,10 +238,27 @@ class SimpleMailboxMessageTest {
     }
 
     @Test
+    void buildShouldThrowOnMissingThreadId() {
+        Date internalDate = new Date();
+        assertThatThrownBy(() -> SimpleMailboxMessage.builder()
+            .messageId(MESSAGE_ID)
+            .mailboxId(TEST_ID)
+            .internalDate(internalDate)
+            .bodyStartOctet(BODY_START_OCTET)
+            .size(SIZE)
+            .content(CONTENT_STREAM)
+            .flags(new Flags())
+            .properties(new PropertyBuilder())
+            .build())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void buildShouldThrowOnMissingMailboxId() {
         Date internalDate = new Date();
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
                 .messageId(MESSAGE_ID)
+                .threadId(THREAD_ID)
                 .internalDate(internalDate)
                 .bodyStartOctet(BODY_START_OCTET)
                 .size(SIZE)
@@ -249,6 +273,7 @@ class SimpleMailboxMessageTest {
     void buildShouldThrowOnMissingInternalDate() {
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
                 .messageId(MESSAGE_ID)
+                .threadId(THREAD_ID)
                 .mailboxId(TEST_ID)
                 .bodyStartOctet(BODY_START_OCTET)
                 .size(SIZE)
@@ -264,6 +289,7 @@ class SimpleMailboxMessageTest {
         Date internalDate = new Date();
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
                 .messageId(MESSAGE_ID)
+                .threadId(THREAD_ID)
                 .mailboxId(TEST_ID)
                 .internalDate(internalDate)
                 .size(SIZE)
@@ -279,6 +305,7 @@ class SimpleMailboxMessageTest {
         Date internalDate = new Date();
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
                 .messageId(MESSAGE_ID)
+                .threadId(THREAD_ID)
                 .mailboxId(TEST_ID)
                 .internalDate(internalDate)
                 .bodyStartOctet(BODY_START_OCTET)
@@ -294,6 +321,7 @@ class SimpleMailboxMessageTest {
         Date internalDate = new Date();
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
                 .messageId(MESSAGE_ID)
+                .threadId(THREAD_ID)
                 .mailboxId(TEST_ID)
                 .internalDate(internalDate)
                 .bodyStartOctet(BODY_START_OCTET)
@@ -309,6 +337,7 @@ class SimpleMailboxMessageTest {
         Date internalDate = new Date();
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
                 .messageId(MESSAGE_ID)
+                .threadId(THREAD_ID)
                 .mailboxId(TEST_ID)
                 .internalDate(internalDate)
                 .bodyStartOctet(BODY_START_OCTET)
@@ -324,6 +353,7 @@ class SimpleMailboxMessageTest {
         Date internalDate = new Date();
         assertThatThrownBy(() -> SimpleMailboxMessage.builder()
                 .messageId(MESSAGE_ID)
+                .threadId(THREAD_ID)
                 .mailboxId(TEST_ID)
                 .internalDate(internalDate)
                 .bodyStartOctet(BODY_START_OCTET)
@@ -336,7 +366,7 @@ class SimpleMailboxMessageTest {
 
     @Test
     void simpleMessageShouldReturnThreadIdWhichWrapsMessageId() {
-        assertThat(message.getThreadId().getBaseMessageId()).isEqualTo(message.getMessageId());
+        assertThat(message.getThreadId().getBaseMessageId()).isInstanceOf(MessageId.class);
     }
 
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculatorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculatorTest.java
@@ -31,6 +31,7 @@ import javax.mail.Flags.Flag;
 import org.apache.james.mailbox.ApplicableFlagBuilder;
 import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -104,7 +105,7 @@ class ApplicableFlagCalculatorTest {
         String content = "Any content";
         int bodyStart = 10;
 
-        return new SimpleMailboxMessage(new DefaultMessageId(), new Date(), content.length(), bodyStart,
+        return new SimpleMailboxMessage(new DefaultMessageId(), ThreadId.fromBaseMessageId(new DefaultMessageId()), new Date(), content.length(), bodyStart,
             new ByteContent(content.getBytes()), messageFlags, new PropertyBuilder().build(), TestId.of(1));
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndexContract.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndexContract.java
@@ -34,6 +34,7 @@ import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.junit.jupiter.api.Test;
@@ -43,10 +44,12 @@ public interface ListeningMessageSearchIndexContract {
     int SIZE = 25;
     int BODY_START_OCTET = 100;
     MessageId MESSAGE_ID = TestMessageId.of(21L);
+    ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
     MessageUid MESSAGE_UID = MessageUid.of(28);
     
     SimpleMailboxMessage.Builder MESSAGE_BUILDER = SimpleMailboxMessage.builder()
         .messageId(MESSAGE_ID)
+        .threadId(THREAD_ID)
         .uid(MESSAGE_UID)
         .bodyStartOctet(BODY_START_OCTET)
         .internalDate(new Date(1433628000000L))

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -71,6 +71,7 @@ import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageResult;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
@@ -631,6 +632,7 @@ class MailboxesRoutesTest {
 
                 SimpleMailboxMessage message = SimpleMailboxMessage.builder()
                     .messageId(InMemoryMessageId.of(42L))
+                    .threadId(ThreadId.fromBaseMessageId(InMemoryMessageId.of(42L)))
                     .uid(uid)
                     .content(new ByteContent(content))
                     .size(content.length)
@@ -1050,6 +1052,7 @@ class MailboxesRoutesTest {
 
                 SimpleMailboxMessage message = SimpleMailboxMessage.builder()
                     .messageId(InMemoryMessageId.of(42L))
+                    .threadId(ThreadId.fromBaseMessageId(InMemoryMessageId.of(42L)))
                     .uid(uid)
                     .content(new ByteContent(content))
                     .size(content.length)

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -90,6 +90,7 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageResult;
+import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
@@ -1547,6 +1548,7 @@ class UserMailboxesRoutesTest {
 
                 SimpleMailboxMessage message = SimpleMailboxMessage.builder()
                     .messageId(InMemoryMessageId.of(42L))
+                    .threadId(ThreadId.fromBaseMessageId(InMemoryMessageId.of(42L)))
                     .uid(uid)
                     .content(new ByteContent(content))
                     .size(content.length)


### PR DESCRIPTION
After adding threadId property to SimpleMailboxMessage, we can enable setting threadId through MessageFactory::createMessage params