### PR TITLE
JAMES-3605 RabbitMQ reconnection handlers should restart consummers

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
@@ -31,6 +31,8 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
@@ -42,6 +44,8 @@ import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 
 public class SimpleConnectionPool implements AutoCloseable {
+    public static final Logger LOGGER = LoggerFactory.getLogger(SimpleConnectionPool.class);
+
     public static class Configuration {
         @FunctionalInterface
         public interface RequiresRetries {
@@ -123,6 +127,7 @@ public class SimpleConnectionPool implements AutoCloseable {
         boolean updated = connectionReference.compareAndSet(previous, current);
         if (updated) {
             if (previous != null && previous != current) {
+                LOGGER.warn("Replacing current RabbitMQ connection...");
                 return Flux.fromIterable(reconnectionHandlers)
                     .concatMap(handler -> handler.handleReconnection(current))
                     .then()

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQExtension.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQExtension.java
@@ -34,14 +34,12 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 import com.github.fge.lambdas.consumers.ThrowingConsumer;
-import com.google.common.collect.ImmutableSet;
 
 import reactor.rabbitmq.Sender;
 
 public class RabbitMQExtension implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback, ParameterResolver {
 
     private static final Consumer<DockerRabbitMQ> DO_NOTHING = dockerRabbitMQ -> { };
-    public static final ImmutableSet<SimpleConnectionPool.ReconnectionHandler> RECONNECTION_HANDLERS = ImmutableSet.of();
 
     public enum DockerRestartPolicy {
         PER_TEST(DockerRabbitMQ::start, DockerRabbitMQ::start, DockerRabbitMQ::stop, DockerRabbitMQ::stop),
@@ -142,7 +140,6 @@ public class RabbitMQExtension implements BeforeAllCallback, BeforeEachCallback,
 
         RabbitMQConnectionFactory connectionFactory = createRabbitConnectionFactory();
         connectionPool = new SimpleConnectionPool(connectionFactory,
-            RECONNECTION_HANDLERS,
             SimpleConnectionPool.Configuration.builder()
                 .retries(2)
                 .initialDelay(Duration.ofMillis(5)));

--- a/event-bus/distributed/src/main/java/org/apache/james/events/EventBusReconnectionHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/EventBusReconnectionHandler.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.events;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
+import org.reactivestreams.Publisher;
+
+import com.rabbitmq.client.Connection;
+
+import reactor.core.publisher.Mono;
+
+public class EventBusReconnectionHandler implements SimpleConnectionPool.ReconnectionHandler {
+    private final RabbitMQEventBus rabbitMQEventBus;
+
+    @Inject
+    public EventBusReconnectionHandler(RabbitMQEventBus rabbitMQEventBus) {
+        this.rabbitMQEventBus = rabbitMQEventBus;
+    }
+
+    @Override
+    public Publisher<Void> handleReconnection(Connection connection) {
+        return Mono.fromRunnable(rabbitMQEventBus::restart);
+    }
+}

--- a/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
@@ -95,6 +95,11 @@ public class RabbitMQEventBus implements EventBus, Startable {
         }
     }
 
+    public void restart() {
+        keyRegistrationHandler.restart();
+        groupRegistrationHandler.restart();
+    }
+
     @VisibleForTesting
     void startWithoutStartingKeyRegistrationHandler() {
         if (!isRunning && !isStopping) {

--- a/mailet/amqp/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
+++ b/mailet/amqp/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
@@ -52,7 +52,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.ConnectionFactory;
 
@@ -79,7 +78,6 @@ import reactor.rabbitmq.Sender;
  */
 public class AmqpForwardAttribute extends GenericMailet {
     private static final Logger LOGGER = LoggerFactory.getLogger(AmqpForwardAttribute.class);
-    private static final ImmutableSet<SimpleConnectionPool.ReconnectionHandler> RECONNECTION_HANDLERS = ImmutableSet.of();
     private static final int MAX_THREE_RETRIES = 3;
     private static final int MIN_DELAY_OF_TEN_MILLISECONDS = 10;
     private static final int CONNECTION_TIMEOUT_OF_ONE_HUNDRED_MILLISECOND = 100;
@@ -127,8 +125,7 @@ public class AmqpForwardAttribute extends GenericMailet {
                 .shutdownTimeoutInMs(SHUTDOWN_TIMEOUT_OF_ONE_HUNDRED_MILLISECOND)
                 .networkRecoveryIntervalInMs(NETWORK_RECOVERY_INTERVAL_OF_ONE_HUNDRED_MILLISECOND)
                 .build();
-            connectionPool = new SimpleConnectionPool(new RabbitMQConnectionFactory(rabbitMQConfiguration),
-                RECONNECTION_HANDLERS, SimpleConnectionPool.Configuration.builder()
+            connectionPool = new SimpleConnectionPool(new RabbitMQConnectionFactory(rabbitMQConfiguration), SimpleConnectionPool.Configuration.builder()
                 .retries(2)
                 .initialDelay(Duration.ofMillis(5)));
             reactorRabbitMQChannelPool = new ReactorRabbitMQChannelPool(connectionPool.getResilientConnection(),

--- a/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
+++ b/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
@@ -20,8 +20,6 @@
 
 package org.apache.james.mpt.imapmailbox.rabbitmq.host;
 
-import static org.apache.james.backends.rabbitmq.RabbitMQExtension.RECONNECTION_HANDLERS;
-
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -78,8 +76,7 @@ public class RabbitMQEventBusHostSystem extends JamesImapHostSystem {
     public void beforeTest() throws Exception {
         super.beforeTest();
 
-        connectionPool = new SimpleConnectionPool(dockerRabbitMQ.createRabbitConnectionFactory(),
-            RECONNECTION_HANDLERS, SimpleConnectionPool.Configuration.builder()
+        connectionPool = new SimpleConnectionPool(dockerRabbitMQ.createRabbitConnectionFactory(), SimpleConnectionPool.Configuration.builder()
                 .retries(2)
                 .initialDelay(Duration.ofMillis(5)));
         reactorRabbitMQChannelPool = new ReactorRabbitMQChannelPool(connectionPool.getResilientConnection(),

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
@@ -27,6 +27,7 @@ import org.apache.james.backends.rabbitmq.ReceiverProvider;
 import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
 import org.apache.james.events.EventBus;
 import org.apache.james.events.EventBusId;
+import org.apache.james.events.EventBusReconnectionHandler;
 import org.apache.james.events.EventDeadLetters;
 import org.apache.james.events.KeyReconnectionHandler;
 import org.apache.james.events.NamingStrategy;
@@ -62,6 +63,11 @@ public class JMAPEventBusModule extends AbstractModule {
         return InitilizationOperationBuilder
             .forClass(RabbitMQEventBus.class)
             .init(instance::start);
+    }
+
+    @ProvidesIntoSet
+    SimpleConnectionPool.ReconnectionHandler provideReconnectionHandler(@Named(InjectionKeys.JMAP) RabbitMQEventBus eventBus) {
+        return new EventBusReconnectionHandler(eventBus);
     }
 
     @ProvidesIntoSet

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/RabbitMQEventBusModule.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/RabbitMQEventBusModule.java
@@ -23,6 +23,7 @@ import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
 import org.apache.james.event.json.MailboxEventSerializer;
 import org.apache.james.events.EventBus;
 import org.apache.james.events.EventBusId;
+import org.apache.james.events.EventBusReconnectionHandler;
 import org.apache.james.events.EventSerializer;
 import org.apache.james.events.KeyReconnectionHandler;
 import org.apache.james.events.NamingStrategy;
@@ -57,6 +58,7 @@ public class RabbitMQEventBusModule extends AbstractModule {
 
         Multibinder<SimpleConnectionPool.ReconnectionHandler> reconnectionHandlerMultibinder = Multibinder.newSetBinder(binder(), SimpleConnectionPool.ReconnectionHandler.class);
         reconnectionHandlerMultibinder.addBinding().to(KeyReconnectionHandler.class);
+        reconnectionHandlerMultibinder.addBinding().to(EventBusReconnectionHandler.class);
     }
 
     @ProvidesIntoSet

--- a/server/container/guice/queue/rabbitmq/pom.xml
+++ b/server/container/guice/queue/rabbitmq/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-mailetcontainer-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-queue-api</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
+++ b/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
@@ -95,7 +95,8 @@ public class RabbitMQModule extends AbstractModule {
         Multibinder.newSetBinder(binder(), StartUpCheck.class).addBinding().to(CassandraMailQueueViewStartUpCheck.class);
         Multibinder.newSetBinder(binder(), HealthCheck.class).addBinding().to(RabbitMQHealthCheck.class);
 
-        Multibinder.newSetBinder(binder(), SimpleConnectionPool.ReconnectionHandler.class);
+        Multibinder<SimpleConnectionPool.ReconnectionHandler> reconnectionHandlerMultibinder = Multibinder.newSetBinder(binder(), SimpleConnectionPool.ReconnectionHandler.class);
+        reconnectionHandlerMultibinder.addBinding().to(SpoolerReconnectionHandler.class);
     }
 
     @Provides

--- a/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
+++ b/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
@@ -19,6 +19,7 @@
 package org.apache.james.modules.queue.rabbitmq;
 
 import java.io.FileNotFoundException;
+import java.util.Set;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -55,6 +56,8 @@ import org.apache.james.queue.rabbitmq.view.cassandra.EnqueuedMailsDAO;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfigurationModule;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.EventsourcingConfigurationManagement;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
 import org.apache.james.utils.PropertiesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +67,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.ProvidesIntoSet;
 
 import reactor.rabbitmq.RabbitFlux;
 import reactor.rabbitmq.ReceiverOptions;
@@ -127,6 +131,13 @@ public class RabbitMQModule extends AbstractModule {
     @Singleton
     public MailQueueFactory<? extends MailQueue> provideMailQueueFactoryGenerics(MailQueueFactory<RabbitMQMailQueue> queueFactory) {
         return queueFactory;
+    }
+
+    @ProvidesIntoSet
+    InitializationOperation configureUsersRepository(SimpleConnectionPool pool, Set<SimpleConnectionPool.ReconnectionHandler> reconnectionHandlers) {
+        return InitilizationOperationBuilder
+            .forClass(SimpleConnectionPool.class)
+            .init(() -> pool.init(reconnectionHandlers));
     }
 
     @Provides

--- a/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/SpoolerReconnectionHandler.java
+++ b/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/SpoolerReconnectionHandler.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.queue.rabbitmq;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
+import org.apache.james.mailetcontainer.impl.JamesMailSpooler;
+import org.reactivestreams.Publisher;
+
+import com.rabbitmq.client.Connection;
+
+import reactor.core.publisher.Mono;
+
+public class SpoolerReconnectionHandler implements SimpleConnectionPool.ReconnectionHandler {
+    private final JamesMailSpooler spooler;
+
+    @Inject
+    public SpoolerReconnectionHandler(JamesMailSpooler spooler) {
+        this.spooler = spooler;
+    }
+
+    @Override
+    public Publisher<Void> handleReconnection(Connection connection) {
+        return Mono.fromRunnable(spooler::restart);
+    }
+}

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
@@ -65,7 +65,7 @@ public class RabbitMQMailQueue implements ManageableMailQueue {
 
     @Override
     public void close() {
-        dequeuer.close();
+
     }
 
     @Override

--- a/server/task/task-memory/src/main/java/org/apache/james/task/WorkQueue.java
+++ b/server/task/task-memory/src/main/java/org/apache/james/task/WorkQueue.java
@@ -28,6 +28,10 @@ public interface WorkQueue extends Closeable, Startable {
 
     }
 
+    default void restart() {
+
+    }
+
     void submit(TaskWithId taskWithId);
 
     void cancel(TaskId taskId);

--- a/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
+++ b/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
@@ -25,14 +25,12 @@ import java.util
 import com.google.common.annotations.VisibleForTesting
 import javax.annotation.PreDestroy
 import javax.inject.Inject
-
 import org.apache.james.eventsourcing.eventstore.{EventStore, History}
 import org.apache.james.eventsourcing.{AggregateId, EventSourcingSystem, Subscriber}
 import org.apache.james.lifecycle.api.Startable
 import org.apache.james.task.TaskManager.ReachedTimeoutException
 import org.apache.james.task._
 import org.apache.james.task.eventsourcing.TaskCommand._
-
 import reactor.core.publisher.{Flux, Mono}
 import reactor.core.scala.publisher.SMono
 import reactor.core.scheduler.Schedulers
@@ -74,6 +72,8 @@ class EventSourcingTaskManager @Inject @VisibleForTesting private[eventsourcing]
   private val workQueue: WorkQueue = workQueueSupplier(eventSourcingSystem)
 
   def start(): Unit = workQueue.start()
+
+  def restart(): Unit = workQueue.restart()
 
   override def submit(task: Task): TaskId = {
     val taskId = TaskId.generateTaskId


### PR DESCRIPTION
## Why?

After upgrading RabbitMQ to 3.8.17 we noticed that, once in a while, messages were not consumed anymore. The consumers alocated to it died and were not replaced.

This results in emails / updates being delayed.

## Possible explanation

For any reason (GC, network failure) some timeout was exceeded and the connection deemed unusable.

Upon connection replacement, no attempt is made to resume the consumer.

## Current fix

Restart James.

## Expected behaviour

We expect James, upon connection replacement, to happily restart its consumers.

## How?

Reconnection handler should also resume consummers.