### PR TITLE
JAMES-3607 Functional healthcheck exercising mail reception

### DIFF
--- a/docs/modules/servers/pages/distributed/configure/healthcheck.adoc
+++ b/docs/modules/servers/pages/distributed/configure/healthcheck.adoc
@@ -12,4 +12,11 @@ Use this configuration to define the initial delay and period for the Periodical
 
 | healthcheck.period
 | Define the period between two periodical health checks (default: 60s). Units supported are (ms - millisecond, s - second, m - minute, h - hour, d - day). Default unit is millisecond.
+
+| reception.check.user
+| User to be using for running the "mail reception" health check. The user must exist.
+If not specified, the mail reception check is a noop.
+
+| reception.check.timeout
+| Period after which mail reception is considered faulty. Defaults to one minute.
 |===

--- a/docs/modules/servers/pages/distributed/operate/webadmin.adoc
+++ b/docs/modules/servers/pages/distributed/operate/webadmin.adoc
@@ -77,6 +77,9 @@ Supported health checks include:
 * *EventDeadLettersHealthCheck*
 * *Guice application lifecycle*
 * *JPA Backend*: JPA storage.
+* *MailReceptionCheck* We rely on a configured user, send an email to him and
+assert that the email is well received, and can be read within the given configured
+period. Unhealthy means that the email could not be received before reacing the timeout.
 * *MessageFastViewProjection* Health check of the component storing JMAP properties
 which are fast to retrieve. Those properties are computed in advance
 from messages and persisted in order to archive a better performance.

--- a/pom.xml
+++ b/pom.xml
@@ -1428,6 +1428,11 @@
             </dependency>
             <dependency>
                 <groupId>${james.groupId}</groupId>
+                <artifactId>james-server-feature-checks</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
                 <artifactId>james-server-fetchmail</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/server/container/feature-checks/pom.xml
+++ b/server/container/feature-checks/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>james-server</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>james-server-feature-checks</artifactId>
+    <name>Apache James :: Server :: Feature checks</name>
+
+    <description>Advanced functional health checks for a James server</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mailet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/server/container/feature-checks/src/main/java/org/apache/james/healthcheck/MailReceptionCheck.java
+++ b/server/container/feature-checks/src/main/java/org/apache/james/healthcheck/MailReceptionCheck.java
@@ -1,0 +1,270 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.healthcheck;
+
+import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.mail.internet.InternetAddress;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.core.Username;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.core.healthcheck.ComponentName;
+import org.apache.james.core.healthcheck.HealthCheck;
+import org.apache.james.core.healthcheck.Result;
+import org.apache.james.events.Event;
+import org.apache.james.events.EventBus;
+import org.apache.james.events.EventListener;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.events.MailboxEvents.Added;
+import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.exception.MailboxNotFoundException;
+import org.apache.james.mailbox.model.FetchGroup;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.server.core.MailImpl;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.util.DurationParser;
+import org.apache.mailet.MailetContext;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+
+public class MailReceptionCheck implements HealthCheck {
+    public static class Configuration {
+        private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
+        public static final Configuration DEFAULT = new Configuration(Optional.empty(), DEFAULT_TIMEOUT);
+
+        public static Configuration from(org.apache.commons.configuration2.Configuration configuration) {
+            Optional<Username> username = Optional.ofNullable(configuration.getString("reception.check.user", null))
+                .map(Username::of);
+            Duration timeout = Optional.ofNullable(configuration.getString("reception.check.timeout", null))
+                .map(s -> DurationParser.parse(s, ChronoUnit.SECONDS))
+                .orElse(DEFAULT_TIMEOUT);
+
+            return new Configuration(username, timeout);
+        }
+
+        private final Optional<Username> checkUser;
+        private final Duration timeout;
+
+        public Configuration(Optional<Username> checkUser, Duration timeout) {
+            this.checkUser = checkUser;
+            this.timeout = timeout;
+        }
+
+        public Optional<Username> getCheckUser() {
+            return checkUser;
+        }
+
+        public Duration getTimeout() {
+            return timeout;
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (o instanceof Configuration) {
+                Configuration that = (Configuration) o;
+                return Objects.equals(checkUser, that.checkUser)
+                    && Objects.equals(timeout, that.timeout);
+            }
+            return false;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(checkUser, timeout);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                .add("checkUser", checkUser)
+                .add("timeout", timeout)
+                .toString();
+        }
+    }
+
+    public static class Content {
+        public static Content generate() {
+            return new Content(UUID.randomUUID());
+        }
+
+        private final UUID uuid;
+
+        private Content(UUID uuid) {
+            this.uuid = uuid;
+        }
+
+        public String asString() {
+            return uuid.toString();
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (o instanceof Content) {
+                Content that = (Content) o;
+                return Objects.equals(uuid, that.uuid);
+            }
+            return false;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(uuid);
+        }
+
+        @Override
+        public String toString() {
+            return asString();
+        }
+    }
+
+    public static class AwaitReceptionListener implements EventListener.ReactiveEventListener {
+        private final Sinks.Many<Added> sink;
+
+        public AwaitReceptionListener() {
+            sink = Sinks.many().multicast().onBackpressureBuffer();
+        }
+
+        @Override
+        public Publisher<Void> reactiveEvent(Event event) {
+            if (event instanceof Added) {
+                return Mono.fromRunnable(() -> sink.emitNext((Added) event, FAIL_FAST))
+                    .subscribeOn(Schedulers.elastic())
+                    .then();
+            }
+            return Mono.empty();
+        }
+
+        public Flux<Added> addedEvents() {
+            return sink.asFlux();
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailReceptionCheck.class);
+
+    private final MailetContext mailetContext;
+    private final MailboxManager mailboxManager;
+    private final EventBus eventBus;
+    private final UsersRepository usersRepository;
+    private final Configuration configuration;
+
+    @Inject
+    public MailReceptionCheck(MailetContext mailetContext, MailboxManager mailboxManager, EventBus eventBus, UsersRepository usersRepository, Configuration configuration) {
+        this.mailetContext = mailetContext;
+        this.mailboxManager = mailboxManager;
+        this.eventBus = eventBus;
+        this.usersRepository = usersRepository;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public ComponentName componentName() {
+        return new ComponentName("MailReceptionCheck");
+    }
+
+    @Override
+    public Publisher<Result> check() {
+        return configuration.getCheckUser()
+            .map(this::check)
+            .orElse(Mono.just(Result.healthy(componentName())));
+    }
+
+    private Mono<Result> check(Username username) {
+        MailboxSession session = mailboxManager.createSystemSession(username);
+        AwaitReceptionListener listener = new AwaitReceptionListener();
+
+        return retrieveInbox(username, session)
+            .flatMap(mailbox -> Mono.usingWhen(
+                Mono.from(eventBus.register(listener, new MailboxIdRegistrationKey(mailbox.getId()))),
+                registration -> sendMail(username)
+                    .flatMap(content -> checkReceived(session, listener, mailbox, content)),
+                registration -> Mono.fromRunnable(registration::unregister)))
+            .subscribeOn(Schedulers.elastic())
+            .timeout(configuration.getTimeout(), Mono.error(() -> new RuntimeException("HealthCheck email was not received after " + configuration.getTimeout().toMillis() + "ms")))
+            .onErrorResume(e -> {
+                LOGGER.error("Mail reception check failed", e);
+                return Mono.just(Result.unhealthy(componentName(), e.getMessage()));
+            });
+    }
+
+    private Mono<MessageManager> retrieveInbox(Username username, MailboxSession session) {
+        MailboxPath mailboxPath = MailboxPath.inbox(username);
+        return Mono.from(mailboxManager.getMailboxReactive(mailboxPath, session))
+            .onErrorResume(MailboxNotFoundException.class, e -> Mono.fromCallable(() -> mailboxManager.createMailbox(mailboxPath, session))
+                .then(Mono.from(mailboxManager.getMailboxReactive(mailboxPath, session))));
+    }
+
+    private Mono<Result> checkReceived(MailboxSession session, AwaitReceptionListener listener, MessageManager mailbox, Content content) {
+        return listener.addedEvents()
+            .flatMapIterable(Added::getUids)
+            .flatMap(uid -> Mono.fromCallable(() -> mailbox.getMessages(MessageRange.one(uid), FetchGroup.FULL_CONTENT, session)))
+            .flatMapIterable(ImmutableList::copyOf)
+            .filter(Throwing.predicate(messageResult -> IOUtils.toString(messageResult.getBody().getInputStream()).contains(content.asString())))
+            // Cleanup our testing mail
+            .doOnNext(messageResult -> {
+                try {
+                    mailbox.delete(ImmutableList.of(messageResult.getUid()), session);
+                } catch (MailboxException e) {
+                    LOGGER.warn("Failed to delete Health check testing email", e);
+                }
+            })
+            .map(any -> Result.healthy(componentName()))
+            .next();
+    }
+
+    private Mono<Content> sendMail(Username username) {
+        Content content = Content.generate();
+
+        return Mono.fromCallable(() -> usersRepository.getMailAddressFor(username))
+            .flatMap(address -> Mono.fromRunnable(Throwing.runnable(() ->
+                mailetContext.sendMail(MailImpl.builder()
+                    .name(content.asString())
+                    .sender(address)
+                    .addRecipient(address)
+                    .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                        .addFrom(new InternetAddress(address.asString()))
+                        .addToRecipient(address.asString())
+                        .setSubject(content.asString())
+                        .setText(content.asString()))
+                    .build()))))
+            .thenReturn(content);
+    }
+}

--- a/server/container/guice/mailbox/pom.xml
+++ b/server/container/guice/mailbox/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-feature-checks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-configuration</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxModule.java
@@ -24,6 +24,7 @@ import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.store.SystemMailboxesProviderImpl;
+import org.apache.james.modules.mailbox.MailReceptionHealthCheckModule;
 import org.apache.james.modules.mailbox.PreDeletionHookModule;
 import org.apache.james.utils.GuiceProbe;
 
@@ -36,6 +37,7 @@ public class MailboxModule extends AbstractModule {
     @Override
     protected void configure() {
         install(new PreDeletionHookModule());
+        install(new MailReceptionHealthCheckModule());
 
         Multibinder<GuiceProbe> probeMultiBinder = Multibinder.newSetBinder(binder(), GuiceProbe.class);
         probeMultiBinder.addBinding().to(MailboxProbeImpl.class);

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailReceptionHealthCheckModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailReceptionHealthCheckModule.java
@@ -1,0 +1,58 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import java.io.FileNotFoundException;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.core.healthcheck.HealthCheck;
+import org.apache.james.healthcheck.MailReceptionCheck;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+
+public class MailReceptionHealthCheckModule extends AbstractModule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailReceptionHealthCheckModule.class);
+    private static final String FILENAME = "healthcheck";
+
+    @Override
+    protected void configure() {
+        Multibinder<HealthCheck> healthCheckMultibinder = Multibinder.newSetBinder(binder(), HealthCheck.class);
+        healthCheckMultibinder.addBinding().to(MailReceptionCheck.class);
+    }
+
+    @Singleton
+    @Provides
+    MailReceptionCheck.Configuration configuration(PropertiesProvider propertiesProvider) throws ConfigurationException {
+        try {
+            Configuration configuration = propertiesProvider.getConfigurations(FILENAME);
+            return MailReceptionCheck.Configuration.from(configuration);
+        } catch (FileNotFoundException e) {
+            LOGGER.warn("Could not find {} configuration file, using default configuration", FILENAME);
+            return MailReceptionCheck.Configuration.DEFAULT;
+        }
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -51,6 +51,7 @@
         <module>blob</module>
 
         <module>container/core</module>
+        <module>container/feature-checks</module>
         <module>container/filesystem-api</module>
         <module>container/guice</module>
         <module>container/lifecycle-api</module>

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/MailReceptionCheckIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/MailReceptionCheckIntegrationTest.java
@@ -1,0 +1,136 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.integration.rabbitmq;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.james.jmap.JMAPTestingConstants.ALICE;
+import static org.apache.james.jmap.JMAPTestingConstants.ALICE_PASSWORD;
+import static org.apache.james.jmap.JMAPTestingConstants.DOMAIN;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.apache.james.CassandraExtension;
+import org.apache.james.CassandraRabbitMQJamesConfiguration;
+import org.apache.james.CassandraRabbitMQJamesServerMain;
+import org.apache.james.DockerElasticSearchExtension;
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.SearchConfiguration;
+import org.apache.james.core.healthcheck.ResultStatus;
+import org.apache.james.events.RetryBackoffConfiguration;
+import org.apache.james.healthcheck.MailReceptionCheck;
+import org.apache.james.junit.categories.BasicFeature;
+import org.apache.james.modules.AwsS3BlobStoreExtension;
+import org.apache.james.modules.RabbitMQExtension;
+import org.apache.james.modules.blobstore.BlobStoreConfiguration;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.WebAdminGuiceProbe;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.integration.WebadminIntegrationTestModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.restassured.RestAssured;
+
+@Tag(BasicFeature.TAG)
+class MailReceptionCheckIntegrationTest {
+    private static final RabbitMQExtension RABBIT_MQ_EXTENSION = new RabbitMQExtension();
+    public static final CassandraExtension CASSANDRA_EXTENSION = new CassandraExtension();
+
+    @RegisterExtension
+    static JamesServerExtension testExtension = new JamesServerBuilder<CassandraRabbitMQJamesConfiguration>(tmpDir ->
+        CassandraRabbitMQJamesConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .blobStore(BlobStoreConfiguration.builder()
+                    .s3()
+                    .disableCache()
+                    .deduplication()
+                    .noCryptoConfig())
+            .searchConfiguration(SearchConfiguration.elasticSearch())
+            .build())
+        .extension(new DockerElasticSearchExtension())
+        .extension(CASSANDRA_EXTENSION)
+        .extension(new AwsS3BlobStoreExtension())
+        .extension(RABBIT_MQ_EXTENSION)
+        .server(configuration -> CassandraRabbitMQJamesServerMain.createServer(configuration)
+            .overrideWith(new WebadminIntegrationTestModule())
+            .overrideWith(binder -> binder.bind(MailReceptionCheck.Configuration.class)
+                .toInstance(new MailReceptionCheck.Configuration(
+                    Optional.of(ALICE), Duration.ofSeconds(10))))
+            // Enforce a single eventBus retry. Required as Current Quotas are handled by the eventBus.
+            .overrideWith(binder -> binder.bind(RetryBackoffConfiguration.class)
+                .toInstance(RetryBackoffConfiguration.builder()
+                    .maxRetries(1)
+                    .firstBackoff(Duration.ofMillis(2))
+                    .jitterFactor(0.5)
+                    .build())))
+        .build();
+
+    @BeforeEach
+    void setUp(GuiceJamesServer guiceJamesServer) throws Exception {
+        guiceJamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DOMAIN)
+            .addUser(ALICE.asString(), ALICE_PASSWORD);
+
+        WebAdminGuiceProbe webAdminGuiceProbe = guiceJamesServer.getProbe(WebAdminGuiceProbe.class);
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminGuiceProbe.getWebAdminPort())
+            .build();
+    }
+
+    @Test
+    void shouldBeHealthy() {
+        given()
+            .pathParam("componentName", "MailReceptionCheck")
+        .when()
+            .get("/healthcheck/checks/{componentName}")
+        .then()
+            .body("componentName", equalTo("MailReceptionCheck"))
+            .body("escapedComponentName", equalTo("MailReceptionCheck"))
+            .body("status", equalTo(ResultStatus.HEALTHY.getValue()))
+            .body("cause", is(nullValue()));
+    }
+
+    @Test
+    void shouldBeUnhealthyWhenRabbitMQIsPaused() throws Exception {
+        RABBIT_MQ_EXTENSION.dockerRabbitMQ().pause();
+        Thread.sleep(1000);
+        try {
+            given()
+                .pathParam("componentName", "MailReceptionCheck")
+            .when()
+                .get("/healthcheck/checks/{componentName}")
+            .then()
+                .body("componentName", equalTo("MailReceptionCheck"))
+                .body("escapedComponentName", equalTo("MailReceptionCheck"))
+                .body("status", equalTo(ResultStatus.UNHEALTHY.getValue()));
+        } finally {
+            RABBIT_MQ_EXTENSION.dockerRabbitMQ().unpause();
+        }
+    }
+}

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -100,6 +100,9 @@ Supported health checks include:
  - **EventDeadLettersHealthCheck**: Included in all Guice products.
  - **Guice application lifecycle**: included in all Guice products.
  - **JPA Backend**: JPA storage. Included in JPA Guice based products.
+ - **MailReceptionCheck** We rely on a configured user, send an email to him and
+ assert that the email is well received, and can be read within the given configured
+ period. Unhealthy means that the email could not be received before reacing the timeout.
  - **MessageFastViewProjection**: included in memory and Cassandra based Guice products. 
  Health check of the component storing JMAP properties which are fast to retrieve. 
  Those properties are computed in advance from messages and persisted in order to archive a better performance. 

--- a/src/site/xdoc/server/config-healthcheck.xml
+++ b/src/site/xdoc/server/config-healthcheck.xml
@@ -35,6 +35,13 @@
             <dl>
                 <dt><strong>healthcheck.period</strong></dt>
                 <dd>Define the period between two periodical health checks (default: 60)</dd>
+
+                <dt><strong>reception.check.user</strong></dt>
+                <dd>User to be using for running the "mail reception" health check. The user must exist.
+                    If not specified, the mail reception check is a noop.</dd>
+
+                <dt><strong>reception.check.timeout</strong></dt>
+                <dd>Period after which mail reception is considered faulty. Defaults to one minute.</dd>
             </dl>
         </section>
     </body>


### PR DESCRIPTION
## Why?

As described in JAMES-3605, RabbitMQ consumers can end up being stuck.

In such a scenario we are not able to detect the failure and end up relying on cunsumer reports to restart James.

We would like to have a health-check, allowing automatic testing about mail reception. (Both periodical logs and also a HTTP endpoint for integration with a monitoring system)...

So a healthcheck no longer for a technical component but for a feature.


## How?

In `healthcheck.properties` on could configure a user to run reception checks:

```
reception.checks.user=test@domain.tld
```

If configured, the healthcheck would then send a mail to the user, await the email via the eventbus, then retrieve its content.

To be placed in a new `server/container/feature-checks` maven project.

## Definition of done

 - Given a paused RabbitMQ the check fails for the distributed server
 - Given a working James the check passes.

## Disclaimer

The idea had been first expressed by @mbaechler years ago...