### PR TITLE
Various small performance enhancements when sending messages via JMAP

### DIFF
--- a/core/src/main/java/org/apache/james/core/Username.java
+++ b/core/src/main/java/org/apache/james/core/Username.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.core;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -28,8 +27,6 @@ import javax.mail.internet.AddressException;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 
 public class Username {
     public static final int MAXIMUM_MAIL_ADDRESS_LENGTH = 255;
@@ -40,14 +37,16 @@ public class Username {
         Preconditions.checkArgument(username.length() <= MAXIMUM_MAIL_ADDRESS_LENGTH,
             "username length should not be longer than %s characters", MAXIMUM_MAIL_ADDRESS_LENGTH);
 
-        List<String> parts = ImmutableList.copyOf(Splitter.on('@').split(username));
-        switch (parts.size()) {
-            case 1:
-                return fromLocalPartWithoutDomain(username);
-            case 2:
-                return fromLocalPartWithDomain(parts.get(0), parts.get(1));
+        int atPosition = username.indexOf('@');
+        if (atPosition < 0) {
+            return fromLocalPartWithoutDomain(username);
         }
-        throw new IllegalArgumentException("The username should not contain multiple domain delimiter. Value: " + username);
+        String userPart = username.substring(0, atPosition);
+        String domainPart = username.substring(atPosition + 1);
+        if (domainPart.indexOf('@') >= 0) {
+            throw new IllegalArgumentException("The username should not contain multiple domain delimiter. Value: " + username);
+        }
+        return fromLocalPartWithDomain(userPart, domainPart);
     }
 
     public static Username fromLocalPartWithDomain(String localPart, String domain) {

--- a/core/src/test/java/org/apache/james/core/UsernameTest.java
+++ b/core/src/test/java/org/apache/james/core/UsernameTest.java
@@ -154,6 +154,12 @@ class UsernameTest {
     }
 
     @Test
+    void fromUsernameShouldThrowWhenMultipleDomainDelimiterTogether() {
+        assertThatThrownBy(() -> Username.of("aa@@aa"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void fromUsernameShouldThrowWhenEndsWithDomainDelimiter() {
         assertThatThrownBy(() -> Username.of("aa@"))
             .isInstanceOf(IllegalArgumentException.class);

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartParser.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartParser.java
@@ -30,6 +30,8 @@ import org.apache.james.mailbox.model.ContentType.MediaType;
 import org.apache.james.mailbox.model.ContentType.SubType;
 import org.apache.james.mailbox.store.mail.model.Message;
 import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.field.LenientFieldParser;
 import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
 import org.apache.james.mime4j.message.MaximalBodyDescriptor;
 import org.apache.james.mime4j.stream.EntityState;
@@ -57,7 +59,7 @@ public class MimePartParser {
         this.currentlyBuildMimePart = new RootMimePartContainerBuilder();
         this.stream = new MimeTokenStream(
             MimeConfig.PERMISSIVE,
-            new DefaultBodyDescriptorBuilder());
+            new DefaultBodyDescriptorBuilder(null, new LenientFieldParser(), DecodeMonitor.SILENT));
     }
 
     public MimePart parse() throws IOException, MimeException {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MimeDescriptorImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MimeDescriptorImpl.java
@@ -36,6 +36,8 @@ import org.apache.james.mailbox.model.Header;
 import org.apache.james.mailbox.model.MimeDescriptor;
 import org.apache.james.mailbox.store.streaming.CountingInputStream;
 import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.field.LenientFieldParser;
 import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
 import org.apache.james.mime4j.message.MaximalBodyDescriptor;
 import org.apache.james.mime4j.stream.EntityState;
@@ -49,7 +51,8 @@ public class MimeDescriptorImpl implements MimeDescriptor {
         // Disable line length limit
         // See https://issues.apache.org/jira/browse/IMAP-132
         //
-        final MimeTokenStream parser = new MimeTokenStream(MimeConfig.PERMISSIVE, new DefaultBodyDescriptorBuilder());
+        final MimeTokenStream parser = new MimeTokenStream(MimeConfig.PERMISSIVE,
+            new DefaultBodyDescriptorBuilder(null, new LenientFieldParser(), DecodeMonitor.SILENT));
         
         parser.parse(stream);
         

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -91,7 +91,9 @@ import org.apache.james.mailbox.store.quota.QuotaChecker;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.streaming.CountingInputStream;
 import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.field.LenientFieldParser;
 import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
 import org.apache.james.mime4j.message.HeaderImpl;
 import org.apache.james.mime4j.message.MaximalBodyDescriptor;
@@ -436,7 +438,8 @@ public class StoreMessageManager implements MessageManager {
     }
 
     private MimeTokenStream getParser(BodyOffsetInputStream bIn) {
-        final MimeTokenStream parser = new MimeTokenStream(MimeConfig.PERMISSIVE, new DefaultBodyDescriptorBuilder());
+        final MimeTokenStream parser = new MimeTokenStream(MimeConfig.PERMISSIVE,
+            new DefaultBodyDescriptorBuilder(null, new LenientFieldParser(), DecodeMonitor.SILENT));
 
         parser.setRecursionMode(RecursionMode.M_NO_RECURSE);
         parser.parse(bIn);

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
@@ -55,6 +55,7 @@ import org.apache.james.mime4j.dom.field.FieldName;
 import org.apache.james.mime4j.dom.field.UnstructuredField;
 import org.apache.james.mime4j.field.ContentIdFieldImpl;
 import org.apache.james.mime4j.field.Fields;
+import org.apache.james.mime4j.field.LenientFieldParser;
 import org.apache.james.mime4j.field.UnstructuredFieldImpl;
 import org.apache.james.mime4j.message.BasicBodyFactory;
 import org.apache.james.mime4j.message.BodyPart;
@@ -132,7 +133,8 @@ public class MIMEMessageConverter {
             throw new IllegalArgumentException("creationMessageEntry is either null or has null message");
         }
 
-        Message.Builder messageBuilder = Message.Builder.of();
+        Message.Builder messageBuilder = Message.Builder.of()
+            .use(new LenientFieldParser());
         if (isMultipart(creationMessageEntry.getValue(), messageAttachments)) {
             messageBuilder.setBody(createMultipart(creationMessageEntry.getValue(), messageAttachments, session));
         } else {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessor.java
@@ -122,6 +122,9 @@ public class SetMessagesUpdateProcessor implements SetMessagesProcessor {
 
     @Override
     public Mono<SetMessagesResponse> processReactive(SetMessagesRequest request, MailboxSession mailboxSession) {
+        if (!request.hasUpdates()) {
+            return Mono.just(SetMessagesResponse.builder().build());
+        }
         return Mono.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + "SetMessagesUpdateProcessor",
             listMailboxIdsForRole(mailboxSession, Role.OUTBOX)
                 .flatMap(outboxIds -> prepareResponse(request, mailboxSession, outboxIds).map(SetMessagesResponse.Builder::build))

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/SetMessagesRequest.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/SetMessagesRequest.java
@@ -168,6 +168,10 @@ public class SetMessagesRequest implements JmapRequest {
         return Maps.transformValues(update, func -> func.apply(converter));
     }
 
+    public boolean hasUpdates() {
+        return !update.isEmpty();
+    }
+
     public List<MessageId> getDestroy() {
         return destroy;
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/send/PostDequeueDecorator.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/send/PostDequeueDecorator.java
@@ -135,7 +135,7 @@ public class PostDequeueDecorator extends MailQueueItemDecorator {
     private void moveFromOutboxToSentWithSeenFlag(MessageId messageId, MailboxSession mailboxSession) {
         assertMessageBelongsToOutbox(messageId, mailboxSession)
             .then(getSentMailboxId(mailboxSession)
-                .switchIfEmpty(Mono.error(new MailboxRoleNotFoundException(Role.SENT)))
+                .switchIfEmpty(Mono.error(() -> new MailboxRoleNotFoundException(Role.SENT)))
                 .flatMap(sentMailboxId ->
                         Mono.from(messageIdManager.setInMailboxesReactive(messageId,
                             ImmutableList.of(sentMailboxId), mailboxSession))


### PR DESCRIPTION
## Before

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      29532 (OK=29532  KO=0     )
> min response time                                      6 (OK=6      KO=-     )
> max response time                                   5137 (OK=5137   KO=-     )
> mean response time                                   344 (OK=344    KO=-     )
> std deviation                                        325 (OK=325    KO=-     )
> response time 50th percentile                        241 (OK=241    KO=-     )
> response time 75th percentile                        370 (OK=370    KO=-     )
> response time 95th percentile                        848 (OK=848    KO=-     )
> response time 99th percentile                       1777 (OK=1777   KO=-     )
> mean requests/sec                                 40.678 (OK=40.678 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         27913 ( 95%)
> 800 ms < t < 1200 ms                                 748 (  3%)
> t > 1200 ms                                          871 (  3%)
> failed                                                 0 (  0%)
================================================================================
```


## After

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      29790 (OK=29790  KO=0     )
> min response time                                      8 (OK=8      KO=-     )
> max response time                                   5403 (OK=5403   KO=-     )
> mean response time                                   316 (OK=316    KO=-     )
> std deviation                                        256 (OK=256    KO=-     )
> response time 50th percentile                        248 (OK=248    KO=-     )
> response time 75th percentile                        327 (OK=327    KO=-     )
> response time 95th percentile                        691 (OK=691    KO=-     )
> response time 99th percentile                       1363 (OK=1363   KO=-     )
> mean requests/sec                                 40.977 (OK=40.977 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         28893 ( 97%)
> 800 ms < t < 1200 ms                                 460 (  2%)
> t > 1200 ms                                          437 (  1%)
> failed                                                 0 (  0%)
================================================================================
```