### PR TITLE
[SCALA_CHECKSTYLE] Setup scalafix & Implement some rules

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,5 +1,8 @@
 rules = [
-    RemoveUnused
+    DisableSyntax,
+    ProcedureSyntax,
+    NoValInForComprehension,
+    LeakingImplicitClassVal
 ]
 
 RemoveUnused.imports = true
@@ -7,3 +10,17 @@ RemoveUnused.privates = false
 RemoveUnused.locals = true
 RemoveUnused.patternvars = false
 RemoveUnused.implicits = false
+
+DisableSyntax.noVars = false
+DisableSyntax.noThrows = false
+DisableSyntax.noNulls = false
+DisableSyntax.noReturns = false
+DisableSyntax.noWhileLoops = false
+DisableSyntax.noAsInstanceOf = false
+DisableSyntax.noIsInstanceOf = false
+DisableSyntax.noXml = false
+DisableSyntax.noDefaultArgs = false
+DisableSyntax.noFinalVal = true
+DisableSyntax.noFinalize = true
+DisableSyntax.noValPatterns = false
+DisableSyntax.noUniversalEquality = false

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,9 @@
+rules = [
+    RemoveUnused
+]
+
+RemoveUnused.imports = true
+RemoveUnused.privates = false
+RemoveUnused.locals = true
+RemoveUnused.patternvars = false
+RemoveUnused.implicits = false

--- a/event-sourcing/event-sourcing-core/pom.xml
+++ b/event-sourcing/event-sourcing-core/pom.xml
@@ -87,6 +87,13 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.github.evis</groupId>
+                <artifactId>scalafix-maven-plugin</artifactId>
+                <configuration>
+                    <config>${project.parent.parent.basedir}/.scalafix.conf</config>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/event-sourcing/event-sourcing-pojo/pom.xml
+++ b/event-sourcing/event-sourcing-pojo/pom.xml
@@ -52,6 +52,13 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.github.evis</groupId>
+                <artifactId>scalafix-maven-plugin</artifactId>
+                <configuration>
+                    <config>${project.parent.parent.basedir}/.scalafix.conf</config>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/mailbox/event/json/pom.xml
+++ b/mailbox/event/json/pom.xml
@@ -99,6 +99,13 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.github.evis</groupId>
+                <artifactId>scalafix-maven-plugin</artifactId>
+                <configuration>
+                    <config>${project.parent.parent.basedir}/.scalafix.conf</config>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/mdn/pom.xml
+++ b/mdn/pom.xml
@@ -90,6 +90,13 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.github.evis</groupId>
+                <artifactId>scalafix-maven-plugin</artifactId>
+                <configuration>
+                    <config>${project.parent.basedir}/.scalafix.conf</config>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2819,6 +2819,14 @@
                     <version>2.7.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>io.github.evis</groupId>
+                    <artifactId>scalafix-maven-plugin</artifactId>
+                    <version>0.1.4_0.9.23</version>
+                    <configuration>
+                        <config>${basedir}/.scalafix.conf</config>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.scalatest</groupId>
                     <artifactId>scalatest-maven-plugin</artifactId>
                     <version>2.0.0</version>
@@ -2847,7 +2855,15 @@
                             <arg>-unchecked</arg>
                             <arg>-deprecation</arg>
                             <arg>-explaintypes</arg>
+                            <arg>-Ywarn-unused</arg>
                         </args>
+                        <compilerPlugins>
+                            <compilerPlugin>
+                                <groupId>org.scalameta</groupId>
+                                <artifactId>semanticdb-scalac_${scala.version}</artifactId>
+                                <version>4.4.23</version>
+                            </compilerPlugin>
+                        </compilerPlugins>
                     </configuration>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -2824,7 +2824,17 @@
                     <version>0.1.4_0.9.23</version>
                     <configuration>
                         <config>${basedir}/.scalafix.conf</config>
+                        <mode>CHECK</mode>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>scala-check-style</id>
+                            <goals>
+                                <goal>scalafix</goal>
+                            </goals>
+                            <phase>compile</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.scalatest</groupId>

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/pom.xml
@@ -83,6 +83,13 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.github.evis</groupId>
+                <artifactId>scalafix-maven-plugin</artifactId>
+                <configuration>
+                    <config>${project.parent.parent.parent.basedir}/.scalafix.conf</config>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailChangesMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailChangesMethodContract.scala
@@ -210,15 +210,15 @@ trait EmailChangesMethodContract {
       .setBody("testmail", StandardCharsets.UTF_8)
       .build
     val messageId1: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
-    val state1: State = waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
+    waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
     val messageId2: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
-    val state2: State = waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
+    waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
     val messageId3: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
-    val state3: State = waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
+    waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
     val messageId4: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
-    val state4: State = waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
+    waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
     val messageId5: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
-    val state5: State = waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
+    waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
     val messageId6: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
     val state6: State = waitForNextState(server, AccountId.fromUsername(BOB), State.INITIAL)
 
@@ -312,7 +312,7 @@ trait EmailChangesMethodContract {
     val mailboxProbe: MailboxProbeImpl = server.getProbe(classOf[MailboxProbeImpl])
     val path: MailboxPath = MailboxPath.forUser(BOB, "mailbox1")
 
-    val mailboxId1 = mailboxProbe.createMailbox(path)
+    mailboxProbe.createMailbox(path)
     val mailboxId2 = mailboxProbe.createMailbox(MailboxPath.forUser(BOB, "mailbox2"))
 
     val message: Message = Message.Builder

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailGetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailGetMethodContract.scala
@@ -3198,7 +3198,7 @@ trait EmailGetMethodContract {
   @Test
   def receivedAtPropertyShouldBeReturned(server: GuiceJamesServer): Unit = {
     val path = MailboxPath.inbox(BOB)
-    val mailboxId: MailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)
     val message: Message = Message.Builder
       .of
       .setSubject("test")

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailImportContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailImportContract.scala
@@ -672,7 +672,7 @@ trait EmailImportContract {
   @Test
   def importShouldFailWhenBlobNotOwned(server: GuiceJamesServer): Unit = {
     val andrePath = MailboxPath.inbox(ANDRE)
-    val andreId: MailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
     val bobPath = MailboxPath.inbox(BOB)
     val bobId: MailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(bobPath)
     val receivedAt = ZonedDateTime.now().minusDays(1)
@@ -743,7 +743,7 @@ trait EmailImportContract {
   @Test
   def importShouldSucceedWhenBlobDelegated(server: GuiceJamesServer): Unit = {
     val andrePath = MailboxPath.inbox(ANDRE)
-    val andreId: MailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
     val bobPath = MailboxPath.inbox(BOB)
     val bobId: MailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(bobPath)
     val receivedAt = ZonedDateTime.now().minusDays(1)

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
@@ -147,7 +147,7 @@ trait EmailQueryMethodContract {
   def hasAttachmentShouldKeepMessageWithAttachmentWhenTrue(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
     mailboxProbe.createMailbox(MailboxPath.inbox(BOB))
-    val messageId1: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB),
         AppendCommand.from(
           buildTestMessage))
@@ -459,8 +459,8 @@ trait EmailQueryMethodContract {
   @Test
   def emailInSharedMailboxesShouldNotBeDisplayedWhenNoExtension(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val andreInboxId = mailboxProbe.createMailbox(inbox(ANDRE))
-    val messageId1: MessageId = mailboxProbe
+    mailboxProbe.createMailbox(inbox(ANDRE))
+    mailboxProbe
       .appendMessage(ANDRE.asString, inbox(ANDRE),
         AppendCommand.from(
           Message.Builder
@@ -521,7 +521,7 @@ trait EmailQueryMethodContract {
   @Test
   def emailInSharedMailboxesShouldBeDisplayedWhenExtension(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val andreInboxId = mailboxProbe.createMailbox(inbox(ANDRE))
+    mailboxProbe.createMailbox(inbox(ANDRE))
     val messageId1: MessageId = mailboxProbe
       .appendMessage(ANDRE.asString, inbox(ANDRE),
         AppendCommand.from(
@@ -585,7 +585,7 @@ trait EmailQueryMethodContract {
   def inMailboxFilterShouldReturnEmptyForSharedMailboxesWhenNoExtension(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
     val andreInboxId = mailboxProbe.createMailbox(inbox(ANDRE))
-    val messageId1: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(ANDRE.asString, inbox(ANDRE),
         AppendCommand.from(
           Message.Builder
@@ -714,7 +714,7 @@ trait EmailQueryMethodContract {
   def inMailboxOtherThanFilterShouldReturnEmptyForSharedMailboxesWhenNoExtension(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
     val andreInboxId = mailboxProbe.createMailbox(inbox(ANDRE))
-    val messageId1: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(ANDRE.asString, inbox(ANDRE),
         AppendCommand.from(
           Message.Builder
@@ -775,8 +775,8 @@ trait EmailQueryMethodContract {
   def inMailboxOtherThanFilterShouldAcceptSharedMailboxesWhenExtension(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
     val andreInboxId = mailboxProbe.createMailbox(inbox(ANDRE))
-    val bobInboxId = mailboxProbe.createMailbox(inbox(BOB))
-    val messageId1: MessageId = mailboxProbe
+    mailboxProbe.createMailbox(inbox(BOB))
+    mailboxProbe
       .appendMessage(ANDRE.asString, inbox(ANDRE),
         AppendCommand.from(
           Message.Builder
@@ -851,7 +851,7 @@ trait EmailQueryMethodContract {
     server.getProbe(classOf[MailboxProbeImpl]).createMailbox(mailboxPath)
     val requestDate = Date.from(ZonedDateTime.now().minusDays(1).toInstant)
     val messageId1: MessageId = sendMessageToBobInbox(server, message, requestDate)
-    val messageId2: MessageId = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, mailboxPath, AppendCommand.from(
         ClassLoaderUtils.getSystemResourceAsSharedStream("eml/multipart_simple.eml")))
       .getMessageId
@@ -989,7 +989,7 @@ trait EmailQueryMethodContract {
   @Test
   def headerExistsShouldBeCaseInsentive(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val bobInboxId = mailboxProbe.createMailbox(inbox(BOB))
+    mailboxProbe.createMailbox(inbox(BOB))
     val messageId1: MessageId = mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
@@ -1000,7 +1000,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId2: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1060,7 +1060,7 @@ trait EmailQueryMethodContract {
   @Test
   def headerShouldAllowToMatchMailWithSpecificHeaderSet(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val bobInboxId = mailboxProbe.createMailbox(inbox(BOB))
+    mailboxProbe.createMailbox(inbox(BOB))
     val messageId1: MessageId = mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
@@ -1071,7 +1071,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId2: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1131,7 +1131,7 @@ trait EmailQueryMethodContract {
   @Test
   def headerShouldAllowToMatchMailWithSpecificValueHeaderSet(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val bobInboxId = mailboxProbe.createMailbox(inbox(BOB))
+    mailboxProbe.createMailbox(inbox(BOB))
     val messageId1: MessageId = mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
@@ -1142,7 +1142,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId2: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1151,7 +1151,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId3: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1212,7 +1212,7 @@ trait EmailQueryMethodContract {
   @Test
   def headerContainsShouldBeCaseInsentive(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val bobInboxId = mailboxProbe.createMailbox(inbox(BOB))
+    mailboxProbe.createMailbox(inbox(BOB))
     val messageId1: MessageId = mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
@@ -1223,7 +1223,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId2: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1232,7 +1232,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId3: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1293,8 +1293,8 @@ trait EmailQueryMethodContract {
   @Test
   def headerShouldRejectWhenMoreThanTwoItems(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val bobInboxId = mailboxProbe.createMailbox(inbox(BOB))
-    val messageId1: MessageId = mailboxProbe
+    mailboxProbe.createMailbox(inbox(BOB))
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1304,7 +1304,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId2: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1313,7 +1313,7 @@ trait EmailQueryMethodContract {
             .setBody("testmail", StandardCharsets.UTF_8)
             .build))
       .getMessageId
-    val messageId3: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, inbox(BOB),
         AppendCommand.from(
           Message.Builder
@@ -1377,7 +1377,7 @@ trait EmailQueryMethodContract {
           buildTestMessage))
       .getMessageId
 
-    val messageId2: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.from(
         ClassLoaderUtils.getSystemResourceAsSharedStream("eml/multipart_simple.eml")))
       .getMessageId
@@ -1435,14 +1435,14 @@ trait EmailQueryMethodContract {
     val afterRequestDate = Date.from(ZonedDateTime.now().toInstant)
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
     mailboxProbe.createMailbox(MailboxPath.inbox(BOB))
-    val messageId1: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB),
         AppendCommand.builder()
           .withInternalDate(beforeRequestDate)
           .build(buildTestMessage))
       .getMessageId
 
-    val messageId2: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder()
           .withInternalDate(beforeRequestDate)
         .build(ClassLoaderUtils.getSystemResourceAsSharedStream("eml/multipart_simple.eml")))
@@ -1455,7 +1455,7 @@ trait EmailQueryMethodContract {
           .build(buildTestMessage))
       .getMessageId
 
-    val messageId4: MessageId = mailboxProbe
+    mailboxProbe
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder()
         .withInternalDate(afterRequestDate)
         .build(ClassLoaderUtils.getSystemResourceAsSharedStream("eml/multipart_simple.eml")))
@@ -2902,17 +2902,17 @@ trait EmailQueryMethodContract {
   @Test
   def minSizeShouldBeInclusive(server: GuiceJamesServer): Unit = {
     val message1: Message = simpleMessage("short")
-    val size1: Int = computeSize(message1)
+    computeSize(message1)
     // One char more than message1
     val message2: Message = simpleMessage("short!")
     val size2: Int = computeSize(message2)
     // One char more than message2
     val message3: Message = simpleMessage("short!!")
-    val size3: Int = computeSize(message3)
+    computeSize(message3)
 
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
     mailboxProbe.createMailbox(inbox(BOB))
-    val id1 = mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message1)).getMessageId
+    mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message1)).getMessageId
     val id2 = mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message2)).getMessageId
     val id3 = mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message3)).getMessageId
 
@@ -2959,19 +2959,19 @@ trait EmailQueryMethodContract {
   @Test
   def maxSizeShouldBeExclusive(server: GuiceJamesServer): Unit = {
     val message1: Message = simpleMessage("looooooooooooooong")
-    val size1: Int = computeSize(message1)
+    computeSize(message1)
     // One char more than message3
     val message2: Message = simpleMessage("looooooooooooooong!")
     val size2: Int = computeSize(message2)
     // One char more than message4
     val message3: Message = simpleMessage("looooooooooooooong!!")
-    val size3: Int = computeSize(message3)
+    computeSize(message3)
 
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
     mailboxProbe.createMailbox(inbox(BOB))
     val id1 = mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message1)).getMessageId
-    val id2 = mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message2)).getMessageId
-    val id3 = mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message3)).getMessageId
+    mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message2)).getMessageId
+    mailboxProbe.appendMessage(BOB.asString, inbox(BOB), AppendCommand.from(message3)).getMessageId
 
     val request =
       s"""{
@@ -3894,7 +3894,7 @@ trait EmailQueryMethodContract {
           .withInternalDate(Date.from(ZonedDateTime.now().minusDays(2).toInstant))
           .build(message))
         .getMessageId
-    val messageId2: MessageId = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
         .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder()
           .withInternalDate(Date.from(ZonedDateTime.now().minusDays(1).toInstant))
           .build(message))
@@ -4471,13 +4471,13 @@ trait EmailQueryMethodContract {
           .setFrom("user@domain.tld")
           .build))
       .getMessageId
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setFrom("other@domain.tld")
           .build))
       .getMessageId
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setFrom("yet@other.tld")
@@ -4489,7 +4489,7 @@ trait EmailQueryMethodContract {
           .setFrom("yet@other.tld", "user@domain.tld")
           .build))
       .getMessageId
-    val messageId5 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -4549,7 +4549,7 @@ trait EmailQueryMethodContract {
       .of
       .setSubject("test")
       .setBody("testmail", StandardCharsets.UTF_8)
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setFrom("user@domain.tld")
@@ -4567,7 +4567,7 @@ trait EmailQueryMethodContract {
           .setFrom("display@other.tld")
           .build))
       .getMessageId
-    val messageId4 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -4621,13 +4621,13 @@ trait EmailQueryMethodContract {
           .setTo("user@domain.tld")
           .build))
       .getMessageId
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setTo("other@domain.tld")
           .build))
       .getMessageId
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setTo("yet@other.tld")
@@ -4639,7 +4639,7 @@ trait EmailQueryMethodContract {
           .setTo("yet@other.tld", "user@domain.tld")
           .build))
       .getMessageId
-    val messageId5 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -4699,7 +4699,7 @@ trait EmailQueryMethodContract {
       .of
       .setSubject("test")
       .setBody("testmail", StandardCharsets.UTF_8)
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setTo("user@domain.tld")
@@ -4717,7 +4717,7 @@ trait EmailQueryMethodContract {
           .setTo("display@other.tld")
           .build))
       .getMessageId
-    val messageId4 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -4771,13 +4771,13 @@ trait EmailQueryMethodContract {
           .setCc(DefaultAddressParser.DEFAULT.parseMailbox("user@domain.tld"))
           .build))
       .getMessageId
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setCc(DefaultAddressParser.DEFAULT.parseMailbox("other@domain.tld"))
           .build))
       .getMessageId
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setCc(DefaultAddressParser.DEFAULT.parseMailbox("yet@other.tld"))
@@ -4790,7 +4790,7 @@ trait EmailQueryMethodContract {
             DefaultAddressParser.DEFAULT.parseMailbox("user@domain.tld"))
           .build))
       .getMessageId
-    val messageId5 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -4850,7 +4850,7 @@ trait EmailQueryMethodContract {
       .of
       .setSubject("test")
       .setBody("testmail", StandardCharsets.UTF_8)
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setCc(DefaultAddressParser.DEFAULT.parseMailbox("user@domain.tld"))
@@ -4868,7 +4868,7 @@ trait EmailQueryMethodContract {
           .setCc(DefaultAddressParser.DEFAULT.parseMailbox("display@other.tld"))
           .build))
       .getMessageId
-    val messageId4 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -4922,13 +4922,13 @@ trait EmailQueryMethodContract {
           .setBcc(DefaultAddressParser.DEFAULT.parseMailbox("user@domain.tld"))
           .build))
       .getMessageId
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setBcc(DefaultAddressParser.DEFAULT.parseMailbox("other@domain.tld"))
           .build))
       .getMessageId
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setBcc(DefaultAddressParser.DEFAULT.parseMailbox("yet@other.tld"))
@@ -4941,7 +4941,7 @@ trait EmailQueryMethodContract {
             DefaultAddressParser.DEFAULT.parseMailbox("user@domain.tld"))
           .build))
       .getMessageId
-    val messageId5 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -5001,7 +5001,7 @@ trait EmailQueryMethodContract {
       .of
       .setSubject("test")
       .setBody("testmail", StandardCharsets.UTF_8)
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setBcc(DefaultAddressParser.DEFAULT.parseMailbox("user@domain.tld"))
@@ -5019,7 +5019,7 @@ trait EmailQueryMethodContract {
           .setBcc(DefaultAddressParser.DEFAULT.parseMailbox("display@other.tld"))
           .build))
       .getMessageId
-    val messageId4 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -5072,13 +5072,13 @@ trait EmailQueryMethodContract {
           .setSubject("Yet another day in paradise")
           .build))
       .getMessageId
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setSubject("Welcome to hell")
           .build))
       .getMessageId
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -5131,13 +5131,13 @@ trait EmailQueryMethodContract {
           .setSubject("Yet another day in paradise")
           .build))
       .getMessageId
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder
           .setSubject("Welcome to hell")
           .build))
       .getMessageId
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(
         messageBuilder.build))
       .getMessageId
@@ -5642,11 +5642,11 @@ trait EmailQueryMethodContract {
   def emailQueryShouldSupportAndOperator(server: GuiceJamesServer): Unit = {
     val message: Message = buildTestMessage
     server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("custom")).build(message))
       .getMessageId
 
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("another_custom")).build(message))
       .getMessageId
 
@@ -5714,7 +5714,7 @@ trait EmailQueryMethodContract {
         .build(message))
       .getMessageId
 
-    val messageId4 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().build(message))
       .getMessageId
 
@@ -5761,19 +5761,19 @@ trait EmailQueryMethodContract {
   def emailQueryShouldSupportNotOperator(server: GuiceJamesServer): Unit = {
     val message: Message = buildTestMessage
     server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder()
         .withFlags(new Flags("custom"))
         .build(message))
       .getMessageId
 
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder()
         .withFlags(new Flags("another_custom"))
         .build(message))
       .getMessageId
 
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder()
         .withFlags(new FlagsBuilder().add("custom", "another_custom").build())
         .build(message))
@@ -5926,15 +5926,15 @@ trait EmailQueryMethodContract {
   def inMailboxShouldBeRejectedWhenInOperator(server: GuiceJamesServer): Unit = {
     val message: Message = buildTestMessage
     val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("custom")).build(message))
       .getMessageId
 
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("another_custom")).build(message))
       .getMessageId
 
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new FlagsBuilder().add("custom", "another_custom").build()).build(message))
       .getMessageId
 
@@ -5989,15 +5989,15 @@ trait EmailQueryMethodContract {
   def inMailboxOtherThanShouldBeRejectedWhenInOperator(server: GuiceJamesServer): Unit = {
     val message: Message = buildTestMessage
     val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("custom")).build(message))
       .getMessageId
 
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("another_custom")).build(message))
       .getMessageId
 
-    val messageId3 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new FlagsBuilder().add("custom", "another_custom").build()).build(message))
       .getMessageId
 
@@ -6096,11 +6096,11 @@ trait EmailQueryMethodContract {
   def nestedOperatorsShouldBeSupported(server: GuiceJamesServer): Unit = {
     val message: Message = buildTestMessage
     server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("custom")).build(message))
       .getMessageId
 
-    val messageId2 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.builder().withFlags(new Flags("another_custom")).build(message))
       .getMessageId
 
@@ -6197,7 +6197,7 @@ trait EmailQueryMethodContract {
     val message: Message = buildTestMessage
     server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
 
-    val messageId1 = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB),
         AppendCommand.builder()
           .withFlags(new FlagsBuilder().add("custom_1", "custom_2").build())

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailSetMethodContract.scala
@@ -1101,7 +1101,7 @@ trait EmailSetMethodContract {
   @Test
   def createShouldRejectEmptyMailboxIds(server: GuiceJamesServer): Unit = {
     val andrePath = MailboxPath.inbox(ANDRE)
-    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
 
     val request =
       s"""{
@@ -1142,7 +1142,7 @@ trait EmailSetMethodContract {
   @Test
   def createShouldRejectInvalidMailboxIds(server: GuiceJamesServer): Unit = {
     val andrePath = MailboxPath.inbox(ANDRE)
-    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
 
     val request =
       s"""{
@@ -1185,7 +1185,7 @@ trait EmailSetMethodContract {
   @Test
   def createShouldRejectNoMailboxIds(server: GuiceJamesServer): Unit = {
     val andrePath = MailboxPath.inbox(ANDRE)
-    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(andrePath)
 
     val request =
       s"""{
@@ -2923,7 +2923,7 @@ trait EmailSetMethodContract {
     val messageId = responseAsJson
       .\("id")
       .get.asInstanceOf[JsString].value
-    val size = responseAsJson
+    responseAsJson
       .\("size")
       .get.asInstanceOf[JsNumber].value
 
@@ -3255,7 +3255,7 @@ trait EmailSetMethodContract {
     val payload = "123456789\r\n".getBytes(StandardCharsets.UTF_8)
     val htmlBody: String = "<!DOCTYPE html><html><head><title></title></head><body><div>I have the most <b>brilliant</b> plan. Let me tell you all about it. What we do is, we</div></body></html>"
 
-    val uploadResponse: String = `given`
+    `given`
       .basePath("")
       .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
       .contentType("text/plain")
@@ -5522,7 +5522,7 @@ trait EmailSetMethodContract {
   @Test
   def invalidPatchPropertyShouldFail(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val mailboxId1: MailboxId = mailboxProbe.createMailbox(MailboxPath.inbox(BOB))
+    mailboxProbe.createMailbox(MailboxPath.inbox(BOB))
 
     val messageId: MessageId = mailboxProbe
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB),
@@ -5571,7 +5571,7 @@ trait EmailSetMethodContract {
   @Test
   def invalidMailboxPartialUpdatePropertyShouldFail(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val mailboxId1: MailboxId = mailboxProbe.createMailbox(MailboxPath.inbox(BOB))
+    mailboxProbe.createMailbox(MailboxPath.inbox(BOB))
 
     val messageId: MessageId = mailboxProbe
       .appendMessage(BOB.asString, MailboxPath.inbox(BOB),

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxChangesMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxChangesMethodContract.scala
@@ -1054,7 +1054,7 @@ trait MailboxChangesMethodContract {
     val provisioningState: State = provisionSystemMailboxes(server)
 
     val path1 = MailboxPath.forUser(BOB, "mailbox1")
-    val mailboxId1: String = mailboxProbe
+    mailboxProbe
       .createMailbox(path1)
       .serialize
 
@@ -1226,7 +1226,7 @@ trait MailboxChangesMethodContract {
       .createMailbox(MailboxPath.forUser(BOB, "mailbox5"))
       .serialize
 
-    val mailboxId6: String = mailboxProbe
+    mailboxProbe
       .createMailbox(MailboxPath.forUser(BOB, "mailbox6"))
       .serialize
 
@@ -1634,7 +1634,7 @@ trait MailboxChangesMethodContract {
       .setSubject("test")
       .setBody("testmail", StandardCharsets.UTF_8)
       .build
-    val messageId1: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
+    mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
     val messageId2: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
     val messageId3: MessageId = mailboxProbe.appendMessage(BOB.asString(), path, AppendCommand.from(message)).getMessageId
 
@@ -1977,7 +1977,7 @@ trait MailboxChangesMethodContract {
   }
 
   private def provisionSystemMailboxes(server: GuiceJamesServer): State = {
-    val mailboxId: MailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))
     val jmapGuiceProbe: JmapGuiceProbe = server.getProbe(classOf[JmapGuiceProbe])
 
     val request =

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxQueryMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxQueryMethodContract.scala
@@ -184,7 +184,7 @@ trait MailboxQueryMethodContract {
   @Test
   def queryByRoleShouldNotReturnDelegatedMailboxes(server: GuiceJamesServer): Unit = {
     val andreInbox = MailboxPath.inbox(ANDRE)
-    val andreInboxId: MailboxId = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .createMailbox(andreInbox)
     val bobInboxId: MailboxId = server.getProbe(classOf[MailboxProbeImpl])
       .createMailbox(MailboxPath.inbox(BOB))
@@ -245,7 +245,7 @@ trait MailboxQueryMethodContract {
   @Test
   def queryByRoleShouldNotReturnDelegatedMailboxesWhenCaseVariation(server: GuiceJamesServer): Unit = {
     val andreInbox = MailboxPath.inbox(ANDRE)
-    val andreInboxId: MailboxId = server.getProbe(classOf[MailboxProbeImpl])
+    server.getProbe(classOf[MailboxProbeImpl])
       .createMailbox(andreInbox)
     val bobInboxId: MailboxId = server.getProbe(classOf[MailboxProbeImpl])
       .createMailbox(MailboxPath.forUser(BOB, "InBoX"))

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -7644,7 +7644,7 @@ trait MailboxSetMethodContract {
   @Test
   def updateShouldHandleNotFoundClientId(server: GuiceJamesServer): Unit = {
     val mailboxProbe = server.getProbe(classOf[MailboxProbeImpl])
-    val mailboxId: MailboxId = mailboxProbe.createMailbox(MailboxPath.forUser(BOB, "mailbox"))
+    mailboxProbe.createMailbox(MailboxPath.forUser(BOB, "mailbox"))
 
     val response = `given`
       .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
@@ -1069,7 +1069,7 @@ trait WebSocketContract {
   def pushEnableRequestWithPushStateShouldReturnServerState(server: GuiceJamesServer): Unit = {
     val bobPath = MailboxPath.inbox(BOB)
     val accountId: AccountId = AccountId.fromUsername(BOB)
-    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(bobPath)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(bobPath)
 
     Thread.sleep(100)
 

--- a/server/protocols/jmap-rfc-8621/pom.xml
+++ b/server/protocols/jmap-rfc-8621/pom.xml
@@ -189,6 +189,13 @@
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.github.evis</groupId>
+                <artifactId>scalafix-maven-plugin</artifactId>
+                <configuration>
+                    <config>${project.parent.parent.basedir}/.scalafix.conf</config>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/UserProvisioning.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/UserProvisioning.scala
@@ -25,7 +25,6 @@ import javax.inject.Inject
 import org.apache.james.core.Username
 import org.apache.james.mailbox.MailboxSession
 import org.apache.james.metrics.api.MetricFactory
-import org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD
 import org.apache.james.user.api.{AlreadyExistInUsersRepositoryException, UsersRepository, UsersRepositoryException}
 import reactor.core.scala.publisher.SMono
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailGetSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailGetSerializer.scala
@@ -29,7 +29,6 @@ import org.apache.james.mailbox.model.{Cid, MailboxId, MessageId}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-import scala.language.implicitConversions
 
 object EmailBodyPartToSerialize {
   def from(part: EmailBodyPart): EmailBodyPartToSerialize = EmailBodyPartToSerialize(

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
@@ -25,7 +25,6 @@ import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Anchor, A
 import org.apache.james.mailbox.model.{MailboxId, MessageId}
 import play.api.libs.json._
 
-import scala.language.implicitConversions
 import scala.util.Try
 
 class EmailQuerySerializer @Inject()(mailboxIdFactory: MailboxId.Factory) {


### PR DESCRIPTION
In order to checkstyle for scala. Ref: https://github.com/linagora/james-project/issues/4348
- Tool: Scalafix (https://scalacenter.github.io/scalafix/)
- Maven plugin: scalafix-maven-plugin (https://github.com/evis/scalafix-maven-plugin)

**How to run:**
```bash
    mvn -pl event-sourcing/event-sourcing-core,event-sourcing/event-sourcing-pojo,server/protocols/jmap-rfc-8621,server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common,mailbox/event/json,mdn clean compile test-compile scalafix:scalafix -Dscalafix.mode=AUTO_SUPPRESS_LINTER_ERRORS
```
Read more `scalafix.mode`: https://www.javadoc.io/doc/ch.epfl.scala/scalafix-interfaces/0.9.5/scalafix/interfaces/ScalafixMainMode.html

**Scope** 
The modules have scala code
```
- event-sourcing/event-sourcing-core,
- event-sourcing/event-sourcing-pojo,
- server/protocols/jmap-rfc-8621,
- server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common,
- mailbox/event/json,
- mdn
```
