### PR TITLE
[PERFORMANCE] DropWizardMetricFactory: optimize wrapping monos 

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
@@ -79,6 +79,9 @@ public class SendMDNProcessor implements SetMessagesProcessor {
 
     @Override
     public SetMessagesResponse process(SetMessagesRequest request, MailboxSession mailboxSession) {
+        if (request.getSendMDN().isEmpty()) {
+            return SetMessagesResponse.builder().build();
+        }
         return metricFactory.decorateSupplierWithTimerMetric(JMAP_PREFIX + "SendMDN",
             () -> handleMDNCreation(request, mailboxSession));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
@@ -116,6 +116,9 @@ public class SetMessagesCreationProcessor implements SetMessagesProcessor {
 
     @Override
     public Mono<SetMessagesResponse> processReactive(SetMessagesRequest request, MailboxSession mailboxSession) {
+        if (request.getCreate().isEmpty()) {
+            return Mono.just(SetMessagesResponse.builder().build());
+        }
         return Mono.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + "SetMessageCreationProcessor",
             Flux.fromIterable(request.getCreate())
                 .flatMap(create -> handleCreate(create, mailboxSession))

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesDestructionProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesDestructionProcessor.java
@@ -57,6 +57,9 @@ public class SetMessagesDestructionProcessor implements SetMessagesProcessor {
 
     @Override
     public Mono<SetMessagesResponse> processReactive(SetMessagesRequest request, MailboxSession mailboxSession) {
+        if (request.getDestroy().isEmpty()) {
+            return Mono.just(SetMessagesResponse.builder().build());
+        }
         return Mono.from(metricFactory.decoratePublisherWithTimerMetric(JMAP_PREFIX + "SetMessageDestructionProcessor",
             delete(request.getDestroy(), mailboxSession)));
     }


### PR DESCRIPTION
## Before

![Screenshot from 2021-07-15 11-54-37](https://user-images.githubusercontent.com/6928740/125730891-2b7d7474-99c2-44c7-bf57-bbe722fdfa29.png)

A good part of applicative CPU is used calling cancels on fluxes to get back a mono.

Zoom:

![Screenshot from 2021-07-15 11-55-55](https://user-images.githubusercontent.com/6928740/125730978-ebc5c0cf-0931-4bc4-8d43-17a7b8b2df24.png)

Here is the associated gatling result:

![Screenshot from 2021-07-15 11-56-43](https://user-images.githubusercontent.com/6928740/125731036-af039d73-57f5-458b-940f-6d14be1f9029.png)

## After

Most of the cancels are gone (remains the ones of the authentication strategy)

![Screenshot from 2021-07-15 11-57-45](https://user-images.githubusercontent.com/6928740/125731125-dd39b597-da91-4685-90b3-57712bfa8a0a.png)

Which translates with better gating perfs (~10% mean time and ~7% p99 decrease, ~0.5% throughput increase)

![Screenshot from 2021-07-15 11-59-46](https://user-images.githubusercontent.com/6928740/125731536-5400b587-2d3f-48a9-948a-0104be399eb8.png)
