### PR TITLE
Do not host download artifacts on maven central

### DIFF
--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -412,9 +412,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
 
 
     <p>Sources:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-api/3.3.0/apache-mailet-api-3.6.0-sources.jar">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-api/3.3.0/apache-mailet-api-3.6.0-sources.jar.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-api/3.3.0/apache-mailet-api-3.6.0-sources.jar.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-api-3.6.0-sources.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-api-3.6.0-sources.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-api-3.6.0-sources.jar.asc">PGP</a>]
     </p>
 
     <p>You can use the mailet API using this maven dependency:</p>
@@ -430,9 +430,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
     </pre>
 
     <p>Direct download link:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-api/3.6.0/apache-mailet-api-3.6.0.jar.sha1">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-api/3.6.0/apache-mailet-api-3.6.0.jar.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-api/3.6.0/apache-mailet-api-3.6.0.jar.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-api-3.6.0.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-api-3.6.0.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-api-3.6.0.jar.asc">PGP</a>]
     </p>
     
   </section>
@@ -442,9 +442,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
     <p>Apache Mailet Base 3.6.0 is the latest stable version.</p>
 
     <p>Sources:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-base/3.6.0/apache-mailet-base-3.6.0-sources.zip">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-base/3.6.0/apache-mailet-base-3.6.0-sources.zip.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-base/3.6.0/apache-mailet-base-3.6.0-sources.zip.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-base-3.6.0-sources.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-base-3.6.0-sources.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-base-3.6.0-sources.jar.asc">PGP</a>]
     </p>
 
     <p>You can use the mailet Base using this maven dependency:</p>
@@ -460,9 +460,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
     </pre>
 
     <p>Direct download link:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-base/3.6.0/apache-mailet-base-3.6.0.jar">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-base/3.6.0/apache-mailet-base-3.6.0.jar.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-base/3.6.0/apache-mailet-base-3.6.0.jar.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-base-3.6.0.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-base-3.6.0.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-base-3.6.0.jar.asc">PGP</a>]
     </p>
 
   </section>
@@ -472,9 +472,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
     <p>Apache Mailet Standard 3.6.0 is the latest stable version. </p>
 
     <p>Sources:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-standard/3.6.0/apache-mailet-standard-3.6.0-sources.zip">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-standard/3.6.0/apache-mailet-standard-3.6.0-sources.zip.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-standard/3.6.0/apache-mailet-standard-3.6.0-sources.zip.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-standard-3.6.0-sources.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-standard-3.6.0-sources.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-standard-3.6.0-sources.jar.asc">PGP</a>]
     </p>
 
     <p>You can use mailet Standard content using this maven dependency:</p>
@@ -490,9 +490,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
     </pre>
 
     <p>Direct download link:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-standard/3.6.0/apache-mailet-standard-3.6.0.jar">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-standard/3.6.0/apache-mailet-standard-3.6.0.jar.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-standard/3.6.0/apache-mailet-standard-3.6.0.jar.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-standard-3.6.0.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-standard-3.6.0.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-standard-3.6.0.jar.asc">PGP</a>]
     </p>
 
   </section>
@@ -516,9 +516,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
   </div>
 
     <p>Sources:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-crypto/3.6.0/apache-mailet-crypto-3.6.0-sources.zip">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-crypto/3.6.0/apache-mailet-crypto-3.6.0-sources.zip.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-crypto/3.6.0/apache-mailet-crypto-3.6.0-sources.zip.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-crypto-3.6.0-sources.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-crypto-3.6.0-sources.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0//apache-mailet-crypto-3.6.0-sources.jar.asc">PGP</a>]
     </p>
 
     <p>You can use Mailet Crypto content using this maven dependency:</p>
@@ -534,9 +534,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
     </pre>
 
     <p>Direct download link:
-      <a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-crypto/3.6.0/apache-mailet-crypto-3.6.0.jar">(Jar)</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-crypto/3.6.0/apache-mailet-crypto-3.6.0.jar.sha1">SHA-1</a>]
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/apache-mailet-crypto/3.6.0/apache-mailet-crypto-3.6.0.jar.asc">PGP</a>]
+      <a href="https://www.apache.org/dyn/closer.lua/james/mailets/3.6.0/apache-mailet-crypto-3.6.0.jar">(Jar)</a>
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-crypto-3.6.0.jar.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/mailets/3.6.0/apache-mailet-crypto-3.6.0.jar.asc">PGP</a>]
     </p>
     
   </section>

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -585,13 +585,14 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
     <p>Apache HUPA 0.0.2 is the latest stable version:</p>
     <ul>
 
-      <li>Source (ZIP Format): <a
-              href="https://repo1.maven.org/maven2/org/apache/james/hupa/hupa-parent/0.0.2/hupa-parent-0.0.2-source-release.zip">hupa-parent-0.0.2-source-release.zip</a>
-        [<a href="https://repo1.maven.org/maven2/org/apache/james/hupa/hupa-parent/0.0.2/hupa-parent-0.0.2-source-release.zip.asc">PGP</a>]
+      <li>Source (ZIP Format): <a href="https://www.apache.org/dyn/closer.lua/james/0.0.2/hupa-parent-0.0.2-source-release.zip">hupa-parent-0.0.2-source-release.zip</a>
+        [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-parent-0.0.2-source-release.zip.sha512">SHA-512</a>]
+        [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-parent-0.0.2-source-release.zip.asc">PGP</a>]
       </li>
     
-    <li>Binary (Java WAR): <a href="https://repo1.maven.org/maven2/org/apache/james/hupa/hupa/0.0.2/hupa-0.0.2.war">hupa-0.0.2.war</a>
-      [<a href="https://repo1.maven.org/maven2/org/apache/james/hupa/hupa/0.0.2/hupa-0.0.2.war.asc">PGP</a>]
+    <li>Binary (Java WAR): <a href="https://www.apache.org/dyn/closer.lua/james/0.0.2/hupa-0.0.2.war">hupa-0.0.2.war</a>
+      [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-0.0.2.war.sha512">SHA-512</a>]
+      [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-0.0.2.war.asc">PGP</a>]
     </li>
     
     <li>Jars (including source and javadocs) for the modules are distributed through the standard 


### PR DESCRIPTION
I received the following notice:

```
Sorry, but the announce cannot be accepted.
There are some some errors on the download page.

Sources for releases must be downloaded from the ASF mirror system.
The links for the mailet 3.6.0 sources currently point to the Maven repo.
They must use the mirror system via closer.lua and the associated sigs and
hashes must be served from downloads.apache.org/james...

Please fix the download page, check, and submit a fresh announce.
Thanks!

Sebb
```