### PR TITLE
[RELEASE] Drop HUPA section from download page

### DIFF
--- a/docs/modules/community/pages/release.adoc
+++ b/docs/modules/community/pages/release.adoc
@@ -186,7 +186,7 @@ I use the following script to set up the uploads:
 # $2: Key footprint to use for signing
 
 sha512sum $1 > $1.sha512
-gpg -u $2 --output $1.asc --detach-sig $1
+gpg -u $2 --output $1.asc --detach-sig --armor $1
 svn add $1
 svn propset svn:mime-type application/octet-stream $1
 svn add $1.sha512

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -580,27 +580,6 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
   
   </section>
 
-  <section name="Apache HUPA">
-  
-    <p>Apache HUPA 0.0.2 is the latest stable version:</p>
-    <ul>
-
-      <li>Source (ZIP Format): <a href="https://www.apache.org/dyn/closer.lua/james/0.0.2/hupa-parent-0.0.2-source-release.zip">hupa-parent-0.0.2-source-release.zip</a>
-        [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-parent-0.0.2-source-release.zip.sha512">SHA-512</a>]
-        [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-parent-0.0.2-source-release.zip.asc">PGP</a>]
-      </li>
-    
-    <li>Binary (Java WAR): <a href="https://www.apache.org/dyn/closer.lua/james/0.0.2/hupa-0.0.2.war">hupa-0.0.2.war</a>
-      [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-0.0.2.war.sha512">SHA-512</a>]
-      [<a href="https://downloads.apache.org/james/hupa/0.0.2/hupa-0.0.2.war.asc">PGP</a>]
-    </li>
-    
-    <li>Jars (including source and javadocs) for the modules are distributed through the standard 
-    <a href='https://maven.apache.org'>Maven</a> repositories on <a href="https://repo1.maven.org/maven2/org/apache/james/hupa">https://repo1.maven.org/maven2/org/apache/james/hupa</a>.</li>
-    </ul>
-  
-  </section>
-
 </body>
 
 </document>


### PR DESCRIPTION
Some ASF bot complains about it: The links for the hupa artifacts are missing the /hupa/ subdirectory segment.

```
It looks like it needs extra registry with INFRA, which is likely not something
that would happen given the soon to come retirement of Apache HUPA.
```

Despite the files being on https://archive.apache.org/dist/james/hupa/0.0.2/
they are not exported through the Apache mirrors.

CF https://www.apache.org/dyn/closer.lua/james/0.0.2/hupa-parent-0.0.2-source-release.zip

```
The requested file or directory is not on the mirrors.

The object is in not in our archive https://archive.apache.org/dist/
```