### PR TITLE
[JAMES-3616] WebAdmin: hide Jetty version

### DIFF
--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/ResponseHeaderFilter.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/ResponseHeaderFilter.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin;
+
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+
+public class ResponseHeaderFilter implements Filter {
+
+    @Override
+    public void handle(Request request, Response response) throws Exception {
+        response.header("Server", "");
+    }
+}

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
@@ -114,6 +114,7 @@ public class WebAdminServer implements Startable {
             service.awaitInitialization();
             LOGGER.info("Web admin server started");
         }
+        hideSpecificResponseHeader();
         return this;
     }
 
@@ -181,6 +182,10 @@ public class WebAdminServer implements Startable {
                 .cause(ex)
                 .asString());
         });
+    }
+
+    private void hideSpecificResponseHeader() {
+        service.before(new ResponseHeaderFilter());
     }
 
     @PreDestroy

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminServerTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminServerTest.java
@@ -22,6 +22,7 @@ import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.blankOrNullString;
 
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.util.Port;
@@ -74,6 +75,25 @@ class WebAdminServerTest {
                 .get()
             .then()
                 .body(is(firstAnswer));
+        } finally {
+            server.destroy();
+        }
+    }
+
+    @Test
+    void serverFieldShouldBeHidden() {
+        WebAdminServer server = WebAdminUtils.createWebAdminServer(myPublicRouteWithConstAnswer("1"))
+            .start();
+
+        try {
+            RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(server)
+                .setBasePath("/myRoute")
+                .build();
+
+            when()
+                .get()
+            .then()
+                .header("Server", blankOrNullString());
         } finally {
             server.destroy();
         }


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/JAMES-3616

Should remove this header is better (instead of changing it).
But look like `spark` does not support removing.