### PR TITLE
[Documentation] Write more How To

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,61 @@
+# Examples
+
+This submodule shows how one can work with James. 
+
+Each subprojects illustrate a specific concept.
+
+## How to customize mail processing
+
+At the heart of James lies the Mailet container, which allows mail processing. This is splitted into smaller units, with specific responsibilities:
+
+ - `Mailets`: Are operations performed with the mail: modifying it, performing a side-effect, etc...
+ - `Matchers`: Are per-recipient conditions for mailet executions
+ - `Processors`: Are matcher/mailet pair execution threads
+
+Once we define the mailet container content through the mailetcontailer.xml file. Hence, we can arrange James standard 
+components to achieve basic logic. But what if our goals are more complex? What if we need our own processing components?
+
+[This example](custom-mailets) shows how to write such components!
+
+## Configure Custom Mailbox Listeners
+
+Mailbox Listener is a component in James Mailbox System. Each time an action is applied on a mailbox(adding, deleting),
+ or on an email(adding, deleting, updating flags...), then an event representing that action is generated and delivered 
+ to all the Listeners that had been registered before. After receiving events, listeners retrieve information from the 
+ events then execute their business (Indexing emails in ElasticSearch, updating quota of users, detecting spam emails...)
+ 
+**Mailbox Listeners** allow customizing the behaviour of James used as a Mail Delivery Agent (MDA). 
+
+[This example](custom-listeners) shows how to write such components!
+
+## Configure Custom SMTP hooks
+
+SMTP hooks allow integrating third party systems with the SMTP stack, allows writing additional SMTP extensions, for 
+instance. 
+
+[This example](custom-smtp-hooks) shows how to write such components!
+
+## Configure Custom SMTP commands
+
+This subproject demonstrates how to write custom commands for Apache James SMTP server. 
+
+[This example](custom-smtp-command) shows how to write additional SMTP commands!
+
+## Configure Custom WebAdmin routes
+
+The current project demonstrates how to write custom webadmin routes for Apache James. This enables writing new 
+administrative features exposed over a REST API. This can allow you to write some additional features, make James 
+interact with third party systems, do advance reporting... 
+
+[This example](custom-webadmin-route) shows how to write additional Webadmin routes!
+
+## Write Custom James server assembly
+
+[This example](custom-james-assembly) demonstrates how to write a custom assembly in order to write your own tailor-made server.
+               
+This enables:
+               
+ - Arbitrary composition of technologies (example JPA mailbox with Cassandra user management)
+ - Write any additional components
+ - Drop any unneeded component
+ - You have control on the dependencies and can reduce the classpath size

--- a/examples/custom-james-assembly/README.md
+++ b/examples/custom-james-assembly/README.md
@@ -1,0 +1,154 @@
+# Assemble a James server tailored to your needs
+
+Read this page [on the website](http://james.apache.org/howTo/custom-james-assembly.html).
+
+The current project demonstrates how to write a custom assembly in order to write your
+own tailor-made server.
+
+This enables:
+
+ - Arbitrary composition of technologies (example JPA mailbox with Cassandra user management)
+ - Write any additional components
+ - Drop any unneeded component
+ - You have control on the dependencies and can reduce the classpath size
+
+## Example: Write an IMAP+SMTP only memory server
+
+In order to do this select the modules you wished to assemble [in the Guice building blocks](https://github.com/apache/james-project/tree/master/server/container/guice). We encourage you to have
+a fine grain control of your dependencies but for the sake of simplicity this example will reuse the dependencies of an
+existing James application:
+
+```
+<dependency>
+    <groupId>${james.groupId}</groupId>
+    <artifactId>james-server-memory-app</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
+
+Once done assemble the guice modules together in a class implementing `JamesServerMain`:
+
+```
+public class CustomJamesServerMain implements JamesServerMain {
+       public static final Module PROTOCOLS = Modules.combine(
+           new IMAPServerModule(),
+           new ProtocolHandlerModule(),
+           new MailRepositoryTaskSerializationModule(),
+           new SMTPServerModule());
+   
+       public static final Module CUSTOM_SERVER_MODULE = Modules.combine(
+           new MailetProcessingModule(),
+           new MailboxModule(),
+           new MemoryDataModule(),
+           new MemoryEventStoreModule(),
+           new MemoryMailboxModule(),
+           new MemoryMailQueueModule(),
+           new TaskManagerModule(),
+           new RawPostDequeueDecoratorModule(),
+           binder -> binder.bind(MailetContainerModule.DefaultProcessorsConfigurationSupplier.class)
+               .toInstance(BaseHierarchicalConfiguration::new));
+   
+       public static final Module CUSTOM_SERVER_AGGREGATE_MODULE = Modules.combine(
+           CUSTOM_SERVER_MODULE,
+           PROTOCOLS);
+   
+       public static void main(String[] args) throws Exception {
+           Configuration configuration = Configuration.builder()
+               .useWorkingDirectoryEnvProperty()
+               .build();
+   
+           JamesServerMain.main(GuiceJamesServer.forConfiguration(configuration)
+               .combineWith(CUSTOM_SERVER_AGGREGATE_MODULE));
+       }
+   }
+```
+
+You need to write a minimal main method launching your guice module composition.
+
+We do provide in this example [JIB](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin) to package this custom James assembly into docker:
+
+```
+<plugin>
+    <groupId>com.google.cloud.tools</groupId>
+    <artifactId>jib-maven-plugin</artifactId>
+    <version>2.7.1</version>
+    <configuration>
+        <from>
+            <image>adoptopenjdk:11-jdk-hotspot</image>
+        </from>
+        <to>
+            <image>apache/james</image>
+            <tags>
+                <tag>custom-latest</tag>
+            </tags>
+        </to>
+        <container>
+            <mainClass>org.apache.james.examples.CustomJamesServerMain</mainClass>
+            <ports>
+                <port>25</port> <!-- JMAP -->
+                <port>143</port> <!-- IMAP -->
+            </ports>
+            <appRoot>/root</appRoot>
+            <jvmFlags>
+                <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
+                <jvmFlag>-Dworking.directory=/root/</jvmFlag>
+            </jvmFlags>
+            <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+        </container>
+        <extraDirectories>
+            <paths>
+                <path>
+                    <from>sample-configuration</from>
+                    <into>/root/conf</into>
+                </path>
+            </paths>
+        </extraDirectories>
+    </configuration>
+    <executions>
+        <execution>
+            <goals>
+                <goal>buildTar</goal>
+            </goals>
+            <phase>package</phase>
+        </execution>
+    </executions>
+</plugin>
+```
+
+We provide a minimal [sample configuration](https://github.com/apache/james-project/tree/master/examples/custom-james-assembly/sample-configuration).
+
+You can compile this example project:
+
+```
+mvn clean install
+```
+
+Create a keystore (default password being `james72laBalle`):
+
+```
+keytool -genkey -alias james -keyalg RSA -keystore keystore
+```
+
+Import the build result:
+
+```
+$ docker load -i target/jib-image.tar
+```
+
+Then launch your custom server with docker:
+
+```
+docker run \
+    -v $PWD/keystore:/root/conf/keystore \
+    -p 25:25 \
+    -p 143:143 \
+    -ti  \ 
+    apache/james:custom-latest
+```
+
+You will see that your custom James server starts smoothly:
+
+```
+...
+09:40:25.884 [INFO ] o.a.j.GuiceJamesServer - JAMES server started
+```

--- a/examples/custom-james-assembly/pom.xml
+++ b/examples/custom-james-assembly/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.james.examples</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>custom-james-assembly</artifactId>
+
+    <name>Apache James :: Examples :: Custom James server assembly</name>
+    <description>Assemble your own James server tailored to your needs.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-memory-app</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>2.7.1</version>
+                <configuration>
+                    <from>
+                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                    </from>
+                    <to>
+                        <image>apache/james</image>
+                        <tags>
+                            <tag>custom-latest</tag>
+                        </tags>
+                    </to>
+                    <container>
+                        <mainClass>org.apache.james.examples.CustomJamesServerMain</mainClass>
+                        <ports>
+                            <port>25</port> <!-- JMAP -->
+                            <port>143</port> <!-- IMAP -->
+                        </ports>
+                        <appRoot>/root</appRoot>
+                        <jvmFlags>
+                            <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
+                            <jvmFlag>-Dworking.directory=/root/</jvmFlag>
+                        </jvmFlags>
+                        <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+                    </container>
+                    <extraDirectories>
+                        <paths>
+                            <path>
+                                <from>sample-configuration</from>
+                                <into>/root/conf</into>
+                            </path>
+                        </paths>
+                    </extraDirectories>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>buildTar</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/custom-james-assembly/sample-configuration/imapserver.xml
+++ b/examples/custom-james-assembly/sample-configuration/imapserver.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Read https://james.apache.org/server/config-imap4.html for further details -->
+
+
+<imapservers>
+    <imapserver enabled="true">
+        <jmxName>imapserver</jmxName>
+        <bind>0.0.0.0:143</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="true">
+            <!-- To create a new keystore execute:
+            keytool -genkey -alias james -keyalg RSA -keystore /path/to/james/conf/keystore
+              -->
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+        </tls>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <idleTimeInterval>120</idleTimeInterval>
+        <idleTimeIntervalUnit>SECONDS</idleTimeIntervalUnit>
+        <enableIdle>true</enableIdle>
+    </imapserver>
+</imapservers>

--- a/examples/custom-james-assembly/sample-configuration/logback.xml
+++ b/examples/custom-james-assembly/sample-configuration/logback.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one   
+  or more contributor license agreements.  See the NOTICE file 
+  distributed with this work for additional information        
+  regarding copyright ownership.  The ASF licenses this file   
+  to you under the Apache License, Version 2.0 (the            
+  "License"); you may not use this file except in compliance   
+  with the License.  You may obtain a copy of the License at   
+                                                               
+    http://www.apache.org/licenses/LICENSE-2.0                 
+                                                               
+  Unless required by applicable law or agreed to in writing,   
+  software distributed under the License is distributed on an  
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       
+  KIND, either express or implied.  See the License for the    
+  specific language governing permissions and limitations      
+  under the License.                                           
+ -->
+
+<configuration>
+
+        <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+                <resetJUL>true</resetJUL>
+        </contextListener>
+
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                        <pattern>%d{HH:mm:ss.SSS} %highlight([%-5level]) %logger{15} - %msg%n%rEx</pattern>
+                        <immediateFlush>false</immediateFlush>
+                </encoder>
+        </appender>
+
+        <appender name="LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>/logs/james.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+                    <fileNamePattern>/logs/james.%i.log.tar.gz</fileNamePattern>
+                    <minIndex>1</minIndex>
+                    <maxIndex>3</maxIndex>
+                </rollingPolicy>
+
+                <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+                    <maxFileSize>100MB</maxFileSize>
+                </triggeringPolicy>
+
+                <encoder>
+                        <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+                        <immediateFlush>false</immediateFlush>
+                </encoder>
+        </appender>
+
+        <root level="WARN">
+                <appender-ref ref="CONSOLE" />
+                <appender-ref ref="LOG_FILE" />
+        </root>
+
+        <logger name="org.apache.james" level="INFO" />
+</configuration>

--- a/examples/custom-james-assembly/sample-configuration/mailetcontainer.xml
+++ b/examples/custom-james-assembly/sample-configuration/mailetcontainer.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-mailetcontainer.html for further details -->
+
+<mailetcontainer enableJmx="true">
+
+    <context>
+        <!-- When the domain part of the postmaster mailAddress is missing, the default domain is appended.
+        You can configure it to (for example) <postmaster>postmaster@myDomain.com</postmaster> -->
+        <postmaster>postmaster</postmaster>
+    </context>
+
+    <spooler>
+        <threads>20</threads>
+        <errorRepository>memory://var/mail/error/</errorRepository>
+    </spooler>
+
+    <processors>
+        <processor state="root" enableJmx="true">
+            <mailet match="All" class="PostmasterAlias"/>
+            <mailet match="RelayLimit=30" class="Null"/>
+            <mailet match="All" class="ToProcessor">
+                <processor>transport</processor>
+            </mailet>
+        </processor>
+
+        <processor state="error" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerErrors</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/error/</repositoryPath>
+                <onMailetException>propagate</onMailetException>
+            </mailet>
+        </processor>
+
+        <processor state="transport" enableJmx="true">
+            <matcher name="relay-allowed" match="org.apache.james.mailetcontainer.impl.matchers.Or">
+                <matcher match="SMTPAuthSuccessful"/>
+                <matcher match="SMTPIsAuthNetwork"/>
+                <matcher match="SentByMailet"/>
+            </matcher>
+
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>bcc</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="ToProcessor">
+                <processor>local-delivery</processor>
+            </mailet>
+            <mailet match="HostIsLocal" class="ToProcessor">
+                <processor>local-address-error</processor>
+                <notice>550 - Requested action not taken: no such user here</notice>
+            </mailet>
+            <mailet match="relay-allowed" class="ToProcessor">
+                <processor>relay</processor>
+            </mailet>
+            <mailet match="All" class="ToProcessor">
+                <processor>relay-denied</processor>
+            </mailet>
+        </processor>
+
+        <processor state="local-delivery" enableJmx="true">
+            <mailet match="All" class="Sieve"/>
+            <mailet match="All" class="AddDeliveredToHeader"/>
+            <mailet match="All" class="LocalDelivery"/>
+        </processor>
+
+        <processor state="relay" enableJmx="true">
+            <mailet match="All" class="RemoteDelivery">
+                <outgoingQueue>outgoing</outgoingQueue>
+                <delayTime>5000, 100000, 500000</delayTime>
+                <maxRetries>3</maxRetries>
+                <maxDnsProblemRetries>0</maxDnsProblemRetries>
+                <deliveryThreads>10</deliveryThreads>
+                <sendpartial>true</sendpartial>
+                <bounceProcessor>bounces</bounceProcessor>
+            </mailet>
+        </processor>
+
+        <processor state="local-address-error" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerLocalAddressError</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <attachment>none</attachment>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/address-error/</repositoryPath>
+            </mailet>
+        </processor>
+
+        <processor state="relay-denied" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerRelayDenied</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <attachment>none</attachment>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/relay-denied/</repositoryPath>
+                <notice>Warning: You are sending an e-mail to a remote server. You must be authenticated to perform such an operation</notice>
+            </mailet>
+        </processor>
+
+        <processor state="bounces" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>bounces</metricName>
+            </mailet>
+            <mailet match="All" class="DSNBounce">
+                <passThrough>false</passThrough>
+            </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
+        </processor>
+
+    </processors>
+
+</mailetcontainer>
+
+

--- a/examples/custom-james-assembly/sample-configuration/mailrepositorystore.xml
+++ b/examples/custom-james-assembly/sample-configuration/mailrepositorystore.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-mailrepositorystore.html for further details -->
+
+<mailrepositorystore>
+    <defaultProtocol>memory</defaultProtocol>
+    <mailrepositories>
+        <mailrepository class="org.apache.james.mailrepository.memory.MemoryMailRepository">
+            <protocols>
+                <protocol>memory</protocol>
+            </protocols>
+        </mailrepository>
+    </mailrepositories>
+</mailrepositorystore>

--- a/examples/custom-james-assembly/sample-configuration/smtpserver.xml
+++ b/examples/custom-james-assembly/sample-configuration/smtpserver.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-smtp-lmtp.html#SMTP_Configuration for further details -->
+
+<smtpservers>
+    <smtpserver enabled="true">
+        <jmxName>smtpserver-global</jmxName>
+        <bind>0.0.0.0:25</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <connectiontimeout>360</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <authRequired>false</authRequired>
+        <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
+        <verifyIdentity>false</verifyIdentity>
+        <maxmessagesize>0</maxmessagesize>
+        <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
+</smtpservers>
+
+

--- a/examples/custom-james-assembly/src/main/java/org/apache/james/examples/CustomJamesServerMain.java
+++ b/examples/custom-james-assembly/src/main/java/org/apache/james/examples/CustomJamesServerMain.java
@@ -1,0 +1,74 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.examples;
+
+import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerMain;
+import org.apache.james.modules.MailboxModule;
+import org.apache.james.modules.MailetProcessingModule;
+import org.apache.james.modules.data.MemoryDataModule;
+import org.apache.james.modules.eventstore.MemoryEventStoreModule;
+import org.apache.james.modules.mailbox.MemoryMailboxModule;
+import org.apache.james.modules.protocols.IMAPServerModule;
+import org.apache.james.modules.protocols.ProtocolHandlerModule;
+import org.apache.james.modules.protocols.SMTPServerModule;
+import org.apache.james.modules.queue.memory.MemoryMailQueueModule;
+import org.apache.james.modules.server.MailRepositoryTaskSerializationModule;
+import org.apache.james.modules.server.MailetContainerModule;
+import org.apache.james.modules.server.RawPostDequeueDecoratorModule;
+import org.apache.james.modules.server.TaskManagerModule;
+import org.apache.james.server.core.configuration.Configuration;
+
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+public class CustomJamesServerMain implements JamesServerMain {
+    public static final Module PROTOCOLS = Modules.combine(
+        new IMAPServerModule(),
+        new ProtocolHandlerModule(),
+        new MailRepositoryTaskSerializationModule(),
+        new SMTPServerModule());
+
+    public static final Module CUSTOM_SERVER_MODULE = Modules.combine(
+        new MailetProcessingModule(),
+        new MailboxModule(),
+        new MemoryDataModule(),
+        new MemoryEventStoreModule(),
+        new MemoryMailboxModule(),
+        new MemoryMailQueueModule(),
+        new TaskManagerModule(),
+        new RawPostDequeueDecoratorModule(),
+        binder -> binder.bind(MailetContainerModule.DefaultProcessorsConfigurationSupplier.class)
+            .toInstance(BaseHierarchicalConfiguration::new));
+
+    public static final Module CUSTOM_SERVER_AGGREGATE_MODULE = Modules.combine(
+        CUSTOM_SERVER_MODULE,
+        PROTOCOLS);
+
+    public static void main(String[] args) throws Exception {
+        Configuration configuration = Configuration.builder()
+            .useWorkingDirectoryEnvProperty()
+            .build();
+
+        JamesServerMain.main(GuiceJamesServer.forConfiguration(configuration)
+            .combineWith(CUSTOM_SERVER_AGGREGATE_MODULE));
+    }
+}

--- a/examples/custom-listeners/README.md
+++ b/examples/custom-listeners/README.md
@@ -1,0 +1,5 @@
+# Writing custom Mailbox listeners
+
+Mailbox listeners allow extending the behaviour of mail delivery agents.
+
+Read this page [on the website](http://james.apache.org/howTo/custom-listeners.html) to see how to run this example.

--- a/examples/custom-mailets/README.md
+++ b/examples/custom-mailets/README.md
@@ -1,0 +1,6 @@
+# How to customize mail processing
+
+Mailet and matcher allow in depth customisation of mail processing within 
+Apache James, even allowing writing custom components.
+
+Read this page [on the website](http://james.apache.org/howTo/mail-processing.html) to see how to run this example.

--- a/examples/custom-smtp-command/README.md
+++ b/examples/custom-smtp-command/README.md
@@ -1,0 +1,151 @@
+# Creating your own SMTP commands
+
+Read this page [on the website](http://james.apache.org/howTo/custom-smtp-commands.html).
+
+The current project demonstrates how to write custom commands for Apache James SMTP server.
+
+Start by importing the dependencies:
+
+```
+<dependency>
+    <groupId>org.apache.james.protocols</groupId>
+    <artifactId>protocols-smtp/artifactId>
+</dependency>
+```
+
+You can write your commands by extending the `CommandHandler<SMTPSession>` class. For instance:
+
+```
+/**
+  * Copy of NoopCmdHandler
+  */
+public class MyNoopCmdHandler implements CommandHandler<SMTPSession> {
+    private static final Collection<String> COMMANDS = ImmutableSet.of("MYNOOP");
+
+    private static final Response NOOP = new SMTPResponse(SMTPRetCode.MAIL_OK,
+        DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.UNDEFINED_STATUS) + " OK")
+        .immutable();
+
+    @Override
+    public Response onCommand(SMTPSession session, Request request) {
+        return NOOP;
+    }
+    
+    @Override
+    public Collection<String> getImplCommands() {
+        return COMMANDS;
+    }
+}
+```
+
+You then need to list the exposed SMTP commands with a `HandlersPackage`. For instance:
+
+```
+/**
+ * This class copies CoreCmdHandlerLoader adding support for MYNOOP command
+ */
+public class MyCmdHandlerLoader implements HandlersPackage {
+
+    private final List<String> commands = new LinkedList<>();
+
+    public MyCmdHandlerLoader() {
+        Stream.of(
+            JamesWelcomeMessageHandler.class,
+            CommandDispatcher.class,
+            AuthCmdHandler.class,
+            JamesDataCmdHandler.class,
+            EhloCmdHandler.class,
+            ExpnCmdHandler.class,
+            HeloCmdHandler.class,
+            HelpCmdHandler.class,
+            JamesMailCmdHandler.class,
+            NoopCmdHandler.class,
+            QuitCmdHandler.class,
+            JamesRcptCmdHandler.class,
+            RsetCmdHandler.class,
+            VrfyCmdHandler.class,
+            MailSizeEsmtpExtension.class,
+            UsersRepositoryAuthHook.class,
+            AuthRequiredToRelayRcptHook.class,
+            SenderAuthIdentifyVerificationRcptHook.class,
+            PostmasterAbuseRcptHook.class,
+            ReceivedDataLineFilter.class,
+            DataLineJamesMessageHookHandler.class,
+            StartTlsCmdHandler.class,
+            AddDefaultAttributesMessageHook.class,
+            SendMailHandler.class,
+            UnknownCmdHandler.class,
+            CommandHandlerResultLogger.class,
+            HookResultLogger.class,
+            // Support MYNOOP
+            MyNoopCmdHandler.class)
+        .map(Class::getName)
+        .forEachOrdered(commands::add);
+    }
+
+    @Override
+    public List<String> getHandlers() {
+        return commands;
+    }
+}
+```
+
+Then compile this little project:
+
+```
+mvn clean install
+```
+
+Write a configuration file telling James to use your `HandlerPackage`:
+
+```
+<smtpservers>
+    <smtpserver enabled="true">
+        <jmxName>smtpserver-global</jmxName>
+        <bind>0.0.0.0:25</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <!-- ... -->
+        <handlerchain coreHandlersPackage="org.apache.james.examples.MyCmdHandlerLoader">
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+        </handlerchain>
+    </smtpserver>
+</smtpservers>
+```
+
+Create a keystore (default password being `james72laBalle`):
+
+```
+keytool -genkey -alias james -keyalg RSA -keystore keystore
+```
+
+Then start a James server with your JAR and the configuration:
+
+```
+docker run -d \
+  -v $PWD/smtpserver.xml:/root/conf/smtpserver.xml \
+  -v $PWD/exts:/root/extensions-jars \
+  -v $PWD/keystore:/root/conf/keystore \
+  -p 25:25 \
+  apache/james:memory-latest
+```
+
+You can play with `telnet` utility with the resulting server:
+
+```
+$ telnet 127.0.0.1 25
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+220 Apache JAMES awesome SMTP Server
+MYNOOP
+250 2.0.0 OK
+quit
+221 2.0.0 1f0274082fc6 Service closing transmission channel
+Connection closed by foreign host.
+```

--- a/examples/custom-smtp-command/pom.xml
+++ b/examples/custom-smtp-command/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.james.examples</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>custom-smtp-command</artifactId>
+
+    <name>Apache James :: Examples :: Custom SMTP Command</name>
+    <description>Example of how to extend James existing SMTP implementation by adding your own commands</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-protocols-smtp</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/custom-smtp-command/src/main/java/org/apache/james/examples/MyCmdHandlerLoader.java
+++ b/examples/custom-smtp-command/src/main/java/org/apache/james/examples/MyCmdHandlerLoader.java
@@ -1,0 +1,101 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.examples;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.james.protocols.api.handler.CommandDispatcher;
+import org.apache.james.protocols.api.handler.CommandHandlerResultLogger;
+import org.apache.james.protocols.lib.handler.HandlersPackage;
+import org.apache.james.protocols.smtp.core.ExpnCmdHandler;
+import org.apache.james.protocols.smtp.core.HeloCmdHandler;
+import org.apache.james.protocols.smtp.core.HelpCmdHandler;
+import org.apache.james.protocols.smtp.core.NoopCmdHandler;
+import org.apache.james.protocols.smtp.core.PostmasterAbuseRcptHook;
+import org.apache.james.protocols.smtp.core.QuitCmdHandler;
+import org.apache.james.protocols.smtp.core.ReceivedDataLineFilter;
+import org.apache.james.protocols.smtp.core.RsetCmdHandler;
+import org.apache.james.protocols.smtp.core.UnknownCmdHandler;
+import org.apache.james.protocols.smtp.core.VrfyCmdHandler;
+import org.apache.james.protocols.smtp.core.esmtp.AuthCmdHandler;
+import org.apache.james.protocols.smtp.core.esmtp.EhloCmdHandler;
+import org.apache.james.protocols.smtp.core.esmtp.MailSizeEsmtpExtension;
+import org.apache.james.protocols.smtp.core.esmtp.StartTlsCmdHandler;
+import org.apache.james.protocols.smtp.core.log.HookResultLogger;
+import org.apache.james.smtpserver.AddDefaultAttributesMessageHook;
+import org.apache.james.smtpserver.AuthRequiredToRelayRcptHook;
+import org.apache.james.smtpserver.DataLineJamesMessageHookHandler;
+import org.apache.james.smtpserver.JamesDataCmdHandler;
+import org.apache.james.smtpserver.JamesMailCmdHandler;
+import org.apache.james.smtpserver.JamesRcptCmdHandler;
+import org.apache.james.smtpserver.JamesWelcomeMessageHandler;
+import org.apache.james.smtpserver.SendMailHandler;
+import org.apache.james.smtpserver.SenderAuthIdentifyVerificationRcptHook;
+import org.apache.james.smtpserver.UsersRepositoryAuthHook;
+
+/**
+ * This class copies CoreCmdHandlerLoader adding support for MYNOOP command
+ */
+public class MyCmdHandlerLoader implements HandlersPackage {
+
+    private final List<String> commands = new LinkedList<>();
+
+    public MyCmdHandlerLoader() {
+        Stream.of(
+            JamesWelcomeMessageHandler.class,
+            CommandDispatcher.class,
+            AuthCmdHandler.class,
+            JamesDataCmdHandler.class,
+            EhloCmdHandler.class,
+            ExpnCmdHandler.class,
+            HeloCmdHandler.class,
+            HelpCmdHandler.class,
+            JamesMailCmdHandler.class,
+            NoopCmdHandler.class,
+            QuitCmdHandler.class,
+            JamesRcptCmdHandler.class,
+            RsetCmdHandler.class,
+            VrfyCmdHandler.class,
+            MailSizeEsmtpExtension.class,
+            UsersRepositoryAuthHook.class,
+            AuthRequiredToRelayRcptHook.class,
+            SenderAuthIdentifyVerificationRcptHook.class,
+            PostmasterAbuseRcptHook.class,
+            ReceivedDataLineFilter.class,
+            DataLineJamesMessageHookHandler.class,
+            StartTlsCmdHandler.class,
+            AddDefaultAttributesMessageHook.class,
+            SendMailHandler.class,
+            UnknownCmdHandler.class,
+            CommandHandlerResultLogger.class,
+            HookResultLogger.class,
+            // Support MYNOOP
+            MyNoopCmdHandler.class)
+        .map(Class::getName)
+        .forEachOrdered(commands::add);
+    }
+
+    @Override
+    public List<String> getHandlers() {
+        return commands;
+    }
+}

--- a/examples/custom-smtp-command/src/main/java/org/apache/james/examples/MyNoopCmdHandler.java
+++ b/examples/custom-smtp-command/src/main/java/org/apache/james/examples/MyNoopCmdHandler.java
@@ -1,0 +1,53 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.examples;
+
+import java.util.Collection;
+
+import org.apache.james.protocols.api.Request;
+import org.apache.james.protocols.api.Response;
+import org.apache.james.protocols.api.handler.CommandHandler;
+import org.apache.james.protocols.smtp.SMTPResponse;
+import org.apache.james.protocols.smtp.SMTPRetCode;
+import org.apache.james.protocols.smtp.SMTPSession;
+import org.apache.james.protocols.smtp.dsn.DSNStatus;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+  * Copy of NoopCmdHandler
+  */
+public class MyNoopCmdHandler implements CommandHandler<SMTPSession> {
+    private static final Collection<String> COMMANDS = ImmutableSet.of("MYNOOP");
+
+    private static final Response NOOP = new SMTPResponse(SMTPRetCode.MAIL_OK,
+        DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.UNDEFINED_STATUS) + " OK")
+        .immutable();
+
+    @Override
+    public Response onCommand(SMTPSession session, Request request) {
+        return NOOP;
+    }
+    
+    @Override
+    public Collection<String> getImplCommands() {
+        return COMMANDS;
+    }
+}

--- a/examples/custom-smtp-command/src/main/resources/smtpserver.xml
+++ b/examples/custom-smtp-command/src/main/resources/smtpserver.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Demonstrate how to configure custom hooks -->
+
+<smtpservers>
+    <smtpserver enabled="true">
+        <jmxName>smtpserver-global</jmxName>
+        <bind>0.0.0.0:25</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <connectiontimeout>360</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <authRequired>false</authRequired>
+        <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
+        <verifyIdentity>false</verifyIdentity>
+        <maxmessagesize>0</maxmessagesize>
+        <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain coreHandlersPackage="org.apache.james.examples.MyCmdHandlerLoader">
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+        </handlerchain>
+    </smtpserver>
+</smtpservers>
+
+

--- a/examples/custom-smtp-hooks/README.md
+++ b/examples/custom-smtp-hooks/README.md
@@ -2,10 +2,10 @@
 
 Read this page [on the website](http://james.apache.org/howTo/custom-smtp-hooks.html).
 
-The current project demonstrate how to write custom behaviours for Apache James SMTP server
+The current project demonstrates how to write custom behaviours for Apache James SMTP server
 by the means of SMTP hooks.
 
-SMTP hooks allows integrating third party systems with the SMTP stack, allows writing additional SMTP extensions, for
+SMTP hooks allow integrating third party systems with the SMTP stack and writing additional SMTP extensions, for
 instance.
 
 Start by importing the dependencies:

--- a/examples/custom-smtp-hooks/README.md
+++ b/examples/custom-smtp-hooks/README.md
@@ -1,0 +1,141 @@
+# Writing custom behaviour for Apache James SMTP server
+
+Read this page [on the website](http://james.apache.org/howTo/custom-smtp-hooks.html).
+
+The current project demonstrate how to write custom behaviours for Apache James SMTP server
+by the means of SMTP hooks.
+
+SMTP hooks allows integrating third party systems with the SMTP stack, allows writing additional SMTP extensions, for
+instance.
+
+Start by importing the dependencies:
+
+```
+<dependency>
+    <groupId>org.apache.james.protocols</groupId>
+    <artifactId>protocols-smtp/artifactId>
+</dependency>
+```
+
+Allows writing the following hooks:
+
+ - `AuthHook`: hook in the AUTH Command
+ - `HeloHook`: hook in the HELO Command
+ - `MailHook`: hook in the MAIL Command
+ - `MailParametersHook`: hook for MAIL Command parameters
+ - `RcptHook`: hook in the RCPT Command
+ - `MessageHook`: hook in the DATA Command
+ - `QuitHook`: hook in the QUIT Command
+ - `UnknownHook`: hook for unknown commands
+ 
+```
+<dependency>
+    <groupId>org.apache.james</groupId>
+    <artifactId>james-server-protocols-smtp</artifactId>
+</dependency>
+```
+
+Allows writing the following hooks:
+
+ - `JamesMessageHook`: DATA command. Allows access to the message content.
+ 
+James comes bundled with [provided SMTP hooks for common features](http://james.apache.org/server/dev-provided-smtp-hooks.html).
+We encourage you to review them before starting writing your own hooks.
+
+## Writing your own hooks
+ 
+In this example we implement a single RCPT hook:
+
+```
+public class LoggingRcptHook implements RcptHook {
+    @Override
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt, Map<String, String> parameters) {
+        System.out.println("RCPT TO " + rcpt + "with parameters " + parameters);
+
+        // Continue the SMTP transaction
+        return HookResult.DECLINED;
+    }
+}
+```
+
+You can compile this example project:
+
+```
+mvn clean install
+```
+
+Then embed your extension into a James server. First configure your hook:
+
+```
+<?xml version="1.0"?>
+<smtpservers>
+    <smtpserver enabled="true">
+        <jmxName>smtpserver-global</jmxName>
+        <bind>0.0.0.0:25</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <!-- ... -->
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+            <handler class="org.apache.james.examples.LoggingRcptHook"/>
+        </handlerchain>
+    </smtpserver>
+</smtpservers>
+```
+
+Create a keystore (default password being `james72laBalle`):
+
+```
+keytool -genkey -alias james -keyalg RSA -keystore keystore
+```
+
+Then start a James server with your JAR and the configuration:
+
+```
+docker run -d \
+  -v $PWD/smtpserver.xml:/root/conf/smtpserver.xml \
+  -v $PWD/exts:/root/extensions-jars \
+  -v $PWD/keystore:/root/conf/keystore \
+  -p 25:25 \
+  apache/james:memory-latest
+```
+
+You can play with `telnet` utility with the resulting server:
+
+```
+$ telnet 127.0.0.1 25
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+220 Apache JAMES awesome SMTP Server
+EHLO toto.com
+250-177b73020637 Hello toto.com [172.17.0.1])
+250-PIPELINING
+250-ENHANCEDSTATUSCODES
+250 8BITMIME
+RCPT TO: <b@c.com>
+503 5.5.0 Need MAIL before RCPT
+MAIL FROM: <b@c.com>
+250 2.1.0 Sender <b@c.com> OK
+RCPT TO: <c@d.com>
+550 5.7.1 Requested action not taken: relaying denied
+quit
+```
+
+Now looking at the logs we can verify that our RCPT have well been executed:
+
+```
+06:49:15.734 [INFO ] o.a.j.GuiceJamesServer - JAMES server started
+06:49:30.275 [INFO ] o.a.j.p.n.BasicChannelUpstreamHandler - Connection established from 172.17.0.1
+06:50:18.892 [INFO ] o.a.j.i.n.ImapChannelUpstreamHandler - Connection established from 172.17.0.1
+06:50:19.152 [INFO ] o.a.j.i.n.ImapChannelUpstreamHandler - Connection closed for 172.17.0.1
+RCPT TO c@d.comwith parameters {TO:=, <c@d.com>=}
+```
+
+Note that hooks can also be written for the LMTP protocol.

--- a/examples/custom-smtp-hooks/pom.xml
+++ b/examples/custom-smtp-hooks/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.james.examples</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>custom-smtp-hooks</artifactId>
+
+    <name>Apache James :: Examples :: Custom SMTP Hooks</name>
+    <description>Example of how to extend James existing SMTP implementation</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-protocols-smtp</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/custom-smtp-hooks/src/main/java/org/apache/james/examples/LoggingRcptHook.java
+++ b/examples/custom-smtp-hooks/src/main/java/org/apache/james/examples/LoggingRcptHook.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.examples;
+
+import java.util.Map;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
+import org.apache.james.protocols.smtp.SMTPSession;
+import org.apache.james.protocols.smtp.hook.HookResult;
+import org.apache.james.protocols.smtp.hook.RcptHook;
+
+public class LoggingRcptHook implements RcptHook {
+    @Override
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt, Map<String, String> parameters) {
+        System.out.println("RCPT TO " + rcpt + "with parameters " + parameters);
+
+        // Continue the SMTP transaction
+        return HookResult.DECLINED;
+    }
+}

--- a/examples/custom-smtp-hooks/src/main/resources/smtpserver.xml
+++ b/examples/custom-smtp-hooks/src/main/resources/smtpserver.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Demonstrate how to configure custom hooks -->
+
+<smtpservers>
+    <smtpserver enabled="true">
+        <jmxName>smtpserver-global</jmxName>
+        <bind>0.0.0.0:25</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <connectiontimeout>360</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <authRequired>false</authRequired>
+        <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
+        <verifyIdentity>false</verifyIdentity>
+        <maxmessagesize>0</maxmessagesize>
+        <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+            <handler class="org.apache.james.examples.LoggingRcptHook"/>
+        </handlerchain>
+    </smtpserver>
+    <smtpserver enabled="true">
+        <jmxName>smtpserver-TLS</jmxName>
+        <bind>0.0.0.0:465</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="true" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <connectiontimeout>360</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <!--
+           Authorize only local users
+        -->
+        <authRequired>true</authRequired>
+        <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
+        <!-- Trust authenticated users -->
+        <verifyIdentity>false</verifyIdentity>
+        <maxmessagesize>0</maxmessagesize>
+        <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+            <handler class="org.apache.james.examples.LoggingRcptHook"/>
+        </handlerchain>
+    </smtpserver>
+    <smtpserver enabled="true">
+        <jmxName>smtpserver-authenticated</jmxName>
+        <bind>0.0.0.0:587</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="true">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <connectiontimeout>360</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <!--
+           Authorize only local users
+        -->
+        <authRequired>true</authRequired>
+        <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
+        <!-- Trust authenticated users -->
+        <verifyIdentity>false</verifyIdentity>
+        <maxmessagesize>0</maxmessagesize>
+        <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+            <handler class="org.apache.james.examples.LoggingRcptHook"/>
+        </handlerchain>
+    </smtpserver>
+</smtpservers>
+
+

--- a/examples/custom-webadmin-route/README.md
+++ b/examples/custom-webadmin-route/README.md
@@ -1,0 +1,79 @@
+# Writing custom webadmin routes
+
+Read this page [on the website](http://james.apache.org/howTo/custom-webadmin-routes.html).
+
+The current project demonstrates how to write custom webadmin routes for Apache James. This enables writing new 
+administrative features exposed over a REST API. This can allow you to write some additional features, make James 
+interact with third party systems, do advance reporting... 
+
+Start by importing the dependencies:
+
+```
+<dependency>
+    <groupId>org.apache.james</groupId>
+    <artifactId>james-server-webadmin-core</artifactId>
+</dependency>
+```
+
+You can then write your first route using the [Spark Java](https://sparkjava.com/) framework:
+
+```
+public class RouteA implements Routes {
+    @Override
+    public String getBasePath() {
+        return "/hello/a";
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(getBasePath(), (req, res) -> "RouteA\n");
+    }
+}
+```
+
+Knowing that:
+ - entending `Routes` will ensure that authentication is requested if configured.
+ - extending `PublicRoutes` will not request authentication.
+ 
+You can compile this example project:
+
+```
+mvn clean install
+```
+
+Then embed your route into a James server. First configure your route into `webadmin.properties`:
+
+```
+enabled=true
+port=8000
+host=localhost
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+extensions.routes=org.apache.james.examples.RouteA
+```
+
+Create a keystore (default password being `james72laBalle`):
+
+```
+keytool -genkey -alias james -keyalg RSA -keystore keystore
+```
+
+Then start a James server with your JAR and the configuration:
+
+```
+$ docker run -d \
+   -v $PWD/webadmin.properties:/root/conf/webadmin.properties \
+   -v $PWD/exts:/root/extensions-jars \
+   -v $PWD/keystore:/root/conf/keystore \
+   -p 25:25 \
+   apache/james:memory-latest
+```
+
+You can play with `curl` utility with the resulting server:
+
+```
+$ curl -XGET http://172.17.0.2:8000/hello/a
+RouteA
+```

--- a/examples/custom-webadmin-route/pom.xml
+++ b/examples/custom-webadmin-route/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.james.examples</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>custom-webadmin-route</artifactId>
+
+    <name>Apache James :: Examples :: Custom WebAdmin route</name>
+    <description>Example of how to extend James by adding your own webadmin routes</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/custom-webadmin-route/src/main/java/org/apache/james/examples/RouteA.java
+++ b/examples/custom-webadmin-route/src/main/java/org/apache/james/examples/RouteA.java
@@ -1,0 +1,37 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.examples;
+
+
+import org.apache.james.webadmin.Routes;
+
+import spark.Service;
+
+public class RouteA implements Routes {
+    @Override
+    public String getBasePath() {
+        return "/hello/a";
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(getBasePath(), (req, res) -> "RouteA\n");
+    }
+}

--- a/examples/custom-webadmin-route/src/main/resources/webadmin.properties
+++ b/examples/custom-webadmin-route/src/main/resources/webadmin.properties
@@ -1,0 +1,25 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+enabled=true
+port=8000
+host=localhost
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+extensions.routes=org.apache.james.examples.RouteA

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,6 +33,7 @@
   <modules>
     <module>custom-listeners</module>
     <module>custom-mailets</module>
+    <module>custom-smtp-hooks</module>
   </modules>
   <properties>
     <james.groupId>org.apache.james</james.groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,21 +25,25 @@
     <version>23</version>
     <relativePath />
   </parent>
+
   <groupId>org.apache.james.examples</groupId>
   <artifactId>examples</artifactId>
   <version>3.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache James :: Examples</name>
-  <modules>
-    <module>custom-listeners</module>
-    <module>custom-mailets</module>
-    <module>custom-smtp-command</module>
-    <module>custom-smtp-hooks</module>
-  </modules>
+
   <properties>
     <james.groupId>org.apache.james</james.groupId>
     <james.baseVersion>${project.version}</james.baseVersion>
     <maven.compiler.target>1.11</maven.compiler.target>
     <maven.compiler.source>1.11</maven.compiler.source>
   </properties>
+
+  <modules>
+    <module>custom-listeners</module>
+    <module>custom-mailets</module>
+    <module>custom-smtp-command</module>
+    <module>custom-smtp-hooks</module>
+    <module>custom-webadmin-route</module>
+  </modules>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,6 +33,7 @@
   <modules>
     <module>custom-listeners</module>
     <module>custom-mailets</module>
+    <module>custom-smtp-command</module>
     <module>custom-smtp-hooks</module>
   </modules>
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -40,6 +40,7 @@
   </properties>
 
   <modules>
+    <module>custom-james-assembly</module>
     <module>custom-listeners</module>
     <module>custom-mailets</module>
     <module>custom-smtp-command</module>

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/MailParametersHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/MailParametersHook.java
@@ -21,7 +21,7 @@ package org.apache.james.protocols.smtp.hook;
 import org.apache.james.protocols.smtp.SMTPSession;
 
 /**
- * Implement this interfaces to hook in the MAIL Command
+ * Implement this interfaces to hook in the MAIL Command parameters
  * 
  */
 public interface MailParametersHook extends Hook {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/QuitHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/QuitHook.java
@@ -25,7 +25,7 @@ package org.apache.james.protocols.smtp.hook;
 import org.apache.james.protocols.smtp.SMTPSession;
 
 /**
- * Implement this interfaces to hook in the MAIL Command
+ * Implement this interfaces to hook in the QUIT Command
  * 
  */
 public interface QuitHook extends Hook {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
@@ -28,7 +28,7 @@ import org.apache.james.protocols.smtp.SMTPSession;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Implement this interfaces to hook in the MAIL Command
+ * Implement this interfaces to hook in the RCPT Command
  */
 public interface RcptHook extends Hook {
     /**

--- a/src/homepage/howTo/custom-james-assembly.html
+++ b/src/homepage/howTo/custom-james-assembly.html
@@ -1,0 +1,190 @@
+---
+layout: howTo
+---
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!-- Main -->
+<div id="main">
+
+    <!-- Introduction -->
+    <section id="intro" class="main special">
+        <div class="">
+            <div class="content align-left">
+                <header class="major">
+                    <h1><b>Write Custom James server assembly</b></h1>
+                </header>
+                <p>
+                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-james-assembly">GitHub</a>.
+                </p>
+
+                <p>
+                    The current project demonstrates how to write a custom assembly in order to write your
+                    own tailor-made server.
+                </p>
+
+                <ul>This enables:
+                    <li>Arbitrary composition of technologies (example JPA mailbox with Cassandra user management)</li>
+                    <li>Write any additional components</li>
+                    <li>Drop any unneeded component</li>
+                    <li>You have control on the dependencies and can reduce the classpath size</li>
+                </ul>
+
+                <header class="major">
+                    <h2><b>Example: Write an IMAP+SMTP only memory server</b></h2>
+                </header>
+
+                <p>
+                    In order to do this select the modules you wished to assemble
+                    <a href="https://github.com/apache/james-project/tree/master/server/container/guice">in the Guice building blocks</a>.
+                    We encourage you to have a fine grain control of your dependencies but for the sake of simplicity
+                    this example will reuse the dependencies of an existing James application:
+                </p>
+
+                <pre><code>&lt;dependency&gt;
+    &lt;groupId&gt;${james.groupId}&lt;/groupId&gt;
+    &lt;artifactId&gt;james-server-memory-app&lt;/artifactId&gt;
+    &lt;version&gt;${project.version}&lt;/version&gt;
+&lt;/dependency&gt;</code></pre>
+
+                <p>Once done assemble the guice modules together in a class implementing <code>JamesServerMain</code>:</p>
+
+                <pre><code>public class CustomJamesServerMain implements JamesServerMain {
+       public static final Module PROTOCOLS = Modules.combine(
+           new IMAPServerModule(),
+           new ProtocolHandlerModule(),
+           new MailRepositoryTaskSerializationModule(),
+           new SMTPServerModule());
+
+       public static final Module CUSTOM_SERVER_MODULE = Modules.combine(
+           new MailetProcessingModule(),
+           new MailboxModule(),
+           new MemoryDataModule(),
+           new MemoryEventStoreModule(),
+           new MemoryMailboxModule(),
+           new MemoryMailQueueModule(),
+           new TaskManagerModule(),
+           new RawPostDequeueDecoratorModule(),
+           binder -&gt; binder.bind(MailetContainerModule.DefaultProcessorsConfigurationSupplier.class)
+               .toInstance(BaseHierarchicalConfiguration::new));
+
+       public static final Module CUSTOM_SERVER_AGGREGATE_MODULE = Modules.combine(
+           CUSTOM_SERVER_MODULE,
+           PROTOCOLS);
+
+       public static void main(String[] args) throws Exception {
+           Configuration configuration = Configuration.builder()
+               .useWorkingDirectoryEnvProperty()
+               .build();
+
+           JamesServerMain.main(GuiceJamesServer.forConfiguration(configuration)
+               .combineWith(CUSTOM_SERVER_AGGREGATE_MODULE));
+       }
+   }</code></pre>
+
+                <p>You need to write a minimal main method launching your guice module composition.</p>
+
+                <p>We do provide in this example <a href="https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin">JIB</a>
+                    to package this custom James assembly into docker:</p>
+
+                <pre><code>&lt;plugin&gt;
+    &lt;groupId&gt;com.google.cloud.tools&lt;/groupId&gt;
+    &lt;artifactId&gt;jib-maven-plugin&lt;/artifactId&gt;
+    &lt;version&gt;2.7.1&lt;/version&gt;
+    &lt;configuration&gt;
+        &lt;from&gt;
+            &lt;image&gt;adoptopenjdk:11-jdk-hotspot&lt;/image&gt;
+        &lt;/from&gt;
+        &lt;to&gt;
+            &lt;image&gt;apache/james&lt;/image&gt;
+            &lt;tags&gt;
+                &lt;tag&gt;custom-latest&lt;/tag&gt;
+            &lt;/tags&gt;
+        &lt;/to&gt;
+        &lt;container&gt;
+            &lt;mainClass&gt;org.apache.james.examples.CustomJamesServerMain&lt;/mainClass&gt;
+            &lt;ports&gt;
+                &lt;port&gt;25&lt;/port&gt; &lt;!-- JMAP --&gt;
+                &lt;port&gt;143&lt;/port&gt; &lt;!-- IMAP --&gt;
+            &lt;/ports&gt;
+            &lt;appRoot&gt;/root&lt;/appRoot&gt;
+            &lt;jvmFlags&gt;
+                &lt;jvmFlag&gt;-Dlogback.configurationFile=/root/conf/logback.xml&lt;/jvmFlag&gt;
+                &lt;jvmFlag&gt;-Dworking.directory=/root/&lt;/jvmFlag&gt;
+            &lt;/jvmFlags&gt;
+            &lt;creationTime&gt;USE_CURRENT_TIMESTAMP&lt;/creationTime&gt;
+        &lt;/container&gt;
+        &lt;extraDirectories&gt;
+            &lt;paths&gt;
+                &lt;path&gt;
+                    &lt;from&gt;sample-configuration&lt;/from&gt;
+                    &lt;into&gt;/root/conf&lt;/into&gt;
+                &lt;/path&gt;
+            &lt;/paths&gt;
+        &lt;/extraDirectories&gt;
+    &lt;/configuration&gt;
+    &lt;executions&gt;
+        &lt;execution&gt;
+            &lt;goals&gt;
+                &lt;goal&gt;buildTar&lt;/goal&gt;
+            &lt;/goals&gt;
+            &lt;phase&gt;package&lt;/phase&gt;
+        &lt;/execution&gt;
+    &lt;/executions&gt;
+&lt;/plugin&gt;}</code></pre>
+
+                <p>We provide a minimal <a href="https://github.com/apache/james-project/tree/master/examples/custom-james-assembly/sample-configuration">sample configuration</a>.
+                </p>
+
+                <p>You can compile this example project:</p>
+
+                <pre><code>mvn clean install</code></pre>
+
+                <p>Create a keystore (default password being <code>james72laBalle</code>):</p>
+
+                <pre><code>keytool -genkey -alias james -keyalg RSA -keystore keystore</code></pre>
+
+                <p>Import the build result:</p>
+
+                <pre><code>$ docker load -i target/jib-image.tar</code></pre>
+
+                <p>Then launch your custom server with docker:</p>
+
+                <pre><code>docker run \
+    -v $PWD/keystore:/root/conf/keystore \
+    -p 25:25 \
+    -p 143:143 \
+    -ti  \
+    apache/james:custom-latest
+                </code></pre>
+
+                <p>You will see that your custom James server starts smoothly:</p>
+
+                <pre><code>...
+09:40:25.884 [INFO ] o.a.j.GuiceJamesServer - JAMES server started</code></pre>
+            </div>
+            <footer class="major">
+                <ul class="actions align-center">
+                    <li><a href="index.html" class="button">go back to other how-tos</a></li>
+                </ul>
+            </footer>
+        </div>
+    </section>
+
+</div>

--- a/src/homepage/howTo/custom-smtp-commands.html
+++ b/src/homepage/howTo/custom-smtp-commands.html
@@ -1,0 +1,184 @@
+---
+layout: howTo
+---
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!-- Main -->
+<div id="main">
+
+    <!-- Introduction -->
+    <section id="intro" class="main special">
+        <div class="">
+            <div class="content align-left">
+                <header class="major">
+                    <h1><b>Configure Custom SMTP commands</b></h1>
+                </header>
+
+                <p>
+                    The current project demonstrates how to write custom commands for Apache James SMTP server.
+                </p>
+
+                <p>
+                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-smtp-commands">GitHub</a>.
+                </p>
+
+                <p>
+                    Start by importing the dependencies:
+                </p>
+
+                <pre><code>&lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;james-server-protocols-smtp&lt;/artifactId&gt;
+&lt;/dependency&gt;
+                </code></pre>
+
+                <p>You can write your commands by extending the <code>CommandHandler&lt;SMTPSession&gt;</code> class. For instance:</p>
+
+                <pre><code>/**
+  * Copy of NoopCmdHandler
+  */
+public class MyNoopCmdHandler implements CommandHandler&lt;SMTPSession&gt; {
+    private static final Collection&lt;String&gt; COMMANDS = ImmutableSet.of(&quot;MYNOOP&quot;);
+
+    private static final Response NOOP = new SMTPResponse(SMTPRetCode.MAIL_OK,
+        DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.UNDEFINED_STATUS) + &quot; OK&quot;)
+        .immutable();
+
+    @Override
+    public Response onCommand(SMTPSession session, Request request) {
+        return NOOP;
+    }
+
+    @Override
+    public Collection&lt;String&gt; getImplCommands() {
+        return COMMANDS;
+    }
+}</code></pre>
+
+                <p>You then need to list the exposed SMTP commands with a <code>HandlersPackage</code>. For instance:</p>
+
+                <pre><code>/**
+ * This class copies CoreCmdHandlerLoader adding support for MYNOOP command
+ */
+public class MyCmdHandlerLoader implements HandlersPackage {
+
+    private final List&lt;String&gt; commands = new LinkedList&lt;&gt;();
+
+    public MyCmdHandlerLoader() {
+        Stream.of(
+            JamesWelcomeMessageHandler.class,
+            CommandDispatcher.class,
+            AuthCmdHandler.class,
+            JamesDataCmdHandler.class,
+            EhloCmdHandler.class,
+            ExpnCmdHandler.class,
+            HeloCmdHandler.class,
+            HelpCmdHandler.class,
+            JamesMailCmdHandler.class,
+            NoopCmdHandler.class,
+            QuitCmdHandler.class,
+            JamesRcptCmdHandler.class,
+            RsetCmdHandler.class,
+            VrfyCmdHandler.class,
+            MailSizeEsmtpExtension.class,
+            UsersRepositoryAuthHook.class,
+            AuthRequiredToRelayRcptHook.class,
+            SenderAuthIdentifyVerificationRcptHook.class,
+            PostmasterAbuseRcptHook.class,
+            ReceivedDataLineFilter.class,
+            DataLineJamesMessageHookHandler.class,
+            StartTlsCmdHandler.class,
+            AddDefaultAttributesMessageHook.class,
+            SendMailHandler.class,
+            UnknownCmdHandler.class,
+            CommandHandlerResultLogger.class,
+            HookResultLogger.class,
+            // Support MYNOOP
+            MyNoopCmdHandler.class)
+        .map(Class::getName)
+        .forEachOrdered(commands::add);
+    }
+
+    @Override
+    public List&lt;String&gt; getHandlers() {
+        return commands;
+    }
+}</code></pre>
+
+                <p>You can compile this example project:</p>
+
+                <pre><code>mvn clean install</code></pre>
+
+                <p>Write a configuration file telling James to use your <code>HandlerPackage</code>:</p>
+
+                <pre><code>&lt;smtpservers&gt;
+    &lt;smtpserver enabled=&quot;true&quot;&gt;
+        &lt;jmxName&gt;smtpserver-global&lt;/jmxName&gt;
+        &lt;bind&gt;0.0.0.0:25&lt;/bind&gt;
+        &lt;connectionBacklog&gt;200&lt;/connectionBacklog&gt;
+        &lt;tls socketTLS=&quot;false&quot; startTLS=&quot;false&quot;&gt;
+            &lt;keystore&gt;file://conf/keystore&lt;/keystore&gt;
+            &lt;secret&gt;james72laBalle&lt;/secret&gt;
+            &lt;provider&gt;org.bouncycastle.jce.provider.BouncyCastleProvider&lt;/provider&gt;
+            &lt;algorithm&gt;SunX509&lt;/algorithm&gt;
+        &lt;/tls&gt;
+        &lt;!-- ... --&gt;
+        &lt;handlerchain coreHandlersPackage=&quot;org.apache.james.examples.MyCmdHandlerLoader&quot;&gt;
+            &lt;handler class=&quot;org.apache.james.smtpserver.fastfail.ValidRcptHandler&quot;/&gt;
+        &lt;/handlerchain&gt;
+    &lt;/smtpserver&gt;
+&lt;/smtpservers&gt;</code></pre>
+
+                <p>Create a keystore (default password being <code>james72laBalle</code>):</p>
+
+                <pre><code>keytool -genkey -alias james -keyalg RSA -keystore keystore</code></pre>
+
+                <p>Then start a James server with your JAR and the configuration:</p>
+
+                <pre><code>docker run -d \
+  -v $PWD/smtpserver.xml:/root/conf/smtpserver.xml \
+  -v $PWD/exts:/root/extensions-jars \
+  -v $PWD/keystore:/root/conf/keystore \
+  -p 25:25 \
+  apache/james:memory-latest
+                </code></pre>
+
+                <p>You can play with <code>telnet</code> utility with the resulting server and use the <code>MYNOOP</code> command:</p>
+
+                <pre><code>$ $ telnet 127.0.0.1 25
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+220 Apache JAMES awesome SMTP Server
+MYNOOP
+250 2.0.0 OK
+quit
+221 2.0.0 1f0274082fc6 Service closing transmission channel
+Connection closed by foreign host.</code></pre>
+            </div>
+            <footer class="major">
+                <ul class="actions align-center">
+                    <li><a href="index.html" class="button">go back to other how-tos</a></li>
+                </ul>
+            </footer>
+        </div>
+    </section>
+
+</div>

--- a/src/homepage/howTo/custom-smtp-hooks.html
+++ b/src/homepage/howTo/custom-smtp-hooks.html
@@ -1,0 +1,184 @@
+---
+layout: howTo
+---
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!-- Main -->
+<div id="main">
+
+    <!-- Introduction -->
+    <section id="intro" class="main special">
+        <div class="">
+            <div class="content align-left">
+                <header class="major">
+                    <h1><b>Configure Custom SMTP hooks</b></h1>
+                </header>
+
+                <p>
+                    The current project demonstrates how to write custom behaviors for Apache James SMTP server
+                    by the means of SMTP hooks.
+                </p>
+
+                <p>
+                    SMTP hooks allow integrating third party systems with the SMTP stack and writing additional SMTP extensions, for
+                    instance.
+                </p>
+
+                <p>
+                    Start by importing the dependencies:
+                </p>
+
+                <pre><code>&lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james.protocols&lt;/groupId&gt;
+    &lt;artifactId&gt;protocols-smtp/artifactId&gt;
+&lt;/dependency&gt;
+                </code></pre>
+
+                <ul>Allows writing the following hooks:
+                    <li><b>AuthHook</b>: hook in the AUTH Command</li>
+                    <li><b>HeloHook</b>: hook in the HELO Command</li>
+                    <li><b>MailHook</b>: hook in the MAIL Command</li>
+                    <li><b>MailParametersHook</b>: hook in the MAIL Command parameters</li>
+                    <li><b>RcptHook</b>: hook in the RCPT Command</li>
+                    <li><b>MessageHook</b>: hook in the DATA Command</li>
+                    <li><b>QuitHook</b>: hook in the QUIT Command</li>
+                    <li><b>UnknownHook</b>: hook for unknown commands</li>
+                </ul>
+
+                <pre><code>&lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;james-server-protocols-smtp&lt;/artifactId&gt;
+&lt;/dependency&gt;
+                </code></pre>
+
+                <p>James comes bundled with <a href="http://james.apache.org/server/dev-provided-smtp-hooks.html">provided SMTP hooks for common features</a>.
+                    We encourage you to review them before starting writing your own hooks.</p>
+
+                <ul>Allows writing the following hooks:
+                    <li><b>JamesMessageHook</b>: DATA command. Allows access to the message content.</li>
+                </ul>
+
+                <header class="major">
+                    <h2><b>Writing your own hooks</b></h2>
+                </header>
+
+                <p>
+                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-smtp-hooks">GitHub</a>.
+                </p>
+
+                <p>
+                    In this example we implement a single RCPT hook:
+                </p>
+
+                <pre><code>public class LoggingRcptHook implements RcptHook {
+    @Override
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt, Map&lt;String, String&gt; parameters) {
+        System.out.println(&quot;RCPT TO &quot; + rcpt + &quot;with parameters &quot; + parameters);
+
+        // Continue the SMTP transaction
+        return HookResult.DECLINED;
+    }
+}
+                </code></pre>
+
+                <p>You can compile this example project:</p>
+
+                <pre><code>mvn clean install</code></pre>
+
+                <p>Then embed your extension into a James server. First configure your hook:</p>
+
+                <pre><code>&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;smtpservers&gt;
+    &lt;smtpserver enabled=&quot;true&quot;&gt;
+        &lt;jmxName&gt;smtpserver-global&lt;/jmxName&gt;
+        &lt;bind&gt;0.0.0.0:25&lt;/bind&gt;
+        &lt;connectionBacklog&gt;200&lt;/connectionBacklog&gt;
+        &lt;tls socketTLS=&quot;false&quot; startTLS=&quot;false&quot;&gt;
+            &lt;keystore&gt;file://conf/keystore&lt;/keystore&gt;
+            &lt;secret&gt;james72laBalle&lt;/secret&gt;
+            &lt;provider&gt;org.bouncycastle.jce.provider.BouncyCastleProvider&lt;/provider&gt;
+            &lt;algorithm&gt;SunX509&lt;/algorithm&gt;
+        &lt;/tls&gt;
+        &lt;!-- ... --&gt;
+        &lt;handlerchain&gt;
+            &lt;handler class=&quot;org.apache.james.smtpserver.fastfail.ValidRcptHandler&quot;/&gt;
+            &lt;handler class=&quot;org.apache.james.smtpserver.CoreCmdHandlerLoader&quot;/&gt;
+            &lt;handler class=&quot;org.apache.james.examples.LoggingRcptHook&quot;/&gt;
+        &lt;/handlerchain&gt;
+    &lt;/smtpserver&gt;
+&lt;/smtpservers&gt;
+                </code></pre>
+
+                <p>Create a keystore (default password being <code>james72laBalle</code>):</p>
+
+                <pre><code>keytool -genkey -alias james -keyalg RSA -keystore keystore</code></pre>
+
+                <p>Then start a James server with your JAR and the configuration:</p>
+
+                <pre><code>docker run -d \
+  -v $PWD/smtpserver.xml:/root/conf/smtpserver.xml \
+  -v $PWD/exts:/root/extensions-jars \
+  -v $PWD/keystore:/root/conf/keystore \
+  -p 25:25 \
+  apache/james:memory-latest
+                </code></pre>
+
+                <p>You can play with <code>telnet</code> utility with the resulting server:</p>
+
+                <pre><code>$ telnet 127.0.0.1 25
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+220 Apache JAMES awesome SMTP Server
+EHLO toto.com
+250-177b73020637 Hello toto.com [172.17.0.1])
+250-PIPELINING
+250-ENHANCEDSTATUSCODES
+250 8BITMIME
+RCPT TO: &lt;b@c.com&gt;
+503 5.5.0 Need MAIL before RCPT
+MAIL FROM: &lt;b@c.com&gt;
+250 2.1.0 Sender &lt;b@c.com&gt; OK
+RCPT TO: &lt;c@d.com&gt;
+550 5.7.1 Requested action not taken: relaying denied
+quit
+                </code></pre>
+
+                <p>
+                    Now looking at the logs we can verify that our RCPT have well been executed:
+                </p>
+
+                <pre><code>06:49:15.734 [INFO ] o.a.j.GuiceJamesServer - JAMES server started
+06:49:30.275 [INFO ] o.a.j.p.n.BasicChannelUpstreamHandler - Connection established from 172.17.0.1
+06:50:18.892 [INFO ] o.a.j.i.n.ImapChannelUpstreamHandler - Connection established from 172.17.0.1
+06:50:19.152 [INFO ] o.a.j.i.n.ImapChannelUpstreamHandler - Connection closed for 172.17.0.1
+RCPT TO c@d.comwith parameters {TO:=, &lt;c@d.com&gt;=}</code></pre>
+
+                <p>Note that hooks can also be written for the LMTP protocol.</p>
+            </div>
+            <footer class="major">
+                <ul class="actions align-center">
+                    <li><a href="index.html" class="button">go back to other how-tos</a></li>
+                </ul>
+            </footer>
+        </div>
+    </section>
+
+</div>

--- a/src/homepage/howTo/custom-webadmin-routes.html
+++ b/src/homepage/howTo/custom-webadmin-routes.html
@@ -1,0 +1,114 @@
+---
+layout: howTo
+---
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!-- Main -->
+<div id="main">
+
+    <!-- Introduction -->
+    <section id="intro" class="main special">
+        <div class="">
+            <div class="content align-left">
+                <header class="major">
+                    <h1><b>Configure Custom WebAdmin routes</b></h1>
+                </header>
+
+                <p>
+                    The current project demonstrates how to write custom webadmin routes for Apache James. This enables writing new
+                    administrative features exposed over a REST API. This can allow you to write some additional features, make James
+                    interact with third party systems, do advance reporting...
+                </p>
+
+                <p>
+                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-webadmin-routes">GitHub</a>.
+                </p>
+
+                <p>
+                    Start by importing the dependencies:
+                </p>
+
+                <pre><code>&lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;james-server-webadmin-core&lt;/artifactId&gt;
+&lt;/dependency&gt;
+                </code></pre>
+
+                <p>You can then write your first route using the <a href="https://sparkjava.com/">Spark Java</a> framework:</p>
+
+                <pre><code>public class RouteA implements Routes {
+    @Override
+    public String getBasePath() {
+        return &quot;/hello/a&quot;;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(getBasePath(), (req, res) -&gt; &quot;RouteA\n&quot;);
+    }
+}</code></pre>
+
+                <ul>Knowing that:
+                    <li>entending <b>Routes</b>: will ensure that authentication is requested if configured.</li>
+                    <li>entending <b>PublicRoutes</b>: will not request authentication.</li>
+                </ul>
+
+                <p>You can compile this example project:</p>
+
+                <pre><code>mvn clean install</code></pre>
+
+                <p>Then embed your route into a James server. First configure your route into <code>webadmin.properties</code>:</p>
+
+                <pre><code>enabled=true
+port=8000
+host=localhost
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+extensions.routes=org.apache.james.examples.RouteA</code></pre>
+
+                <p>Create a keystore (default password being <code>james72laBalle</code>):</p>
+
+                <pre><code>keytool -genkey -alias james -keyalg RSA -keystore keystore</code></pre>
+
+                <p>Then start a James server with your JAR and the configuration:</p>
+
+                <pre><code>docker run -d \
+   -v $PWD/webadmin.properties:/root/conf/webadmin.properties \
+   -v $PWD/exts:/root/extensions-jars \
+   -v $PWD/keystore:/root/conf/keystore \
+   -p 25:25 \
+   apache/james:memory-latest</code></pre>
+
+                <p>You can play with <code>curl</code> utility with the resulting server:</p>
+
+                <pre><code>$ curl -XGET http://172.17.0.2:8000/hello/a
+RouteA</code></pre>
+            </div>
+            <footer class="major">
+                <ul class="actions align-center">
+                    <li><a href="index.html" class="button">go back to other how-tos</a></li>
+                </ul>
+            </footer>
+        </div>
+    </section>
+
+</div>

--- a/src/homepage/howTo/index.html
+++ b/src/homepage/howTo/index.html
@@ -88,6 +88,13 @@ layout: howTo
                class="james-schema" >
               <span class="fa fa-sitemap"></span>Configure Custom SMTP commands<span class="fa fa-long-arrow-right"></span>
             </a>
+            <a href="custom-webadmin-routes.html"
+               data-lightbox="james-schema"
+               data-title="Configure Custom WebAdmin routes"
+               alt="Configure Custom WebAdmin routes"
+               class="james-schema" >
+              <span class="fa fa-sitemap"></span>Configure Custom WebAdmin routes<span class="fa fa-long-arrow-right"></span>
+            </a>
 
             <br/>
             <br/>

--- a/src/homepage/howTo/index.html
+++ b/src/homepage/howTo/index.html
@@ -95,6 +95,13 @@ layout: howTo
                class="james-schema" >
               <span class="fa fa-sitemap"></span>Configure Custom WebAdmin routes<span class="fa fa-long-arrow-right"></span>
             </a>
+            <a href="custom-james-assembly.html"
+               data-lightbox="james-schema"
+               data-title="Write Custom James server assembly"
+               alt="Write Custom James server assembly"
+               class="james-schema" >
+              <span class="fa fa-sitemap"></span>Write Custom James server assembly<span class="fa fa-long-arrow-right"></span>
+            </a>
 
             <br/>
             <br/>

--- a/src/homepage/howTo/index.html
+++ b/src/homepage/howTo/index.html
@@ -58,7 +58,7 @@ layout: howTo
             <header class="major">
               <h2>Customize James</h2>
             </header>
-            <p class="align-left">This section will show you how to modify James to use it in your purpose</p>
+            <p class="align-left">This section will show you how to modify James to use it in your purpose, and embed your own code.</p>
             <a href="mail-processing.html"
                data-lightbox="james-schema"
                data-title="Customized mail processing"
@@ -79,6 +79,14 @@ layout: howTo
                alt="Configure Custom SMTP hooks"
                class="james-schema" >
               <span class="fa fa-sitemap"></span>Configure Custom SMTP hooks<span class="fa fa-long-arrow-right"></span>
+            </a>
+            <br/>
+            <a href="custom-smtp-commands.html"
+               data-lightbox="james-schema"
+               data-title="Configure Custom SMTP commands"
+               alt="Configure Custom SMTP commands"
+               class="james-schema" >
+              <span class="fa fa-sitemap"></span>Configure Custom SMTP commands<span class="fa fa-long-arrow-right"></span>
             </a>
 
             <br/>

--- a/src/homepage/howTo/index.html
+++ b/src/homepage/howTo/index.html
@@ -73,6 +73,13 @@ layout: howTo
                class="james-schema" >
               <span class="fa fa-sitemap"></span>Configure Custom Listeners<span class="fa fa-long-arrow-right"></span>
             </a>
+            <a href="custom-smtp-hooks.html"
+               data-lightbox="james-schema"
+               data-title="Configure Custom SMTP hooks"
+               alt="Configure Custom SMTP hooks"
+               class="james-schema" >
+              <span class="fa fa-sitemap"></span>Configure Custom SMTP hooks<span class="fa fa-long-arrow-right"></span>
+            </a>
 
             <br/>
             <br/>


### PR DESCRIPTION
![Screenshot from 2021-07-30 17-06-34](https://user-images.githubusercontent.com/6928740/127637742-f0911a09-32f8-4cae-bc69-f88eef34b17e.png)

The following PR aims at providing more hands on example on how to write custom components and load them into Apache James, including:

 - SMTP hooks
 - SMTP commands
 - WebAdmin routes

We also demonstrate how to assemble a tailor made James server.

For each of them we include an example and a how-to on the WebSite.

Also, a README pointing to the how to had been added for existing examples, providing more context. A README lists the various examples, easing discovery of examples on GitHub.

Finally we fix inaccurate JavaDoc for some SMTP hooks.