### PR TITLE
[UPGRADE] Drop guavate

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/components/CassandraModule.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/components/CassandraModule.java
@@ -28,7 +28,6 @@ import java.util.function.Function;
 import com.datastax.driver.core.schemabuilder.Create;
 import com.datastax.driver.core.schemabuilder.CreateType;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -79,10 +78,10 @@ public interface CassandraModule {
         public Builder modules(Collection<CassandraModule> modules) {
             tables.addAll(modules.stream()
                 .flatMap(module -> module.moduleTables().stream())
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
             types.addAll(modules.stream()
                 .flatMap(module -> module.moduleTypes().stream())
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
             return this;
         }
 

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTypesProvider.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTypesProvider.java
@@ -29,7 +29,6 @@ import org.apache.james.backends.cassandra.components.CassandraType;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.UserType;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableMap;
 
 public class CassandraTypesProvider {
@@ -43,7 +42,7 @@ public class CassandraTypesProvider {
 
         userTypes = module.moduleTypes()
             .stream()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                     CassandraType::getName,
                     type -> keyspaceMetadata.getUserType(type.getName())));
     }

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
@@ -33,7 +33,6 @@ import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class ClusterConfiguration {
@@ -241,7 +240,7 @@ public class ClusterConfiguration {
 
         return Arrays.stream(ipAndPorts)
             .map(string -> Host.parseConfString(string, DEFAULT_CASSANDRA_PORT))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static Optional<PoolingOptions> readPoolingOptions(Configuration configuration) {

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
@@ -26,7 +26,6 @@ import java.util.function.Predicate;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.Statement;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class StatementRecorder {
@@ -47,7 +46,7 @@ public class StatementRecorder {
                 .filter(BoundStatement.class::isInstance)
                 .map(BoundStatement.class::cast)
                 .filter(condition)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         List<Statement> select(List<Statement> statements);

--- a/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ElasticSearchConfiguration.java
+++ b/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ElasticSearchConfiguration.java
@@ -40,7 +40,6 @@ import org.apache.james.backends.es.v7.ElasticSearchConfiguration.SSLConfigurati
 import org.apache.james.backends.es.v7.ElasticSearchConfiguration.SSLConfiguration.SSLValidationStrategy;
 import org.apache.james.util.Host;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -512,7 +511,7 @@ public class ElasticSearchConfiguration {
         } else {
             return multiHosts.stream()
                 .map(ipAndPort -> Host.parse(ipAndPort, DEFAULT_PORT_AS_OPTIONAL))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
     }
 

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.james.util.Host;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -552,7 +551,7 @@ public class RabbitMQConfiguration {
         List<Host> hosts = Optional.ofNullable(configuration.getList(String.class, HOSTS))
             .map(hostList -> hostList.stream()
                 .map(string -> Host.parseConfString(string, DEFAULT_PORT))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .orElse(ImmutableList.of());
 
         ManagementCredentials managementCredentials = ManagementCredentials.from(configuration);

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
@@ -40,7 +40,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.TrustStrategy;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
@@ -185,6 +185,6 @@ public class RabbitMQConnectionFactory {
         return connectionFactory.newConnection(configuration.rabbitMQHosts()
             .stream()
             .map(host -> new Address(host.getHostName(), host.getPort()))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 }

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQClusterTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQClusterTest.java
@@ -52,7 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.rabbitmq.client.Address;
@@ -137,7 +136,7 @@ class RabbitMQClusterTest {
 
             awaitAtMostOneMinute.until(() -> consumer2.getConsumedMessages().size() == nbMessages);
 
-            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(Guavate.toImmutableList());
+            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(ImmutableList.toImmutableList());
             assertThat(consumer2.getConsumedMessages()).containsOnlyElementsOf(expectedResult);
         }
 
@@ -158,7 +157,7 @@ class RabbitMQClusterTest {
 
             awaitAtMostOneMinute.until(() -> consumer2.getConsumedMessages().size() == nbMessages);
 
-            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(Guavate.toImmutableList());
+            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(ImmutableList.toImmutableList());
             assertThat(consumer2.getConsumedMessages()).containsOnlyElementsOf(expectedResult);
         }
 
@@ -215,7 +214,7 @@ class RabbitMQClusterTest {
 
             awaitAtMostOneMinute.until(() -> consumer.getConsumedMessages().size() == nbMessages);
 
-            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(Guavate.toImmutableList());
+            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(ImmutableList.toImmutableList());
             assertThat(consumer.getConsumedMessages()).containsOnlyElementsOf(expectedResult);
         }
 
@@ -257,7 +256,7 @@ class RabbitMQClusterTest {
 
                 awaitAtMostOneMinute.until(() -> consumer.getConsumedMessages().size() == nbMessages);
 
-                List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(Guavate.toImmutableList());
+                List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(ImmutableList.toImmutableList());
                 assertThat(consumer.getConsumedMessages()).containsOnlyElementsOf(expectedResult);
             }
         }
@@ -284,7 +283,7 @@ class RabbitMQClusterTest {
 
             awaitAtMostOneMinute.until(() -> consumer.getConsumedMessages().size() == nbMessages);
 
-            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(Guavate.toImmutableList());
+            List<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(ImmutableList.toImmutableList());
             assertThat(consumer.getConsumedMessages()).containsOnlyElementsOf(expectedResult);
         }
 

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQTest.java
@@ -56,7 +56,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -229,7 +228,7 @@ class RabbitMQTest {
                 awaitAtMostOneMinute.until(
                     () -> countReceivedMessages(consumer2, consumer3, consumer4) == 30);
 
-                ImmutableList<Integer> expectedResult = IntStream.range(0, 10).boxed().collect(Guavate.toImmutableList());
+                ImmutableList<Integer> expectedResult = IntStream.range(0, 10).boxed().collect(ImmutableList.toImmutableList());
                 // Check every subscriber have receive all the messages.
                 assertThat(consumer2.getConsumedMessages()).containsOnlyElementsOf(expectedResult);
                 assertThat(consumer3.getConsumedMessages()).containsOnlyElementsOf(expectedResult);
@@ -269,7 +268,7 @@ class RabbitMQTest {
                 awaitAtMostOneMinute.until(
                     () -> countReceivedMessages(consumer2, consumer3, consumer4) == nbMessages);
 
-                ImmutableList<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(Guavate.toImmutableList());
+                ImmutableList<Integer> expectedResult = IntStream.range(0, nbMessages).boxed().collect(ImmutableList.toImmutableList());
 
                 assertThat(
                     Iterables.concat(

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/core/src/main/java/org/apache/james/core/builder/MimeMessageBuilder.java
+++ b/core/src/main/java/org/apache/james/core/builder/MimeMessageBuilder.java
@@ -45,7 +45,6 @@ import javax.mail.util.ByteArrayDataSource;
 import org.apache.commons.io.IOUtils;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
@@ -117,7 +116,7 @@ public class MimeMessageBuilder {
         public MultipartBuilder addBodies(BodyPartBuilder... bodyParts) {
             this.bodyParts.addAll(Arrays.stream(bodyParts)
                 .map(Throwing.function(BodyPartBuilder::build).sneakyThrow())
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
             return this;
         }
 
@@ -298,21 +297,21 @@ public class MimeMessageBuilder {
     public MimeMessageBuilder addToRecipient(String... tos) throws AddressException {
         this.to.addAll(Arrays.stream(tos)
             .map(Throwing.function(InternetAddress::new))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
         return this;
     }
 
     public MimeMessageBuilder addCcRecipient(String... ccs) throws AddressException {
         this.cc.addAll(Arrays.stream(ccs)
             .map(Throwing.function(InternetAddress::new))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
         return this;
     }
 
     public MimeMessageBuilder addBccRecipient(String... bccs) throws AddressException {
         this.bcc.addAll(Arrays.stream(bccs)
             .map(Throwing.function(InternetAddress::new))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
         return this;
     }
 

--- a/core/src/main/java/org/apache/james/util/Host.java
+++ b/core/src/main/java/org/apache/james/util/Host.java
@@ -22,7 +22,6 @@ package org.apache.james.util;
 import java.util.List;
 import java.util.Optional;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -47,7 +46,7 @@ public class Host {
             .stream()
             .map(string -> Host.parse(string, defaultPort))
             .distinct()
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public static Host from(String hostname, int port) {

--- a/event-bus/api/src/test/java/org/apache/james/events/EventBusTestFixture.java
+++ b/event-bus/api/src/test/java/org/apache/james/events/EventBusTestFixture.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.james.core.Username;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -187,7 +186,7 @@ public interface EventBusTestFixture {
             Preconditions.checkArgument(parts.get(0).equals(TestEvent.class.getCanonicalName()));
 
             Event.EventId eventId = Event.EventId.of(UUID.fromString(parts.get(1)));
-            Username username = Username.of(Joiner.on("&").join(parts.stream().skip(2).collect(Guavate.toImmutableList())));
+            Username username = Username.of(Joiner.on("&").join(parts.stream().skip(2).collect(ImmutableList.toImmutableList())));
             return new TestEvent(eventId, username);
         }
     }

--- a/event-bus/api/src/test/java/org/apache/james/events/EventDeadLettersContract.java
+++ b/event-bus/api/src/test/java/org/apache/james/events/EventDeadLettersContract.java
@@ -36,7 +36,6 @@ import org.apache.james.events.EventDeadLetters.InsertionId;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -87,7 +86,7 @@ interface EventDeadLettersContract {
 
     static ImmutableMap<Integer, Group> concurrentGroups() {
         return IntStream.range(0, CONCURRENT_GROUPS.size()).boxed()
-            .collect(Guavate.toImmutableMap(Function.identity(), CONCURRENT_GROUPS::get));
+            .collect(ImmutableMap.toImmutableMap(Function.identity(), CONCURRENT_GROUPS::get));
     }
 
     static Event event(Event.EventId eventId) {

--- a/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
@@ -39,7 +39,7 @@ import org.apache.james.util.StructuredLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.rabbitmq.client.AMQP;
@@ -171,7 +171,7 @@ public class EventDispatcher {
         return remoteDispatch(serializedEvent,
             keys.stream()
                 .map(RoutingKey::of)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private Mono<Void> remoteDispatch(byte[] serializedEvent, Collection<RoutingKey> routingKeys) {

--- a/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
@@ -39,7 +39,7 @@ import org.apache.james.backends.rabbitmq.ReceiverProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -136,7 +136,7 @@ class GroupRegistrationHandler {
             .flatMapIterable(aa -> groupRegistrations.values()
                 .stream()
                 .map(group -> Pair.of(group, aa))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .flatMap(event -> event.getLeft().runListenerReliably(DEFAULT_RETRY_COUNT, event.getRight()))
                 .then(Mono.<Void>fromRunnable(acknowledgableDelivery::ack).subscribeOn(Schedulers.elastic()))
             .then()

--- a/event-bus/distributed/src/main/java/org/apache/james/events/LocalListenerRegistry.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/LocalListenerRegistry.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
@@ -96,7 +95,7 @@ class LocalListenerRegistry {
     }
 
     private ImmutableSet<EventListener.ReactiveEventListener> removeListenerFromSet(EventListener listener, ImmutableSet<EventListener.ReactiveEventListener> listeners) {
-        ImmutableSet<EventListener.ReactiveEventListener> remainingListeners = listeners.stream().filter(not(listener::equals)).collect(Guavate.toImmutableSet());
+        ImmutableSet<EventListener.ReactiveEventListener> remainingListeners = listeners.stream().filter(not(listener::equals)).collect(ImmutableSet.toImmutableSet());
         if (remainingListeners.isEmpty()) {
             return ImmutableSet.of();
         }

--- a/event-bus/distributed/src/main/java/org/apache/james/events/RoutingKeyConverter.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/RoutingKeyConverter.java
@@ -27,8 +27,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public class RoutingKeyConverter {
@@ -66,7 +66,7 @@ public class RoutingKeyConverter {
     @Inject
     public RoutingKeyConverter(Set<RegistrationKey.Factory> factories) {
         this.factories = factories.stream()
-            .collect(Guavate.toImmutableMap(factory -> factory.forClass().getName()));
+            .collect(ImmutableMap.toImmutableMap(factory -> factory.forClass().getName(), f -> f));
     }
 
     RegistrationKey toRegistrationKey(String routingKey) {

--- a/event-bus/in-vm/src/main/java/org/apache/james/events/InVMEventBus.java
+++ b/event-bus/in-vm/src/main/java/org/apache/james/events/InVMEventBus.java
@@ -27,8 +27,8 @@ import javax.inject.Inject;
 
 import org.apache.james.events.delivery.EventDelivery;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
@@ -118,6 +118,6 @@ public class InVMEventBus implements EventBus {
     private Set<EventListener.ReactiveEventListener> registeredListenersByKeys(Set<RegistrationKey> keys) {
         return keys.stream()
             .flatMap(registrationKey -> registrations.get(registrationKey).stream())
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/event-sourcing/event-sourcing-core/pom.xml
+++ b/event-sourcing/event-sourcing-core/pom.xml
@@ -52,10 +52,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-scala-extensions_${scala.base}</artifactId>
         </dependency>

--- a/event-sourcing/event-store-api/pom.xml
+++ b/event-sourcing/event-store-api/pom.xml
@@ -48,10 +48,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-scala-extensions_${scala.base}</artifactId>
             <scope>test</scope>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -57,13 +57,13 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/json/src/main/java/org/apache/james/json/DTOConverter.java
+++ b/json/src/main/java/org/apache/james/json/DTOConverter.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public class DTOConverter<T, U extends DTO> {
@@ -39,12 +39,12 @@ public class DTOConverter<T, U extends DTO> {
 
     public DTOConverter(Set<? extends DTOModule<? extends T, ? extends U>> modules) {
         typeToModule = modules.stream()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 DTOModule::getDomainObjectType,
                 Function.identity()));
 
         domainClassToModule = modules.stream()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 DTOModule::getDomainObjectClass,
                 Function.identity()));
     }

--- a/json/src/main/java/org/apache/james/json/JsonGenericSerializer.java
+++ b/json/src/main/java/org/apache/james/json/JsonGenericSerializer.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -64,7 +63,7 @@ public class JsonGenericSerializer<T, U extends DTO> {
         }
 
         default JsonGenericSerializer<T, U> withMultipleNestedTypeModules(Set<DTOModule<?, ?>>... modules) {
-            return withNestedTypeModules(Arrays.stream(modules).flatMap(Collection::stream).collect(Guavate.toImmutableSet()));
+            return withNestedTypeModules(Arrays.stream(modules).flatMap(Collection::stream).collect(ImmutableSet.toImmutableSet()));
         }
 
         default JsonGenericSerializer<T, U> withoutNestedType() {

--- a/mailbox/api/pom.xml
+++ b/mailbox/api/pom.xml
@@ -64,10 +64,6 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/acl/UnionMailboxACLResolver.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/acl/UnionMailboxACLResolver.java
@@ -37,7 +37,7 @@ import org.apache.james.mailbox.model.MailboxACL.Right;
 import org.apache.james.mailbox.model.MailboxACL.SpecialName;
 import org.apache.james.mime4j.dom.address.Mailbox;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -291,7 +291,7 @@ public class UnionMailboxACLResolver implements MailboxACLResolver {
                 .filter(not(implicitRights::contains))
                 .map(Rfc4314Rights::new),
             Stream.of(implicitRights))
-        .collect(Guavate.toImmutableList());
+        .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxEvents.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxEvents.java
@@ -45,7 +45,6 @@ import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.model.UpdatedFlags;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -410,7 +409,7 @@ public interface MailboxEvents {
             return getUids()
                 .stream()
                 .map(uid -> getMetaData(uid).getMessageId())
-                .collect(Guavate.toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
         }
     }
 
@@ -483,14 +482,14 @@ public interface MailboxEvents {
         public Collection<MessageUid> getUids() {
             return updatedFlags.stream()
                 .map(UpdatedFlags::getUid)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         public Collection<MessageId> getMessageIds() {
             return updatedFlags.stream()
                 .map(UpdatedFlags::getMessageId)
                 .flatMap(Optional::stream)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         public List<UpdatedFlags> getUpdatedFlags() {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/FetchGroup.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/FetchGroup.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 
@@ -97,7 +96,7 @@ public class FetchGroup extends Profiles<FetchGroup> {
                 partContentDescriptors.stream()
                     .filter(descriptor -> !descriptor.path().equals(path)),
                 Stream.of(newContent))
-                .collect(Guavate.toImmutableSet()));
+                .collect(ImmutableSet.toImmutableSet()));
     }
 
     public FetchGroup addPartContent(MimePath path, Profile... profiles) {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
@@ -38,10 +38,10 @@ import org.apache.james.core.Username;
 import org.apache.james.mailbox.exception.UnsupportedRightException;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -705,7 +705,7 @@ public class MailboxACL {
     public MailboxACL(Map.Entry<EntryKey, Rfc4314Rights>... entries) {
         this(Optional.ofNullable(entries)
                 .map(array -> Arrays.stream(array)
-                    .collect(Guavate.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
+                    .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
                 .orElseGet(ImmutableMap::of));
     }
 
@@ -782,7 +782,7 @@ public class MailboxACL {
                 entry.getKey(),
                 except(entry.getValue(), other.getEntries().get(entry.getKey()))))
             .filter(pair -> !pair.getValue().isEmpty())
-            .collect(Guavate.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     private Rfc4314Rights except(Rfc4314Rights thisRight, Rfc4314Rights exceptRights) {
@@ -826,7 +826,7 @@ public class MailboxACL {
                     .map(entry -> Pair.of(entry.getKey(),
                         entry.getKey().equals(key) ? replacement : entry.getValue()))
                     .filter(pair -> pair.getValue() != null && !pair.getValue().isEmpty())
-                    .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)));
+                    .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)));
         } else {
             return Optional.ofNullable(replacement)
                 .filter(Predicate.not(Rfc4314Rights::isEmpty))
@@ -866,11 +866,11 @@ public class MailboxACL {
             Stream.concat(
                     this.entries.entrySet().stream(),
                     other.getEntries().entrySet().stream())
-                .collect(Guavate.toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue))
+                .collect(ImmutableListMultimap.toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue))
                 .asMap()
                 .entrySet()
                 .stream()
-                .collect(Guavate.toImmutableMap(Map.Entry::getKey, e -> union(e.getValue()))));
+                .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, e -> union(e.getValue()))));
     }
 
     private Rfc4314Rights union(Collection<Rfc4314Rights> rights) {
@@ -888,6 +888,6 @@ public class MailboxACL {
         return this.entries.entrySet().stream()
             .filter(entry -> !entry.getKey().isNegative())
             .filter(entry -> entry.getKey().getNameType().equals(nameType))
-            .collect(Guavate.entriesToMap());
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MimePath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MimePath.java
@@ -25,8 +25,8 @@ package org.apache.james.mailbox.model;
 import java.util.Arrays;
 import java.util.List;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Describes a path within a multipart MIME message. All implementations
@@ -68,7 +68,7 @@ public final class MimePath {
     public final String toString() {
         List<Integer> parts = Arrays.stream(positions)
             .boxed()
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return "MIMEPath:"
             + Joiner.on('.')

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -31,8 +31,8 @@ import org.apache.james.mailbox.exception.MailboxNameException;
 import org.apache.james.mailbox.exception.TooLongMailboxNameException;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -379,14 +379,14 @@ class MailboxPathTest {
     @Test
     void getParentShouldReturnParents() {
         MailboxPath mailboxPath = MailboxPath.forUser(USER, "inbox.folder.subfolder");
-        assertThat(mailboxPath.getParents('.').collect(Guavate.toImmutableList()))
+        assertThat(mailboxPath.getParents('.').collect(ImmutableList.toImmutableList()))
             .containsExactly(MailboxPath.forUser(USER, "inbox"), MailboxPath.forUser(USER, "inbox.folder"));
     }
 
     @Test
     void getParentShouldReturnEmptyWhenTopLevelMailbox() {
         MailboxPath mailboxPath = MailboxPath.forUser(USER, "inbox");
-        assertThat(mailboxPath.getParents('.').collect(Guavate.toImmutableList()))
+        assertThat(mailboxPath.getParents('.').collect(ImmutableList.toImmutableList()))
             .isEmpty();
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
@@ -48,8 +48,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -94,7 +94,7 @@ public class DefaultMailboxBackup implements MailboxBackup {
         List<MailAccountContent> accountContents = getAccountContentForUser(session);
         List<MailboxWithAnnotations> mailboxes = accountContents.stream()
             .map(MailAccountContent::getMailboxWithAnnotations)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         Stream<MessageResult> messages = allMessagesForUser(accountContents);
         archive(mailboxes, messages, destination);
@@ -152,7 +152,7 @@ public class DefaultMailboxBackup implements MailboxBackup {
             .map(MailboxMetaData::getPath);
         List<MailAccountContent> mailboxes = paths
             .flatMap(path -> getMailboxWithAnnotationsFromPath(session, path))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return mailboxes;
     }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/ZipMailArchiveRestorer.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/ZipMailArchiveRestorer.java
@@ -39,8 +39,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class ZipMailArchiveRestorer implements MailArchiveRestorer {
 
@@ -71,7 +71,7 @@ public class ZipMailArchiveRestorer implements MailArchiveRestorer {
         return mailboxes.stream()
             .flatMap(Throwing.<MailboxWithAnnotationsArchiveEntry, Stream<ImmutablePair<SerializedMailboxId, MessageManager>>>function(
                 mailboxEntry -> restoreMailboxEntry(session, mailboxEntry).stream()).sneakyThrow())
-            .collect(Guavate.entriesToImmutableMap());
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private List<MailboxWithAnnotationsArchiveEntry> readMailboxes(MailArchiveIterator iterator) {

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/zip/ZipEntryType.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/zip/ZipEntryType.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 
 public enum ZipEntryType {
@@ -42,7 +42,7 @@ public enum ZipEntryType {
         Stream<Integer> indices = IntStream.range(0, values().length).boxed();
 
         entryByOrdinal = Streams.zip(indices, valuesAsStream, ImmutablePair::of)
-            .collect(Guavate.entriesToImmutableMap());
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public static Optional<ZipEntryType> zipEntryType(int ordinal) {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipAssert.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipAssert.java
@@ -45,7 +45,6 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class ZipAssert extends AbstractAssert<ZipAssert, ZipFile> implements AutoCloseable {
@@ -176,7 +175,7 @@ public class ZipAssert extends AbstractAssert<ZipAssert, ZipFile> implements Aut
     private <T> List<T> sortAndCollect(Optional<Comparator<T>> sortBy, Stream<T> stream) {
         Stream<T> sortedStream = sortBy.map(comparator -> stream.sorted(comparator))
             .orElse(stream);
-        return sortedStream.collect(Guavate.toImmutableList());
+        return sortedStream.collect(ImmutableList.toImmutableList());
     }
 
     /**
@@ -305,6 +304,6 @@ public class ZipAssert extends AbstractAssert<ZipAssert, ZipFile> implements Aut
     private ImmutableList<ZipExtraField> extractJamesExtraFields(ZipArchiveEntry entry) {
         return Stream.of(entry.getExtraFields())
             .filter(field -> field instanceof WithZipHeader)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
@@ -28,7 +28,6 @@ import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -52,7 +51,7 @@ public class AttachmentLoader {
 
     private Mono<List<MessageAttachmentMetadata>> loadAttachments(Stream<MessageAttachmentRepresentation> messageAttachmentRepresentations, MessageMapper.FetchType fetchType) {
         if (fetchType == MessageMapper.FetchType.Body || fetchType == MessageMapper.FetchType.Full) {
-            return getAttachments(messageAttachmentRepresentations.collect(Guavate.toImmutableList()));
+            return getAttachments(messageAttachmentRepresentations.collect(ImmutableList.toImmutableList()));
         } else {
             return Mono.just(ImmutableList.of());
         }
@@ -64,7 +63,7 @@ public class AttachmentLoader {
                 .flatMapSequential(attachmentRepresentation ->
                         attachmentMapper.getAttachmentsAsMono(attachmentRepresentation.getAttachmentId())
                             .map(attachment -> constructMessageAttachment(attachment, attachmentRepresentation)))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
     }
 
     private MessageAttachmentMetadata constructMessageAttachment(AttachmentMetadata attachment, MessageAttachmentRepresentation messageAttachmentRepresentation) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLDAOV2.java
@@ -40,7 +40,6 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -150,6 +149,6 @@ public class CassandraACLDAOV2 {
             .stream()
             .map(MailboxACL.Right::asCharacter)
             .map(String::valueOf)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAnnotationMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAnnotationMapper.java
@@ -47,9 +47,9 @@ import org.apache.james.mailbox.store.transaction.NonTransactionalMapper;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Select;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 public class CassandraAnnotationMapper extends NonTransactionalMapper implements AnnotationMapper {
 
@@ -83,7 +83,7 @@ public class CassandraAnnotationMapper extends NonTransactionalMapper implements
         CassandraId cassandraId = (CassandraId)mailboxId;
         return keys.stream()
             .flatMap(annotation -> getAnnotationsByKeyWithOneDepth(cassandraId, annotation))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -91,7 +91,7 @@ public class CassandraAnnotationMapper extends NonTransactionalMapper implements
         CassandraId cassandraId = (CassandraId)mailboxId;
         return keys.stream()
             .flatMap(annotation -> getAnnotationsByKeyWithAllDepth(cassandraId, annotation))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -141,7 +141,7 @@ public class CassandraAnnotationMapper extends NonTransactionalMapper implements
     private Select.Where getStoredAnnotationsQueryForKeys(CassandraId mailboxId, Set<MailboxAnnotationKey> keys) {
         return getStoredAnnotationsQuery(mailboxId).and(in(CassandraAnnotationTable.KEY, keys.stream()
             .map(MailboxAnnotationKey::asString)
-            .collect(Guavate.toImmutableList())));
+            .collect(ImmutableList.toImmutableList())));
     }
 
     private Select.Where getStoredAnnotationsQueryLikeKey(CassandraId mailboxId, String key) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -46,8 +46,8 @@ import org.apache.james.util.io.CurrentPositionInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
 
 import reactor.core.publisher.Flux;
@@ -82,7 +82,7 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
         Preconditions.checkArgument(attachmentIds != null);
         return Flux.fromIterable(attachmentIds)
             .flatMap(this::getAttachmentsAsMono, DEFAULT_CONCURRENCY)
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
     }
 
@@ -135,13 +135,13 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
     @Override
     public Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) throws MailboxException {
         return attachmentMessageIdDAO.getOwnerMessageIds(attachmentId)
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
     }
 
     @Override
     public Collection<Username> getOwners(AttachmentId attachmentId) throws MailboxException {
-        return ownerDAO.retrieveOwners(attachmentId).collect(Guavate.toImmutableList()).block();
+        return ownerDAO.retrieveOwners(attachmentId).collect(ImmutableList.toImmutableList()).block();
     }
 
     private Mono<MessageAttachmentMetadata> storeAttachmentAsync(ParsedAttachment parsedAttachment, MessageId ownerMessageId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
@@ -37,7 +37,6 @@ import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.util.streams.Iterators;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -99,7 +98,7 @@ public class CassandraIndexTableHandler {
                     .flatMap(message -> updateDeletedMessageProjectionOnDelete(mailboxId, message.getComposedMessageId().getUid(), message.getFlags()), DEFAULT_CONCURRENCY),
             decrementCountersOnDeleteFlags(mailboxId, metaData.stream()
                 .map(ComposedMessageIdWithMetaData::getFlags)
-                .collect(Guavate.toImmutableList())))
+                .collect(ImmutableList.toImmutableList())))
             .then();
     }
 
@@ -135,10 +134,10 @@ public class CassandraIndexTableHandler {
         int lowConcurrency = 2;
         ImmutableSet<String> userFlags = messages.stream()
             .flatMap(message -> Stream.of(message.createFlags().getUserFlags()))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
         List<Flags> flags = messages.stream()
             .flatMap(message -> Stream.of(message.createFlags()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return Flux.mergeDelayError(Queues.XS_BUFFER_SIZE,
                 Flux.fromIterable(messages)
@@ -170,7 +169,7 @@ public class CassandraIndexTableHandler {
         return applicableFlagDAO.updateApplicableFlags(mailboxId,
             updatedFlags.stream()
                 .flatMap(flags -> Iterators.toStream(flags.userFlagIterator()))
-                .collect(Guavate.toImmutableSet()));
+                .collect(ImmutableSet.toImmutableSet()));
     }
 
     private Mono<Void> updateDeletedOnFlagsUpdate(CassandraId mailboxId, List<UpdatedFlags> updatedFlags) {
@@ -199,7 +198,7 @@ public class CassandraIndexTableHandler {
     private Mono<Void> decrementCountersOnDelete(CassandraId mailboxId, Collection<MessageMetaData> metaData) {
         return decrementCountersOnDeleteFlags(mailboxId, metaData.stream()
             .map(MessageMetaData::getFlags)
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 
     private Mono<Void> decrementCountersOnDeleteFlags(CassandraId mailboxId, Collection<Flags> flags) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -74,7 +74,6 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.UDTValue;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
 import com.google.common.primitives.Bytes;
@@ -207,7 +206,7 @@ public class CassandraMessageDAO {
     private ImmutableList<UDTValue> buildAttachmentUdt(MailboxMessage message) {
         return message.getAttachments().stream()
             .map(this::toUDT)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private UDTValue toUDT(MessageAttachmentMetadata messageAttachment) {
@@ -231,7 +230,7 @@ public class CassandraMessageDAO {
                 .setString(Properties.NAMESPACE, property.getNamespace())
                 .setString(Properties.NAME, property.getLocalName())
                 .setString(Properties.VALUE, property.getValue()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public Mono<MessageRepresentation> retrieveMessage(ComposedMessageIdWithMetaData id, FetchType fetchType) {
@@ -264,7 +263,7 @@ public class CassandraMessageDAO {
                 row.getInt(BODY_START_OCTET),
                 new ByteContent(content),
                 getProperties(row),
-                getAttachments(row).collect(Guavate.toImmutableList()),
+                getAttachments(row).collect(ImmutableList.toImmutableList()),
                 headerId,
                 bodyId));
     }
@@ -281,7 +280,7 @@ public class CassandraMessageDAO {
                 row.getInt(BODY_START_OCTET),
                 new ByteContent(EMPTY_BYTE_ARRAY),
                 getProperties(row),
-                getAttachments(row).collect(Guavate.toImmutableList()),
+                getAttachments(row).collect(ImmutableList.toImmutableList()),
                 headerId,
                 bodyId);
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
@@ -90,7 +90,6 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.TypeTokens;
 import com.datastax.driver.core.UDTValue;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
 import com.google.common.primitives.Bytes;
@@ -256,13 +255,13 @@ public class CassandraMessageDAOV3 {
     private ImmutableList<UDTValue> buildAttachmentUdt(MailboxMessage message) {
         return message.getAttachments().stream()
             .map(this::toUDT)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private ImmutableList<UDTValue> buildAttachmentUdt(List<MessageAttachmentRepresentation> attachments) {
         return attachments.stream()
             .map(this::toUDT)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private UDTValue toUDT(MessageAttachmentMetadata messageAttachment) {
@@ -319,7 +318,7 @@ public class CassandraMessageDAOV3 {
                 row.getInt(BODY_START_OCTET_LOWERCASE),
                 new ByteContent(content),
                 getProperties(row),
-                getAttachments(row).collect(Guavate.toImmutableList()),
+                getAttachments(row).collect(ImmutableList.toImmutableList()),
                 headerId,
                 bodyId));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -60,7 +60,7 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 import reactor.core.publisher.Flux;
@@ -278,7 +278,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
             .map(mailboxId -> (CassandraId) mailboxId)
             .concatMap(mailboxId -> flagsUpdateWithRetry(newState, updateMode, mailboxId, messageId))
             .flatMap(this::updateCounts, ReactorUtils.DEFAULT_CONCURRENCY)
-            .collect(Guavate.toImmutableListMultimap(Pair::getLeft, Pair::getRight));
+            .collect(ImmutableListMultimap.toImmutableListMultimap(Pair::getLeft, Pair::getRight));
     }
 
     private Flux<Pair<MailboxId, UpdatedFlags>> flagsUpdateWithRetry(Flags newState, MessageManager.FlagsUpdateMode updateMode, MailboxId mailboxId, MessageId messageId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
@@ -50,7 +50,7 @@ import org.apache.james.mailbox.store.mail.UidProvider;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -144,7 +144,7 @@ public class CassandraUidProvider implements UidProvider {
     private List<MessageUid> range(MessageUid lowerExclusive, MessageUid higherInclusive) {
         return LongStream.range(lowerExclusive.asLong() + 1, higherInclusive.asLong() + 1)
             .mapToObj(MessageUid::of)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/eventsourcing/acl/ACLDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/eventsourcing/acl/ACLDTO.java
@@ -28,13 +28,13 @@ import org.apache.james.mailbox.model.MailboxACL;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 public class ACLDTO {
     public static ACLDTO fromACL(MailboxACL acl) {
         return new ACLDTO(acl.getEntries().entrySet().stream()
             .map(entry -> Pair.of(entry.getKey().serialize(), entry.getValue().serialize()))
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)));
     }
 
     private final Map<String, String> entries;
@@ -53,7 +53,7 @@ public class ACLDTO {
         return new MailboxACL(entries.entrySet().stream()
             .map(Throwing.function(entry -> Pair.of(MailboxACL.EntryKey.deserialize(entry.getKey()),
                 MailboxACL.Rfc4314Rights.deserialize(entry.getValue()))))
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)));
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTask.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTask.java
@@ -32,7 +32,6 @@ import org.apache.james.task.TaskType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.scheduler.Schedulers;
@@ -100,6 +99,6 @@ public class RecomputeMailboxCountersTask implements Task {
             snapshot.getProcessedMailboxCount(),
             snapshot.getFailedMailboxes().stream()
                 .map(MailboxId::serialize)
-                .collect(Guavate.toImmutableList())));
+                .collect(ImmutableList.toImmutableList())));
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTask.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTask.java
@@ -30,7 +30,6 @@ import org.apache.james.task.TaskType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class SolveMailboxInconsistenciesTask implements Task {
@@ -108,7 +107,7 @@ public class SolveMailboxInconsistenciesTask implements Task {
             snapshot.getProcessedMailboxPathEntries(),
             snapshot.getFixedInconsistencies().stream()
                 .map(MailboxId::serialize)
-                .collect(Guavate.toImmutableList()),
+                .collect(ImmutableList.toImmutableList()),
             snapshot.getConflictingEntries(),
             snapshot.getErrors()));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMessageInconsistenciesTask.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMessageInconsistenciesTask.java
@@ -31,7 +31,6 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class SolveMessageInconsistenciesTask implements Task {
@@ -133,10 +132,10 @@ public class SolveMessageInconsistenciesTask implements Task {
             snapshot.getAddedMessageIdEntries(), snapshot.getUpdatedMessageIdEntries(), snapshot.getRemovedMessageIdEntries(), runningOptions,
             snapshot.getFixedInconsistencies().stream()
                 .map(this::toMessageInconsistenciesEntry)
-                .collect(Guavate.toImmutableList()),
+                .collect(ImmutableList.toImmutableList()),
             snapshot.getErrors().stream()
                 .map(this::toMessageInconsistenciesEntry)
-                .collect(Guavate.toImmutableList())));
+                .collect(ImmutableList.toImmutableList())));
     }
 
     private MessageInconsistenciesEntry toMessageInconsistenciesEntry(ComposedMessageId composedMessageId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManager.java
@@ -34,7 +34,7 @@ import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -149,7 +149,7 @@ public class CassandraPerUserMaxQuotaManager implements MaxQuotaManager {
                 .map(limit -> Pair.of(Quota.Scope.Domain, limit)),
             globalQuota.getGlobalMaxMessage()
                 .map(limit -> Pair.of(Quota.Scope.Global, limit)))
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 Pair::getKey,
                 Pair::getValue));
     }
@@ -169,7 +169,7 @@ public class CassandraPerUserMaxQuotaManager implements MaxQuotaManager {
                 .map(limit -> Pair.of(Quota.Scope.Domain, limit)),
             globalQuota.getGlobalMaxStorage()
                 .map(limit -> Pair.of(Quota.Scope.Global, limit)))
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 Pair::getKey,
                 Pair::getValue));
     }
@@ -193,7 +193,7 @@ public class CassandraPerUserMaxQuotaManager implements MaxQuotaManager {
                 domainLimits.getSizeLimit().stream().map(limit -> Pair.of(Quota.Scope.Domain, limit)),
                 globalLimits.stream().map(limit -> Pair.of(Quota.Scope.Global, limit)))
             .flatMap(Function.identity())
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 Pair::getKey,
                 Pair::getValue));
     }
@@ -204,7 +204,7 @@ public class CassandraPerUserMaxQuotaManager implements MaxQuotaManager {
                 domainLimits.getCountLimit().stream().map(limit -> Pair.of(Quota.Scope.Domain, limit)),
                 globalLimits.stream().map(limit -> Pair.of(Quota.Scope.Global, limit)))
             .flatMap(Function.identity())
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 Pair::getKey,
                 Pair::getValue));
     }

--- a/mailbox/elasticsearch-v7/pom.xml
+++ b/mailbox/elasticsearch-v7/pom.xml
@@ -129,10 +129,6 @@
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndex.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndex.java
@@ -18,7 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.elasticsearch.v7.events;
 
-import static com.github.steveash.guavate.Guavate.toImmutableList;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.james.mailbox.elasticsearch.v7.json.JsonMessageConstants.IS_ANSWERED;
 import static org.apache.james.mailbox.elasticsearch.v7.json.JsonMessageConstants.IS_DELETED;
 import static org.apache.james.mailbox.elasticsearch.v7.json.JsonMessageConstants.IS_DRAFT;

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessage.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessage.java
@@ -39,7 +39,6 @@ import org.apache.james.mailbox.store.search.SearchUtil;
 import org.apache.james.mime4j.MimeException;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -182,7 +181,7 @@ public class IndexableMessage {
         private List<MimePart> setFlattenedAttachments(MimePart parsingResult, IndexAttachments indexAttachments) {
             if (IndexAttachments.YES.equals(indexAttachments)) {
                 return parsingResult.getAttachmentsStream()
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
             } else {
                 return ImmutableList.of();
             }

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/query/QueryConverter.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/query/QueryConverter.java
@@ -34,7 +34,6 @@ import org.apache.james.mailbox.model.SearchQuery;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class QueryConverter {
@@ -72,7 +71,7 @@ public class QueryConverter {
         }
         ImmutableList<String> ids = mailboxIds.stream()
                 .map(MailboxId::serialize)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         return Optional.of(termsQuery(JsonMessageConstants.MAILBOX_ID, ids));
     }
 

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/search/ElasticSearchSearcherTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/search/ElasticSearchSearcherTest.java
@@ -74,7 +74,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 class ElasticSearchSearcherTest {
 
@@ -145,15 +145,15 @@ class ElasticSearchSearcherTest {
         List<MailboxPath> mailboxPaths = IntStream
             .range(0, numberOfMailboxes)
             .mapToObj(index -> MailboxPath.forUser(USERNAME, "mailbox" + index))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         List<MailboxId> mailboxIds = mailboxPaths.stream()
             .map(Throwing.<MailboxPath, MailboxId>function(mailboxPath -> storeMailboxManager.createMailbox(mailboxPath, session).get()).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         List<ComposedMessageId> composedMessageIds = mailboxPaths.stream()
             .map(Throwing.<MailboxPath, ComposedMessageId>function(mailboxPath -> addMessage(session, mailboxPath)).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), composedMessageIds.size());
 
@@ -164,7 +164,7 @@ class ElasticSearchSearcherTest {
         List<MessageId> expectedMessageIds = composedMessageIds
             .stream()
             .map(ComposedMessageId::getMessageId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         assertThat(storeMailboxManager.search(multimailboxesSearchQuery, session, numberOfMailboxes + 1)
             .collectList().block())
             .containsExactlyInAnyOrderElementsOf(expectedMessageIds);

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAnnotationMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAnnotationMapper.java
@@ -40,7 +40,6 @@ import org.apache.james.mailbox.store.mail.AnnotationMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -64,7 +63,7 @@ public class JPAAnnotationMapper extends JPATransactionalMapper implements Annot
             .getResultList()
             .stream()
             .map(READ_ROW)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -78,7 +77,7 @@ public class JPAAnnotationMapper extends JPATransactionalMapper implements Annot
                             .setParameter("idParam", jpaId.getRawId())
                             .setParameter("keyParam", input.asString())
                             .getSingleResult()))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (NoResultException e) {
             return ImmutableList.of();
         }
@@ -112,7 +111,7 @@ public class JPAAnnotationMapper extends JPATransactionalMapper implements Annot
                     .stream()
                     .map(READ_ROW)
                     .filter(predicateFunction.apply(key)))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (NoResultException e) {
             return ImmutableList.of();
         }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -56,7 +56,6 @@ import org.apache.james.mailbox.store.mail.utils.ApplicableFlagCalculator;
 import org.apache.openjpa.persistence.ArgumentException;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
@@ -426,7 +425,7 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
     private List<MessageUid> getUidList(List<MailboxMessage> messages) {
         return messages.stream()
             .map(message -> message.getUid())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private int deleteMessagesInMailbox(JPAId mailboxId) {

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -69,8 +69,8 @@ import org.apache.openjpa.persistence.jdbc.ElementJoinColumns;
 import org.apache.openjpa.persistence.jdbc.Index;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Abstract base class for JPA based implementations of
@@ -366,7 +366,7 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
     public Properties getProperties() {
         return new PropertyBuilder(properties.stream()
             .map(JPAProperty::toProperty)
-            .collect(Guavate.toImmutableList()))
+            .collect(ImmutableList.toImmutableList()))
             .build();
     }
 
@@ -523,7 +523,7 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
                 .map(Throwing.<ParsedAttachment, MessageAttachmentMetadata>function(
                     attachmentMetadata -> attachmentMetadata.asMessageAttachment(generateFixedAttachmentId(counter.incrementAndGet())))
                     .sneakyThrow())
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
@@ -35,7 +35,7 @@ import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 public class JPAPerUserMaxQuotaManager implements MaxQuotaManager {
 
@@ -124,7 +124,7 @@ public class JPAPerUserMaxQuotaManager implements MaxQuotaManager {
             Pair.of(Quota.Scope.Domain, quotaRoot.getDomain().flatMap(domainQuotaFunction)),
             Pair.of(Quota.Scope.Global, dao.getGlobalMaxMessage()))
         .filter(pair -> pair.getValue().isPresent())
-        .collect(Guavate.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
+        .collect(ImmutableMap.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
     }
 
     @Override
@@ -135,7 +135,7 @@ public class JPAPerUserMaxQuotaManager implements MaxQuotaManager {
             Pair.of(Quota.Scope.Domain, quotaRoot.getDomain().flatMap(domainQuotaFunction)),
             Pair.of(Quota.Scope.Global, dao.getGlobalMaxStorage()))
         .filter(pair -> pair.getValue().isPresent())
-        .collect(Guavate.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
+        .collect(ImmutableMap.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
     }
 
     @Override

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/user/JPASubscriptionMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/user/JPASubscriptionMapper.java
@@ -37,7 +37,7 @@ import org.apache.james.mailbox.jpa.user.model.JPASubscription;
 import org.apache.james.mailbox.store.user.SubscriptionMapper;
 import org.apache.james.mailbox.store.user.model.Subscription;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * JPA implementation of a {@link SubscriptionMapper}. This class is not thread-safe!
@@ -81,7 +81,7 @@ public class JPASubscriptionMapper extends JPATransactionalMapper implements Sub
                 .getResultList()
                 .stream()
                 .map(JPASubscription::toSubscription)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (PersistenceException e) {
             throw new SubscriptionException(e);
         }

--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
@@ -120,7 +120,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
@@ -480,7 +479,7 @@ public class LuceneMessageSearchIndex extends ListeningMessageSearchIndex {
             .map(searchResult -> searchResult.getMessageId().get())
             .filter(SearchUtil.distinct())
             .limit(Long.valueOf(limit).intValue())
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
     
     private List<SearchResult> searchMultimap(Collection<MailboxId> mailboxIds, SearchQuery searchQuery) throws MailboxException {

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -55,7 +55,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
@@ -277,7 +276,7 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
                .map(ignored -> Arrays.stream(maildirRoot.listFiles())
                        .flatMap(Throwing.<File, Stream<Mailbox>>function(domain -> visitUsersForMailboxList(domain, domain.listFiles()).stream()).sneakyThrow()))
                .switchIfEmpty(Mono.fromCallable(() -> visitUsersForMailboxList(null, maildirRoot.listFiles()).stream()))
-               .flatMapIterable(mailboxes -> mailboxes.collect(Guavate.toImmutableList()));
+               .flatMapIterable(mailboxes -> mailboxes.collect(ImmutableList.toImmutableList()));
     }
 
     private List<Mailbox> visitUsersForMailboxList(File domain, File[] users) throws MailboxException {

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
@@ -56,7 +56,8 @@ import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.apache.james.mailbox.store.mail.utils.ApplicableFlagCalculator;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class MaildirMessageMapper extends AbstractMessageMapper {
 
@@ -251,13 +252,13 @@ public class MaildirMessageMapper extends AbstractMessageMapper {
     private Map<MessageUid, MessageMetaData> deleteDeletedMessages(Mailbox mailbox, List<MailboxMessage> messages) throws MailboxException {
         return messages.stream()
             .peek(Throwing.<MailboxMessage>consumer(message -> delete(mailbox, message)).sneakyThrow())
-            .collect(Guavate.toImmutableMap(MailboxMessage::getUid, MailboxMessage::metaData));
+            .collect(ImmutableMap.toImmutableMap(MailboxMessage::getUid, MailboxMessage::metaData));
     }
 
     private List<MessageUid> getUidList(List<MailboxMessage> messages) {
         return messages.stream()
             .map(MailboxMessage::getUid)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
@@ -50,7 +50,7 @@ import org.apache.james.mime4j.stream.MimeTokenStream;
 import org.apache.james.mime4j.stream.RecursionMode;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 
 public class MaildirMessage implements Message {
@@ -278,7 +278,7 @@ public class MaildirMessage implements Message {
                 .map(Throwing.<ParsedAttachment, MessageAttachmentMetadata>function(
                     attachmentMetadata -> attachmentMetadata.asMessageAttachment(generateFixedAttachmentId(counter.incrementAndGet())))
                     .sneakyThrow())
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/user/MaildirSubscriptionMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/user/MaildirSubscriptionMapper.java
@@ -37,8 +37,8 @@ import org.apache.james.mailbox.store.transaction.NonTransactionalMapper;
 import org.apache.james.mailbox.store.user.SubscriptionMapper;
 import org.apache.james.mailbox.store.user.model.Subscription;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -71,7 +71,7 @@ public class MaildirSubscriptionMapper extends NonTransactionalMapper implements
         Set<String> subscriptionNames = readSubscriptionsForUser(user);
         return subscriptionNames.stream()
             .map(subscription -> new Subscription(user, subscription))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -120,7 +120,7 @@ public class MaildirSubscriptionMapper extends NonTransactionalMapper implements
             try (BufferedReader reader = new BufferedReader(fileReader)) {
                 return reader.lines()
                     .filter(Predicate.not(Strings::isNullOrEmpty))
-                    .collect(Guavate.toImmutableSet());
+                    .collect(ImmutableSet.toImmutableSet());
             }
         }
     }

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAnnotationMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAnnotationMapper.java
@@ -32,9 +32,9 @@ import org.apache.james.mailbox.model.MailboxAnnotationKey;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.store.mail.AnnotationMapper;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 
 public class InMemoryAnnotationMapper implements AnnotationMapper {
@@ -53,7 +53,7 @@ public class InMemoryAnnotationMapper implements AnnotationMapper {
                 .entrySet()
                 .stream()
                 .map(input -> MailboxAnnotation.newInstance(new MailboxAnnotationKey(input.getKey()), input.getValue()))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } finally {
             lock.readLock().unlock();
         }
@@ -69,7 +69,7 @@ public class InMemoryAnnotationMapper implements AnnotationMapper {
         return retrieveAllAnnotations((InMemoryId) mailboxId)
             .stream()
             .filter(input -> keys.contains(input.getKey()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -77,7 +77,7 @@ public class InMemoryAnnotationMapper implements AnnotationMapper {
         return retrieveAllAnnotations((InMemoryId) mailboxId)
             .stream()
             .filter(getPredicateFilterByAll(keys))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -85,7 +85,7 @@ public class InMemoryAnnotationMapper implements AnnotationMapper {
         return getAnnotationsByKeysWithAllDepth(mailboxId, keys)
             .stream()
             .filter(getPredicateFilterByOne(keys))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Predicate<MailboxAnnotation> getPredicateFilterByAll(final Set<MailboxAnnotationKey> keys) {

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAttachmentMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAttachmentMapper.java
@@ -40,7 +40,6 @@ import org.apache.james.mailbox.model.ParsedAttachment;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -116,7 +115,7 @@ public class InMemoryAttachmentMapper implements AttachmentMapper {
             .map(Throwing.<ParsedAttachment, MessageAttachmentMetadata>function(
                 typedContent -> storeAttachmentForMessage(ownerMessageId, typedContent))
                 .sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private MessageAttachmentMetadata storeAttachmentForMessage(MessageId ownerMessageId, ParsedAttachment parsedAttachment) throws MailboxException {

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
@@ -47,8 +47,8 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 import reactor.core.publisher.Flux;
@@ -67,7 +67,7 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
     @Override
     public List<MailboxMessage> find(Collection<MessageId> messageIds, MessageMapper.FetchType fetchType) {
         return findReactive(messageIds, fetchType)
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
     }
 
@@ -97,7 +97,7 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
         return find(ImmutableList.of(messageId), MessageMapper.FetchType.Metadata)
             .stream()
             .map(MailboxMessage::getMailboxId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -142,7 +142,7 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
             .filter(message -> mailboxIds.contains(message.getMailboxId()))
             .map(updateMessage(newState, updateMode))
             .distinct()
-            .collect(Guavate.toImmutableListMultimap(
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
                 Pair::getKey,
                 Pair::getValue)))
             .subscribeOn(Schedulers.elastic());

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMapper.java
@@ -46,7 +46,8 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.apache.james.mailbox.store.mail.utils.ApplicableFlagCalculator;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class InMemoryMessageMapper extends AbstractMessageMapper {
     private final Map<InMemoryId, Map<MessageUid, MailboxMessage>> mailboxByUid;
@@ -132,7 +133,7 @@ public class InMemoryMessageMapper extends AbstractMessageMapper {
             .filter(MailboxMessage::isRecent)
             .map(MailboxMessage::getUid)
             .sorted()
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -167,7 +168,7 @@ public class InMemoryMessageMapper extends AbstractMessageMapper {
             .stream()
             .filter(message -> uids.contains(message.getUid()))
             .peek(message -> delete(mailbox, message))
-            .collect(Guavate.toImmutableMap(MailboxMessage::getUid, MailboxMessage::metaData));
+            .collect(ImmutableMap.toImmutableMap(MailboxMessage::getUid, MailboxMessage::metaData));
     }
 
     @Override

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/quota/InMemoryPerUserMaxQuotaManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/quota/InMemoryPerUserMaxQuotaManager.java
@@ -33,7 +33,7 @@ import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 public class InMemoryPerUserMaxQuotaManager implements MaxQuotaManager {
 
@@ -79,7 +79,7 @@ public class InMemoryPerUserMaxQuotaManager implements MaxQuotaManager {
                 Pair.of(Quota.Scope.Domain, quotaRoot.getDomain().flatMap(domainQuotaFunction)),
                 Pair.of(Quota.Scope.Global, maxMessage))
             .filter(pair -> pair.getValue().isPresent())
-            .collect(Guavate.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
     }
 
     @Override
@@ -90,7 +90,7 @@ public class InMemoryPerUserMaxQuotaManager implements MaxQuotaManager {
                 Pair.of(Quota.Scope.Domain, quotaRoot.getDomain().flatMap(domainQuotaFunction)),
                 Pair.of(Quota.Scope.Global, maxStorage))
             .filter(pair -> pair.getValue().isPresent())
-            .collect(Guavate.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, value -> value.getValue().get()));
     }
 
     @Override

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/user/InMemorySubscriptionMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/user/InMemorySubscriptionMapper.java
@@ -26,8 +26,8 @@ import org.apache.james.mailbox.store.transaction.NonTransactionalMapper;
 import org.apache.james.mailbox.store.user.SubscriptionMapper;
 import org.apache.james.mailbox.store.user.model.Subscription;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 
 public class InMemorySubscriptionMapper extends NonTransactionalMapper implements SubscriptionMapper {
@@ -55,7 +55,7 @@ public class InMemorySubscriptionMapper extends NonTransactionalMapper implement
 
             return subscriptions.stream()
                 .map(mailbox -> new Subscription(user, mailbox))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
     }
 

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
@@ -75,7 +75,6 @@ import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -151,7 +150,7 @@ public class InMemoryIntegrationResources implements IntegrationResources<StoreM
             default RequireQuotaManager preDeletionHooks(Collection<PreDeletionHook> preDeletionHooks) {
                 return preDeletionHooksFactories(preDeletionHooks.stream()
                     .map(RequirePreDeletionHooks::toFactory)
-                    .collect(Guavate.toImmutableList()));
+                    .collect(ImmutableList.toImmutableList()));
             }
 
             default RequireQuotaManager noPreDeletionHooks() {
@@ -354,7 +353,7 @@ public class InMemoryIntegrationResources implements IntegrationResources<StoreM
             ImmutableSet<PreDeletionHook> preDeletionHooksSet = preDeletionHooksFactories.build()
                 .stream()
                 .map(biFunction -> biFunction.apply(preInstanciationStage))
-                .collect(Guavate.toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
             return new PreDeletionHooks(preDeletionHooksSet, new RecordingMetricFactory());
         }
     }

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreVaultGarbageCollectionTask.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreVaultGarbageCollectionTask.java
@@ -34,7 +34,7 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
@@ -60,7 +60,7 @@ public class BlobStoreVaultGarbageCollectionTask implements Task {
         public List<String> getDeletedBuckets() {
             return deletedBuckets.stream()
                 .map(BucketName::asString)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         @Override

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreVaultGarbageCollectionTaskAdditionalInformationDTO.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreVaultGarbageCollectionTaskAdditionalInformationDTO.java
@@ -30,7 +30,7 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 
 public class BlobStoreVaultGarbageCollectionTaskAdditionalInformationDTO implements AdditionalInformationDTO {
     static BlobStoreVaultGarbageCollectionTaskAdditionalInformationDTO fromDomainObject(BlobStoreVaultGarbageCollectionTask.AdditionalInformation additionalInformation, String type) {
@@ -82,7 +82,7 @@ public class BlobStoreVaultGarbageCollectionTaskAdditionalInformationDTO impleme
             deletedBuckets
                 .stream()
                 .map(BucketName::of)
-                .collect(Guavate.toImmutableSet()),
+                .collect(ImmutableSet.toImmutableSet()),
             timestamp);
     }
 

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationConverter.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationConverter.java
@@ -37,7 +37,6 @@ import org.apache.james.vault.metadata.DeletedMessageWithStorageInformation;
 import org.apache.james.vault.metadata.StorageInformation;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class DeletedMessageWithStorageInformationConverter {
@@ -84,12 +83,12 @@ public class DeletedMessageWithStorageInformationConverter {
     private ImmutableList<MailboxId> deserializeOriginMailboxes(List<String> originMailboxes) {
         return originMailboxes.stream()
             .map(mailboxId -> mailboxIdFactory.fromString(mailboxId))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private ImmutableList<MailAddress> deserializeRecipients(List<String> recipients) throws AddressException {
         return recipients.stream()
             .map(Throwing.<String, MailAddress>function(MailAddress::new).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationDTO.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationDTO.java
@@ -32,7 +32,6 @@ import org.apache.james.vault.metadata.StorageInformation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -87,13 +86,13 @@ public class DeletedMessageWithStorageInformationDTO {
         private static ImmutableList<String> serializeOriginMailboxes(List<MailboxId> originMailboxes) {
             return originMailboxes.stream()
                 .map(MailboxId::serialize)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         private static ImmutableList<String> serializeRecipients(List<MailAddress> recipients) {
             return recipients.stream()
                 .map(MailAddress::asString)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         private static String serializeZonedDateTime(ZonedDateTime time) {

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/query/QueryTranslator.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/query/QueryTranslator.java
@@ -50,9 +50,9 @@ import org.apache.james.vault.search.Operator;
 import org.apache.james.vault.search.Query;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableTable;
 
 public class QueryTranslator {
@@ -197,7 +197,7 @@ public class QueryTranslator {
     public QueryDTO toDTO(Query query) throws QueryTranslatorException {
         List<QueryElement> queryElements = query.getCriteria().stream()
             .map(this::toDTO)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         return new QueryDTO(Combinator.AND.getValue(), queryElements);
     }
 
@@ -224,7 +224,7 @@ public class QueryTranslator {
         return Query.and(queryDTO.getCriteria().stream()
             .map(queryElement -> (CriterionDTO) queryElement)
             .map(Throwing.function(this::translate))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 
     private boolean combinatorIsValid(String combinator) {

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
@@ -175,7 +174,7 @@ class DeletedMessageVaultHookTest {
 
         ImmutableList<MessageId> ids = IntStream.range(0, 1000)
             .mapToObj(Throwing.intFunction(i -> appendMessage(messageManager).getMessageId()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         assertThatCode(() -> Mono.from(messageIdManager.delete(ids, aliceSession)).subscribeOn(Schedulers.elastic()).block())
             .doesNotThrowAnyException();
@@ -199,7 +198,7 @@ class DeletedMessageVaultHookTest {
         long messageSize = messageSize(bobMessageManager, composedMessageId);
 
         DeletedMessage deletedMessage = buildDeletedMessage(ImmutableList.of(aliceMailbox), messageId, ALICE, messageSize);
-        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(Guavate.toImmutableList()).block(), bobSession);
+        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(ImmutableList.toImmutableList()).block(), bobSession);
 
         assertThat(Flux.from(messageVault.search(ALICE, Query.ALL)).blockFirst())
             .isEqualTo(deletedMessage);
@@ -220,7 +219,7 @@ class DeletedMessageVaultHookTest {
         MessageManager bobMessageManager = mailboxManager.getMailbox(aliceMailbox, bobSession);
         appendMessage(aliceMessageManager);
 
-        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(Guavate.toImmutableList()).block(), bobSession);
+        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(ImmutableList.toImmutableList()).block(), bobSession);
 
         assertThat(Flux.from(messageVault.search(BOB, Query.ALL)).collectList().block())
             .isEmpty();
@@ -246,7 +245,7 @@ class DeletedMessageVaultHookTest {
 
         long messageSize = messageSize(bobMessageManager, composedMessageId);
         DeletedMessage deletedMessage = buildDeletedMessage(ImmutableList.of(bobMailbox), messageId, BOB, messageSize);
-        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(Guavate.toImmutableList()).block(), bobSession);
+        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(ImmutableList.toImmutableList()).block(), bobSession);
 
         assertThat(Flux.from(messageVault.search(BOB, Query.ALL)).blockFirst())
             .isEqualTo(deletedMessage);
@@ -270,7 +269,7 @@ class DeletedMessageVaultHookTest {
 
         messageIdManager.setInMailboxes(messageId, ImmutableList.of(bobMailbox), bobSession);
 
-        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(Guavate.toImmutableList()).block(), bobSession);
+        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(ImmutableList.toImmutableList()).block(), bobSession);
 
         assertThat(Flux.from(messageVault.search(ALICE, Query.ALL)).collectList().block())
             .isEmpty();
@@ -296,7 +295,7 @@ class DeletedMessageVaultHookTest {
 
         long messageSize = messageSize(bobMessageManager, composedMessageId);
         DeletedMessage deletedMessage = buildDeletedMessage(ImmutableList.of(bobMailbox), messageId, BOB, messageSize);
-        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(Guavate.toImmutableList()).block(), bobSession);
+        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(ImmutableList.toImmutableList()).block(), bobSession);
 
         assertThat(Flux.from(messageVault.search(BOB, Query.ALL)).blockFirst())
             .isEqualTo(deletedMessage);
@@ -320,7 +319,7 @@ class DeletedMessageVaultHookTest {
 
         messageIdManager.setInMailboxes(messageId, ImmutableList.of(aliceMailbox, bobMailbox), bobSession);
 
-        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(Guavate.toImmutableList()).block(), bobSession);
+        bobMessageManager.delete(Flux.from(bobMessageManager.search(searchQuery, bobSession)).collect(ImmutableList.toImmutableList()).block(), bobSession);
 
         assertThat(Flux.from(messageVault.search(ALICE, Query.ALL)).collectList().block())
             .isEmpty();

--- a/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/QuotaMailingListenerConfiguration.java
+++ b/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/QuotaMailingListenerConfiguration.java
@@ -34,7 +34,6 @@ import org.apache.james.mailbox.quota.model.QuotaThreshold;
 import org.apache.james.mailbox.quota.model.QuotaThresholds;
 import org.apache.james.util.DurationParser;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -87,7 +86,7 @@ public class QuotaMailingListenerConfiguration {
                 RenderingInformation.from(
                     Optional.ofNullable(node.getString(XmlKeys.BODY_TEMPLATE)),
                     Optional.ofNullable(node.getString(XmlKeys.SUBJECT_TEMPLATE)))))
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 pair -> new QuotaThreshold(pair.getLeft()),
                 Pair::getRight));
     }

--- a/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/aggregates/UserQuotaThresholds.java
+++ b/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/aggregates/UserQuotaThresholds.java
@@ -42,7 +42,6 @@ import org.apache.james.mailbox.quota.model.QuotaThresholdChange;
 import org.apache.james.mailbox.quota.model.QuotaThresholdHistory;
 import org.apache.james.mailbox.quota.model.QuotaThresholds;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -163,7 +162,7 @@ public class UserQuotaThresholds {
                 .map(QuotaThresholdChangedEvent::getSizeHistoryEvolution)
                 .map(HistoryEvolution::getThresholdChange)
                 .flatMap(Optional::stream)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private QuotaThresholdHistory computeCountHistory() {
@@ -172,7 +171,7 @@ public class UserQuotaThresholds {
                 .map(QuotaThresholdChangedEvent::getCountHistoryEvolution)
                 .map(HistoryEvolution::getThresholdChange)
                 .flatMap(Optional::stream)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private List<QuotaThresholdChangedEvent> generateEvents(HistoryEvolution countHistoryEvolution, HistoryEvolution sizeHistoryEvolution, Quota<QuotaCountLimit, QuotaCountUsage> countQuota, Quota<QuotaSizeLimit, QuotaSizeUsage> sizeQuota) {

--- a/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/model/QuotaThresholdHistory.java
+++ b/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/model/QuotaThresholdHistory.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -49,7 +48,7 @@ public class QuotaThresholdHistory {
     public QuotaThresholdHistory(List<QuotaThresholdChange> changes) {
         this.changes = changes.stream()
             .sorted(Comparator.comparing(QuotaThresholdChange::getInstant))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public HistoryEvolution compareWithCurrentThreshold(QuotaThresholdChange thresholdChange, Duration gracePeriod) {

--- a/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/model/QuotaThresholds.java
+++ b/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/model/QuotaThresholds.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 
 import org.apache.james.mailbox.model.Quota;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
@@ -40,7 +39,7 @@ public class QuotaThresholds {
     public QuotaThresholds(List<QuotaThreshold> quotaThresholds) {
         this.quotaThresholds = quotaThresholds.stream()
             .sorted(Comparator.comparing(QuotaThreshold::getQuotaOccupationRatio).reversed())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public QuotaThreshold highestExceededThreshold(Quota<?, ?> quota) {

--- a/mailbox/plugin/quota-search-elasticsearch-v7/src/main/java/org/apache/james/quota/search/elasticsearch/v7/ElasticSearchQuotaSearcher.java
+++ b/mailbox/plugin/quota-search-elasticsearch-v7/src/main/java/org/apache/james/quota/search/elasticsearch/v7/ElasticSearchQuotaSearcher.java
@@ -38,7 +38,6 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
@@ -62,7 +61,7 @@ public class ElasticSearchQuotaSearcher implements QuotaSearcher {
             return searchHits(query)
                 .map(SearchHit::getId)
                 .map(Username::of)
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
                 .block();
         } catch (Exception e) {
             throw new RuntimeException("Unexpected exception while executing " + query, e);

--- a/mailbox/plugin/quota-search-scanning/src/main/java/org/apache/james/quota/search/scanning/ScanningQuotaSearcher.java
+++ b/mailbox/plugin/quota-search-scanning/src/main/java/org/apache/james/quota/search/scanning/ScanningQuotaSearcher.java
@@ -34,7 +34,7 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.util.streams.Iterators;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class ScanningQuotaSearcher implements QuotaSearcher {
     private final UsersRepository usersRepository;
@@ -54,7 +54,7 @@ public class ScanningQuotaSearcher implements QuotaSearcher {
             .skip(query.getOffset().getValue());
 
         return limit(results, query.getLimit())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Stream<Username> limit(Stream<Username> results, Limit limit) {

--- a/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
+++ b/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
@@ -47,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -112,7 +111,7 @@ public class SpamAssassinListener implements SpamEventListener {
                 .stream()
                 .flatMap(range -> retrieveMessages(messageMapper, mailbox, range))
                 .map(Throwing.function(MailboxMessage::getFullContent))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
             spamAssassin.learnHam(contents, event.getUsername());
         }
     }
@@ -153,7 +152,7 @@ public class SpamAssassinListener implements SpamEventListener {
             .find(messageMoveEvent.getMessageIds(), MessageMapper.FetchType.Full)
             .stream()
             .map(Throwing.function(Message::getFullContent))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @VisibleForTesting

--- a/mailbox/store/pom.xml
+++ b/mailbox/store/pom.xml
@@ -78,10 +78,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
@@ -25,8 +25,8 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MessageRange;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 public class MessageBatcher {
 
@@ -53,7 +53,7 @@ public class MessageBatcher {
                 .stream()
                 .flatMap(Throwing.function(range -> batchedOperation.execute(range)
                                                                     .stream()))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } else {
             return batchedOperation.execute(set);
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageMovesWithMailbox.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageMovesWithMailbox.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MessageMoves;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -110,7 +109,7 @@ public class MessageMovesWithMailbox {
             .targetMailboxes(targetMailboxes)
             .previousMailboxes(previousMailboxes.stream()
                 .filter(predicate)
-                .collect(Guavate.toImmutableSet()))
+                .collect(ImmutableSet.toImmutableSet()))
             .build();
     }
 
@@ -119,7 +118,7 @@ public class MessageMovesWithMailbox {
             .previousMailboxes(previousMailboxes)
             .targetMailboxes(targetMailboxes.stream()
                 .filter(predicate)
-                .collect(Guavate.toImmutableSet()))
+                .collect(ImmutableSet.toImmutableSet()))
             .build();
     }
 
@@ -127,10 +126,10 @@ public class MessageMovesWithMailbox {
         return MessageMoves.builder()
             .previousMailboxIds(previousMailboxes.stream()
                 .map(Mailbox::getMailboxId)
-                .collect(Guavate.toImmutableSet()))
+                .collect(ImmutableSet.toImmutableSet()))
             .targetMailboxIds(targetMailboxes.stream()
                 .map(Mailbox::getMailboxId)
-                .collect(Guavate.toImmutableSet()))
+                .collect(ImmutableSet.toImmutableSet()))
             .build();
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -46,7 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -104,7 +104,7 @@ public class StoreAttachmentManager implements AttachmentManager {
             ImmutableSet<AttachmentId> owned = Sets.difference(ImmutableSet.copyOf(attachmentIds), referencedByMessages)
                 .stream()
                 .filter(Throwing.<AttachmentId>predicate(id -> isExplicitlyAOwner(id, mailboxSession)).sneakyThrow())
-                .collect(Guavate.toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
 
             return ImmutableSet.<AttachmentId>builder()
                 .addAll(referencedByMessages)
@@ -129,7 +129,7 @@ public class StoreAttachmentManager implements AttachmentManager {
                 attachmentId -> getRelatedMessageIds(attachmentId, mailboxSession).stream()
                     .map(messageId -> Pair.of(messageId, attachmentId)))
                 .sneakyThrow())
-            .collect(Guavate.toImmutableListMultimap(
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
                 Pair::getKey,
                 Pair::getValue))
             .asMap();
@@ -139,7 +139,7 @@ public class StoreAttachmentManager implements AttachmentManager {
         return entries.entrySet().stream()
             .filter(entry -> accessibleMessages.contains(entry.getKey()))
             .flatMap(entry -> entry.getValue().stream())
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     private boolean isExplicitlyAOwner(AttachmentId attachmentId, MailboxSession mailboxSession) throws MailboxException {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -95,9 +95,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -369,7 +369,7 @@ public class StoreMailboxManager implements MailboxManager {
         return intermediatePaths
             .stream()
             .flatMap(Throwing.<MailboxPath, Stream<MailboxId>>function(mailboxPath -> manageMailboxCreation(mailboxSession, isRootPath, mailboxPath)).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Stream<MailboxId> manageMailboxCreation(MailboxSession mailboxSession, boolean isRootPath, MailboxPath mailboxPath) throws MailboxException {
@@ -462,7 +462,7 @@ public class StoreMailboxManager implements MailboxManager {
 
         return quotaRootPublisher.zipWith(messageCountPublisher).flatMap(quotaRootWithMessageCount -> messageMapper.findInMailboxReactive(mailbox, MessageRange.all(), MessageMapper.FetchType.Metadata, UNLIMITED)
             .map(message -> MetadataWithMailboxId.from(message.metaData(), message.getMailboxId()))
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .flatMap(metadata -> {
                 long totalSize = metadata.stream()
                     .map(MetadataWithMailboxId::getMessageMetaData)
@@ -687,7 +687,7 @@ public class StoreMailboxManager implements MailboxManager {
                 List<MailboxPath> hierarchyLevels = path.getHierarchyLevels(session.getPathDelimiter());
                 return Lists.reverse(hierarchyLevels).stream().skip(1);
             })
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 Function.identity(),
                 any -> true,
                 (a, b) -> true));
@@ -786,7 +786,7 @@ public class StoreMailboxManager implements MailboxManager {
     public Flux<MessageId> search(MultimailboxesSearchQuery expression, MailboxSession session, long limit) {
         return getInMailboxIds(expression, session)
             .filter(id -> !expression.getNotInMailboxes().contains(id))
-            .collect(Guavate.toImmutableSet())
+            .collect(ImmutableSet.toImmutableSet())
             .flatMapMany(Throwing.function(ids -> index.search(session, ids, expression.getSearchQuery(), limit)));
     }
 
@@ -841,7 +841,7 @@ public class StoreMailboxManager implements MailboxManager {
             .list()
             .map(Mailbox::generateAssociatedPath)
             .distinct()
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -108,9 +108,9 @@ import org.apache.james.util.streams.Iterators;
 import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 
 import reactor.core.publisher.Flux;
@@ -670,7 +670,7 @@ public class StoreMessageManager implements MessageManager {
         MessageMapper messageMapper = mapperFactory.getMessageMapper(mailboxSession);
 
         Iterator<UpdatedFlags> it = messageMapper.execute(() -> messageMapper.updateFlags(getMailboxEntity(), new FlagsUpdateCalculator(flags, flagsUpdateMode), set));
-        List<UpdatedFlags> updatedFlags = Iterators.toStream(it).collect(Guavate.toImmutableList());
+        List<UpdatedFlags> updatedFlags = Iterators.toStream(it).collect(ImmutableList.toImmutableList());
 
         eventBus.dispatch(EventFactory.flagsUpdated()
                 .randomEventId()
@@ -682,7 +682,7 @@ public class StoreMessageManager implements MessageManager {
             .subscribeOn(Schedulers.elastic())
             .block();
 
-        return updatedFlags.stream().collect(Guavate.toImmutableMap(
+        return updatedFlags.stream().collect(ImmutableMap.toImmutableMap(
             UpdatedFlags::getUid,
             UpdatedFlags::getNewFlags));
     }
@@ -771,7 +771,7 @@ public class StoreMessageManager implements MessageManager {
 
         return updatedFlags.stream()
             .map(UpdatedFlags::getUid)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private void runPredeletionHooks(List<MessageUid> uids, MailboxSession session) {
@@ -781,7 +781,7 @@ public class StoreMessageManager implements MessageManager {
             .publishOn(Schedulers.elastic())
             .flatMap(range -> messageMapper.findInMailboxReactive(mailbox, range, FetchType.Metadata, UNLIMITED), DEFAULT_CONCURRENCY)
             .map(mailboxMessage -> MetadataWithMailboxId.from(mailboxMessage.metaData(), mailboxMessage.getMailboxId()))
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .map(DeleteOperation::from);
 
         deleteOperation.flatMap(preDeletionHooks::runHooks).block();
@@ -828,7 +828,7 @@ public class StoreMessageManager implements MessageManager {
             List<MailboxMessage> originalMessages = groupedOriginalRows.next();
             originalRowsCopy.addAll(originalMessages.stream()
                 .map(MailboxMessage::metaData)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
             List<MessageMetaData> data = messageMapper.execute(
                 () -> messageMapper.move(getMailboxEntity(), originalMessages));
             movedRows.addAll(data);
@@ -864,7 +864,7 @@ public class StoreMessageManager implements MessageManager {
                     .messageMoves(messageMoves)
                     .messageId(messageIds.build())
                     .build(),
-                messageMoves.impactedMailboxIds().map(MailboxIdRegistrationKey::new).collect(Guavate.toImmutableSet())))
+                messageMoves.impactedMailboxIds().map(MailboxIdRegistrationKey::new).collect(ImmutableSet.toImmutableSet())))
             .subscribeOn(Schedulers.elastic())
             .blockLast();
 
@@ -906,7 +906,7 @@ public class StoreMessageManager implements MessageManager {
                     .messageId(messageIds.build())
                     .session(session)
                     .build(),
-                messageMoves.impactedMailboxIds().map(MailboxIdRegistrationKey::new).collect(Guavate.toImmutableSet())))
+                messageMoves.impactedMailboxIds().map(MailboxIdRegistrationKey::new).collect(ImmutableSet.toImmutableSet())))
             .subscribeOn(Schedulers.elastic())
             .blockLast();
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.function.Function;
 
 import org.apache.james.core.Username;
 import org.apache.james.core.quota.QuotaCountLimit;
@@ -52,7 +53,6 @@ import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
@@ -129,7 +129,7 @@ public class EventFactory {
         default T addMetaData(Iterable<MessageMetaData> metaData) {
             return metaData(ImmutableList.copyOf(metaData)
                 .stream()
-                .collect(Guavate.toImmutableSortedMap(MessageMetaData::getUid)));
+                .collect(ImmutableSortedMap.toImmutableSortedMap(MessageUid::compareTo, MessageMetaData::getUid, Function.identity())));
         }
 
         default T addMetaData(Iterator<MessageMetaData> metaData) {
@@ -140,7 +140,7 @@ public class EventFactory {
             return metaData(ImmutableList.copyOf(messages)
                 .stream()
                 .map(MailboxMessage::metaData)
-                .collect(Guavate.toImmutableSortedMap(MessageMetaData::getUid)));
+                .collect(ImmutableSortedMap.toImmutableSortedMap(MessageUid::compareTo, MessageMetaData::getUid, Function.identity())));
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/FetchGroupConverter.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/FetchGroupConverter.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.model.FetchGroup;
 import org.apache.james.mailbox.model.FetchGroup.Profile;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class FetchGroupConverter {
     /**
@@ -40,7 +40,7 @@ public class FetchGroupConverter {
         Collection<MessageMapper.FetchType> fetchTypes = group.profiles()
             .stream()
             .map(FetchGroupConverter::toFetchType)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return reduce(fetchTypes);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -46,7 +46,6 @@ import org.apache.james.util.streams.Iterators;
 import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
@@ -182,7 +181,7 @@ public interface MessageMapper extends Mapper {
     default List<MessageMetaData> copy(Mailbox mailbox, List<MailboxMessage> original) throws MailboxException {
         return original.stream()
             .map(Throwing.<MailboxMessage, MessageMetaData>function(message -> copy(mailbox, message)).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
     
     /**
@@ -197,7 +196,7 @@ public interface MessageMapper extends Mapper {
     default List<MessageMetaData> move(Mailbox mailbox, List<MailboxMessage> original) throws MailboxException {
         return original.stream()
             .map(Throwing.<MailboxMessage, MessageMetaData>function(message -> move(mailbox, message)).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
@@ -26,7 +26,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -58,6 +58,6 @@ public interface UidProvider {
     default Mono<List<MessageUid>> nextUids(MailboxId mailboxId, int count) {
         return Flux.range(0, count)
             .flatMap(i -> nextUidReactive(mailboxId))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/MessageParser.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/MessageParser.java
@@ -50,7 +50,6 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
@@ -101,7 +100,7 @@ public class MessageParser {
             if (body instanceof Multipart) {
                 Multipart multipartBody = (Multipart) body;
                 return listAttachments(multipartBody, Context.fromSubType(multipartBody.getSubType()))
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
             } else {
                 return ImmutableList.of();
             }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
@@ -47,7 +47,6 @@ import java.util.TreeMap;
 
 import org.apache.james.mailbox.store.mail.model.Property;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
@@ -95,7 +94,7 @@ public class Properties {
         return properties.stream()
             .filter(property -> property.isNamed(namespace, localName))
             .map(Property::getValue)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculator.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculator.java
@@ -25,8 +25,8 @@ import org.apache.james.mailbox.ApplicableFlagBuilder;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.util.streams.Iterators;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 
 public class ApplicableFlagCalculator {
@@ -41,7 +41,7 @@ public class ApplicableFlagCalculator {
         return ApplicableFlagBuilder.builder()
             .add(Iterators.toStream(mailboxMessages.iterator())
                 .map(MailboxMessage::createFlags)
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .build();
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/utils/MimeMessageHeadersUtil.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/utils/MimeMessageHeadersUtil.java
@@ -30,7 +30,7 @@ import org.apache.james.mime4j.field.UnstructuredFieldImpl;
 import org.apache.james.mime4j.message.HeaderImpl;
 import org.apache.james.mime4j.stream.Field;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class MimeMessageHeadersUtil {
     public static Optional<MimeMessageId> parseMimeMessageId(HeaderImpl headers) {
@@ -46,7 +46,7 @@ public class MimeMessageHeadersUtil {
         if (!mimeMessageIdFields.isEmpty()) {
             List<MimeMessageId> mimeMessageIdList = mimeMessageIdFields.stream()
                 .map(mimeMessageIdField -> new MimeMessageId(mimeMessageIdField.getBody()))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
             return Optional.of(mimeMessageIdList);
         }
         return Optional.empty();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/comparator/CombinedComparator.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/comparator/CombinedComparator.java
@@ -26,8 +26,8 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.model.SearchQuery.Sort;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -41,7 +41,7 @@ public class CombinedComparator implements Comparator<MailboxMessage> {
         Preconditions.checkArgument(!sorts.isEmpty());
         return new CombinedComparator(sorts.stream()
             .map(toComparator())
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 
     private static Function<Sort, Comparator<MailboxMessage>> toComparator() {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerStorageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerStorageTest.java
@@ -52,8 +52,8 @@ import org.apache.james.mailbox.model.MessageResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public abstract class AbstractMessageIdManagerStorageTest {
     public static final Flags FLAGS = new Flags();
@@ -225,7 +225,7 @@ public abstract class AbstractMessageIdManagerStorageTest {
         List<MailboxId> messageMailboxIds = messageIdManager.getMessage(messageId, FetchGroup.MINIMAL, aliceSession)
             .stream()
             .map(MessageResult::getMailboxId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         assertThat(messageMailboxIds).containsOnly(aliceMailbox1.getMailboxId(), aliceMailbox3.getMailboxId());
     }
@@ -438,7 +438,7 @@ public abstract class AbstractMessageIdManagerStorageTest {
         List<Flags> flags = messageIdManager.getMessage(messageId, FetchGroup.MINIMAL, aliceSession)
             .stream()
             .map(MessageResult::getFlags)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         assertThat(flags).hasSize(2);
         assertThat(flags.get(0)).isEqualTo(newFlags);
@@ -456,7 +456,7 @@ public abstract class AbstractMessageIdManagerStorageTest {
         List<Flags> flags = messageIdManager.getMessage(messageId1, FetchGroup.MINIMAL, aliceSession)
             .stream()
             .map(MessageResult::getFlags)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         assertThat(flags).hasSize(1);
         assertThat(flags.get(0)).isEqualTo(FLAGS);
@@ -472,7 +472,7 @@ public abstract class AbstractMessageIdManagerStorageTest {
         List<Flags> flags = messageIdManager.getMessage(messageId1, FetchGroup.MINIMAL, aliceSession)
             .stream()
             .map(MessageResult::getFlags)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         assertThat(flags).hasSize(1);
         assertThat(flags.get(0)).isEqualTo(FLAGS);
@@ -488,7 +488,7 @@ public abstract class AbstractMessageIdManagerStorageTest {
         List<Flags> flags = messageIdManager.getMessage(messageId1, FetchGroup.MINIMAL, aliceSession)
             .stream()
             .map(MessageResult::getFlags)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         assertThat(flags).hasSize(1);
         assertThat(flags.get(0)).isEqualTo(FLAGS);
@@ -504,7 +504,7 @@ public abstract class AbstractMessageIdManagerStorageTest {
 
         Map<MessageId, Flags> flags = messageIdManager.getMessages(ImmutableList.of(messageId1, messageId2), FetchGroup.MINIMAL, aliceSession)
             .stream()
-            .collect(Guavate.toImmutableMap(MessageResult::getMessageId, MessageResult::getFlags));
+            .collect(ImmutableMap.toImmutableMap(MessageResult::getMessageId, MessageResult::getFlags));
 
         assertThat(flags).hasSize(2);
         assertThat(flags.get(messageId1)).isEqualTo(newFlags);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssert.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssert.java
@@ -27,8 +27,8 @@ import org.apache.james.core.Username;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class ListMailboxAssert {
@@ -39,7 +39,7 @@ public class ListMailboxAssert {
         return mailboxes.stream()
             .map(mailbox ->
                 new InnerMailbox(mailbox.getMailboxId(), mailbox.getUser(), mailbox.getName(), mailbox.getNamespace()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private ListMailboxAssert(List<Mailbox> actual) {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssert.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssert.java
@@ -31,8 +31,8 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class ListMessageAssert {
@@ -41,7 +41,7 @@ public class ListMessageAssert {
     private List<InnerMessage> messageToInnerMessage(List<MailboxMessage> messages) {
         return messages.stream()
             .map(message -> getInnerMessage(message))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private InnerMessage getInnerMessage(MailboxMessage message) {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessagePropertiesAssert.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessagePropertiesAssert.java
@@ -24,15 +24,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.function.Function;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 
 
 public class ListMessagePropertiesAssert {
     private List<InnerProperty> propertiesToInnerProperties(List<Property> properties) {
         return properties.stream()
             .map(propertyToInnerProperty())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Function<Property, InnerProperty> propertyToInnerProperty() {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -57,7 +57,6 @@ import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -906,7 +905,7 @@ public abstract class MessageIdMapperTest {
             sut.find(ImmutableList.of(message1.getMessageId(), message2.getMessageId()), FetchType.Metadata)
                 .stream()
                 .map(message -> Pair.of(message.getMessageId(), message.getMailboxId()))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
         assertThat(storedMessages)
             .containsOnly(Pair.of(message1.getMessageId(), benwaInboxMailbox.getMailboxId()));

--- a/mailbox/tika/pom.xml
+++ b/mailbox/tika/pom.xml
@@ -64,10 +64,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaTextExtractor.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaTextExtractor.java
@@ -46,7 +46,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -109,14 +108,14 @@ public class TikaTextExtractor implements TextExtractor {
             ObjectNode node = (ObjectNode) treeNode.get(0);
             return ContentAndMetadata.from(ImmutableList.copyOf(node.fields())
                 .stream()
-                .collect(Guavate.toImmutableMap(Entry::getKey, entry -> asListOfString(entry.getValue()))));
+                .collect(ImmutableMap.toImmutableMap(Entry::getKey, entry -> asListOfString(entry.getValue()))));
         }
 
         @VisibleForTesting List<String> asListOfString(JsonNode jsonNode) {
             if (jsonNode.isArray()) {
                 return ImmutableList.copyOf(jsonNode.elements()).stream()
                     .map(JsonNode::asText)
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
             }
             return ImmutableList.of(jsonNode.asText());
         }
@@ -136,7 +135,7 @@ public class TikaTextExtractor implements TextExtractor {
             return new ContentAndMetadata(Optional.ofNullable(content(contentAndMetadataMap)),
                     contentAndMetadataMap.entrySet().stream()
                         .filter(allHeadersButTika())
-                        .collect(Guavate.toImmutableMap(Entry::getKey, Entry::getValue)));
+                        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)));
         }
 
         private static Predicate<? super Entry<String, List<String>>> allHeadersButTika() {

--- a/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ErrorRecoveryIndexationTask.java
+++ b/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ErrorRecoveryIndexationTask.java
@@ -33,7 +33,6 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class ErrorRecoveryIndexationTask implements Task {
@@ -56,14 +55,14 @@ public class ErrorRecoveryIndexationTask implements Task {
                 .flatMap(dto -> dto.getUids()
                     .stream()
                     .map(uid -> new ReIndexingExecutionFailures.ReIndexingFailure(mailboxIdFactory.fromString(dto.getMailboxId()), MessageUid.of(uid))))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         private List<MailboxId> mailboxFailuresFromDTO(Optional<List<String>> mailboxFailures) {
             return mailboxFailures.map(mailboxIdList ->
                     mailboxIdList.stream()
                         .map(mailboxIdFactory::fromString)
-                        .collect(Guavate.toImmutableList()))
+                        .collect(ImmutableList.toImmutableList()))
                 .orElse(ImmutableList.of());
         }
 

--- a/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ErrorRecoveryIndexationTaskDTO.java
+++ b/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ErrorRecoveryIndexationTaskDTO.java
@@ -32,7 +32,8 @@ import org.apache.james.server.task.json.dto.TaskDTO;
 import org.apache.james.server.task.json.dto.TaskDTOModule;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 public class ErrorRecoveryIndexationTaskDTO implements TaskDTO {
@@ -51,19 +52,19 @@ public class ErrorRecoveryIndexationTaskDTO implements TaskDTO {
         Multimap<MailboxId, ReIndexingExecutionFailures.ReIndexingFailure> failuresByMailboxId = task.getPreviousFailures()
             .messageFailures()
             .stream()
-            .collect(Guavate.toImmutableListMultimap(ReIndexingExecutionFailures.ReIndexingFailure::getMailboxId, Function.identity()));
+            .collect(ImmutableListMultimap.toImmutableListMultimap(ReIndexingExecutionFailures.ReIndexingFailure::getMailboxId, Function.identity()));
 
         List<ReindexingFailureDTO> failureDTOs = failuresByMailboxId.asMap()
             .entrySet()
             .stream()
             .map(ErrorRecoveryIndexationTaskDTO::failuresByMailboxToReindexingFailureDTO)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         List<String> failureMailboxDTOs = task.getPreviousFailures()
             .mailboxFailures()
             .stream()
             .map(MailboxId::serialize)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         return new ErrorRecoveryIndexationTaskDTO(type, failureDTOs, Optional.of(failureMailboxDTOs), Optional.of(RunningOptionsDTO.toDTO(task.getRunningOptions())));
     }
 
@@ -74,7 +75,7 @@ public class ErrorRecoveryIndexationTaskDTO implements TaskDTO {
             .stream()
             .map(ReIndexingExecutionFailures.ReIndexingFailure::getUid)
             .map(MessageUid::asLong)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         return new ReindexingFailureDTO(entry.getKey().serialize(), uids);
     }
 

--- a/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ReprocessingContextInformationDTO.java
+++ b/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ReprocessingContextInformationDTO.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.james.json.DTOModule;
@@ -34,7 +35,6 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -95,7 +95,7 @@ public class ReprocessingContextInformationDTO implements AdditionalInformationD
                     details.getFailedReprocessedMailCount(),
                     Optional.empty(),
                     Optional.of(serializeFailures(details.failures())),
-                    Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(Guavate.toImmutableList())),
+                    Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(ImmutableList.toImmutableList())),
                     details.timestamp(),
                     Optional.of(RunningOptionsDTO.toDTO(details.getRunningOptions()))))
                 .typeName(ErrorRecoveryIndexationTask.PREVIOUS_FAILURES_INDEXING.asString())
@@ -145,7 +145,7 @@ public class ReprocessingContextInformationDTO implements AdditionalInformationD
                     details.getFailedReprocessedMailCount(),
                     Optional.empty(),
                     Optional.of(serializeFailures(details.failures())),
-                    Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(Guavate.toImmutableList())),
+                    Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(ImmutableList.toImmutableList())),
                     details.timestamp(),
                     Optional.of(RunningOptionsDTO.toDTO(details.getRunningOptions()))))
                 .typeName(FullReindexingTask.FULL_RE_INDEXING.asString())
@@ -169,12 +169,12 @@ public class ReprocessingContextInformationDTO implements AdditionalInformationD
             .stream()
             .flatMap(failuresForMailbox ->
                 getReIndexingFailureStream(mailboxIdFactory, failuresForMailbox))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return new ReIndexingExecutionFailures(reIndexingFailures,
             mailboxFailures.stream()
                 .map(mailboxIdFactory::fromString)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private static Stream<ReIndexingExecutionFailures.ReIndexingFailure> getReIndexingFailureStream(MailboxId.Factory mailboxIdFactory, ReindexingFailureDTO failuresForMailbox) {
@@ -187,7 +187,7 @@ public class ReprocessingContextInformationDTO implements AdditionalInformationD
     static List<ReindexingFailureDTO> serializeFailures(ReIndexingExecutionFailures failures) {
         ImmutableListMultimap<MailboxId, ReIndexingExecutionFailures.ReIndexingFailure> failuresByMailbox = failures.messageFailures()
             .stream()
-            .collect(Guavate.toImmutableListMultimap(ReIndexingExecutionFailures.ReIndexingFailure::getMailboxId));
+            .collect(ImmutableListMultimap.toImmutableListMultimap(ReIndexingExecutionFailures.ReIndexingFailure::getMailboxId, Function.identity()));
 
         return failuresByMailbox
             .asMap()
@@ -197,7 +197,7 @@ public class ReprocessingContextInformationDTO implements AdditionalInformationD
                 new ReindexingFailureDTO(
                     failureByMailbox.getKey().serialize(),
                     extractMessageUidsFromFailure(failureByMailbox)))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static ImmutableList<Long> extractMessageUidsFromFailure(Map.Entry<MailboxId, Collection<ReIndexingExecutionFailures.ReIndexingFailure>> failureByMailbox) {
@@ -205,7 +205,7 @@ public class ReprocessingContextInformationDTO implements AdditionalInformationD
             .getValue()
             .stream()
             .map(failure -> failure.getUid().asLong())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     static List<ReindexingFailureDTO> resolveFailure(Optional<List<ReindexingFailureDTO>> failures, Optional<List<ReindexingFailureDTO>> messageFailures) {

--- a/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/SingleMailboxReindexingTaskAdditionalInformationDTO.java
+++ b/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/SingleMailboxReindexingTaskAdditionalInformationDTO.java
@@ -30,7 +30,6 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class SingleMailboxReindexingTaskAdditionalInformationDTO implements AdditionalInformationDTO {
@@ -54,7 +53,7 @@ public class SingleMailboxReindexingTaskAdditionalInformationDTO implements Addi
                 details.getFailedReprocessedMailCount(),
                 Optional.empty(),
                 Optional.of(ReprocessingContextInformationDTO.serializeFailures(details.failures())),
-                Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(Guavate.toImmutableList())),
+                Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(ImmutableList.toImmutableList())),
                 details.timestamp(),
                 Optional.of(RunningOptionsDTO.toDTO(details.getRunningOptions()))
                 ))

--- a/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/UserReindexingTaskAdditionalInformationDTO.java
+++ b/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/UserReindexingTaskAdditionalInformationDTO.java
@@ -32,7 +32,6 @@ import org.apache.mailbox.tools.indexer.ReprocessingContextInformationDTO.Reinde
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class UserReindexingTaskAdditionalInformationDTO implements AdditionalInformationDTO {
@@ -56,7 +55,7 @@ public class UserReindexingTaskAdditionalInformationDTO implements AdditionalInf
                 details.getFailedReprocessedMailCount(),
                 Optional.empty(),
                 Optional.of(ReprocessingContextInformationDTO.serializeFailures(details.failures())),
-                Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(Guavate.toImmutableList())),
+                Optional.of(details.failures().mailboxFailures().stream().map(MailboxId::serialize).collect(ImmutableList.toImmutableList())),
                 details.timestamp(),
                 Optional.of(RunningOptionsDTO.toDTO(details.getRunningOptions()))))
             .typeName(UserReindexingTask.USER_RE_INDEXING.asString())

--- a/mailbox/tools/quota-recompute/src/main/java/org/apache/james/mailbox/quota/task/RecomputeCurrentQuotasTask.java
+++ b/mailbox/tools/quota-recompute/src/main/java/org/apache/james/mailbox/quota/task/RecomputeCurrentQuotasTask.java
@@ -31,7 +31,6 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.scheduler.Schedulers;
@@ -105,6 +104,6 @@ public class RecomputeCurrentQuotasTask implements Task {
             snapshot.getFailedQuotaRoots()
                 .stream()
                 .map(QuotaRoot::asString)
-                .collect(Guavate.toImmutableList()), runningOptions));
+                .collect(ImmutableList.toImmutableList()), runningOptions));
     }
 }

--- a/mailet/amqp/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
+++ b/mailet/amqp/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -152,7 +151,7 @@ public class AmqpForwardAttribute extends GenericMailet {
             .splitToList(userInfo);
         ImmutableList<String> passwordParts = parts.stream()
             .skip(1)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return new RabbitMQConfiguration.ManagementCredentials(
             parts.get(0),

--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -64,10 +64,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -37,9 +37,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 /** 
  * Strong typing for attribute value, which represents the value of an attribute stored in a mail.
@@ -237,7 +237,7 @@ public class AttributeValue<T> {
             Map<String, AttributeValue<U>> castedMap = aMap.entrySet()
                 .stream()
                 .flatMap(entry -> entry.getValue().asAttributeValueOf(type).stream().map(castedValue -> Pair.of(entry.getKey(), castedValue)))
-                .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+                .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
             return Optional.of(new AttributeValue<>(castedMap, new Serializer.MapSerializer()));
         } else {
             return Optional.empty();

--- a/mailet/api/src/main/java/org/apache/mailet/DsnParameters.java
+++ b/mailet/api/src/main/java/org/apache/mailet/DsnParameters.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.core.MailAddress;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -175,7 +174,7 @@ public class DsnParameters {
                 .stream()
                 .map(string -> parseValue(string)
                     .orElseThrow(() -> new IllegalArgumentException(string + " could not be associated with any RCPT NOTIFY value")))
-                .collect(Guavate.toImmutableList())));
+                .collect(ImmutableList.toImmutableList())));
         }
 
         public static Optional<Notify> parseValue(String input) {
@@ -389,14 +388,14 @@ public class DsnParameters {
                 .entrySet()
                 .stream()
                 .map(Throwing.function(entry -> Pair.of(new MailAddress(entry.getKey()), Notify.fromAttributeValue(entry.getValue()))))
-                .collect(Guavate.entriesToMap()))
+                .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
             .orElse(ImmutableMap.of());
         Map<MailAddress, MailAddress> orcpt = dsnAttributeValues.getOrcptAttributeValue()
             .map(mapAttributeValue -> mapAttributeValue.value()
                 .entrySet()
                 .stream()
                 .map(Throwing.function(entry -> Pair.of(new MailAddress(entry.getKey()), new MailAddress(entry.getValue().value()))))
-                .collect(Guavate.toImmutableMap(
+                .collect(ImmutableMap.toImmutableMap(
                     Pair::getKey,
                     Pair::getValue)))
             .orElse(ImmutableMap.of());
@@ -408,7 +407,7 @@ public class DsnParameters {
             .map(rcpt -> Pair.of(rcpt, new RecipientDsnParameters(
                 Optional.ofNullable(notify.get(rcpt)),
                 Optional.ofNullable(orcpt.get(rcpt)))))
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 Pair::getKey,
                 Pair::getValue));
         return of(envId, ret, recipientDsnParameters);
@@ -447,13 +446,13 @@ public class DsnParameters {
             .filter(entry -> entry.getValue().getNotifyParameter().isPresent())
             .map(entry -> Pair.of(entry.getKey().asString(),
                 Notify.toAttributeValue(entry.getValue().getNotifyParameter().get())))
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)))
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)))
             .asMapAttributeValueOf(String.class);
         Optional<AttributeValue<Map<String, AttributeValue<String>>>> orcptAttributeValue = AttributeValue.of(rcptParameters.entrySet().stream()
             .filter(entry -> entry.getValue().getOrcptParameter().isPresent())
             .map(entry -> Pair.of(entry.getKey().asString(),
                 AttributeValue.of(entry.getValue().getOrcptParameter().get().asString())))
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)))
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)))
             .asMapAttributeValueOf(String.class);
 
         return new DsnAttributeValues(notifyAttributeValue, orcptAttributeValue, envIdAttributeValue, retAttributeValue);

--- a/mailet/api/src/main/java/org/apache/mailet/MailetContext.java
+++ b/mailet/api/src/main/java/org/apache/mailet/MailetContext.java
@@ -32,7 +32,7 @@ import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.slf4j.Logger;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Defines a set of methods that can be used to interact with the mailet
@@ -259,7 +259,7 @@ public interface MailetContext {
     default Collection<MailAddress> localRecipients(Collection<MailAddress> recipients) {
         return recipients.stream()
             .filter(this::isLocalEmail)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     /**

--- a/mailet/api/src/main/java/org/apache/mailet/PerRecipientHeaders.java
+++ b/mailet/api/src/main/java/org/apache/mailet/PerRecipientHeaders.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import org.apache.james.core.MailAddress;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -33,6 +32,8 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 public class PerRecipientHeaders implements Serializable {
@@ -59,7 +60,7 @@ public class PerRecipientHeaders implements Serializable {
         return headersByRecipient.get(recipient)
             .stream()
             .map(Header::getName)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     public PerRecipientHeaders addHeaderForRecipient(Header header, MailAddress recipient) {
@@ -115,7 +116,7 @@ public class PerRecipientHeaders implements Serializable {
                 Joiner.on(SEPARATOR)
                     .join(parts.stream()
                         .skip(1)
-                        .collect(Guavate.toImmutableList())));
+                        .collect(ImmutableList.toImmutableList())));
         }
 
         private final String name;

--- a/mailet/base/pom.xml
+++ b/mailet/base/pom.xml
@@ -66,10 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailet/base/src/main/java/org/apache/mailet/base/GenericMailet.java
+++ b/mailet/base/src/main/java/org/apache/mailet/base/GenericMailet.java
@@ -37,10 +37,10 @@ import org.apache.mailet.MailetContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 
 /**
@@ -303,7 +303,7 @@ public abstract class GenericMailet implements Mailet, MailetConfig {
         Set<String> bad = Streams.stream(getInitParameterNames())
             .filter(not(allowed::contains))
             .filter(not(ERROR_PARAMETERS::contains))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
 
         if (!bad.isEmpty()) {
             throw new MessagingException("Unexpected init parameters found: " + bad);

--- a/mailet/icalendar/pom.xml
+++ b/mailet/icalendar/pom.xml
@@ -61,10 +61,6 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
@@ -51,9 +51,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 
 import net.fortuna.ical4j.model.Calendar;
 
@@ -184,7 +184,7 @@ public class ICALToJsonAttribute extends GenericMailet {
         Map<String, byte[]> jsonsInByteForm = calendars.entrySet()
             .stream()
             .flatMap(calendar -> toJson(calendar, rawCalendars, mail, transportSender, replyTo))
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
         mail.setAttribute(new Attribute(destinationAttributeName, AttributeValue.ofAny(jsonsInByteForm)));
     }
 

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICalendarParser.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICalendarParser.java
@@ -36,9 +36,9 @@ import org.apache.mailet.base.GenericMailet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.data.ParserException;
@@ -120,7 +120,7 @@ public class ICalendarParser extends GenericMailet {
         Map<String, Calendar> calendars = icsAttachments.entrySet()
             .stream()
             .flatMap(entry -> createCalendar(entry.getKey(), entry.getValue()))
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
 
         mail.setAttribute(new Attribute(destinationAttributeName, AttributeValue.ofAny(calendars)));
     }

--- a/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/AbstractMailetdocsReport.java
+++ b/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/AbstractMailetdocsReport.java
@@ -30,7 +30,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * <p>
@@ -90,11 +90,11 @@ public abstract class AbstractMailetdocsReport extends AbstractMavenReport {
 
         final List<MailetMatcherDescriptor> matchers = descriptors.stream()
             .filter(descriptor -> descriptor.getType() == MailetMatcherDescriptor.Type.MATCHER)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         final List<MailetMatcherDescriptor> mailets = descriptors.stream()
             .filter(descriptor -> descriptor.getType() == MailetMatcherDescriptor.Type.MAILET)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         
         final boolean matchersExist = matchers.size() > 0;
         final boolean mailetsExist = mailets.size() > 0;

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ContactExtractor.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ContactExtractor.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -129,7 +128,7 @@ public class ContactExtractor extends GenericMailet implements Mailet {
                 getRecipients(mimeMessage, Message.RecipientType.TO),
                 getRecipients(mimeMessage, Message.RecipientType.CC),
                 getRecipients(mimeMessage, Message.RecipientType.BCC))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Stream<String> getRecipients(MimeMessage mimeMessage, RecipientType recipientType) throws MessagingException {

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/MailAttributesListToMimeHeaders.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/MailAttributesListToMimeHeaders.java
@@ -35,8 +35,8 @@ import org.apache.mailet.base.GenericMailet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * <p>Convert attributes of type Collection&lt;String&gt; to headers</p>
@@ -66,10 +66,9 @@ public class MailAttributesListToMimeHeaders extends GenericMailet {
             .parse(simpleMappings)
             .entrySet()
             .stream()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                     entry -> AttributeName.of(entry.getKey()),
-                    entry -> entry.getValue()
-            ));
+                    entry -> entry.getValue()));
     }
 
     @Override

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/MailAttributesToMimeHeaders.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/MailAttributesToMimeHeaders.java
@@ -30,7 +30,6 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
@@ -62,7 +61,7 @@ public class MailAttributesToMimeHeaders extends GenericMailet {
             .parse(simpleMappings)
             .entrySet()
             .stream()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 entry -> AttributeName.of(entry.getKey()),
                 entry -> entry.getValue()));
     }

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/MappingArgument.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/MappingArgument.java
@@ -25,7 +25,6 @@ import javax.mail.MessagingException;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +45,7 @@ public class MappingArgument {
             .splitToList(mapping)
             .stream()
             .map(MappingArgument::parseKeyValue)
-            .collect(Guavate.toImmutableMap(Pair::getLeft, Pair::getRight));
+            .collect(ImmutableMap.toImmutableMap(Pair::getLeft, Pair::getRight));
     }
 
     private static Pair<String, String> parseKeyValue(String keyValue) {

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/MimeDecodingMailet.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/MimeDecodingMailet.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
@@ -92,7 +91,7 @@ public class MimeDecodingMailet extends GenericMailet {
                 .entrySet()
                 .stream()
                 .flatMap(convertToMapContent)
-                .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+                .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
 
         mail.setAttribute(new Attribute(attributeName, AttributeValue.ofAny(extractedMimeContentByName)));
     }

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/PostmasterAlias.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/PostmasterAlias.java
@@ -28,7 +28,8 @@ import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Rewrites recipient addresses to make sure email for the postmaster is
@@ -51,7 +52,7 @@ public class PostmasterAlias extends GenericMailet {
         Collection<MailAddress> postmasterAliases = mail.getRecipients()
             .stream()
             .filter(this::isPostmasterAlias)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         if (!postmasterAliases.isEmpty()) {
             mail.setRecipients(
@@ -60,7 +61,7 @@ public class PostmasterAlias extends GenericMailet {
                         .stream()
                         .filter(address -> !postmasterAliases.contains(address)),
                     Stream.of(getMailetContext().getPostmaster()))
-                .collect(Guavate.toImmutableSet()));
+                .collect(ImmutableSet.toImmutableSet()));
         }
     }
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/RecipientToLowerCase.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/RecipientToLowerCase.java
@@ -28,7 +28,7 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * {@link GenericMailet} which convert all Recipients to lowercase
@@ -39,7 +39,7 @@ public class RecipientToLowerCase extends GenericMailet {
     public void service(Mail mail) throws MessagingException {
         mail.setRecipients(mail.getRecipients().stream()
             .map(Throwing.function(this::toLowerCase))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 
     private MailAddress toLowerCase(MailAddress mailAddress) throws AddressException {

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/RemoveMailAttribute.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/RemoveMailAttribute.java
@@ -29,7 +29,6 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.MailetException;
 import org.apache.mailet.base.GenericMailet;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -78,7 +77,7 @@ public class RemoveMailAttribute extends GenericMailet {
             .split(name)
             .iterator())
             .map(AttributeName::of)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/SetMailAttribute.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/SetMailAttribute.java
@@ -28,7 +28,6 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.MailetException;
 import org.apache.mailet.base.GenericMailet;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
@@ -58,7 +57,7 @@ public class SetMailAttribute extends GenericMailet {
     public void init() throws MailetException {
         entries = Streams.stream(getInitParameterNames())
             .map(name -> Attribute.convertToAttribute(name, getInitParameter(name)))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/UseHeaderRecipients.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/UseHeaderRecipients.java
@@ -38,7 +38,6 @@ import org.apache.mailet.base.GenericMailet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
@@ -170,7 +169,7 @@ public class UseHeaderRecipients extends GenericMailet {
             .flatten()
             .stream()
             .map(this::toMailAddress)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private MailAddress toMailAddress(Mailbox mailbox) {

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasHeader.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasHeader.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -36,7 +37,7 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * use:
@@ -87,7 +88,7 @@ public class HasHeader extends GenericMatcher {
                     .stream()
                     .filter(entry -> entry.getValue().getName().equals(headerName))
                     .map(entry -> entry.getKey())
-                    .collect(Guavate.toImmutableSet());
+                    .collect(ImmutableSet.toImmutableSet());
         }
     }
 
@@ -116,8 +117,8 @@ public class HasHeader extends GenericMatcher {
                     .entries()
                     .stream()
                     .filter(entry -> entry.getValue().getName().equals(headerName) && entry.getValue().getValue().equals(headerValue))
-                    .map(entry -> entry.getKey())
-                    .collect(Guavate.toImmutableSet());
+                    .map(Map.Entry::getKey)
+                    .collect(ImmutableSet.toImmutableSet());
         }
     }
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasHeaderWithPrefix.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasHeaderWithPrefix.java
@@ -21,6 +21,7 @@ package org.apache.james.transport.matchers;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import javax.mail.Header;
 import javax.mail.MessagingException;
@@ -30,8 +31,8 @@ import org.apache.james.transport.mailets.utils.MimeMessageUtils;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Matches emails with headers having a given prefix.
@@ -76,7 +77,7 @@ public class HasHeaderWithPrefix extends GenericMatcher {
                 .entries()
                 .stream()
                 .filter(entry -> entry.getValue().getName().startsWith(prefix))
-                .map(entry -> entry.getKey())
-                .collect(Guavate.toImmutableSet());
+                .map(Map.Entry::getKey)
+                .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasMimeTypeParameter.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasMimeTypeParameter.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -83,7 +82,7 @@ public class HasMimeTypeParameter extends GenericMatcher {
                         .splitToList(value)
                         .stream()
                         .map(this::conditionToPair)
-                        .collect(Guavate.toImmutableList());
+                        .collect(ImmutableList.toImmutableList());
                 } catch (IllegalArgumentException e) {
                     throw new MailetException("error parsing configuration", e);
                 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HostIsLocal.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HostIsLocal.java
@@ -23,6 +23,7 @@ package org.apache.james.transport.matchers;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.mail.MessagingException;
@@ -32,7 +33,8 @@ import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 
 /**
  * Matches mail to Domains which are local
@@ -43,7 +45,7 @@ public class HostIsLocal extends GenericMatcher {
     public Collection<MailAddress> match(Mail mail) throws MessagingException {
         return recipientsByDomains(mail)
             .flatMap(this::hasLocalDomain)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Stream<MailAddress> hasLocalDomain(Map.Entry<Domain, Collection<MailAddress>> entry) {
@@ -56,7 +58,7 @@ public class HostIsLocal extends GenericMatcher {
     private Stream<Map.Entry<Domain, Collection<MailAddress>>> recipientsByDomains(Mail mail) {
         return mail.getRecipients()
             .stream()
-            .collect(Guavate.toImmutableListMultimap(MailAddress::getDomain))
+            .collect(ImmutableListMultimap.toImmutableListMultimap(MailAddress::getDomain, Function.identity()))
             .asMap()
             .entrySet()
             .stream();

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
@@ -28,10 +28,10 @@ import org.apache.mailet.base.GenericMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 
 /**
  * <p>Checkes the sender's displayed domain name against a supplied list.</p>
@@ -64,7 +64,7 @@ public class SenderHostIs extends GenericMatcher {
             .splitToList(condition)
             .stream()
             .map(Domain::of)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     /**

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/utils/MailAddressCollectionReader.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/utils/MailAddressCollectionReader.java
@@ -27,10 +27,10 @@ import javax.mail.internet.AddressException;
 
 import org.apache.james.core.MailAddress;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 
 
 public class MailAddressCollectionReader {
@@ -41,7 +41,7 @@ public class MailAddressCollectionReader {
             .stream()
             .filter(Predicate.not(Strings::isNullOrEmpty))
             .map(MailAddressCollectionReader::getMailAddress)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     private static Optional<MailAddress> getMailAddress(String s) {

--- a/mailet/test/pom.xml
+++ b/mailet/test/pom.xml
@@ -54,10 +54,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
@@ -54,7 +54,6 @@ import org.apache.mailet.PerRecipientHeaders;
 import org.apache.mailet.PerRecipientHeaders.Header;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -182,7 +181,7 @@ public class FakeMail implements Mail {
             Preconditions.checkNotNull(recipients, "'recipients' can not be null");
             return recipients(Arrays.stream(recipients)
                 .map(Throwing.function(MailAddress::new))
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
         }
 
         public Builder recipient(MailAddress recipient) {

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMailContext.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMailContext.java
@@ -48,7 +48,6 @@ import org.slf4j.Logger;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.functions.ThrowingFunction;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -71,7 +70,7 @@ public class FakeMailContext implements MailetContext {
             .recipients(mail.getRecipients())
             .message(mail.getMessage())
             .state(mail.getState())
-            .attributes(mail.attributes().collect(Guavate.toImmutableList()))
+            .attributes(mail.attributes().collect(ImmutableList.toImmutableList()))
             .fromMailet();
     }
 
@@ -169,10 +168,9 @@ public class FakeMailContext implements MailetContext {
             public Builder attributes(List<Attribute> attributes) {
                 this.attributes.putAll(attributes
                     .stream()
-                    .collect(Guavate.toImmutableMap(
+                    .collect(ImmutableMap.toImmutableMap(
                             attribute -> attribute.getName(),
-                            Function.identity()
-                    )));
+                            Function.identity())));
                 return this;
             }
 

--- a/metrics/metrics-tests/pom.xml
+++ b/metrics/metrics-tests/pom.xml
@@ -51,10 +51,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingMetricFactory.java
+++ b/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingMetricFactory.java
@@ -32,8 +32,8 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.metrics.api.TimeMetric;
 import org.reactivestreams.Publisher;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
@@ -94,6 +94,6 @@ public class RecordingMetricFactory implements MetricFactory {
     public Map<String, Integer> countForPrefixName(String prefixName) {
         return counters.entrySet().stream()
             .filter(entry -> entry.getKey().startsWith(prefixName))
-            .collect(Guavate.toImmutableMap(Map.Entry::getKey, e -> e.getValue().get()));
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, e -> e.getValue().get()));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,6 @@
         <maven-reporting-impl.version>3.0.0</maven-reporting-impl.version>
         <maven-reporting-api.version>3.0</maven-reporting-api.version>
         <qdox.version>2.0.0</qdox.version>
-        <guavate.version>1.0.0</guavate.version>
         <javax.activation.groupId>javax.activation</javax.activation.groupId>
         <javax.activation.artifactId>activation</javax.activation.artifactId>
         <javax.persistence.version>1.0.2</javax.persistence.version>
@@ -2085,11 +2084,6 @@
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-lambda</artifactId>
                 <version>1.2.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.steveash.guavate</groupId>
-                <artifactId>guavate</artifactId>
-                <version>${guavate.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/protocols/api/pom.xml
+++ b/protocols/api/pom.xml
@@ -43,10 +43,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/protocols/api/src/test/java/org/apache/james/protocols/api/AbstractProtocolTransportTest.java
+++ b/protocols/api/src/test/java/org/apache/james/protocols/api/AbstractProtocolTransportTest.java
@@ -34,7 +34,7 @@ import java.util.stream.IntStream;
 import org.apache.james.protocols.api.handler.LineHandler;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Test-case for PROTOCOLS-62
@@ -48,7 +48,7 @@ public class AbstractProtocolTransportTest {
     void testWriteOrder() throws InterruptedException, UnsupportedEncodingException {
         final List<Response> messages = IntStream.range(0, 2000)
             .mapToObj(i -> new TestResponse())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         checkWrittenResponses(messages);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConfiguration.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConfiguration.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.imap.api.message.Capability;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -102,7 +101,7 @@ public class ImapConfiguration {
                     .filter(Builder::noBlankString)
                     .map(StringUtils::normalizeSpace)
                     .map(Capability::of)
-                    .collect(Guavate.toImmutableSet());
+                    .collect(ImmutableSet.toImmutableSet());
             return new ImapConfiguration(
                     enableIdle.orElse(DEFAULT_ENABLE_IDLE),
                     idleTimeInterval.orElse(DEFAULT_HEARTBEAT_INTERVAL_IN_SECONDS),

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/response/StatusResponse.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/response/StatusResponse.java
@@ -39,7 +39,7 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.model.UidValidity;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * <p>
@@ -59,7 +59,7 @@ public interface StatusResponse extends ImapResponseMessage {
             .flatMap(charset -> Stream.concat(
                 Stream.of(charset.name()),
                 charset.aliases().stream()))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
 
     /**
      * Gets the server response type of this status message.

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/ImapParserFactory.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/ImapParserFactory.java
@@ -30,7 +30,7 @@ import org.apache.james.imap.decode.ImapCommandParser;
 import org.apache.james.imap.decode.ImapCommandParserFactory;
 import org.apache.james.imap.decode.base.AbstractImapCommandParser;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * A factory for ImapCommand instances, provided based on the command name.
@@ -111,7 +111,7 @@ public class ImapParserFactory implements ImapCommandParserFactory {
             new SetAnnotationCommandParser(statusResponseFactory),
             new GetAnnotationCommandParser(statusResponseFactory));
 
-        imapCommands = parsers.collect(Guavate.toImmutableMap(
+        imapCommands = parsers.collect(ImmutableMap.toImmutableMap(
                 parser -> parser.getCommand().getName(),
                 Function.identity()));
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/StatusCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/StatusCommandParser.java
@@ -33,7 +33,6 @@ import org.apache.james.imap.decode.base.AbstractImapCommandParser;
 import org.apache.james.imap.message.request.StatusRequest;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -59,7 +58,7 @@ public class StatusCommandParser extends AbstractImapCommandParser {
 
         EnumSet<StatusDataItems.StatusItem> items = EnumSet.copyOf(words.stream()
             .map(Throwing.function(this::parseStatus).sneakyThrow())
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
 
         return new StatusDataItems(items);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/main/DefaultImapEncoderFactory.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/main/DefaultImapEncoderFactory.java
@@ -56,7 +56,7 @@ import org.apache.james.imap.encode.VanishedResponseEncoder;
 import org.apache.james.imap.encode.XListResponseEncoder;
 import org.apache.james.imap.encode.base.EndImapEncoder;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * TODO: perhaps a POJO would be better
@@ -68,7 +68,7 @@ public class DefaultImapEncoderFactory implements ImapEncoderFactory {
 
         DefaultImapEncoder(Stream<ImapResponseEncoder> encoders, EndImapEncoder endImapEncoder) {
             this.encoders = encoders
-                .collect(Guavate.toImmutableMap(
+                .collect(ImmutableMap.toImmutableMap(
                     ImapResponseEncoder::acceptableMessages,
                     Function.identity()));
             this.endImapEncoder = endImapEncoder;

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -46,7 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 
@@ -103,7 +103,7 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
                     .stream())
                 .sneakyThrow())
             .map(IdRange::from)
-            .collect(Guavate.toImmutableList()))
+            .collect(ImmutableList.toImmutableList()))
             .toArray(IdRange[]::new);
 
         // get folder UIDVALIDITY

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetAnnotationProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetAnnotationProcessor.java
@@ -50,7 +50,6 @@ import org.apache.james.util.MDCBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 
@@ -116,7 +115,7 @@ public class GetAnnotationProcessor extends AbstractMailboxProcessor<GetAnnotati
 
         return mailboxAnnotations.stream()
             .filter(lowerPredicate)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private List<MailboxAnnotation> getMailboxAnnotations(ImapSession session, Set<MailboxAnnotationKey> keys, GetAnnotationRequest.Depth depth, MailboxPath mailboxPath) throws MailboxException {
@@ -147,7 +146,7 @@ public class GetAnnotationProcessor extends AbstractMailboxProcessor<GetAnnotati
         ImmutableSortedSet<Integer> overLimitSizes = mailboxAnnotations.stream()
             .filter(filterOverSizedAnnotation)
             .map(MailboxAnnotation::size)
-            .collect(Guavate.toImmutableSortedSet(Comparator.reverseOrder()));
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.reverseOrder()));
 
         if (overLimitSizes.isEmpty()) {
             return Optional.empty();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaProcessor.java
@@ -41,7 +41,6 @@ import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
@@ -100,7 +99,7 @@ public class GetQuotaProcessor extends AbstractMailboxProcessor<GetQuotaRequest>
         // If any of the mailboxes owned by quotaRoot user can be read by the current user, then we should respond to him.
         final MailboxSession mailboxSession = session.getMailboxSession();
         List<Mailbox> mailboxList = Flux.from(quotaRootResolver.retrieveAssociatedMailboxes(quotaRoot, mailboxSession))
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .subscribeOn(Schedulers.elastic())
             .block();
         for (Mailbox mailbox : mailboxList) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
@@ -68,7 +68,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
@@ -212,7 +211,7 @@ public class SearchProcessor extends AbstractMailboxProcessor<SearchRequest> imp
         if (useUids) {
             return uids.stream()
                 .map(MessageUid::asLong)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } else {
             return uids.stream()
                 .map(uid -> session.getSelected().msn(uid))
@@ -220,13 +219,13 @@ public class SearchProcessor extends AbstractMailboxProcessor<SearchRequest> imp
                     nullableMsn.fold(
                         Stream::empty,
                         msn -> Stream.of(Integer.valueOf(msn.asInt()).longValue()))))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
     }
 
     private Collection<MessageUid> performUidSearch(MessageManager mailbox, SearchQuery query, MailboxSession msession) throws MailboxException {
         return Flux.from(mailbox.search(query, msession))
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -61,7 +61,6 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.UpdatedFlags;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -159,7 +158,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
             applicableFlags = applicableFlags.updateWithNewFlags(messageManager.getApplicableFlags(mailboxSession));
         }
         ImmutableList<MessageUid> uids = Flux.from(messageManager.search(SearchQuery.of(SearchQuery.all()), mailboxSession))
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
         uidMsnConverter.addAll(uids);
     }

--- a/protocols/pop3/src/test/java/org/apache/james/protocols/pop3/utils/MockMailbox.java
+++ b/protocols/pop3/src/test/java/org/apache/james/protocols/pop3/utils/MockMailbox.java
@@ -31,7 +31,7 @@ import org.apache.james.protocols.pop3.mailbox.ImapMailbox;
 import org.apache.james.protocols.pop3.mailbox.ImapMessageMetaData;
 import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 @SuppressWarnings("deprecation")
 public class MockMailbox extends ImapMailbox {
@@ -83,7 +83,7 @@ public class MockMailbox extends ImapMailbox {
         return messages.values()
             .stream()
             .map(m -> m.meta)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
@@ -45,8 +45,8 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -226,7 +226,7 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
         return Splitter.on(' ').splitToList(rcptOptions)
             .stream()
             .map(this::parseParameter)
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
     }
 
     private Pair<String, String> parseParameter(String rcptOption) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
@@ -35,7 +35,6 @@ import org.apache.james.protocols.smtp.dsn.DSNStatus;
 import org.apache.james.protocols.smtp.hook.HeloHook;
 import org.apache.james.protocols.smtp.hook.HookResult;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -164,7 +163,7 @@ public class EhloCmdHandler extends AbstractHookableCmdHandler<HeloHook> impleme
             .addAll(ESMTP_FEATURES)
             .addAll(getHooks().stream()
                 .flatMap(heloHook -> heloHook.implementedEsmtpFeatures().stream())
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .build();
     }
 

--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -44,9 +44,9 @@ import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
 import com.google.common.io.FileBackedOutputStream;
 
@@ -293,7 +293,7 @@ public class S3BlobStoreDAO implements BlobStoreDAO, Startable, Closeable {
     private Mono<List<ObjectIdentifier>> buildListForBatch(Flux<S3Object> batch) {
         return batch
             .map(element -> ObjectIdentifier.builder().key(element.key()).build())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Mono<DeleteObjectsResponse> deleteObjects(BucketName bucketName, List<ObjectIdentifier> identifiers) {

--- a/server/container/core/src/main/java/org/apache/james/server/core/Envelope.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/Envelope.java
@@ -34,8 +34,8 @@ import org.apache.james.mime4j.dom.address.MailboxList;
 import org.apache.james.util.StreamUtils;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 
 public class Envelope {
     public interface ValidationPolicy {
@@ -70,7 +70,7 @@ public class Envelope {
 
         return new Envelope(sender,
             StreamUtils.flatten(Stream.of(to, cc, bcc))
-                .collect(Guavate.toImmutableSet()));
+                .collect(ImmutableSet.toImmutableSet()));
     }
 
     private static Optional<MailAddress> newMailAddress(ValidationPolicy validationPolicy, String addressAsString) {

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
@@ -59,7 +59,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -110,7 +109,7 @@ public class MailImpl implements Disposable, Mail {
 
     private static ImmutableList<Attribute> duplicateAttributes(Mail mail) {
         try {
-            return mail.attributes().map(Attribute::duplicate).collect(Guavate.toImmutableList());
+            return mail.attributes().map(Attribute::duplicate).collect(ImmutableList.toImmutableList());
         } catch (IllegalStateException e) {
             LOGGER.error("Error while cloning Mail attributes", e);
             return ImmutableList.of();
@@ -186,7 +185,7 @@ public class MailImpl implements Disposable, Mail {
         public Builder addRecipients(String... recipients) {
             return addRecipients(Arrays.stream(recipients)
                 .map(Throwing.function(MailAddress::new))
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
         }
 
         public Builder addRecipient(MailAddress recipient) {
@@ -290,7 +289,7 @@ public class MailImpl implements Disposable, Mail {
     private static ImmutableList<MailAddress> getRecipients(MimeMessage mimeMessage) throws MessagingException {
         return Arrays.stream(mimeMessage.getAllRecipients())
             .map(Throwing.function(MailImpl::castToMailAddress).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static MailAddress getSender(MimeMessage mimeMessage) throws MessagingException {

--- a/server/container/guice/blob/export/src/main/java/org/apache/james/modules/BlobExportImplChoice.java
+++ b/server/container/guice/blob/export/src/main/java/org/apache/james/modules/BlobExportImplChoice.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.configuration2.Configuration;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -44,7 +43,7 @@ public enum  BlobExportImplChoice {
     private static ImmutableList<String> plainImplNames() {
         return Stream.of(values())
             .map(impl -> impl.name)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     static Optional<BlobExportImplChoice> from(Configuration configuration) {

--- a/server/container/guice/common/pom.xml
+++ b/server/container/guice/common/pom.xml
@@ -147,10 +147,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/server/container/guice/common/src/main/java/org/apache/james/StartUpChecksPerformer.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/StartUpChecksPerformer.java
@@ -28,10 +28,10 @@ import org.apache.james.lifecycle.api.StartUpCheck;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import reactor.core.publisher.Flux;
@@ -69,7 +69,7 @@ public class StartUpChecksPerformer {
         public List<String> badCheckNames() {
             return badChecks.stream()
                 .map(StartUpCheck.CheckResult::getName)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
     }
 
@@ -86,7 +86,7 @@ public class StartUpChecksPerformer {
             return Flux.fromIterable(startUpChecks)
                 .publishOn(Schedulers.elastic())
                 .map(this::checkQuietly)
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
                 .block();
         }
 
@@ -122,7 +122,7 @@ public class StartUpChecksPerformer {
         List<StartUpCheck.CheckResult> badChecks = startUpChecks.check()
             .stream()
             .filter(StartUpCheck.CheckResult::isBad)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         if (!badChecks.isEmpty()) {
             throw new StartUpChecksException(badChecks);

--- a/server/container/guice/common/src/main/java/org/apache/james/utils/DataProbeImpl.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/DataProbeImpl.java
@@ -35,7 +35,8 @@ import org.apache.james.rrt.lib.Mappings;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.util.streams.Iterators;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class DataProbeImpl implements GuiceProbe, DataProbe {
     private final DomainList domainList;
@@ -91,7 +92,7 @@ public class DataProbeImpl implements GuiceProbe, DataProbe {
 
     @Override
     public List<String> listDomains() throws Exception {
-        return domainList.getDomains().stream().map(Domain::name).collect(Guavate.toImmutableList());
+        return domainList.getDomains().stream().map(Domain::name).collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -99,8 +100,7 @@ public class DataProbeImpl implements GuiceProbe, DataProbe {
         return recipientRewriteTable.getAllMappings()
             .entrySet()
             .stream()
-            .collect(
-                Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                     entry -> entry.getKey().asString(),
                     Map.Entry::getValue));
 

--- a/server/container/guice/common/src/main/java/org/apache/james/utils/GuiceProbeProvider.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/GuiceProbeProvider.java
@@ -22,11 +22,12 @@ package org.apache.james.utils;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.inject.Inject;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 public class GuiceProbeProvider {
     private final Map<Class<GuiceProbe>, GuiceProbe> registry;
@@ -35,7 +36,7 @@ public class GuiceProbeProvider {
     @Inject
     public GuiceProbeProvider(Set<GuiceProbe> guiceProbes) {
         this.registry = guiceProbes.stream()
-            .collect(Guavate.toImmutableMap(guiceProbe -> (Class<GuiceProbe>) guiceProbe.getClass()));
+            .collect(ImmutableMap.toImmutableMap(guiceProbe -> (Class<GuiceProbe>) guiceProbe.getClass(), Function.identity()));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/container/guice/common/src/main/java/org/apache/james/utils/MailRepositoryProbeImpl.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/MailRepositoryProbeImpl.java
@@ -27,7 +27,6 @@ import org.apache.james.mailrepository.api.MailKey;
 import org.apache.james.mailrepository.api.MailRepositoryStore;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class MailRepositoryProbeImpl implements GuiceProbe {
@@ -58,7 +57,7 @@ public class MailRepositoryProbeImpl implements GuiceProbe {
 
     public List<MailRepositoryUrl> listRepositoryUrls() {
         return repositoryStore.getUrls()
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public MailRepositoryStore getMailRepositoryStore() {

--- a/server/container/guice/common/src/test/java/org/apache/james/AggregateGuiceModuleTestRule.java
+++ b/server/container/guice/common/src/test/java/org/apache/james/AggregateGuiceModuleTestRule.java
@@ -25,7 +25,6 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
@@ -63,7 +62,7 @@ public class AggregateGuiceModuleTestRule implements GuiceModuleTestRule {
         List<Module> modules = subrule
                     .stream()
                     .map(GuiceModuleTestRule::getModule)
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
 
         return Modules.combine(modules);
     }

--- a/server/container/guice/common/src/test/java/org/apache/james/JamesServerBuilder.java
+++ b/server/container/guice/common/src/test/java/org/apache/james/JamesServerBuilder.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 
 import org.apache.james.server.core.configuration.Configuration;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
@@ -119,7 +118,7 @@ public class JamesServerBuilder<T extends Configuration> {
         ImmutableList<Module> modules = extensions.build()
             .stream()
             .map(GuiceModuleTestExtension::getModule)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return server
             .buildServer(configurationProvider.buildConfiguration(file))

--- a/server/container/guice/common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
+++ b/server/container/guice/common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.consumers.ThrowingConsumer;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 
@@ -281,7 +280,7 @@ public interface MailsShouldBeWellReceived {
         return IntStream.range(0, nbUsers)
                 .boxed()
                 .map(index -> "user" + index + "@" + DOMAIN)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
     }
 
 }

--- a/server/container/guice/common/src/test/java/org/apache/james/PeriodicalHealthChecksTest.java
+++ b/server/container/guice/common/src/test/java/org/apache/james/PeriodicalHealthChecksTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import ch.qos.logback.classic.Level;
@@ -195,7 +195,7 @@ public class PeriodicalHealthChecksTest {
             softly.assertThat(loggingEvents.list).hasSize(2);
             softly.assertThat(loggingEvents.list.stream()
                 .map(event -> new Tuple(event.getLevel(), event.getFormattedMessage()))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
                 .containsExactlyInAnyOrder(
                     new Tuple(Level.ERROR, "UNHEALTHY: testing : cause"),
                     new Tuple(Level.WARN, "DEGRADED: testing : cause"));

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/DelegatedPropertiesConfiguration.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/DelegatedPropertiesConfiguration.java
@@ -40,7 +40,6 @@ import org.apache.commons.configuration2.sync.LockMode;
 import org.apache.commons.configuration2.sync.Synchronizer;
 import org.apache.commons.lang3.StringUtils;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class DelegatedPropertiesConfiguration implements Configuration {
@@ -289,7 +288,7 @@ public class DelegatedPropertiesConfiguration implements Configuration {
                 .stream()
                 .map(String.class::cast)
                 .flatMap(this::splitAndStripDoubleQuotes)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (ConversionException e) {
             return configuration.getList(key);
         } catch (NoSuchElementException e) {

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/ListenersConfiguration.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/ListenersConfiguration.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -46,7 +45,7 @@ public class ListenersConfiguration {
         return new ListenersConfiguration(listeners
                 .stream()
                 .map(ListenerConfiguration::from)
-                .collect(Guavate.toImmutableList()),
+                .collect(ImmutableList.toImmutableList()),
             consumeGroups.orElse(true));
     }
     

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
@@ -32,7 +32,6 @@ import org.apache.james.utils.ClassName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -59,7 +58,7 @@ public class MailboxListenersLoaderImpl implements Configurable, MailboxListener
     private ImmutableSet<EventListener.ReactiveGroupEventListener> wrap(Set<EventListener.GroupEventListener> nonReactiveGuiceDefinedListeners) {
         return nonReactiveGuiceDefinedListeners.stream()
             .map(EventListener::wrapReactive)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     @Override

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/PreDeletionHookModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/PreDeletionHookModule.java
@@ -28,7 +28,7 @@ import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
@@ -50,6 +50,6 @@ public class PreDeletionHookModule extends AbstractModule {
         return configuration.getHooksConfiguration()
             .stream()
             .map(Throwing.function(loader::createHook).sneakyThrow())
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/PreDeletionHooksConfiguration.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/PreDeletionHooksConfiguration.java
@@ -26,7 +26,6 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -39,7 +38,7 @@ public class PreDeletionHooksConfiguration {
         return new PreDeletionHooksConfiguration(entries
             .stream()
             .map(Throwing.function(PreDeletionHookConfiguration::from).sneakyThrow())
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 
     public static PreDeletionHooksConfiguration forHooks(PreDeletionHookConfiguration... hooks) {

--- a/server/container/guice/mailet/pom.xml
+++ b/server/container/guice/mailet/pom.xml
@@ -77,10 +77,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
@@ -61,7 +61,6 @@ import org.apache.mailet.base.AutomaticallySentMailDetector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -209,7 +208,7 @@ public class MailetContainerModule extends AbstractModule {
                         throw new RuntimeException("Can not perform checks as transport processor is not an instance of " + MailProcessor.class);
                     }
                 })
-                .collect(Guavate.toImmutableListMultimap(
+                .collect(ImmutableListMultimap.toImmutableListMultimap(
                     Pair::getKey,
                     Pair::getValue));
             for (ProcessorsCheck check : processorsCheckSet) {
@@ -257,7 +256,7 @@ public class MailetContainerModule extends AbstractModule {
                     } catch (ConfigurationException e) {
                         return Stream.of(e);
                     }
-                }).collect(Guavate.toImmutableList());
+                }).collect(ImmutableList.toImmutableList());
 
                 if (failures.size() == checks.size()) {
                     throw failures.get(0);

--- a/server/container/guice/mailet/src/main/java/org/apache/james/utils/GuiceMailetLoader.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/utils/GuiceMailetLoader.java
@@ -29,7 +29,7 @@ import org.apache.james.mailetcontainer.api.MailetLoader;
 import org.apache.mailet.Mailet;
 import org.apache.mailet.MailetConfig;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
 public class GuiceMailetLoader implements MailetLoader {
@@ -43,7 +43,7 @@ public class GuiceMailetLoader implements MailetLoader {
     public GuiceMailetLoader(GuiceGenericLoader genericLoader, Set<MailetConfigurationOverride> mailetConfigurationOverrides) {
         this.genericLoader = genericLoader;
         this.configurationOverrides = mailetConfigurationOverrides.stream()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 MailetConfigurationOverride::getClazz,
                 MailetConfigurationOverride::getNewConfiguration));
     }

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
@@ -66,7 +66,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
@@ -254,7 +253,7 @@ public class JMAPModule extends AbstractModule {
                     badCheckDescription(searchCapabilities.contains(SearchCapabilities.AttachmentFileName),
                     "Attachment file name Search support in MailboxManager is required by JMAP Module"))
                 .flatMap(Optional::stream)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
             if (!badCheckDescriptions.isEmpty()) {
                 return CheckResult.builder()

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/MessageIdProbe.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/MessageIdProbe.java
@@ -39,7 +39,7 @@ import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.utils.GuiceProbe;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class MessageIdProbe implements GuiceProbe {
     private final MailboxManager mailboxManager;
@@ -70,6 +70,6 @@ public class MessageIdProbe implements GuiceProbe {
         return messages.stream()
             .flatMap(Throwing.function(messageResult -> messageResult.getLoadedAttachments().stream()))
             .map(MessageAttachmentMetadata::getAttachmentId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -57,7 +57,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -108,7 +107,7 @@ public class WebAdminServerModule extends AbstractModule {
             .map(ClassName::new)
             .map(Throwing.function(loader.<Routes>withNamingSheme(NamingScheme.IDENTITY)::instantiate))
             .peek(routes -> LOGGER.info("Loading WebAdmin route extension {}", routes.getClass().getCanonicalName()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return ImmutableList.<Routes>builder()
             .addAll(routesList)

--- a/server/container/guice/utils/src/main/java/org/apache/james/utils/ExtensionConfiguration.java
+++ b/server/container/guice/utils/src/main/java/org/apache/james/utils/ExtensionConfiguration.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.commons.configuration2.Configuration;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class ExtensionConfiguration {
@@ -34,7 +33,7 @@ public class ExtensionConfiguration {
         return new ExtensionConfiguration(
             Arrays.stream(configuration.getStringArray("guice.extension.module"))
                 .map(ClassName::new)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private final List<ClassName> additionalGuiceModulesForExtensions;

--- a/server/container/guice/utils/src/main/java/org/apache/james/utils/GuiceGenericLoader.java
+++ b/server/container/guice/utils/src/main/java/org/apache/james/utils/GuiceGenericLoader.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
@@ -61,7 +60,7 @@ public class GuiceGenericLoader {
         private Class<T> locateClass(ClassName className, NamingScheme namingScheme) throws ClassNotFoundException {
             ImmutableList<Class<T>> classes = namingScheme.toFullyQualifiedClassNames(className)
                 .flatMap(this::tryLocateClass)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
             if (classes.size() == 0) {
                 throw new ClassNotFoundException(className.getName());
@@ -94,7 +93,7 @@ public class GuiceGenericLoader {
             .stream()
             .map(Throwing.<ClassName, Module>function(className -> instantiateNoChildModule(injector, className)))
             .peek(module -> LOGGER.info("Enabling injects contained in " + module.getClass().getCanonicalName()))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
         this.injector = injector.createChildInjector(additionalExtensionBindings);
     }
 

--- a/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
+++ b/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
@@ -47,8 +47,8 @@ import org.apache.james.util.MDCBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * JMX managmenent for Mailboxes
@@ -111,7 +111,7 @@ public class MailboxManagerManagement extends StandardMBean implements MailboxMa
             boxes = mList.stream()
                 .map(aMList -> aMList.getPath().getName())
                 .sorted()
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (MailboxException e) {
             LOGGER.error("Error list mailboxes for user {}", username, e);
         } catch (IOException e) {
@@ -221,7 +221,7 @@ public class MailboxManagerManagement extends StandardMBean implements MailboxMa
                 .build(),
             Minimal,
             session)
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
     }
 

--- a/server/container/util/pom.xml
+++ b/server/container/util/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/server/container/util/src/main/java/org/apache/james/util/GuavaUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/GuavaUtils.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableListMultimap;
 
 public class GuavaUtils {
@@ -32,6 +31,6 @@ public class GuavaUtils {
         return rights.entrySet()
             .stream()
             .flatMap(e -> e.getValue().stream().map(right -> Pair.of(e.getKey(), right)))
-            .collect(Guavate.toImmutableListMultimap(Pair::getKey, Pair::getValue));
+            .collect(ImmutableListMultimap.toImmutableListMultimap(Pair::getKey, Pair::getValue));
     }
 }

--- a/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
@@ -29,8 +29,8 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 public class StreamUtils {
 
@@ -85,7 +85,7 @@ public class StreamUtils {
         return previous -> {
             List<T> generated = previous.stream()
                 .flatMap(generator)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
             if (generated.isEmpty()) {
                 return Optional.empty();

--- a/server/container/util/src/test/java/org/apache/james/util/CommutativityChecker.java
+++ b/server/container/util/src/test/java/org/apache/james/util/CommutativityChecker.java
@@ -25,8 +25,8 @@ import java.util.function.BinaryOperator;
 import org.apache.commons.lang3.tuple.Pair;
 import org.paukov.combinatorics3.Generator;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 
 public class CommutativityChecker<T> {
     private final Set<T> valuesToTest;
@@ -46,7 +46,7 @@ public class CommutativityChecker<T> {
             .stream()
             .map(list -> Pair.of(list.get(0), list.get(1)))
             .filter(this::isNotCommutative)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     private boolean isNotCommutative(Pair<T, T> pair) {

--- a/server/container/util/src/test/java/org/apache/james/util/ReactorUtilsTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/ReactorUtilsTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.slf4j.MDC;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
@@ -108,7 +107,7 @@ class ReactorUtilsTest {
                     .forOperation(i -> Mono.fromCallable(() -> stopwatch.elapsed(TimeUnit.MILLISECONDS))))
                 .map(i -> i / 100)
                 .doOnSubscribe(signal -> stopwatch.start())
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
                 .block();
 
             // delayElements also delay the first element
@@ -150,7 +149,7 @@ class ReactorUtilsTest {
                     .elements(windowMaxSize)
                     .per(windowDuration)
                     .forOperation(longRunningOperation))
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
                 .block();
 
             assertThat(ongoingProcessingUponComputationStart)
@@ -263,7 +262,7 @@ class ReactorUtilsTest {
                 .take(10)
                 .groupBy(Function.identity())
                 .flatMap(Flux::count)
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
                 .block();
 
             // We verify that we generate 2 elements by slice and not 3
@@ -285,7 +284,7 @@ class ReactorUtilsTest {
                     .per(windowDuration)
                     .forOperation(Mono::just))
                 .take(10)
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
                 .block();
 
             assertThat(results).containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
@@ -304,7 +303,7 @@ class ReactorUtilsTest {
                     .per(windowDuration)
                     .forOperation(Mono::just))
                 .take(10)
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
                 .block();
 
             assertThat(results).containsExactly(0L, 1L);

--- a/server/container/util/src/test/java/org/apache/james/util/StreamUtilsTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/StreamUtilsTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 class StreamUtilsTest {
@@ -38,7 +37,7 @@ class StreamUtilsTest {
     void flattenShouldReturnEmptyWhenEmptyStreams() {
         assertThat(
             StreamUtils.<Integer>flatten(ImmutableList.of())
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .isEmpty();
     }
 
@@ -47,7 +46,7 @@ class StreamUtilsTest {
         assertThat(
             StreamUtils.flatten(ImmutableList.of(
                 Stream.of(1, 2, 3)))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .containsExactly(1, 2, 3);
     }
 
@@ -57,7 +56,7 @@ class StreamUtilsTest {
             StreamUtils.flatten(ImmutableList.of(
                 Stream.of(1, 2, 3),
                 Stream.of(4, 5)))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .containsExactly(1, 2, 3, 4, 5);
     }
 
@@ -66,7 +65,7 @@ class StreamUtilsTest {
         assertThat(
             StreamUtils.flatten(ImmutableList.of(
                 Stream.of()))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .isEmpty();
     }
 
@@ -77,7 +76,7 @@ class StreamUtilsTest {
                 Stream.of(1, 2),
                 Stream.of(),
                 Stream.of(3)))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .containsExactly(1, 2, 3);
     }
 
@@ -85,34 +84,34 @@ class StreamUtilsTest {
     void flattenShouldAcceptEmptyVarArg() {
         assertThat(
             StreamUtils.flatten()
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .isEmpty();
     }
 
     @Test
     void flattenShouldThrowOnNullVarArg() {
         Stream<String>[] streams = null;
-        assertThatThrownBy(() -> StreamUtils.flatten(streams).collect(Guavate.toImmutableList()))
+        assertThatThrownBy(() -> StreamUtils.flatten(streams).collect(ImmutableList.toImmutableList()))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void flattenShouldFlattenNonEmptyVarArg() {
-        assertThat(StreamUtils.flatten(Stream.of(1), Stream.of(2)).collect(Guavate.toImmutableList()))
+        assertThat(StreamUtils.flatten(Stream.of(1), Stream.of(2)).collect(ImmutableList.toImmutableList()))
             .containsExactly(1, 2);
     }
 
     @Test
     void ofNullableShouldReturnEmptyStreamWhenNull() {
         assertThat(StreamUtils.ofNullable(null)
-            .collect(Guavate.toImmutableList()))
+            .collect(ImmutableList.toImmutableList()))
             .isEmpty();
     }
 
     @Test
     void ofNullableShouldReturnAStreamWithElementsOfTheArray() {
         assertThat(StreamUtils.ofNullable(ImmutableList.of(1, 2).toArray())
-            .collect(Guavate.toImmutableList()))
+            .collect(ImmutableList.toImmutableList()))
             .containsExactly(1, 2);
     }
 
@@ -126,7 +125,7 @@ class StreamUtilsTest {
             }
         });
 
-        assertThat(unfolded.collect(Guavate.toImmutableList()))
+        assertThat(unfolded.collect(ImmutableList.toImmutableList()))
             .contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
@@ -138,7 +137,7 @@ class StreamUtilsTest {
             return Optional.of(i + 1);
         });
 
-        assertThat(unfolded.limit(10).collect(Guavate.toImmutableList()))
+        assertThat(unfolded.limit(10).collect(ImmutableList.toImmutableList()))
             .contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         assertThat(counter.get())
@@ -149,7 +148,7 @@ class StreamUtilsTest {
     void unfoldShouldHaveAtLeastTheSeed() {
         Stream<Integer> unfolded = StreamUtils.unfold(1, i -> Optional.empty());
 
-        assertThat(unfolded.collect(Guavate.toImmutableList()))
+        assertThat(unfolded.collect(ImmutableList.toImmutableList()))
             .contains(1);
     }
 
@@ -163,7 +162,7 @@ class StreamUtilsTest {
     void iterateWithZeroLimitShouldHaveOnlyTheSeed() {
         Stream<Integer> generated = StreamUtils.iterate(1, (long) 0, Stream::of);
 
-        assertThat(generated.collect(Guavate.toImmutableList()))
+        assertThat(generated.collect(ImmutableList.toImmutableList()))
             .containsOnly(1);
     }
 
@@ -171,7 +170,7 @@ class StreamUtilsTest {
     void iterateWithEmptyGeneratorShouldHaveOnlyTheSeed() {
         Stream<Integer> generated = StreamUtils.iterate(1, (long) 10, i -> Stream.of());
 
-        assertThat(generated.collect(Guavate.toImmutableList()))
+        assertThat(generated.collect(ImmutableList.toImmutableList()))
             .containsOnly(1);
     }
 
@@ -179,7 +178,7 @@ class StreamUtilsTest {
     void iterateWithGeneratorShouldHaveOnlyTheLimitedElements() {
         Stream<Integer> generated = StreamUtils.iterate(1, (long) 5, i -> Stream.of(i + 1));
 
-        assertThat(generated.collect(Guavate.toImmutableList()))
+        assertThat(generated.collect(ImmutableList.toImmutableList()))
             .containsOnly(1, 2, 3, 4, 5, 6);
     }
 }

--- a/server/container/util/src/test/java/org/apache/james/util/streams/ImmutableCollectorsTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/streams/ImmutableCollectorsTest.java
@@ -30,7 +30,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -41,7 +40,7 @@ class ImmutableCollectorsTest {
     void immutableListCollectorShouldReturnEmptyImmutableListWhenEmptyStream() {
         String[] data = {};
         List<String> actual = Arrays.stream(data)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         assertThat(actual).isInstanceOf(ImmutableList.class);
         assertThat(actual).isEmpty();
     }
@@ -50,7 +49,7 @@ class ImmutableCollectorsTest {
     void immutableListCollectorShouldReturnImmutableListWhenOneElementStream() {
         String[] data = {"a"};
         List<String> actual = Arrays.stream(data)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         assertThat(actual).isInstanceOf(ImmutableList.class);
         assertThat(actual).containsExactly("a");
     }
@@ -59,7 +58,7 @@ class ImmutableCollectorsTest {
     void immutableListCollectorShouldReturnImmutableListWhen3ElementsStream() {
         String[] data = {"a", "b", "c"};
         List<String> actual = Arrays.stream(data)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         assertThat(actual).isInstanceOf(ImmutableList.class);
         assertThat(actual).containsExactly("a", "b", "c");
     }
@@ -68,7 +67,7 @@ class ImmutableCollectorsTest {
     void immutableSetCollectorShouldReturnEmptyImmutableSetWhenEmptyStream() {
         String[] data = {};
         Set<String> actual = Arrays.stream(data)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
         assertThat(actual).isInstanceOf(ImmutableSet.class);
         assertThat(actual).isEmpty();
     }
@@ -77,7 +76,7 @@ class ImmutableCollectorsTest {
     void immutableSetCollectorShouldReturnImmutableSetWhenOneElementStream() {
         String[] data = {"a"};
         Set<String> actual = Arrays.stream(data)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
         assertThat(actual).isInstanceOf(ImmutableSet.class);
         assertThat(actual).containsExactly("a");
     }
@@ -86,7 +85,7 @@ class ImmutableCollectorsTest {
     void immutableSetCollectorShouldReturnImmutableSetWhen3ElementsStream() {
         String[] data = {"a", "b", "c"};
         Set<String> actual = Arrays.stream(data)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
         assertThat(actual).isInstanceOf(ImmutableSet.class);
         assertThat(actual).containsExactly("a", "b", "c");
     }
@@ -96,7 +95,7 @@ class ImmutableCollectorsTest {
     void immutableMapCollectorShouldReturnEmptyImmutableMapWhenEmptyStream() {
         String[] data = {};
         Map<String, Integer> actual = Arrays.stream(data)
-                .collect(Guavate.toImmutableMap(x -> x.toUpperCase(Locale.US), String::length));
+                .collect(ImmutableMap.toImmutableMap(x -> x.toUpperCase(Locale.US), String::length));
         assertThat(actual).isInstanceOf(ImmutableMap.class);
         assertThat(actual).isEmpty();
     }
@@ -105,7 +104,7 @@ class ImmutableCollectorsTest {
     void immutableMapCollectorShouldReturnAppliedImmutableMapWhenOneElementStream() {
         String[] data = {"a"};
         Map<String, Integer> actual = Arrays.stream(data)
-                .collect(Guavate.toImmutableMap(x -> x.toUpperCase(Locale.US), String::length));
+                .collect(ImmutableMap.toImmutableMap(x -> x.toUpperCase(Locale.US), String::length));
         assertThat(actual).isInstanceOf(ImmutableMap.class);
         assertThat(actual).containsExactly(entry("A", 1));
     }
@@ -114,7 +113,7 @@ class ImmutableCollectorsTest {
     void immutableMapCollectorShouldReturnAppliedImmutableMapWhen3ElementsStream() {
         String[] data = {"a", "bb", "ccc"};
         Map<String, Integer> actual = Arrays.stream(data)
-                .collect(Guavate.toImmutableMap(x -> x.toUpperCase(Locale.US), String::length));
+                .collect(ImmutableMap.toImmutableMap(x -> x.toUpperCase(Locale.US), String::length));
         assertThat(actual).isInstanceOf(ImmutableMap.class);
         assertThat(actual).containsExactly(entry("A", 1), entry("BB", 2), entry("CCC", 3));
     }

--- a/server/container/util/src/test/java/org/apache/james/util/streams/LimitTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/streams/LimitTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -55,7 +54,7 @@ class LimitTest {
         assertThat(
             testee
                 .applyOnStream(aList.stream())
-                .collect(Guavate.toImmutableList())
+                .collect(ImmutableList.toImmutableList())
         ).isEqualTo(aList);
     }
 
@@ -74,7 +73,7 @@ class LimitTest {
 
         assertThat(testee
             .applyOnStream(aList.stream())
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
         ).isEqualTo(ImmutableList.of(1, 2, 3));
     }
 

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/lib/MappingsImpl.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/lib/MappingsImpl.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 
 import org.apache.james.rrt.lib.Mapping.Type;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -140,7 +139,7 @@ public class MappingsImpl implements Mappings, Serializable {
             return new MappingsImpl(mappings.build()
                 .stream()
                 .sorted(new DefaultMappingOrderingPolicy().comparator())
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
         }
 
     }
@@ -155,7 +154,7 @@ public class MappingsImpl implements Mappings, Serializable {
     public Iterable<String> asStrings() {
         return mappings.stream()
             .map(Mapping::asString)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/lib/UserRewritter.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/lib/UserRewritter.java
@@ -36,7 +36,6 @@ import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
@@ -121,7 +120,7 @@ public interface UserRewritter extends Serializable {
             return IntStream
                 .rangeClosed(1, match.groupCount())
                 .mapToObj(match::group)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         private String replaceParameters(String input, List<String> parameters) {

--- a/server/data/data-cassandra/src/main/java/org/apache/james/dlp/eventsourcing/cassandra/DLPConfigurationItemDTO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/dlp/eventsourcing/cassandra/DLPConfigurationItemDTO.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.dlp.eventsourcing.cassandra;
 
-import static com.github.steveash.guavate.Guavate.toImmutableList;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 public class DLPConfigurationItemDTO {
 
@@ -52,7 +51,7 @@ public class DLPConfigurationItemDTO {
         return configurationItems
             .stream()
             .map(DLPConfigurationItemDTO::from)
-            .collect(toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public static List<DLPConfigurationItem> fromDTOs(List<DLPConfigurationItemDTO> configurationItems) {
@@ -61,7 +60,7 @@ public class DLPConfigurationItemDTO {
         return configurationItems
             .stream()
             .map(DLPConfigurationItemDTO::toDLPConfiguration)
-            .collect(toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private final String id;

--- a/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
@@ -31,8 +31,8 @@ import org.apache.james.rrt.lib.MappingSource;
 import org.apache.james.rrt.lib.Mappings;
 import org.apache.james.rrt.lib.MappingsImpl;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 public class CassandraRecipientRewriteTable extends AbstractRecipientRewriteTable {
     private final CassandraRecipientRewriteTableDAO cassandraRecipientRewriteTableDAO;
@@ -69,7 +69,7 @@ public class CassandraRecipientRewriteTable extends AbstractRecipientRewriteTabl
     @Override
     public Map<MappingSource, Mappings> getAllMappings() {
         return cassandraRecipientRewriteTableDAO.getAllMappings()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 pair -> pair.getLeft(),
                 pair -> MappingsImpl.fromMappings(pair.getRight()),
                 Mappings::union))

--- a/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableDAO.java
@@ -41,7 +41,7 @@ import org.apache.james.rrt.lib.MappingsImpl;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -108,7 +108,7 @@ public class CassandraRecipientRewriteTableDAO {
             .setString(USER, source.getFixedUser())
             .setString(DOMAIN, source.getFixedDomain()))
             .map(row -> row.getString(MAPPING))
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .map(MappingsImpl::fromCollection)
             .filter(Predicate.not(MappingsImpl::isEmpty));
     }

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveRepository.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveRepository.java
@@ -45,7 +45,7 @@ import org.apache.james.sieverepository.api.exception.QuotaNotFoundException;
 import org.apache.james.sieverepository.api.exception.ScriptNotFoundException;
 import org.apache.james.util.FunctionalUtils;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -149,7 +149,7 @@ public class CassandraSieveRepository implements SieveRepository {
 
     @Override
     public List<ScriptSummary> listScripts(Username username) {
-        return cassandraSieveDAO.listScripts(username).collect(Guavate.toImmutableList()).block();
+        return cassandraSieveDAO.listScripts(username).collect(ImmutableList.toImmutableList()).block();
     }
 
     @Override

--- a/server/data/data-file/src/main/java/org/apache/james/sieverepository/file/SieveFileRepository.java
+++ b/server/data/data-file/src/main/java/org/apache/james/sieverepository/file/SieveFileRepository.java
@@ -57,7 +57,7 @@ import org.apache.james.sieverepository.api.exception.QuotaNotFoundException;
 import org.apache.james.sieverepository.api.exception.ScriptNotFoundException;
 import org.apache.james.sieverepository.api.exception.StorageException;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * <code>SieveFileRepository</code> manages sieve scripts stored on the file system.
@@ -214,7 +214,7 @@ public class SieveFileRepository implements SieveRepository {
         return Stream.of(Optional.ofNullable(getUserDirectory(username).listFiles()).orElse(new File[]{}))
             .filter(file -> !SYSTEM_FILES.contains(file.getName()))
             .map(file -> new ScriptSummary(new ScriptName(file.getName()), isActive.test(file)))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Predicate<File> isActiveValidator(File activeFile) {

--- a/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
@@ -69,9 +69,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Implementation of a MailRepository on a database.
@@ -456,10 +456,9 @@ public class JDBCMailRepository implements MailRepository, Configurable, Initial
                         oos.writeObject(((MailImpl) mc).getAttributesRaw());
                     } else {
                         Map<String, Serializable> temp = mc.attributes()
-                                .collect(Guavate.toImmutableMap(
+                                .collect(ImmutableMap.toImmutableMap(
                                         attribute -> attribute.getName().asString(),
-                                        attribute -> (Serializable) attribute.getValue().value()
-                                ));
+                                        attribute -> (Serializable) attribute.getValue().value()));
 
                         oos.writeObject(temp);
                     }
@@ -491,10 +490,9 @@ public class JDBCMailRepository implements MailRepository, Configurable, Initial
                 oos.writeObject(((MailImpl) mc).getAttributesRaw());
             } else {
                 Map<String, Serializable> temp = mc.attributes()
-                    .collect(Guavate.toImmutableMap(
+                    .collect(ImmutableMap.toImmutableMap(
                             attribute -> attribute.getName().asString(),
-                            attribute -> (Serializable) attribute.getValue().value()
-                    ));
+                            attribute -> (Serializable) attribute.getValue().value()));
                 oos.writeObject(temp);
             }
             oos.flush();
@@ -661,7 +659,7 @@ public class JDBCMailRepository implements MailRepository, Configurable, Initial
             .entrySet()
             .stream()
             .map(entry -> Attribute.convertToAttribute(entry.getKey(), entry.getValue()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/EmailChangeRepositoryDAO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/EmailChangeRepositoryDAO.java
@@ -54,7 +54,6 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.UserType;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -124,7 +123,7 @@ public class EmailChangeRepositoryDAO {
             .filter(CassandraMessageId.class::isInstance)
             .map(CassandraMessageId.class::cast)
             .map(CassandraMessageId::get)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     Flux<EmailChange> getAllChanges(AccountId accountId) {
@@ -167,6 +166,6 @@ public class EmailChangeRepositoryDAO {
     private ImmutableList<MessageId> toIdSet(Set<UUID> uuidSet) {
         return uuidSet.stream()
             .map(CassandraMessageId.Factory::of)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/MailboxChangeRepositoryDAO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/MailboxChangeRepositoryDAO.java
@@ -55,7 +55,6 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.UserType;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -127,7 +126,7 @@ public class MailboxChangeRepositoryDAO {
             .filter(CassandraId.class::isInstance)
             .map(CassandraId.class::cast)
             .map(CassandraId::asUuid)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     Flux<MailboxChange> getAllChanges(AccountId accountId) {
@@ -171,6 +170,6 @@ public class MailboxChangeRepositoryDAO {
     private ImmutableList<MailboxId> toIdSet(Set<UUID> uuidSet) {
         return uuidSet.stream()
             .map(CassandraId::of)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxAndEmailChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxAndEmailChange.java
@@ -32,7 +32,6 @@ import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.SessionProvider;
 import org.apache.james.mailbox.events.MailboxEvents;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -95,7 +94,7 @@ public class MailboxAndEmailChange implements JmapChange {
                             .build()));
 
             return Stream.concat(Stream.of(ownerChange), shareeChanges)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         public List<JmapChange> fromFlagsUpdated(MailboxEvents.FlagsUpdated messageFlagUpdated, ZonedDateTime now, List<AccountId> sharees) {
@@ -141,7 +140,7 @@ public class MailboxAndEmailChange implements JmapChange {
                             .build()));
 
                 return Stream.concat(Stream.of(ownerChange), shareeChanges)
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
             }
             Stream<EmailChange> shareeChanges = sharees.stream()
                 .map(shareeId -> EmailChange.builder()
@@ -153,7 +152,7 @@ public class MailboxAndEmailChange implements JmapChange {
                     .build());
 
             return Stream.concat(Stream.of(ownerEmailChange), shareeChanges)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         public Flux<JmapChange> fromExpunged(MailboxEvents.Expunged expunged, ZonedDateTime now, List<Username> sharees) {

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
@@ -35,7 +35,6 @@ import org.apache.james.mailbox.events.MailboxEvents.MailboxRenamed;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxId;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -156,7 +155,7 @@ public class MailboxChange implements JmapChange {
                     .build());
 
             return Stream.concat(Stream.of(ownerChange), shareeChanges)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         public List<JmapChange> fromMailboxACLUpdated(MailboxACLUpdated mailboxACLUpdated, ZonedDateTime now, List<AccountId> sharees) {
@@ -179,7 +178,7 @@ public class MailboxChange implements JmapChange {
                     .build());
 
             return Stream.concat(Stream.of(ownerChange), shareeChanges)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         public List<JmapChange> fromMailboxDeletion(MailboxDeletion mailboxDeletion, ZonedDateTime now) {
@@ -207,7 +206,7 @@ public class MailboxChange implements JmapChange {
                     .build());
 
             return Stream.concat(Stream.of(ownerChange), shareeChanges)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
     }
 

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepository.java
@@ -34,9 +34,9 @@ import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.exception.ChangeNotFoundException;
 import org.apache.james.jmap.api.model.AccountId;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
@@ -111,7 +111,7 @@ public class MemoryEmailChangeRepository implements EmailChangeRepository {
             .flatMapIterable(currentState -> emailChangeMap.get(accountId).stream()
                 .filter(change -> change.getDate().isAfter(currentState.getDate()))
                 .sorted(Comparator.comparing(EmailChange::getDate))
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private Flux<EmailChange> allChanges(AccountId accountId) {

--- a/server/data/data-jpa/src/main/java/org/apache/james/domainlist/jpa/JPADomainList.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/domainlist/jpa/JPADomainList.java
@@ -38,7 +38,7 @@ import org.apache.james.domainlist.lib.AbstractDomainList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * JPA implementation of the DomainList.<br>
@@ -84,7 +84,7 @@ public class JPADomainList extends AbstractDomainList {
             return resultList
                     .stream()
                     .map(Domain::of)
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
         } catch (PersistenceException e) {
             LOGGER.error("Failed to list domains", e);
             throw new DomainListException("Unable to retrieve domains", e);

--- a/server/data/data-jpa/src/main/java/org/apache/james/user/jpa/JPAUsersDAO.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/user/jpa/JPAUsersDAO.java
@@ -42,8 +42,8 @@ import org.apache.james.user.lib.UsersDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * JPA based UserRepository
@@ -221,7 +221,7 @@ public class JPAUsersDAO implements UsersDAO, Configurable {
             return ((List<String>) entityManager.createNamedQuery("listUserNames").getResultList())
                 .stream()
                 .map(Username::of)
-                .collect(Guavate.toImmutableList()).iterator();
+                .collect(ImmutableList.toImmutableList()).iterator();
 
         } catch (PersistenceException e) {
             LOGGER.debug("Failed to find user", e);

--- a/server/data/data-ldap/pom.xml
+++ b/server/data/data-ldap/pom.xml
@@ -66,10 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
         </dependency>

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPGroupRestriction.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPGroupRestriction.java
@@ -30,7 +30,7 @@ import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.unboundid.ldap.sdk.DN;
 import com.unboundid.ldap.sdk.LDAPConnectionPool;
 import com.unboundid.ldap.sdk.LDAPException;
@@ -138,6 +138,6 @@ public class ReadOnlyLDAPGroupRestriction {
         com.unboundid.ldap.sdk.Attribute members = entry.getAttribute(memberAttribute);
         return Arrays.stream(members.getValues())
             .map(Throwing.function(DN::new))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUsersDAO.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUsersDAO.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 import com.unboundid.ldap.sdk.Attribute;
 import com.unboundid.ldap.sdk.DN;
 import com.unboundid.ldap.sdk.Entry;
@@ -179,7 +179,7 @@ public class ReadOnlyLDAPUsersDAO implements UsersDAO, Configurable {
         return searchResult.getSearchEntries()
             .stream()
             .map(Throwing.function(Entry::getParsedDN))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     private Stream<Username> getAllUsernamesFromLDAP() throws LDAPException {

--- a/server/data/data-library/pom.xml
+++ b/server/data/data-library/pom.xml
@@ -78,10 +78,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/server/data/data-library/src/main/java/org/apache/james/dlp/eventsourcing/aggregates/DLPDomainConfiguration.java
+++ b/server/data/data-library/src/main/java/org/apache/james/dlp/eventsourcing/aggregates/DLPDomainConfiguration.java
@@ -32,7 +32,6 @@ import org.apache.james.eventsourcing.Event;
 import org.apache.james.eventsourcing.EventId;
 import org.apache.james.eventsourcing.eventstore.History;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -56,12 +55,12 @@ public class DLPDomainConfiguration {
         }
 
         State add(List<DLPConfigurationItem> toAdd) {
-            ImmutableSet<DLPConfigurationItem> union = Stream.concat(this.rules.stream(), toAdd.stream()).collect(Guavate.toImmutableSet());
+            ImmutableSet<DLPConfigurationItem> union = Stream.concat(this.rules.stream(), toAdd.stream()).collect(ImmutableSet.toImmutableSet());
             return new State(union);
         }
 
         State remove(List<DLPConfigurationItem> toRemove) {
-            ImmutableSet<DLPConfigurationItem> filtered = rules.stream().filter(rule -> !toRemove.contains(rule)).collect(Guavate.toImmutableSet());
+            ImmutableSet<DLPConfigurationItem> filtered = rules.stream().filter(rule -> !toRemove.contains(rule)).collect(ImmutableSet.toImmutableSet());
             return new State(filtered);
         }
     }
@@ -93,7 +92,7 @@ public class DLPDomainConfiguration {
     }
 
     public List<Event> store(DLPRules updatedRules) {
-        ImmutableSet<DLPConfigurationItem> existingRules = retrieveRules().getItems().stream().collect(Guavate.toImmutableSet());
+        ImmutableSet<DLPConfigurationItem> existingRules = retrieveRules().getItems().stream().collect(ImmutableSet.toImmutableSet());
         ImmutableSet<DLPConfigurationItem> updatedRulesSet = ImmutableSet.copyOf(updatedRules);
 
         Optional<Event> removedRulesEvent = generateRemovedRulesEvent(existingRules, updatedRulesSet);
@@ -102,7 +101,7 @@ public class DLPDomainConfiguration {
         ImmutableList<Event> events = Stream
             .of(removedRulesEvent, addedRulesEvent)
             .flatMap(Optional::stream)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         events.forEach(this::apply);
         return events;

--- a/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
+++ b/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
@@ -194,7 +193,7 @@ public abstract class AbstractDomainList implements DomainList, Configurable {
         Multimap<DomainType, Domain> domainsWithType = getDomainsWithType();
         ImmutableSet<Domain> allDomains = domainsWithType.values()
             .stream()
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
 
         if (configuration.isCacheEnabled()) {
             domainsWithType.get(DomainType.Internal)
@@ -232,7 +231,7 @@ public abstract class AbstractDomainList implements DomainList, Configurable {
     private ImmutableList<Domain> detectIps(Collection<Domain> domains) {
         if (configuration.isAutoDetectIp()) {
             return getDomainsIpStream(domains, dns, LOGGER)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
         return ImmutableList.of();
     }

--- a/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/DomainListConfiguration.java
+++ b/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/DomainListConfiguration.java
@@ -33,7 +33,6 @@ import org.apache.james.core.Domain;
 import org.apache.james.util.DurationParser;
 import org.apache.james.util.StreamUtils;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class DomainListConfiguration {
@@ -147,7 +146,7 @@ public class DomainListConfiguration {
         ImmutableList<Domain> configuredDomains = StreamUtils.ofNullable(config.getStringArray(CONFIGURE_DOMAIN_NAMES))
             .filter(Predicate.not(String::isEmpty))
             .map(Domain::of)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         return builder()
             .autoDetect(Optional.ofNullable(config.getBoolean(CONFIGURE_AUTODETECT, null)))

--- a/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/DomainListManagement.java
+++ b/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/DomainListManagement.java
@@ -30,7 +30,7 @@ import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.api.DomainListException;
 import org.apache.james.domainlist.api.DomainListManagementMBean;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class DomainListManagement extends StandardMBean implements DomainListManagementMBean {
 
@@ -69,7 +69,7 @@ public class DomainListManagement extends StandardMBean implements DomainListMan
             return domainList.getDomains()
                 .stream()
                 .map(Domain::name)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (DomainListException e) {
             throw new Exception(e.getMessage());
         }

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AliasReverseResolverImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AliasReverseResolverImpl.java
@@ -37,7 +37,7 @@ import org.apache.james.rrt.api.RecipientRewriteTableException;
 import org.apache.james.util.StreamUtils;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class AliasReverseResolverImpl implements AliasReverseResolver {
     private final RecipientRewriteTable recipientRewriteTable;
@@ -74,9 +74,9 @@ public class AliasReverseResolverImpl implements AliasReverseResolver {
 
     private CanSendFromImpl.DomainFetcher domainFetcher(Username user) {
         HashMap<Domain, List<Domain>> fetchedDomains = new HashMap<>();
-        List<Domain> userDomains = relatedDomains(user).collect(Guavate.toImmutableList());
+        List<Domain> userDomains = relatedDomains(user).collect(ImmutableList.toImmutableList());
         user.getDomainPart().ifPresent(domain -> fetchedDomains.put(domain, userDomains));
-        Function<Domain, List<Domain>> computeDomain = givenDomain -> Stream.concat(userDomains.stream(), fetchDomains(givenDomain)).collect(Guavate.toImmutableList());
+        Function<Domain, List<Domain>> computeDomain = givenDomain -> Stream.concat(userDomains.stream(), fetchDomains(givenDomain)).collect(ImmutableList.toImmutableList());
         return givenUsername ->
             givenUsername
                 .getDomainPart()

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
@@ -29,7 +29,7 @@ import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.rrt.api.RecipientRewriteTableException;
 import org.apache.james.rrt.api.RecipientRewriteTableManagementMBean;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Management for RecipientRewriteTables
@@ -115,8 +115,7 @@ public class RecipientRewriteTableManagement extends StandardMBean implements Re
         return rrt.getAllMappings()
             .entrySet()
             .stream()
-            .collect(
-                Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                     entry -> entry.getKey().asString(),
                     entry -> entry.getValue()));
     }

--- a/server/data/data-memory/src/main/java/org/apache/james/rrt/memory/MemoryRecipientRewriteTable.java
+++ b/server/data/data-memory/src/main/java/org/apache/james/rrt/memory/MemoryRecipientRewriteTable.java
@@ -35,8 +35,8 @@ import org.apache.james.rrt.lib.MappingSource;
 import org.apache.james.rrt.lib.Mappings;
 import org.apache.james.rrt.lib.MappingsImpl;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimaps;
 
 public class MemoryRecipientRewriteTable extends AbstractRecipientRewriteTable {
@@ -112,7 +112,7 @@ public class MemoryRecipientRewriteTable extends AbstractRecipientRewriteTable {
             .entrySet()
             .stream()
             .map(entry -> Pair.of(entry.getKey(), toMappings(entry.getValue())))
-            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
     }
 
     private MappingsImpl toMappings(Collection<InMemoryMappingEntry> inMemoryMappingEntries) {

--- a/server/mailet/dkim/src/main/java/org/apache/james/jdkim/mailets/MimeMessageHeaders.java
+++ b/server/mailet/dkim/src/main/java/org/apache/james/jdkim/mailets/MimeMessageHeaders.java
@@ -29,7 +29,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.jdkim.api.Headers;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterators;
@@ -46,16 +45,16 @@ final class MimeMessageHeaders implements Headers {
     public MimeMessageHeaders(MimeMessage message) throws MessagingException {
         ImmutableList<Pair<String, String>> headsAndLines = Streams.stream(Iterators.forEnumeration(message.getAllHeaderLines()))
                 .map(Throwing.function(this::extractHeaderLine).sneakyThrow())
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
         fields = headsAndLines
             .stream()
             .map(Pair::getKey)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         headers = headsAndLines
             .stream()
-            .collect(Guavate.toImmutableListMultimap(
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
                 pair -> pair.getKey().toLowerCase(Locale.US),
                 Pair::getValue));
     }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpRandomStoringTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpRandomStoringTest.java
@@ -63,7 +63,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 class SmtpRandomStoringTest {
@@ -76,7 +75,7 @@ class SmtpRandomStoringTest {
     private static final ImmutableList<String> USERS = LongStream.range(0L, USERS_NUMBERS)
         .boxed()
         .map(index -> "user" + index + "@" + DEFAULT_DOMAIN)
-        .collect(Guavate.toImmutableList());
+        .collect(ImmutableList.toImmutableList());
 
     private static final ImmutableList<String> MAILBOXES = ImmutableList.of(MailboxConstants.INBOX, "arbitrary");
     private static final int NUMBER_OF_MAILS = 100;
@@ -165,7 +164,7 @@ class SmtpRandomStoringTest {
         connections = USERS
             .stream()
             .map(this::createIMAPConnection)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         awaitAtMostTenSeconds
             .untilAsserted(() -> checkNumberOfMessages(connections));
@@ -176,7 +175,7 @@ class SmtpRandomStoringTest {
         connections = USERS
             .stream()
             .map(this::createIMAPConnection)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         awaitAtMostTenSeconds
             .untilAsserted(() -> checkMailboxesHaveBeenFilled(connections));

--- a/server/mailet/mailetcontainer-impl/pom.xml
+++ b/server/mailet/mailetcontainer-impl/pom.xml
@@ -104,10 +104,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
         </dependency>

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/LocalResources.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/LocalResources.java
@@ -22,6 +22,7 @@ package org.apache.james.mailetcontainer.impl;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -41,7 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 
 class LocalResources {
     private static final EnumSet<Mapping.Type> ALIAS_TYPES = EnumSet.of(Mapping.Type.Alias, Mapping.Type.DomainAlias);
@@ -105,7 +107,7 @@ class LocalResources {
         return addressByDomains(mailAddresses)
             .flatMap(this::hasLocalDomain)
             .filter(this::belongsToALocalUser)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Stream<MailAddress> hasLocalDomain(Map.Entry<Domain, Collection<MailAddress>> entry) {
@@ -117,8 +119,8 @@ class LocalResources {
 
     private Stream<Map.Entry<Domain, Collection<MailAddress>>> addressByDomains(Collection<MailAddress> mailAddresses) {
         return mailAddresses.stream()
-            .collect(Guavate.toImmutableListMultimap(
-                MailAddress::getDomain))
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
+                MailAddress::getDomain, Function.identity()))
             .asMap()
             .entrySet()
             .stream();

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/MailetProcessorImpl.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/MailetProcessorImpl.java
@@ -40,8 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -156,7 +156,7 @@ public class MailetProcessorImpl extends AbstractStateMailetProcessor {
         ImmutableList<Mail> afterMatching = step.getInFlightMails()
             .stream()
             .flatMap(Throwing.<Mail, Stream<Mail>>function(mail -> matcherSplitter.split(mail).stream()).sneakyThrow())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         afterMatching
             .stream().filter(mail -> mail.removeAttribute(MATCHER_MATCHED_ATTRIBUTE).isPresent())
             .forEach(Throwing.consumer(processor::process).sneakyThrow());
@@ -169,7 +169,7 @@ public class MailetProcessorImpl extends AbstractStateMailetProcessor {
         return step.nextStepBuilder()
             .inFlight(afterMatching.stream()
                 .filter(mail -> mail.getState().equals(getState()))
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .encountered(afterMatching);
     }
 
@@ -199,7 +199,7 @@ public class MailetProcessorImpl extends AbstractStateMailetProcessor {
             this.pairsToBeProcessed = pairs.stream()
                 .map(pair -> Pair.of(new MatcherSplitter(metricFactory, this, pair),
                     new ProcessorImpl(metricFactory, this, pair.getMailet())))
-                .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+                .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
         } catch (Exception e) {
             throw new MessagingException("Unable to setup routing for MailetMatcherPairs", e);
         }

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
@@ -54,7 +54,7 @@ import org.apache.mailet.base.MatcherInverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Abstract base class for {@link MailProcessor} implementations which want to
@@ -161,7 +161,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
     public List<Mailet> getMailets() {
         return pairs.stream()
             .map(MatcherMailetPair::getMailet)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     /**
@@ -170,7 +170,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
     public List<Matcher> getMatchers() {
         return pairs.stream()
             .map(MatcherMailetPair::getMatcher)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public void addListener(MailetProcessorListener listener) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RandomStoring.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RandomStoring.java
@@ -46,8 +46,9 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Mono;
 
@@ -79,7 +80,7 @@ public class RandomStoring extends GenericMailet {
         Collection<MailAddress> mailAddresses = reroutingInfos
             .stream()
             .map(Throwing.function(info -> info.getUser().asMailAddress()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         mail.setRecipients(mailAddresses);
         reroutingInfos.forEach(reroutingInfo ->
@@ -105,13 +106,13 @@ public class RandomStoring extends GenericMailet {
             .distinct()
             .mapToObj(reroutingInfos::get)
             .limit(randomRecipientsNumbers.get())
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     private List<ReroutingInfos> retrieveReroutingInfos() throws UsersRepositoryException {
         return Iterators.toStream(usersRepository.list())
             .flatMap(this::buildReRoutingInfos)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Stream<ReroutingInfos> buildReRoutingInfos(Username username) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -52,10 +52,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -87,10 +87,10 @@ public class RecipientRewriteTableProcessor {
             return originalRcptParameter.map(parameters -> {
                 Map<MailAddress, RecipientDsnParameters> newRcptParameters = executionResult.getNewRecipients().stream()
                     .map(newRcpt -> Pair.of(newRcpt, parameters))
-                    .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue));
+                    .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
                 Map<MailAddress, RecipientDsnParameters> rcptParametersWithoutOriginal = rcptParameters.entrySet().stream()
                     .filter(rcpt -> !rcpt.getKey().equals(originalAddress))
-                    .collect(Guavate.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
 
                 return dsnParameters.withRcptParameters(ImmutableMap.<MailAddress, RecipientDsnParameters>builder()
                     .putAll(rcptParametersWithoutOriginal)
@@ -221,7 +221,7 @@ public class RecipientRewriteTableProcessor {
         return mail.getRecipients()
             .stream()
             .map(convertToMappingData)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Decision executeRrtForRecipient(Mail mail, MailAddress recipient) {
@@ -254,12 +254,12 @@ public class RecipientRewriteTableProcessor {
             .collect(Collectors.partitioningBy(entry -> mailetContext.isLocalServer(entry.getKey())))
             .entrySet()
             .stream()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 Map.Entry::getKey,
                 entry -> entry.getValue()
                     .stream()
                     .flatMap(domainEntry -> domainEntry.getValue().stream())
-                    .collect(Guavate.toImmutableList())));
+                    .collect(ImmutableList.toImmutableList())));
     }
 
     private Stream<Map.Entry<Domain, Collection<MailAddress>>> mailAddressesPerDomain(Mappings mappings) {
@@ -267,8 +267,8 @@ public class RecipientRewriteTableProcessor {
             .map(mapping -> mapping.appendDomainIfNone(defaultDomainSupplier))
             .map(Mapping::asMailAddress)
             .flatMap(Optional::stream)
-            .collect(Guavate.toImmutableListMultimap(
-                MailAddress::getDomain))
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
+                MailAddress::getDomain, Function.identity()))
             .asMap()
             .entrySet()
             .stream();

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/DiscardAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/DiscardAction.java
@@ -26,7 +26,7 @@ import org.apache.jsieve.mail.Action;
 import org.apache.jsieve.mail.ActionDiscard;
 import org.apache.mailet.Mail;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 
 public class DiscardAction extends FileIntoAction implements MailAction {
@@ -43,6 +43,6 @@ public class DiscardAction extends FileIntoAction implements MailAction {
         mail.setRecipients(mail.getRecipients()
             .stream()
             .filter(Predicate.not(Predicate.isEqual(context.getRecipient())))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationAction.java
@@ -35,7 +35,6 @@ import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -85,7 +84,7 @@ public class VacationAction implements MailAction {
             .concat(
                 actionVacation.getAddresses().stream().map(s -> retrieveAddressFromString(s, context)),
                 Stream.of(context.getRecipient()))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
         return !Sets.intersection(currentMailAddresses, allowedMailAddresses).isEmpty();
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/AddressesArrayToMailAddressListConverter.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/AddressesArrayToMailAddressListConverter.java
@@ -30,7 +30,6 @@ import org.apache.james.core.MailAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class AddressesArrayToMailAddressListConverter {
@@ -40,11 +39,10 @@ public class AddressesArrayToMailAddressListConverter {
         if (addresses == null) {
             return ImmutableList.of();
         }
-        return Arrays.asList(addresses)
-            .stream()
-            .map(address -> toMailAddress(address))
+        return Arrays.stream(addresses)
+            .map(AddressesArrayToMailAddressListConverter::toMailAddress)
             .flatMap(Optional::stream)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static Optional<MailAddress> toMailAddress(Address address) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/InternetAddressConverter.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/InternetAddressConverter.java
@@ -25,7 +25,6 @@ import javax.mail.internet.InternetAddress;
 
 import org.apache.james.core.MailAddress;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
@@ -34,6 +33,6 @@ public class InternetAddressConverter {
         Preconditions.checkNotNull(recipients);
         return recipients.stream()
             .map(MailAddress::toInternetAddress)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrer.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrer.java
@@ -42,7 +42,6 @@ import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -163,7 +162,7 @@ public class MailDelivrer {
             .map(addresses ->
                 Arrays.stream(addresses)
                     .map(InternetAddress.class::cast)
-                    .collect(Guavate.toImmutableList()))
+                    .collect(ImmutableList.toImmutableList()))
             .orElse(ImmutableList.of());
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
@@ -49,7 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableListMultimap;
 import com.sun.mail.smtp.SMTPMessage;
 import com.sun.mail.smtp.SMTPTransport;
 
@@ -107,7 +107,7 @@ public class MailDelivrerToHost {
                     .flatMap(DsnParameters.RecipientDsnParameters::getNotifyParameter)
                     .map(this::toJavaxNotify),
                 address))
-            .collect(Guavate.toImmutableListMultimap(
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
                 Pair::getKey,
                 Pair::getValue))
             .asMap()

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
@@ -33,10 +33,10 @@ import org.apache.mailet.base.MailetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class RemoteDeliveryConfiguration {
 
@@ -131,7 +131,7 @@ public class RemoteDeliveryConfiguration {
                 .stream()
                 .filter(propertyName -> propertyName.startsWith(JAVAX_PREFIX))
                 .map(propertyName -> Pair.of(propertyName, mailetConfig.getInitParameter(propertyName)))
-                .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)));
+                .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)));
         return result;
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/DSNDelayRequested.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/DSNDelayRequested.java
@@ -31,9 +31,9 @@ import org.apache.mailet.DsnParameters;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Returns the list of Recipients for which DSN DELAY notifications
@@ -74,7 +74,7 @@ public class DSNDelayRequested extends GenericMatcher {
     public Collection<MailAddress> match(Mail mail) {
         return mail.getRecipients().stream()
             .filter(recipient -> delayRequested(mail, recipient))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Boolean delayRequested(Mail mail, MailAddress recipient) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/DSNFailureRequested.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/DSNFailureRequested.java
@@ -32,9 +32,9 @@ import org.apache.mailet.DsnParameters;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Returns the list of Recipients for which DSN FAILURE notifications
@@ -77,7 +77,7 @@ public class DSNFailureRequested extends GenericMatcher {
     public Collection<MailAddress> match(Mail mail) {
         return mail.getRecipients().stream()
             .filter(recipient -> failureRequested(mail, recipient))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Boolean failureRequested(Mail mail, MailAddress recipient) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/DSNSuccessRequested.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/DSNSuccessRequested.java
@@ -31,9 +31,9 @@ import org.apache.mailet.DsnParameters;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Returns the list of Recipients for which DSN SUCCESS notifications
@@ -74,7 +74,7 @@ public class DSNSuccessRequested extends GenericMatcher {
     public Collection<MailAddress> match(Mail mail) {
         return mail.getRecipients().stream()
             .filter(recipient -> successRequested(mail, recipient))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Boolean successRequested(Mail mail, MailAddress recipient) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsMarkedAsSpam.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsMarkedAsSpam.java
@@ -29,7 +29,7 @@ import org.apache.james.spamassassin.SpamAssassinResult;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * <p>
@@ -67,7 +67,7 @@ public class IsMarkedAsSpam extends GenericMatcher {
         return mail.getRecipients()
             .stream()
             .filter(recipient -> isMarkedAsSpam(mail, recipient))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public boolean isMarkedAsSpam(Mail mail, MailAddress recipient) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/util/MailAddressUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/util/MailAddressUtils.java
@@ -27,7 +27,6 @@ import javax.mail.internet.InternetAddress;
 import org.apache.james.core.MailAddress;
 import org.apache.james.transport.mailets.redirect.SpecialAddress;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class MailAddressUtils {
@@ -46,7 +45,7 @@ public class MailAddressUtils {
 
     public static List<InternetAddress> toInternetAddresses(List<MailAddress> mailAddresses) {
         return streamOfInternetAddress(mailAddresses)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public static InternetAddress[] toInternetAddressArray(List<MailAddress> mailAddresses) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SpecialAddressesUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SpecialAddressesUtils.java
@@ -38,7 +38,6 @@ import org.apache.mailet.base.RFC2822Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -126,7 +125,7 @@ public class SpecialAddressesUtils {
     }
 
     private Set<MailAddress> getSender(Mail mail) {
-        return mail.getMaybeSender().asStream().collect(Guavate.toImmutableSet());
+        return mail.getMaybeSender().asStream().collect(ImmutableSet.toImmutableSet());
     }
 
     private Set<MailAddress> getReplyTos(InternetAddress[] replyToArray) {

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
@@ -40,7 +40,7 @@ import org.apache.mailet.base.test.FakeMailetConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 class SpamAssassinTest {
 
@@ -173,7 +173,7 @@ class SpamAssassinTest {
                 .get(new MailAddress("user1@exemple.com"))
                 .stream()
                 .map(PerRecipientHeaders.Header::getName)
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .contains(SpamAssassinResult.FLAG_MAIL.asString(), SpamAssassinResult.STATUS_MAIL.asString());
     }
 

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/HTTPConfigurationServer.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/HTTPConfigurationServer.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
@@ -147,7 +147,7 @@ public class HTTPConfigurationServer {
     private Publisher<Void> getBehaviors(HttpServerRequest req, HttpServerResponse res) {
         MockSmtpBehaviors mockSmtpBehaviors = new MockSmtpBehaviors(smtpBehaviorRepository.remainingBehaviors()
             .map(MockSMTPBehaviorInformation::getBehavior)
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
 
         try {
             return res.status(OK)

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/SMTPBehaviorRepository.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/SMTPBehaviorRepository.java
@@ -30,7 +30,6 @@ import org.apache.james.mock.smtp.server.model.MockSMTPBehaviorInformation;
 import org.apache.james.mock.smtp.server.model.MockSmtpBehaviors;
 import org.apache.james.mock.smtp.server.model.SMTPExtension;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -78,7 +77,7 @@ class SMTPBehaviorRepository {
                 .getBehaviorList()
                 .stream()
                 .map(MockSMTPBehaviorInformation::from)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
         }
     }
 

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Mail.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Mail.java
@@ -31,7 +31,6 @@ import org.apache.james.core.MailAddress;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -78,7 +77,7 @@ public class Mail {
                 .stream()
                 .filter(argString -> argString.contains("="))
                 .map(Parameter::fromString)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         }
 
         public static Parameter fromString(String argString) {
@@ -270,7 +269,7 @@ public class Mail {
         public static Envelope ofAddresses(MailAddress from, MailAddress... recipients) {
             return new Envelope(from, Stream.of(recipients)
                 .map(Recipient::of)
-                .collect(Guavate.toImmutableSet()), ImmutableSet.of());
+                .collect(ImmutableSet.toImmutableSet()), ImmutableSet.of());
         }
 
         public static Envelope of(MailAddress from, Recipient... recipients) {

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.runnable.ThrowingRunnable;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
@@ -483,7 +482,7 @@ public interface MailRepositoryContract {
         ConcurrentHashMap.KeySetView<MailKey, Boolean> expectedResult = ConcurrentHashMap.newKeySet();
         List<Object> locks = IntStream.range(0, nbKeys)
             .boxed()
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         ThrowingRunnable add = () -> {
             int keyIndex = computeKeyIndex(nbKeys, Math.abs(ThreadLocalRandom.current().nextInt()));

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
@@ -81,7 +81,6 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.UDTValue;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -194,7 +193,7 @@ public class CassandraMailRepositoryMailDAO implements CassandraMailRepositoryMa
         List<MailAddress> recipients = row.getList(RECIPIENTS, String.class)
             .stream()
             .map(Throwing.function(MailAddress::new))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         String state = row.getString(STATE);
         String remoteAddr = row.getString(REMOTE_ADDR);
         String remoteHost = row.getString(REMOTE_HOST);
@@ -225,17 +224,17 @@ public class CassandraMailRepositoryMailDAO implements CassandraMailRepositoryMa
         return rowAttributes.entrySet()
             .stream()
             .map(entry -> new Attribute(AttributeName.of(entry.getKey()), fromByteBuffer(entry.getValue())))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private ImmutableList<String> asStringList(Collection<MailAddress> mailAddresses) {
-        return mailAddresses.stream().map(MailAddress::asString).collect(Guavate.toImmutableList());
+        return mailAddresses.stream().map(MailAddress::asString).collect(ImmutableList.toImmutableList());
     }
 
     private ImmutableMap<String, ByteBuffer> toRawAttributeMap(Mail mail) {
         return mail.attributes()
             .map(attribute -> Pair.of(attribute.getName(), attribute.getValue()))
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 pair -> pair.getLeft().asString(),
                 pair -> toByteBuffer((Serializable) pair.getRight().value())));
     }
@@ -251,7 +250,7 @@ public class CassandraMailRepositoryMailDAO implements CassandraMailRepositoryMa
                     .newValue()
                     .setString(HEADER_NAME, entry.getRight().getName())
                     .setString(HEADER_VALUE, entry.getRight().getValue())))
-            .collect(Guavate.toImmutableMap(Pair::getLeft, Pair::getRight));
+            .collect(ImmutableMap.toImmutableMap(Pair::getLeft, Pair::getRight));
     }
 
     private PerRecipientHeaders fromHeaderMap(Map<String, UDTValue> rawMap) {

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDaoV2.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDaoV2.java
@@ -75,7 +75,6 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TupleType;
 import com.datastax.driver.core.TupleValue;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -182,7 +181,7 @@ public class CassandraMailRepositoryMailDaoV2 implements CassandraMailRepository
         List<MailAddress> recipients = row.getList(RECIPIENTS, String.class)
             .stream()
             .map(Throwing.function(MailAddress::new))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         String state = row.getString(STATE);
         String remoteAddr = row.getString(REMOTE_ADDR);
         String remoteHost = row.getString(REMOTE_HOST);
@@ -213,17 +212,17 @@ public class CassandraMailRepositoryMailDaoV2 implements CassandraMailRepository
         return rowAttributes.entrySet()
             .stream()
             .map(Throwing.function(entry -> new Attribute(AttributeName.of(entry.getKey()), AttributeValue.fromJsonString(entry.getValue()))))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private ImmutableList<String> asStringList(Collection<MailAddress> mailAddresses) {
-        return mailAddresses.stream().map(MailAddress::asString).collect(Guavate.toImmutableList());
+        return mailAddresses.stream().map(MailAddress::asString).collect(ImmutableList.toImmutableList());
     }
 
     private ImmutableMap<String, String> toRawAttributeMap(Mail mail) {
         return mail.attributes()
             .map(attribute -> Pair.of(attribute.getName().asString(), toJson(attribute.getValue())))
-            .collect(Guavate.toImmutableMap(Pair::getLeft, Pair::getRight));
+            .collect(ImmutableMap.toImmutableMap(Pair::getLeft, Pair::getRight));
     }
 
     private ImmutableList<TupleValue> toTupleList(PerRecipientHeaders perRecipientHeaders) {
@@ -231,7 +230,7 @@ public class CassandraMailRepositoryMailDaoV2 implements CassandraMailRepository
             .entries()
             .stream()
             .map(entry -> userHeaderNameHeaderValueTriple.newValue(entry.getKey().asString(), entry.getValue().getName(), entry.getValue().getValue()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private PerRecipientHeaders fromList(List<TupleValue> list) {

--- a/server/mailrepository/mailrepository-memory/src/main/java/org/apache/james/mailrepository/memory/MailRepositoryStoreConfiguration.java
+++ b/server/mailrepository/mailrepository-memory/src/main/java/org/apache/james/mailrepository/memory/MailRepositoryStoreConfiguration.java
@@ -30,7 +30,6 @@ import org.apache.james.mailrepository.api.Protocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
@@ -79,7 +78,7 @@ public class MailRepositoryStoreConfiguration {
         ImmutableList<Item> items = retrieveRegisteredClassConfiguration(configuration)
             .stream()
             .map(MailRepositoryStoreConfiguration::readItem)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         Optional<Protocol> defaultProtocol =
             Optional.ofNullable(configuration.getString("defaultProtocol", null)).map(Protocol::new)
@@ -105,7 +104,7 @@ public class MailRepositoryStoreConfiguration {
 
     private static Item readItem(HierarchicalConfiguration<ImmutableNode> configuration) {
         String className = configuration.getString("[@class]");
-        List<Protocol> protocolStream = Arrays.stream(configuration.getStringArray("protocols.protocol")).map(Protocol::new).collect(Guavate.toImmutableList());
+        List<Protocol> protocolStream = Arrays.stream(configuration.getStringArray("protocols.protocol")).map(Protocol::new).collect(ImmutableList.toImmutableList());
         HierarchicalConfiguration<ImmutableNode> extraConfig = extraConfig(configuration);
 
         return new Item(protocolStream, className, extraConfig);

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/GetMessagesMethodStepdefs.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/GetMessagesMethodStepdefs.java
@@ -54,7 +54,6 @@ import org.apache.james.util.ClassLoaderUtils;
 import org.apache.james.utils.SMTPMessageSender;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
@@ -471,7 +470,7 @@ public class GetMessagesMethodStepdefs {
     public void postWithAListOfIds(List<String> ids) throws Exception {
         requestedMessageIds = ids.stream()
             .map(messageIdStepdefs::getMessageId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         askMessages(requestedMessageIds);
     }
 
@@ -512,7 +511,7 @@ public class GetMessagesMethodStepdefs {
     public void postWithParameters(List<String> ids, List<String> properties) throws Exception {
         requestedMessageIds = ids.stream()
             .map(messageIdStepdefs::getMessageId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         String serializedIds = requestedMessageIds.stream()
             .map(MessageId::serialize)
@@ -565,7 +564,7 @@ public class GetMessagesMethodStepdefs {
 
     @Then("^the notFound list should contain the requested message id$")
     public void assertNotFoundListContainsRequestedMessages() {
-        ImmutableList<String> elements = requestedMessageIds.stream().map(MessageId::serialize).collect(Guavate.toImmutableList());
+        ImmutableList<String> elements = requestedMessageIds.stream().map(MessageId::serialize).collect(ImmutableList.toImmutableList());
         assertThat(httpClient.jsonPath.<List<String>>read(ARGUMENTS + ".notFound"))
             .containsExactlyElementsOf(elements);
     }
@@ -601,7 +600,7 @@ public class GetMessagesMethodStepdefs {
                     .getMailboxId(userMailbox.getKey(), userMailbox.getValue())
                     .serialize()))
             .distinct()
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         assertThat(httpClient.jsonPath.<JSONArray>read(FIRST_MESSAGE + ".mailboxIds"))
             .containsExactlyInAnyOrder(mailboxIds.toArray());

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/MainStepdefs.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/MainStepdefs.java
@@ -34,7 +34,6 @@ import org.apache.james.modules.MailboxProbeImpl;
 import org.apache.james.probe.DataProbe;
 import org.apache.james.utils.DataProbeImpl;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
@@ -79,7 +78,7 @@ public class MainStepdefs {
     public ImmutableList<String> getMailboxIdsList(String username, Stream<String> mailboxes) {
         return mailboxes.map(mailbox -> getMailboxId(username, mailbox)
                 .serialize())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public ImmutableList<String> getMailboxIdsList(String username, Collection<String> mailboxes) {

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/StringListToFlags.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/StringListToFlags.java
@@ -26,14 +26,13 @@ import javax.mail.Flags;
 import org.apache.james.jmap.draft.model.Keyword;
 import org.apache.james.mailbox.FlagsBuilder;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class StringListToFlags {
     public static Flags fromFlagList(List<String> flagList) {
         ImmutableList<Flags> flags = flagList.stream()
             .map(StringListToFlags::toFlags)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         return new FlagsBuilder().add(flags)
             .build();
     }

--- a/server/protocols/jmap-draft/pom.xml
+++ b/server/protocols/jmap-draft/pom.xml
@@ -183,10 +183,6 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <scope>test</scope>

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/json/ObjectMapperFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/json/ObjectMapperFactory.java
@@ -51,7 +51,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -115,7 +114,7 @@ public class ObjectMapperFactory {
     public static class MDNActionModeDeserializer extends JsonDeserializer<DispositionActionMode> {
         private static final ImmutableList<String> ALLOWED_VALUES = Arrays.stream(DispositionActionMode.values())
             .map(DispositionActionMode::getValue)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         @Override
         public DispositionActionMode deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
@@ -129,7 +128,7 @@ public class ObjectMapperFactory {
     public static class MDNSendingModeDeserializer extends JsonDeserializer<DispositionSendingMode> {
         private static final ImmutableList<String> ALLOWED_VALUES = Arrays.stream(DispositionSendingMode.values())
             .map(DispositionSendingMode::getValue)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         @Override
         public DispositionSendingMode deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
@@ -158,7 +157,7 @@ public class ObjectMapperFactory {
     public static class MDNTypeDeserializer extends JsonDeserializer<DispositionType> {
         private static final ImmutableList<String> ALLOWED_VALUES = Arrays.stream(DispositionType.values())
             .map(DispositionType::getValue)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         @Override
         public DispositionType deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/AttachmentChecker.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/AttachmentChecker.java
@@ -33,7 +33,7 @@ import org.apache.james.mailbox.model.AttachmentId;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.predicates.ThrowingPredicate;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -67,7 +67,7 @@ public class AttachmentChecker {
         return attachments.stream()
             .filter(Throwing.predicate(notExists).sneakyThrow())
             .map(Attachment::getBlobId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private AttachmentId getAttachmentId(Attachment attachment) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessageListMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessageListMethod.java
@@ -57,10 +57,10 @@ import org.apache.james.util.MDCBuilder;
 import org.apache.james.util.streams.Limit;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -238,7 +238,7 @@ public class GetMessageListMethod implements Method {
         SearchQuery.Builder searchQueryBuilder = SearchQuery.builder();
 
         messageListRequest.getFilter()
-            .map(filter -> new FilterToCriteria().convert(filter).collect(Guavate.toImmutableList()))
+            .map(filter -> new FilterToCriteria().convert(filter).collect(ImmutableList.toImmutableList()))
             .ifPresent(searchQueryBuilder::andCriteria);
         Set<MailboxId> inMailboxes = buildFilterMailboxesSet(messageListRequest.getFilter(), FilterCondition::getInMailboxes);
         Set<MailboxId> notInMailboxes = buildFilterMailboxesSet(messageListRequest.getFilter(), FilterCondition::getNotInMailboxes);
@@ -273,14 +273,14 @@ public class GetMessageListMethod implements Method {
 
     private Set<MailboxId> buildFilterMailboxesSet(Optional<Filter> maybeFilter, Function<FilterCondition, Optional<List<String>>> mailboxListExtractor) {
         return filterToFilterCondition(maybeFilter)
-            .flatMap(condition -> Guavate.stream(mailboxListExtractor.apply(condition)))
+            .flatMap(condition -> mailboxListExtractor.apply(condition).stream())
             .flatMap(List::stream)
             .map(mailboxIdFactory::fromString)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
     
     private Stream<FilterCondition> filterToFilterCondition(Optional<Filter> maybeCondition) {
-        return Guavate.stream(maybeCondition)
+        return maybeCondition.stream()
             .flatMap(c -> {
                 if (c instanceof FilterCondition) {
                     return Stream.of((FilterCondition)c);

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
@@ -46,7 +46,6 @@ import org.apache.james.util.MDCBuilder;
 
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -128,7 +127,7 @@ public class GetMessagesMethod implements Method {
         MessageProperties.ReadProfile readProfile = getMessagesRequest.getProperties().computeReadLevel();
         MessageViewFactory<? extends MessageView> factory = messageViewFactory.getFactory(readProfile);
         Mono<? extends Set<? extends MessageView>> messageViewsMono = factory.fromMessageIds(getMessagesRequest.getIds(), mailboxSession)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
 
         return messageViewsMono.map(messageViews ->
             GetMessagesResponse.builder()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponseWriterImpl.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/JmapResponseWriterImpl.java
@@ -37,9 +37,9 @@ import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 
@@ -137,6 +137,6 @@ public class JmapResponseWriterImpl implements JmapResponseWriter {
     private Set<String> toFieldNames(Set<? extends Property> properties) {
         return properties.stream()
             .map(Property::asFieldName)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
@@ -68,7 +68,6 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -105,7 +104,7 @@ public class MIMEMessageConverter {
             FieldName.CONTENT_TRANSFER_ENCODING);
     private static final List<String> LOWERCASED_COMPUTED_HEADERS = COMPUTED_HEADERS.stream()
             .map(s -> s.toLowerCase(Locale.ENGLISH))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
     private final BasicBodyFactory bodyFactory;
     private final AttachmentContentLoader attachmentContentLoader;
@@ -232,10 +231,10 @@ public class MIMEMessageConverter {
         MultipartBuilder mixedMultipartBuilder = MultipartBuilder.create(MIXED_SUB_TYPE);
         List<MessageAttachmentMetadata> inlineAttachments = messageAttachments.stream()
             .filter(MessageAttachmentMetadata::isInline)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         List<MessageAttachmentMetadata> besideAttachments = messageAttachments.stream()
             .filter(Predicate.not(MessageAttachmentMetadata::isInline))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         if (inlineAttachments.size() > 0) {
             mixedMultipartBuilder.addBodyPart(relatedInnerMessage(newMessage, inlineAttachments, session));
@@ -350,7 +349,7 @@ public class MIMEMessageConverter {
             .entrySet()
             .stream()
             .filter(entry -> !entry.getKey().equals("name"))
-            .collect(Guavate.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private String encode(String name) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MessageAppender.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MessageAppender.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import javax.inject.Inject;
 import javax.mail.Flags;
@@ -56,9 +57,9 @@ import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.functions.ThrowingFunction;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -177,9 +178,9 @@ public class MessageAppender {
     private ImmutableList<MessageAttachmentMetadata> getMessageAttachments(MailboxSession session, ImmutableList<Attachment> attachments) throws MailboxException {
         Map<AttachmentId, AttachmentMetadata> attachmentsById = attachmentManager.getAttachments(attachments.stream()
             .map(attachment -> AttachmentId.from(attachment.getBlobId().getRawValue()))
-            .collect(Guavate.toImmutableList()), session)
+            .collect(ImmutableList.toImmutableList()), session)
             .stream()
-            .collect(Guavate.toImmutableMap(AttachmentMetadata::getAttachmentId));
+            .collect(ImmutableMap.toImmutableMap(AttachmentMetadata::getAttachmentId, Function.identity()));
 
         ThrowingFunction<Attachment, Optional<MessageAttachmentMetadata>> toMessageAttachment = att -> messageAttachment(att, attachmentsById);
 
@@ -187,7 +188,7 @@ public class MessageAppender {
         return attachments.stream()
             .map(Throwing.function(toMessageAttachment).sneakyThrow())
             .flatMap(Optional::stream)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Optional<MessageAttachmentMetadata> messageAttachment(Attachment attachment, Map<AttachmentId, AttachmentMetadata> attachmentsById) throws MailboxException {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/ReferenceUpdater.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/ReferenceUpdater.java
@@ -42,7 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 import reactor.core.publisher.Flux;
@@ -65,7 +66,7 @@ public class ReferenceUpdater {
 
     public Mono<Void> updateReferences(Headers headers, MailboxSession session) throws MailboxException {
         Map<String, String> headersAsMap = Iterators.toStream(headers.headers())
-            .collect(Guavate.toImmutableMap(Header::getName, Header::getValue));
+            .collect(ImmutableMap.toImmutableMap(Header::getName, Header::getValue));
         return updateReferences(headersAsMap, session);
     }
 
@@ -96,7 +97,7 @@ public class ReferenceUpdater {
                 MessageId reference = Iterables.getOnlyElement(references);
                 return Flux.from(messageIdManager.messageMetadata(reference, session))
                     .map(metaData -> metaData.getComposedMessageId().getMailboxId())
-                    .collect(Guavate.toImmutableList())
+                    .collect(ImmutableList.toImmutableList())
                     .flatMap(mailboxIds -> Mono.from(messageIdManager.setFlagsReactive(flag, FlagsUpdateMode.ADD, reference, mailboxIds, session)));
             })
             .onErrorResume(NoSuchElementException.class, e -> {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
@@ -45,7 +45,6 @@ import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -151,7 +150,7 @@ public class SetFilterMethod implements Method {
     private Mono<JmapResponse> updateFilter(MethodCallId methodCallId, SetFilterRequest request, Username username) throws DuplicatedRuleException, MultipleMailboxIdException {
         ImmutableList<Rule> rules = request.getSingleton().stream()
             .map(JmapRuleDTO::toRule)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         ensureNoDuplicatedRules(rules);
         ensureNoMultipleMailboxesRules(rules);
@@ -168,7 +167,7 @@ public class SetFilterMethod implements Method {
         ImmutableList<Rule.Id> idWithMultipleMailboxes = rules.stream()
             .filter(rule -> rule.getAction().getAppendInMailboxes().getMailboxIds().size() > 1)
             .map(Rule::getId)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         if (!idWithMultipleMailboxes.isEmpty()) {
             throw new MultipleMailboxIdException(idWithMultipleMailboxes);

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
@@ -66,7 +66,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -216,7 +215,7 @@ public class SetMessagesCreationProcessor implements SetMessagesProcessor {
             .stream()
             .distinct()
             .map(mailboxIdFactory::fromString)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private Mono<Builder> performCreate(CreationMessageEntry entry, MailboxSession session) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesDestructionProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesDestructionProcessor.java
@@ -36,9 +36,9 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import reactor.core.publisher.Mono;
 
@@ -77,7 +77,7 @@ public class SetMessagesDestructionProcessor implements SetMessagesProcessor {
                             .type(SetError.Type.NOT_FOUND)
                             .description("The message " + messageId.serialize() + " can't be found")
                             .build()))
-                    .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)))
+                    .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)))
                 .build())
             .onErrorResume(e -> {
                 LOGGER.error("An error occurred when deleting a message", e);
@@ -89,7 +89,7 @@ public class SetMessagesDestructionProcessor implements SetMessagesProcessor {
                                     .type(SetError.Type.ERROR)
                                     .description("An error occurred while deleting messages " + messageId.serialize())
                                     .build()))
-                            .collect(Guavate.toImmutableMap(Pair::getKey, Pair::getValue)))
+                            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)))
                         .build());
             });
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/AttachmentAccessToken.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/AttachmentAccessToken.java
@@ -24,13 +24,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 public class AttachmentAccessToken implements SignedExpiringToken {
@@ -49,7 +49,7 @@ public class AttachmentAccessToken implements SignedExpiringToken {
         String username = Joiner.on(SEPARATOR)
             .join(split.stream()
                 .limit(split.size() - 2)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
 
         String defaultValue = null;
         return builder()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/Emailer.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/Emailer.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -54,7 +53,7 @@ public class Emailer {
             .map(addresses -> addresses.flatten()
                 .stream()
                 .map(Emailer::fromMailbox)
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .orElse(ImmutableList.of());
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/EnvelopeUtils.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/EnvelopeUtils.java
@@ -28,7 +28,7 @@ import org.apache.james.jmap.draft.model.message.view.MessageFullView;
 import org.apache.james.server.core.Envelope;
 import org.apache.james.util.StreamUtils;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 
 public class EnvelopeUtils {
     public static Envelope fromMessage(MessageFullView jmapMessage) {
@@ -42,7 +42,7 @@ public class EnvelopeUtils {
 
         return new Envelope(sender,
             StreamUtils.flatten(Stream.of(to, cc, bcc))
-                .collect(Guavate.toImmutableSet()));
+                .collect(ImmutableSet.toImmutableSet()));
     }
 
     private static Stream<MailAddress> emailersToMailAddresses(List<Emailer> emailers) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/Filter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/Filter.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 import org.apache.james.jmap.draft.json.FilterDeserializer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 @JsonDeserialize(using = FilterDeserializer.class)
 public interface Filter {
@@ -49,7 +49,7 @@ public interface Filter {
 
     default List<FilterCondition> breadthFirstVisit() {
         return this.breadthFirstVisit(0)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     default Stream<FilterCondition> breadthFirstVisit(int depth) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/GetMailboxesRequest.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/GetMailboxesRequest.java
@@ -27,7 +27,6 @@ import org.apache.james.mailbox.model.MailboxId;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -70,7 +69,7 @@ public class GetMailboxesRequest implements JmapRequest {
                 properties.stream()
                     .map(MailboxProperty::findProperty)
                     .flatMap(Optional::stream)
-                    .collect(Guavate.toImmutableSet()));
+                    .collect(ImmutableSet.toImmutableSet()));
             return this;
         }
         

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/Keywords.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/Keywords.java
@@ -33,7 +33,6 @@ import org.apache.james.mailbox.FlagsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -116,7 +115,7 @@ public class Keywords {
             return new Keywords(keywordStream
                     .peek(validator::validate)
                     .filter(filter)
-                    .collect(Guavate.toImmutableSet()));
+                    .collect(ImmutableSet.toImmutableSet()));
         }
 
         public Keywords from(Keyword... keywords) {
@@ -190,7 +189,7 @@ public class Keywords {
 
     public ImmutableMap<String, Boolean> asMap() {
         return keywords.stream()
-            .collect(Guavate.toImmutableMap(Keyword::getFlagName, keyword -> Keyword.FLAG_VALUE));
+            .collect(ImmutableMap.toImmutableMap(Keyword::getFlagName, keyword -> Keyword.FLAG_VALUE));
     }
 
     public ImmutableSet<Keyword> getKeywords() {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -52,11 +51,11 @@ public class MessageProperties {
     }
 
     private ImmutableSet<MessageProperty> toMessageProperties(ImmutableSet<String> properties) {
-        return properties.stream().flatMap(MessageProperty::find).collect(Guavate.toImmutableSet());
+        return properties.stream().flatMap(MessageProperty::find).collect(ImmutableSet.toImmutableSet());
     }
     
     private ImmutableSet<HeaderProperty> toHeadersProperties(ImmutableSet<String> properties) {
-        return properties.stream().flatMap(HeaderProperty::find).collect(Guavate.toImmutableSet());
+        return properties.stream().flatMap(HeaderProperty::find).collect(ImmutableSet.toImmutableSet());
     }
 
     public Optional<ImmutableSet<HeaderProperty>> getOptionalHeadersProperties() {
@@ -204,7 +203,7 @@ public class MessageProperties {
         }
 
         private static final ImmutableMap<String, MessageProperty> LOOKUP_MAP = Arrays.stream(values())
-            .collect(Guavate.toImmutableMap(v -> v.property, Function.identity()));
+            .collect(ImmutableMap.toImmutableMap(v -> v.property, Function.identity()));
     
         public static Stream<MessageProperty> find(String property) {
             Preconditions.checkNotNull(property);
@@ -212,7 +211,7 @@ public class MessageProperties {
         }
 
         public static ImmutableSet<MessageProperty> allOutputProperties() {
-            return Arrays.stream(values()).filter(MessageProperty::outputProperty).collect(Guavate.toImmutableSet());
+            return Arrays.stream(values()).filter(MessageProperty::outputProperty).collect(ImmutableSet.toImmutableSet());
         }
 
         private static boolean outputProperty(MessageProperty p) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/OldKeyword.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/OldKeyword.java
@@ -25,9 +25,9 @@ import java.util.stream.Stream;
 
 import javax.mail.Flags;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
 
 public class OldKeyword {
 
@@ -180,7 +180,7 @@ public class OldKeyword {
                     isFlagged.filter(b -> b).map(b -> Keyword.FLAGGED),
                     isUnread.filter(b -> !b).map(b -> Keyword.SEEN))
                 .flatMap(Optional::stream)
-                .collect(Guavate.toImmutableSet()));
+                .collect(ImmutableSet.toImmutableSet()));
     }
 
     @Override

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/SetMessagesRequest.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/SetMessagesRequest.java
@@ -35,7 +35,6 @@ import org.apache.james.mailbox.model.MessageId;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -119,13 +118,13 @@ public class SetMessagesRequest implements JmapRequest {
         private ImmutableList<CreationMessageEntry> messageCreations() {
             return create.entrySet().stream()
                     .map(entry -> new CreationMessageEntry(entry.getKey(), entry.getValue()))
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
         }
 
         private ImmutableList<MDNCreationEntry> mdnSendings() {
             return sendMDN.entrySet().stream()
                     .map(entry -> new MDNCreationEntry(entry.getKey(), entry.getValue()))
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
         }
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/mailbox/Rights.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/mailbox/Rights.java
@@ -42,9 +42,10 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 
@@ -144,7 +145,7 @@ public class Rights {
         return rights.list()
             .stream()
             .flatMap(right -> Right.forRight(right).stream())
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static boolean isSupported(EntryKey key) {
@@ -191,7 +192,7 @@ public class Rights {
                 .flatMap(entry -> entry.getValue()
                     .stream()
                     .map(v -> Pair.of(entry.getKey(), v)))
-                .collect(Guavate.toImmutableListMultimap(Pair::getKey, Pair::getValue)));
+                .collect(ImmutableListMultimap.toImmutableListMultimap(Pair::getKey, Pair::getValue)));
     }
 
     public MailboxACL toMailboxAcl() {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactory.java
@@ -58,9 +58,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import reactor.core.publisher.Flux;
@@ -210,7 +210,7 @@ public class MessageFullViewFactory implements MessageViewFactory<MessageFullVie
     private List<Attachment> getAttachments(List<MessageAttachmentMetadata> attachments) {
         return attachments.stream()
                 .map(this::fromMailboxAttachment)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
     }
 
     private Attachment fromMailboxAttachment(MessageAttachmentMetadata attachment) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageViewFactory.java
@@ -51,9 +51,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -92,7 +92,7 @@ public interface MessageViewFactory<T extends MessageView> {
         static Set<MailboxId> getMailboxIds(Collection<MessageResult> messageResults) {
             return messageResults.stream()
                 .map(MessageResult::getMailboxId)
-                .collect(Guavate.toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
         }
 
         static Keywords getKeywords(Collection<MessageResult> messageResults) {
@@ -116,7 +116,7 @@ public interface MessageViewFactory<T extends MessageView> {
             return header.getFieldsAsMap()
                 .entrySet()
                 .stream()
-                .collect(Guavate.toImmutableMap(entry -> entry.getValue().get(0).getName(),
+                .collect(ImmutableMap.toImmutableMap(entry -> entry.getValue().get(0).getName(),
                     entry -> entry.getValue().stream()
                         .map(Field::getBody)
                         .map(body -> DecoderUtil.decodeEncodedWords(body, DecodeMonitor.SILENT))

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/FilterToCriteria.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/FilterToCriteria.java
@@ -34,7 +34,6 @@ import org.apache.james.mailbox.model.SearchQuery.AddressType;
 import org.apache.james.mailbox.model.SearchQuery.Criterion;
 import org.apache.james.mailbox.model.SearchQuery.DateResolution;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class FilterToCriteria {
@@ -119,6 +118,6 @@ public class FilterToCriteria {
     private ImmutableList<Criterion> convertCriterias(FilterOperator filter) {
         return filter.getConditions().stream()
             .flatMap(this::convert)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/KeywordsCombiner.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/KeywordsCombiner.java
@@ -26,8 +26,8 @@ import java.util.function.BinaryOperator;
 import org.apache.james.jmap.draft.model.Keyword;
 import org.apache.james.jmap.draft.model.Keywords;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 public class KeywordsCombiner implements BinaryOperator<Keywords> {
@@ -52,13 +52,13 @@ public class KeywordsCombiner implements BinaryOperator<Keywords> {
         return Sets.union(set1, set2)
             .stream()
             .filter(keyword -> !exceptKeywords.contains(keyword))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     public Set<Keyword> intersect(Set<Keyword> set1, Set<Keyword> set2, List<Keyword> forKeywords) {
         return Sets.intersection(set1, set2)
             .stream()
             .filter(forKeywords::contains)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/SortConverter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/SortConverter.java
@@ -27,9 +27,9 @@ import org.apache.james.mailbox.model.SearchQuery.Sort;
 import org.apache.james.mailbox.model.SearchQuery.Sort.Order;
 import org.apache.james.mailbox.model.SearchQuery.Sort.SortClause;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 public class SortConverter {
@@ -53,7 +53,7 @@ public class SortConverter {
         Preconditions.checkNotNull(jmapSorts);
         return jmapSorts.stream()
             .map(SortConverter::toSort)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static Sort toSort(String jmapSort) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/TextCalendarBodyToAttachment.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/TextCalendarBodyToAttachment.java
@@ -33,8 +33,8 @@ import javax.mail.internet.MimeMultipart;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 /**
  * This mailet converts Content-Type of MimeMessage from text/calendar to mulitpart/mixed
@@ -86,7 +86,7 @@ public class TextCalendarBodyToAttachment extends GenericMailet {
         return Collections.list(mimeMessage.getAllHeaders())
             .stream()
             .filter(header -> header.getName().startsWith(CONTENT_HEADER_PREFIX))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private MimeBodyPart createMimeBodyPartWithContentHeadersFromMimeMessage(MimeMessage mimeMessage, List<Header> contentHeaders) throws MessagingException {

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMessagesMethodTest.java
@@ -83,7 +83,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -628,7 +627,7 @@ public class GetMessagesMethodTest {
             .properties(ImmutableList.of("mailboxIds"))
             .build();
 
-        List<JmapResponse> responses = testee.processToStream(request, methodCallId, session).collect(Guavate.toImmutableList());
+        List<JmapResponse> responses = testee.processToStream(request, methodCallId, session).collect(ImmutableList.toImmutableList());
 
         assertThat(responses).hasSize(1);
         Method.Response response = responses.get(0).getResponse();

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/DefaultMailboxesProvisionerTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/DefaultMailboxesProvisionerTest.java
@@ -37,7 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class DefaultMailboxesProvisionerTest {
 
@@ -64,7 +64,7 @@ public class DefaultMailboxesProvisionerTest {
             .containsOnlyElementsOf(DefaultMailboxes.DEFAULT_MAILBOXES
                 .stream()
                 .map(mailboxName -> MailboxPath.forUser(USERNAME, mailboxName))
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     @Test
@@ -98,7 +98,7 @@ public class DefaultMailboxesProvisionerTest {
             .containsOnlyElementsOf(DefaultMailboxes.DEFAULT_MAILBOXES
                 .stream()
                 .map(mailboxName -> MailboxPath.forUser(USERNAME, mailboxName))
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Identity.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Identity.scala
@@ -21,7 +21,7 @@ package org.apache.james.jmap.mail
 
 import java.nio.charset.StandardCharsets
 
-import com.github.steveash.guavate.Guavate
+import com.google.common.collect.ImmutableList
 import com.google.common.hash.Hashing
 import eu.timepit.refined.auto._
 import eu.timepit.refined.refineV
@@ -85,7 +85,7 @@ case class IdentityGetResponse(accountId: AccountId,
 class IdentityFactory @Inject()(canSendFrom: CanSendFrom) {
   def listIdentities(session: MailboxSession): List[Identity] =
     canSendFrom.allValidFromAddressesForUser(session.getUser)
-      .collect(Guavate.toImmutableList()).asScala.toList
+      .collect(ImmutableList.toImmutableList()).asScala.toList
       .flatMap(address =>
         from(address).map(id =>
           Identity(

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/http/MailboxesProvisionerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/http/MailboxesProvisionerTest.scala
@@ -23,7 +23,7 @@ import java.time.Duration
 import java.util.function.Predicate
 
 import com.github.fge.lambdas.Throwing
-import com.github.steveash.guavate.Guavate
+import com.google.common.collect.ImmutableList
 import org.apache.james.core.Username
 import org.apache.james.mailbox.inmemory.InMemoryMailboxManager
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources
@@ -63,7 +63,7 @@ class MailboxesProvisionerTest {
       .containsOnlyElementsOf(DefaultMailboxes.DEFAULT_MAILBOXES
         .stream
         .map((mailboxName: String) => MailboxPath.forUser(USERNAME, mailboxName))
-        .collect(Guavate.toImmutableList()))
+        .collect(ImmutableList.toImmutableList()))
   }
 
   @Test
@@ -98,6 +98,6 @@ class MailboxesProvisionerTest {
       .containsOnlyElementsOf(DefaultMailboxes.DEFAULT_MAILBOXES
         .stream
         .map((mailboxName: String) => MailboxPath.forUser(USERNAME, mailboxName))
-        .collect(Guavate.toImmutableList()))
+        .collect(ImmutableList.toImmutableList()))
   }
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServer.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServer.java
@@ -33,7 +33,7 @@ import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.util.Port;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 import reactor.netty.DisposableServer;
@@ -59,7 +59,7 @@ public class JMAPServer implements Startable {
             .flatMap(version -> jmapRoutesHandlers.stream()
                 .flatMap(handler -> handler.routes(version)
                     .map(route -> Pair.of(version, route))))
-            .collect(Guavate.toImmutableListMultimap(
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
                 Pair::getKey,
                 Pair::getValue));
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/VersionParser.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/VersionParser.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -33,9 +34,9 @@ import javax.inject.Inject;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicHeaderValueParser;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import reactor.netty.http.server.HttpServerRequest;
@@ -53,7 +54,7 @@ public class VersionParser {
                 "%s is not a supported JMAP version", jmapConfiguration);
 
         this.supportedVersions = supportedVersions.stream()
-            .collect(Guavate.toImmutableMap(version -> version.asString().toLowerCase(Locale.US)));
+            .collect(ImmutableMap.toImmutableMap(version -> version.asString().toLowerCase(Locale.US), Function.identity()));
     }
 
     public Set<Version> getSupportedVersions() {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/Authenticator.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/Authenticator.java
@@ -25,7 +25,6 @@ import org.apache.james.jmap.exceptions.NoAuthorizationSuppliedException;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.metrics.api.MetricFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -63,6 +62,6 @@ public class Authenticator {
         return new NoAuthorizationSuppliedException(AuthenticateHeader.of(
             authMethods.stream()
                 .map(AuthenticationStrategy::correspondingChallenge)
-                .collect(Guavate.toImmutableList())));
+                .collect(ImmutableList.toImmutableList())));
     }
 }

--- a/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/MailetContainerHandler.java
+++ b/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/MailetContainerHandler.java
@@ -39,7 +39,6 @@ import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.smtpserver.DataLineJamesMessageHookHandler;
 import org.apache.mailet.Mail;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class MailetContainerHandler extends DataLineJamesMessageHookHandler {
@@ -121,13 +120,13 @@ public class MailetContainerHandler extends DataLineJamesMessageHookHandler {
                         .smtpReturnCode(SMTPRetCode.MAIL_OK)
                         .smtpDescription(DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received <" + recipient.asString() + ">")
                         .build()))
-                    .collect(Guavate.toImmutableList()));
+                    .collect(ImmutableList.toImmutableList()));
 
         } catch (Exception e) {
             return LMTPMultiResponse.of(
                 recipients.stream()
                     .map(recipient -> new SMTPResponse(SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.UNDEFINED_STATUS) + " Temporary error deliver message <" + recipient.asString() + ">"))
-                    .collect(Guavate.toImmutableList()));
+                    .collect(ImmutableList.toImmutableList()));
         }
     }
 
@@ -135,7 +134,7 @@ public class MailetContainerHandler extends DataLineJamesMessageHookHandler {
         return LMTPMultiResponse.of(
             recipients.stream()
                 .map(recipient -> executeFor(mail, recipient))
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private SMTPResponse executeFor(Mail mail, MailAddress recipient) {

--- a/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
+++ b/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
@@ -37,7 +37,6 @@ import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.protocols.pop3.mailbox.Mailbox;
 import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class MailboxAdapter implements Mailbox {
@@ -95,7 +94,7 @@ public class MailboxAdapter implements Mailbox {
     public void remove(String... uids) throws IOException {
         List<MessageUid> uidList = Arrays.stream(uids)
             .map(uid -> MessageUid.of(Long.parseLong(uid)))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         try {
             mailboxManager.startProcessingRequest(session);

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
@@ -43,7 +43,7 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 /**
  * This class can be used to reject email with bogus MX which is send from a
@@ -119,7 +119,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
 
             Collection<String> bannedNetworks = Arrays.stream(networks)
                 .map(String::trim)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
             setBannedNetworks(bannedNetworks, dnsService);
 

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
@@ -48,7 +48,7 @@ import org.apache.james.webadmin.utils.JsonExtractException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import spark.Service;
 
@@ -83,14 +83,14 @@ public class WebAdminServer implements Startable {
     private static List<Routes> privateRoutes(List<Routes> routes) {
         return routes.stream()
             .filter(route -> !(route instanceof PublicRoutes))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static List<PublicRoutes> publicRoutes(List<Routes>  routes) {
         return routes.stream()
             .filter(PublicRoutes.class::isInstance)
             .map(PublicRoutes.class::cast)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public WebAdminServer start() {

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/ExecutionDetailsDto.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/ExecutionDetailsDto.java
@@ -31,14 +31,14 @@ import org.apache.james.task.TaskExecutionDetails;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class ExecutionDetailsDto {
     public static List<ExecutionDetailsDto> from(DTOConverter<TaskExecutionDetails.AdditionalInformation, AdditionalInformationDTO> additionalInformationConverter,
                                                  List<TaskExecutionDetails> tasksDetails) {
         return tasksDetails.stream()
             .map(details -> ExecutionDetailsDto.from(additionalInformationConverter, details))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public static ExecutionDetailsDto from(DTOConverter<TaskExecutionDetails.AdditionalInformation, AdditionalInformationDTO> additionalInformationConverter,

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/HealthCheckRoutes.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/HealthCheckRoutes.java
@@ -42,7 +42,6 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 import io.swagger.annotations.Api;
@@ -138,7 +137,7 @@ public class HealthCheckRoutes implements PublicRoutes {
     public Object getHealthChecks(Request request, Response response) {
         return healthChecks.stream()
                 .map(healthCheck -> new HealthCheckDto(healthCheck.componentName()))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
     }
     
     private int getCorrespondingStatusCode(ResultStatus resultStatus) {

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/tasks/TaskFromRequestRegistry.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/tasks/TaskFromRequestRegistry.java
@@ -29,7 +29,6 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskManager;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -61,7 +60,7 @@ public class TaskFromRequestRegistry implements TaskFromRequest {
 
         public Builder registrations(Collection<TaskRegistration> taskRegistrations) {
             this.tasks.putAll(taskRegistrations.stream()
-                .collect(Guavate.toImmutableMap(
+                .collect(ImmutableMap.toImmutableMap(
                     TaskRegistration::registrationKey,
                     Function.identity())));
             return this;
@@ -161,7 +160,7 @@ public class TaskFromRequestRegistry implements TaskFromRequest {
         ImmutableList<String> supportedTasks = taskGenerators.keySet()
             .stream()
             .map(TaskRegistrationKey::asString)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         return "Supported values are [" + Joiner.on(", ").join(supportedTasks) + "]";
     }
 }

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/dto/DLPConfigurationDTO.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/dto/DLPConfigurationDTO.java
@@ -26,7 +26,6 @@ import org.apache.james.util.streams.Iterables;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
@@ -38,7 +37,7 @@ public class DLPConfigurationDTO {
         return new DLPConfigurationDTO(
             Iterables.toStream(dlpConfigurations)
                 .map(DLPConfigurationItemDTO::toDTO)
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private final ImmutableList<DLPConfigurationItemDTO> rules;
@@ -57,6 +56,6 @@ public class DLPConfigurationDTO {
     public DLPRules toDLPConfiguration() throws DuplicateRulesIdsException {
         return new DLPRules(rules.stream()
             .map(DLPConfigurationItemDTO::toDLPConfiguration)
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 }

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/AliasRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/AliasRoutes.java
@@ -54,9 +54,9 @@ import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -124,7 +124,7 @@ public class AliasRoutes implements Routes {
         return recipientRewriteTable.getMappingsForType(Mapping.Type.Alias)
             .flatMap(mapping -> mapping.asMailAddress().stream())
             .map(MailAddress::asString)
-            .collect(Guavate.toImmutableSortedSet());
+            .collect(ImmutableSortedSet.toImmutableSortedSet(String::compareTo));
     }
 
     @PUT
@@ -245,6 +245,6 @@ public class AliasRoutes implements Routes {
         return recipientRewriteTable.listSources(Mapping.alias(destinationAddress.asString()))
             .sorted(Comparator.comparing(MappingSource::asMailAddressString))
             .map(AliasSourcesResponse::new)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainMappingsRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainMappingsRoutes.java
@@ -46,8 +46,9 @@ import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -157,7 +158,7 @@ public class DomainMappingsRoutes implements Routes {
             .entrySet()
             .stream()
             .filter(mappingsEntry -> mappingsEntry.getValue().contains(Mapping.Type.Domain))
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 mappingsEntry -> mappingsEntry.getKey().getFixedDomain(),
                 mappingsEntry -> toDomainList(mappingsEntry.getValue())
             ));
@@ -213,6 +214,6 @@ public class DomainMappingsRoutes implements Routes {
             .asStream()
             .map(Mapping::asString)
             .map(Mapping.Type.Domain::withoutPrefix)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/ForwardRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/ForwardRoutes.java
@@ -51,8 +51,8 @@ import org.apache.james.webadmin.utils.ErrorResponder.ErrorType;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import io.swagger.annotations.Api;
@@ -127,7 +127,7 @@ public class ForwardRoutes implements Routes {
             message = "Internal server error - Something went bad on the server side.")
     })
     public List<MappingSource> listForwards(Request request, Response response) throws RecipientRewriteTableException {
-        return recipientRewriteTable.getSourcesForType(Mapping.Type.Forward).collect(Guavate.toImmutableList());
+        return recipientRewriteTable.getSourcesForType(Mapping.Type.Forward).collect(ImmutableList.toImmutableList());
     }
 
     @PUT
@@ -238,7 +238,7 @@ public class ForwardRoutes implements Routes {
                 .map(MailAddress::asString)
                 .sorted()
                 .map(ForwardDestinationResponse::new)
-                .collect(Guavate.toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     private void ensureNonEmptyMappings(Mappings mappings) {

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/GroupsRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/GroupsRoutes.java
@@ -52,8 +52,8 @@ import org.apache.james.webadmin.utils.ErrorResponder.ErrorType;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 
 import io.swagger.annotations.Api;
@@ -120,7 +120,7 @@ public class GroupsRoutes implements Routes {
             message = "Internal server error - Something went bad on the server side.")
     })
     public List<MappingSource> listGroups(Request request, Response response) throws RecipientRewriteTableException {
-        return recipientRewriteTable.getSourcesForType(Mapping.Type.Group).collect(Guavate.toImmutableList());
+        return recipientRewriteTable.getSourcesForType(Mapping.Type.Group).collect(ImmutableList.toImmutableList());
     }
 
     @PUT
@@ -239,7 +239,7 @@ public class GroupsRoutes implements Routes {
                 .map(Mapping::asMailAddress)
                 .flatMap(Optional::stream)
                 .map(MailAddress::asString)
-                .collect(Guavate.toImmutableSortedSet());
+                .collect(ImmutableSortedSet.toImmutableSortedSet(String::compareTo));
     }
 
     private void ensureNonEmptyMappings(Mappings mappings) {

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/MappingRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/MappingRoutes.java
@@ -38,7 +38,7 @@ import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 
 import io.swagger.annotations.Api;
@@ -93,7 +93,7 @@ public class MappingRoutes implements Routes {
                     .map(mapping -> Pair.of(
                         entry.getKey().asString(),
                         MappingValueDTO.fromMapping(mapping))))
-                .collect(Guavate.toImmutableListMultimap(Pair::getLeft, Pair::getRight));
+                .collect(ImmutableListMultimap.toImmutableListMultimap(Pair::getLeft, Pair::getRight));
         } catch (RecipientRewriteTableException e) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
@@ -116,7 +116,7 @@ public class MappingRoutes implements Routes {
         return recipientRewriteTable.getStoredMappings(MappingSource.fromUser(username))
             .asStream()
             .map(mapping -> MappingValueDTO.fromMapping(mapping))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }
 

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/UserRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/UserRoutes.java
@@ -55,7 +55,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -282,7 +282,7 @@ public class UserRoutes implements Routes {
             return canSendFrom
                 .allValidFromAddressesForUser(username)
                 .map(MailAddress::asString)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
         } catch (RecipientRewriteTable.ErrorMappingException | RecipientRewriteTableException | UsersRepositoryException e) {
             String errorMessage = String.format("Error while listing allowed From headers for user '%s'", username);
             LOGGER.info(errorMessage, e);

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/DomainAliasService.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/DomainAliasService.java
@@ -32,7 +32,6 @@ import org.apache.james.rrt.lib.MappingSource;
 import org.apache.james.webadmin.dto.DomainAliasResponse;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableSet;
 
 public class DomainAliasService {
@@ -72,7 +71,7 @@ public class DomainAliasService {
     public ImmutableSet<DomainAliasResponse> listDomainAliases(Domain domain) throws RecipientRewriteTableException {
         return recipientRewriteTable.listSources(Mapping.domainAlias(domain))
             .map(DomainAliasResponse::new)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     public boolean hasAliases(Domain domain) throws DomainListException, RecipientRewriteTableException {

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/UserService.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/UserService.java
@@ -35,7 +35,7 @@ import org.apache.james.webadmin.dto.UserResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class UserService {
 
@@ -54,7 +54,7 @@ public class UserService {
             .orElse(Stream.of())
             .map(Username::asString)
             .map(UserResponse::new)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public void removeUser(Username username) throws UsersRepositoryException {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/SerializableReIndexingExecutionFailures.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/SerializableReIndexingExecutionFailures.java
@@ -20,6 +20,7 @@
 package org.apache.james.webadmin.dto;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.indexer.ReIndexingExecutionFailures;
@@ -27,7 +28,8 @@ import org.apache.james.mailbox.model.MailboxId;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 public class SerializableReIndexingExecutionFailures {
@@ -55,7 +57,7 @@ public class SerializableReIndexingExecutionFailures {
             reIndexingExecutionFailures.messageFailures()
                 .stream()
                 .map(failure -> new SerializableReIndexingExecutionFailures.SerializableReIndexingFailure(failure.getMailboxId(), failure.getUid()))
-                .collect(Guavate.toImmutableList()));
+                .collect(ImmutableList.toImmutableList()));
     }
 
     private final List<SerializableReIndexingFailure> failures;
@@ -67,6 +69,6 @@ public class SerializableReIndexingExecutionFailures {
     @JsonValue
     public Multimap<String, SerializableReIndexingFailure> failures() {
         return failures.stream()
-            .collect(Guavate.toImmutableListMultimap(SerializableReIndexingFailure::getSerializedMailboxId));
+            .collect(ImmutableListMultimap.toImmutableListMultimap(SerializableReIndexingFailure::getSerializedMailboxId, Function.identity()));
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/WebAdminReprocessingContextInformationDTO.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/WebAdminReprocessingContextInformationDTO.java
@@ -32,7 +32,7 @@ import org.apache.mailbox.tools.indexer.FullReindexingTask;
 import org.apache.mailbox.tools.indexer.ReprocessingContextInformationDTO;
 import org.apache.mailbox.tools.indexer.RunningOptionsDTO;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class WebAdminReprocessingContextInformationDTO implements AdditionalInformationDTO {
     public static class WebAdminErrorRecoveryIndexationDTO extends WebAdminReprocessingContextInformationDTO {
@@ -101,7 +101,7 @@ public class WebAdminReprocessingContextInformationDTO implements AdditionalInfo
         this.messageFailures = SerializableReIndexingExecutionFailures.from(failures);
         this.mailboxFailures = failures.mailboxFailures().stream()
             .map(MailboxId::serialize)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
         this.timestamp = timestamp;
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/CreateMissingParentsTask.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/CreateMissingParentsTask.java
@@ -45,7 +45,7 @@ import org.apache.james.task.TaskType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -144,7 +144,7 @@ public class CreateMissingParentsTask implements Task {
                 .stream()
                 .filter(path -> path.hasParent(delimiter))
                 .flatMap(path -> path.getParents(delimiter))
-                .collect(Guavate.toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
 
             return Flux.fromIterable(parentPaths)
                 .filter(Predicate.not(mailboxPaths::contains))
@@ -181,9 +181,9 @@ public class CreateMissingParentsTask implements Task {
     @Override
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.of(AdditionalInformation.from(
-            created.stream().map(MailboxId::serialize).collect(Guavate.toImmutableSet()),
+            created.stream().map(MailboxId::serialize).collect(ImmutableSet.toImmutableSet()),
             totalCreated.get(),
-            failures.stream().collect(Guavate.toImmutableSet()),
+            failures.stream().collect(ImmutableSet.toImmutableSet()),
             totalFailure.get()));
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersService.java
@@ -29,8 +29,8 @@ import org.apache.james.events.EventDeadLetters;
 import org.apache.james.events.Group;
 import org.apache.james.task.Task;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 
@@ -48,7 +48,7 @@ public class EventDeadLettersService {
     public List<String> listGroupsAsStrings() {
         return deadLetters.groupsWithFailedEvents()
             .map(Group::asString)
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
     }
 
@@ -56,7 +56,7 @@ public class EventDeadLettersService {
         return deadLetters.failedIds(group)
             .map(EventDeadLetters.InsertionId::getId)
             .map(UUID::toString)
-            .collect(Guavate.toImmutableList())
+            .collect(ImmutableList.toImmutableList())
             .block();
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
@@ -44,8 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 
@@ -87,7 +87,7 @@ public class UserMailboxesService {
         MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
         return listUserMailboxes(mailboxSession)
             .map(mailboxMetaData -> new MailboxResponse(mailboxMetaData.getPath().getName(), mailboxMetaData.getId()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     public boolean testMailboxExists(Username username, MailboxName mailboxName) throws MailboxException, UsersRepositoryException {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserQuotaService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserQuotaService.java
@@ -42,7 +42,7 @@ import org.apache.james.webadmin.dto.UsersQuotaDetailsDTO;
 import org.apache.james.webadmin.dto.ValidatedQuotaDTO;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 public class UserQuotaService {
@@ -146,6 +146,6 @@ public class UserQuotaService {
                 .user(user)
                 .detail(getQuota(user))
                 .build()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -104,7 +104,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -574,7 +573,7 @@ class MailboxesRoutesTest {
                 searchIndex.delete(systemSession, mailbox.getMailboxId(),
                     messages.stream()
                         .map(MessageResult::getUid)
-                        .collect(Guavate.toImmutableList()))
+                        .collect(ImmutableList.toImmutableList()))
                     .block();
 
                 String taskId = with()

--- a/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/dto/MailQueueItemDTO.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/dto/MailQueueItemDTO.java
@@ -27,9 +27,9 @@ import java.util.Optional;
 import org.apache.james.core.MailAddress;
 import org.apache.james.queue.api.ManageableMailQueue;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 public class MailQueueItemDTO {
 
@@ -74,7 +74,7 @@ public class MailQueueItemDTO {
         public Builder recipients(Collection<MailAddress> recipients) {
             this.recipients = recipients.stream()
                     .map(MailAddress::asString)
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
             return this;
         }
 

--- a/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/routes/MailQueueRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/routes/MailQueueRoutes.java
@@ -61,8 +61,8 @@ import org.apache.james.webadmin.utils.Responses;
 import org.eclipse.jetty.http.HttpStatus;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Booleans;
 
 import io.swagger.annotations.Api;
@@ -140,7 +140,7 @@ public class MailQueueRoutes implements Routes {
             (request, response) -> mailQueueFactory.listCreatedMailQueues()
                 .stream()
                 .map(MailQueueName::asString)
-                .collect(Guavate.toImmutableList()),
+                .collect(ImmutableList.toImmutableList()),
             jsonTransformer);
     }
 
@@ -245,7 +245,7 @@ public class MailQueueRoutes implements Routes {
             return limit.applyOnStream(Iterators.toStream(queue.browse()))
                     .map(Throwing.function(MailQueueItemDTO::from).sneakyThrow())
                     .filter(item -> filter(item, isDelayed))
-                    .collect(Guavate.toImmutableList());
+                    .collect(ImmutableList.toImmutableList());
         } catch (MailQueueException e) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.BAD_REQUEST_400)

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueItemDTOTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueItemDTOTest.java
@@ -31,7 +31,7 @@ import org.apache.mailet.base.test.FakeMail;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 class MailQueueItemDTOTest {
     @Test
@@ -54,7 +54,7 @@ class MailQueueItemDTOTest {
         MailQueueItemDTO mailQueueItemDTO = MailQueueItemDTO.from(mailQueueItemView);
         List<String> expectedRecipients = mail.getRecipients().stream()
                 .map(MailAddress::asString)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(mailQueueItemDTO.getName()).isEqualTo(mail.getName());

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +63,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -263,7 +262,7 @@ class MailQueueRoutesTest {
                 String firstMail = "[0]";
                 List<String> expectedRecipients = mail.getRecipients().stream()
                         .map(MailAddress::asString)
-                        .collect(Guavate.toImmutableList());
+                        .collect(ImmutableList.toImmutableList());
 
                 when()
                     .get(FIRST_QUEUE.asString() + "/mails")

--- a/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/dto/MailDto.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/dto/MailDto.java
@@ -44,7 +44,8 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 
@@ -53,7 +54,7 @@ public class MailDto {
         Optional<MessageContent> messageContent = fetchMessage(additionalFields, mail);
         return new MailDto(mail.getName(),
             mail.getMaybeSender().asOptional().map(MailAddress::asString),
-            mail.getRecipients().stream().map(MailAddress::asString).collect(Guavate.toImmutableList()),
+            mail.getRecipients().stream().map(MailAddress::asString).collect(ImmutableList.toImmutableList()),
             Optional.ofNullable(mail.getErrorMessage()),
             Optional.ofNullable(mail.getState()),
             Optional.ofNullable(mail.getRemoteHost()),
@@ -136,7 +137,7 @@ public class MailDto {
         return new HeadersDto(Collections
             .list(message.getAllHeaders())
             .stream()
-            .collect(Guavate.toImmutableListMultimap(Header::getName, (header) -> MimeUtil.unscrambleHeaderValue(header.getValue()))));
+            .collect(ImmutableListMultimap.toImmutableListMultimap(Header::getName, (header) -> MimeUtil.unscrambleHeaderValue(header.getValue()))));
     }
 
     private static Optional<ImmutableMap<String, HeadersDto>> fetchPerRecipientsHeaders(Set<AdditionalField> additionalFields, Mail mail) {
@@ -150,7 +151,7 @@ public class MailDto {
         return Optional.of(headersByRecipient
             .keySet()
             .stream()
-            .collect(Guavate.toImmutableMap(MailAddress::asString, (address) -> fetchPerRecipientHeader(headersByRecipient, address))));
+            .collect(ImmutableMap.toImmutableMap(MailAddress::asString, (address) -> fetchPerRecipientHeader(headersByRecipient, address))));
     }
 
     private static HeadersDto fetchPerRecipientHeader(
@@ -158,7 +159,7 @@ public class MailDto {
             MailAddress address) {
         return new HeadersDto(headersByRecipient.get(address)
             .stream()
-            .collect(Guavate.toImmutableListMultimap(PerRecipientHeaders.Header::getName, PerRecipientHeaders.Header::getValue)));
+            .collect(ImmutableListMultimap.toImmutableListMultimap(PerRecipientHeaders.Header::getName, PerRecipientHeaders.Header::getValue)));
     }
 
     private static Optional<ImmutableMap<String, String>> fetchAttributes(Set<AdditionalField> additionalFields, Mail mail) {
@@ -167,7 +168,7 @@ public class MailDto {
         }
 
         return Optional.of(mail.attributes()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 attribute -> attribute.getName().asString(),
                 attribute -> attribute.getValue().value().toString())));
     }

--- a/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/routes/MailRepositoriesRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/routes/MailRepositoriesRoutes.java
@@ -69,8 +69,9 @@ import org.apache.james.webadmin.utils.ParametersExtractor;
 import org.apache.james.webadmin.utils.Responses;
 import org.eclipse.jetty.http.HttpStatus;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -230,7 +231,7 @@ public class MailRepositoriesRoutes implements Routes {
     })
     public void defineGetMailRepositories() {
         service.get(MAIL_REPOSITORIES,
-            (request, response) -> repositoryStoreService.listMailRepositories().collect(Guavate.toImmutableList()),
+            (request, response) -> repositoryStoreService.listMailRepositories().collect(ImmutableList.toImmutableList()),
             jsonTransformer);
     }
 
@@ -520,7 +521,7 @@ public class MailRepositoriesRoutes implements Routes {
             .splitToList(additionalFieldsParam)
             .stream()
             .map((field) -> AdditionalField.find(field).orElseThrow(() -> new IllegalArgumentException(field)))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     private Optional<String> parseTargetProcessor(Request request) {

--- a/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/service/ClearMailRepositoryTask.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/service/ClearMailRepositoryTask.java
@@ -35,7 +35,7 @@ import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 public class ClearMailRepositoryTask implements Task {
 
@@ -51,7 +51,7 @@ public class ClearMailRepositoryTask implements Task {
 
         public ClearMailRepositoryTask create(MailRepositoryPath mailRepositoryPath) throws MailRepositoryStore.MailRepositoryStoreException {
             List<MailRepository> mailRepositories = mailRepositoryStore.getByPath(mailRepositoryPath)
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
             return new ClearMailRepositoryTask(mailRepositories, mailRepositoryPath);
         }
     }

--- a/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/service/MailRepositoryStoreService.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/service/MailRepositoryStoreService.java
@@ -48,7 +48,6 @@ import org.apache.mailet.Mail;
 import org.eclipse.jetty.http.HttpStatus;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class MailRepositoryStoreService {
@@ -102,7 +101,7 @@ public class MailRepositoryStoreService {
     }
 
     public Task createClearMailRepositoryTask(MailRepositoryPath path) throws MailRepositoryStore.MailRepositoryStoreException, MessagingException {
-        return new ClearMailRepositoryTask(getRepositories(path).collect(Guavate.toImmutableList()), path);
+        return new ClearMailRepositoryTask(getRepositories(path).collect(ImmutableList.toImmutableList()), path);
     }
 
     public Stream<MailRepository> getRepositories(MailRepositoryPath path) throws MailRepositoryStore.MailRepositoryStoreException {

--- a/server/queue/queue-file/src/main/java/org/apache/james/queue/file/FileMailQueueFactory.java
+++ b/server/queue/queue-file/src/main/java/org/apache/james/queue/file/FileMailQueueFactory.java
@@ -33,7 +33,7 @@ import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
 import org.apache.james.queue.api.MailQueueName;
 import org.apache.james.queue.api.ManageableMailQueue;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * {@link MailQueueFactory} implementation which returns {@link FileCacheableMailQueue} instances
@@ -60,7 +60,7 @@ public class FileMailQueueFactory implements MailQueueFactory<ManageableMailQueu
         return queues.values()
             .stream()
             .map(MailQueue::getName)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     /**

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSCacheableMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSCacheableMailQueue.java
@@ -79,10 +79,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 
 import reactor.core.publisher.Flux;
@@ -352,7 +352,7 @@ public class JMSCacheableMailQueue implements ManageableMailQueue, JMSSupport, M
                 Joiner.on('\n')
                     .join(headers.stream()
                         .map(PerRecipientHeaders.Header::asString)
-                        .collect(Guavate.toImmutableList()))));
+                        .collect(ImmutableList.toImmutableList()))));
 
         String recipientsAsString = joiner.join(mail.getRecipients());
 
@@ -363,13 +363,13 @@ public class JMSCacheableMailQueue implements ManageableMailQueue, JMSSupport, M
         String sender = mail.getMaybeSender().asString("");
 
         props.putAll(mail.attributes()
-            .collect(Guavate.toImmutableMap(
+            .collect(ImmutableMap.toImmutableMap(
                 attribute -> attribute.getName().asString(),
                 attribute -> attribute.getValue().toJson().toString())));
 
         ImmutableList<String> attributeNames = mail.attributeNames()
             .map(AttributeName::asString)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
 
         props.put(JAMES_MAIL_ATTRIBUTE_NAMES, joiner.join(attributeNames));
         props.put(JAMES_MAIL_SENDER, sender);
@@ -466,7 +466,7 @@ public class JMSCacheableMailQueue implements ManageableMailQueue, JMSSupport, M
             splitter.splitToList(attributeNames)
             .stream()
             .flatMap(attributeName -> mailAttribute(message, attributeName))
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
 
         builder.sender(MaybeSender.getMailSender(message.getStringProperty(JAMES_MAIL_SENDER)).asOptional());
         builder.state(message.getStringProperty(JAMES_MAIL_STATE));

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/library/AbstractMailQueueFactory.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/library/AbstractMailQueueFactory.java
@@ -40,8 +40,8 @@ import org.apache.james.queue.api.ManageableMailQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * {@link MailQueueFactory} abstract base class which take care of register the
@@ -76,7 +76,7 @@ public abstract class AbstractMailQueueFactory<T extends MailQueue> implements M
         return queues.values()
             .stream()
             .map(MailQueue::getName)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     @PreDestroy

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/library/MailQueueManagement.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/library/MailQueueManagement.java
@@ -42,7 +42,7 @@ import org.apache.james.queue.api.ManageableMailQueue.MailQueueIterator;
 import org.apache.james.queue.api.ManageableMailQueue.Type;
 import org.apache.mailet.Mail;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * JMX MBean implementation which expose management functions by wrapping a
@@ -150,7 +150,7 @@ public class MailQueueManagement extends StandardMBean implements MailQueueManag
             map.put(names[7], m.getRemoteHost());
             map.put(names[8], m.getErrorMessage());
             Map<String, String> attrs = m.attributes()
-                .collect(Guavate.toImmutableMap(
+                .collect(ImmutableMap.toImmutableMap(
                     attribute -> attribute.getName().asString(),
                     attribute -> attribute.getValue().value().toString()));
 

--- a/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
+++ b/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
@@ -52,9 +52,9 @@ import org.reactivestreams.Publisher;
 import org.threeten.extra.Temporals;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import reactor.core.publisher.Flux;
@@ -77,7 +77,7 @@ public class MemoryMailQueueFactory implements MailQueueFactory<MemoryMailQueueF
         return mailQueues.values()
             .stream()
             .map(MemoryCacheableMailQueue::getName)
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     @Override
@@ -201,7 +201,7 @@ public class MemoryMailQueueFactory implements MailQueueFactory<MemoryMailQueueF
         public long remove(Type type, String value) throws MailQueueException {
             ImmutableList<MemoryMailQueueItem> toBeRemoved = mailItems.stream()
                 .filter(item -> shouldRemove(item, type, value))
-                .collect(Guavate.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
             toBeRemoved.forEach(mailItems::remove);
             return toBeRemoved.size();
         }

--- a/server/queue/queue-rabbitmq/pom.xml
+++ b/server/queue/queue-rabbitmq/pom.xml
@@ -147,10 +147,6 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
@@ -44,7 +44,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.consumers.ThrowingBiConsumer;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -59,7 +58,7 @@ class MailReferenceDTO {
             Optional.ofNullable(mail.getRecipients()).map(Collection::stream)
                 .orElse(Stream.empty())
                 .map(MailAddress::asString)
-                .collect(Guavate.toImmutableList()),
+                .collect(ImmutableList.toImmutableList()),
             mail.getName(),
             mail.getMaybeSender().asOptional().map(MailAddress::asString),
             mail.getState(),
@@ -88,7 +87,7 @@ class MailReferenceDTO {
         Function<Attribute, String> value = attribute -> attribute.getValue().toJson().toString();
         return mail
                 .attributes()
-                .collect(Guavate.toImmutableMap(name, value));
+                .collect(ImmutableMap.toImmutableMap(name, value));
     }
 
     private final String enqueueId;
@@ -214,7 +213,7 @@ class MailReferenceDTO {
             .sender(sender.map(MaybeSender::getMailSender).orElse(MaybeSender.nullSender()))
             .addRecipients(recipients.stream()
                 .map(Throwing.<String, MailAddress>function(MailAddress::new).sneakyThrow())
-                .collect(Guavate.toImmutableList()))
+                .collect(ImmutableList.toImmutableList()))
             .errorMessage(errorMessage)
             .remoteAddr(remoteAddr)
             .remoteHost(remoteHost)

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -34,7 +34,7 @@ import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.Slice;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext.SlicingContext;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -102,7 +102,7 @@ public class CassandraMailQueueMailDelete {
                     .filter(slice -> slice.getStartSliceInstant().isBefore(newBrowseStartInstant))
                     .flatMap(slice -> IntStream.range(0, configuration.getBucketCount()).boxed()
                         .map(bucket -> SlicingContext.of(BucketedSlices.BucketId.of(bucket), slice.getStartSliceInstant())))
-                    .collect(Guavate.toImmutableList()))
+                    .collect(ImmutableList.toImmutableList()))
             .concatMap(slice -> deleteEmailsFromBrowseProjection(mailQueueName, slice))
             .concatMap(slice -> enqueuedMailsDAO.deleteBucket(mailQueueName, Slice.of(slice.getTimeRangeStart()), slice.getBucketId()))
             .then(contentStartDAO.updateContentStart(mailQueueName, newBrowseStartInstant));

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
@@ -73,7 +73,6 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.TupleType;
 import com.datastax.driver.core.TupleValue;
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -195,6 +194,6 @@ public class EnqueuedMailsDaoUtil {
             .entries()
             .stream()
             .map(entry -> userHeaderNameHeaderValueTriple.newValue(entry.getKey().asString(), entry.getValue().getName(), entry.getValue().getValue()))
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 }

--- a/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/TasksSerializationModule.java
+++ b/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/TasksSerializationModule.java
@@ -39,7 +39,7 @@ import org.apache.james.task.eventsourcing.Created;
 import org.apache.james.task.eventsourcing.Failed;
 import org.apache.james.task.eventsourcing.Started;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
 
 public interface TasksSerializationModule {
     @FunctionalInterface
@@ -111,6 +111,6 @@ public interface TasksSerializationModule {
         return Stream
             .of(CREATED, STARTED, CANCEL_REQUESTED, CANCELLED, COMPLETED, FAILED, UPDATED)
             .map(moduleFactory -> moduleFactory.create(jsonTaskSerializer, additionalInformationConverter, dtoConverter))
-            .collect(Guavate.toImmutableSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/server/task/task-memory/src/main/java/org/apache/james/task/MemoryTaskManager.java
+++ b/server/task/task-memory/src/main/java/org/apache/james/task/MemoryTaskManager.java
@@ -32,8 +32,8 @@ import javax.inject.Inject;
 
 import org.reactivestreams.Publisher;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -142,7 +142,7 @@ public class MemoryTaskManager implements TaskManager {
         return idToExecutionDetails.entrySet()
             .stream()
             .filter(details -> details.getValue().getStatus().equals(status))
-            .collect(Guavate.entriesToImmutableMap());
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override

--- a/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/TaskAggregateTest.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/TaskAggregateTest.java
@@ -35,7 +35,7 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskId;
 import org.junit.jupiter.api.Test;
 
-import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
 import scala.Option;
@@ -53,7 +53,7 @@ class TaskAggregateTest {
                     Stream.iterate(EventId.first(), EventId::next),
                     Arrays.stream(events),
                     (id, event) -> event.apply(id))
-                .collect(Guavate.toImmutableList())).toList());
+                .collect(ImmutableList.toImmutableList())).toList());
     }
 
     @Test

--- a/server/testing/src/main/java/org/apache/james/utils/DiscreteDistribution.java
+++ b/server/testing/src/main/java/org/apache/james/utils/DiscreteDistribution.java
@@ -26,8 +26,8 @@ import org.apache.commons.math3.distribution.EnumeratedDistribution;
 import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.util.Pair;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 public class DiscreteDistribution<T> {
 
@@ -69,7 +69,7 @@ public class DiscreteDistribution<T> {
     private DiscreteDistribution(List<DistributionEntry<T>> distribution) {
         enumeratedDistribution = new EnumeratedDistribution<>(new MersenneTwister(), distribution.stream()
             .map(DistributionEntry::toPair)
-            .collect(Guavate.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()));
     }
 
     public Stream<T> generateRandomStream() {

--- a/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
+++ b/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
 import com.github.fge.lambdas.Throwing;
-import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class SMTPMessageSender extends ExternalResource implements Closeable, AfterEachCallback {
@@ -149,7 +148,7 @@ public class SMTPMessageSender extends ExternalResource implements Closeable, Af
     public SMTPMessageSender sendMessage(Mail mail) throws MessagingException, IOException {
         String from = mail.getMaybeSender().asString();
         ImmutableList<String> recipients = mail.getRecipients().stream()
-            .map(MailAddress::asString).collect(Guavate.toImmutableList());
+            .map(MailAddress::asString).collect(ImmutableList.toImmutableList());
         String message = asString(mail.getMessage());
 
         return sendMessageWithHeaders(from, recipients, message);

--- a/third-party/linshare/pom.xml
+++ b/third-party/linshare/pom.xml
@@ -56,10 +56,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.steveash.guavate</groupId>
-            <artifactId>guavate</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/third-party/linshare/src/main/java/org/apache/james/linshare/client/ShareRequest.java
+++ b/third-party/linshare/src/main/java/org/apache/james/linshare/client/ShareRequest.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 import org.apache.james.core.MailAddress;
 import org.apache.james.linshare.client.Document.DocumentId;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -128,7 +127,7 @@ public class ShareRequest {
             .stream()
             .map(DocumentId::getId)
             .map(UUID::toString)
-            .collect(Guavate.toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareFixture.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareFixture.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public interface LinshareFixture {
 
@@ -77,7 +77,7 @@ public interface LinshareFixture {
         EXTERNAL_2);
 
     Map<String, Credential> USER_CREDENTIAL_MAP = USER_CREDENTIALS.stream()
-        .collect(Guavate.toImmutableMap(Credential::getUsername, Function.identity()));
+        .collect(ImmutableMap.toImmutableMap(Credential::getUsername, Function.identity()));
 
     String MATCH_ALL_QUERY = "{" +
         "\"combinator\": \"and\"," +


### PR DESCRIPTION
As of 2017-01-12 Guava 21 was released which brings Java 8 support to the library. That removes the need for Guavate. Please upgrade to Guava 21

No release since 2016