### PR TITLE
JAMES-2993 WebAdmin markdown - Fix href Administrating messages

### DIFF
--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -32,7 +32,7 @@ Finally, please note that in case of a malformed URL the 400 bad request respons
  - [Administrating domains](#Administrating_domains)
  - [Administrating users](#Administrating_users)
  - [Administrating mailboxes](#Administrating_mailboxes)
- - [Administrating messages](#Administrating_messages)
+ - [Administrating messages](#Administrating_Messages)
  - [Administrating user mailboxes](#Administrating_user_mailboxes)
  - [Administrating quotas by users](#Administrating_quotas_by_users)
  - [Administrating quotas by domains](#Administrating_quotas_by_domains)


### PR DESCRIPTION
- OLD: https://james.apache.org/server/manage-webadmin.html#Administrating_messages  (not jump to the target line)
- NEW: https://james.apache.org/server/manage-webadmin.html#Administrating_Messages  (working)