### PR TITLE
JAMES-3626 Enforce more Cassandra schema best practices

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -252,7 +252,7 @@ public class CassandraMessageIdDAO {
         ThreadId threadId = metadata.getComposedMessageId().getThreadId();
 
         BoundStatement boundStatement = insert.bind();
-        if (metadata.getComposedMessageId().getFlags().getUserFlags().length == 0) {
+        if (flags.getUserFlags().length == 0) {
             boundStatement.unset(USER_FLAGS);
         } else {
             boundStatement.setSet(USER_FLAGS, ImmutableSet.copyOf(flags.getUserFlags()));

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -352,7 +352,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
 
         return imapUidDAO.updateMetadata(composedMessageId, updatedFlags, previousModseq)
             .filter(FunctionalUtils.identityPredicate())
-            .flatMap(any -> messageIdDAO.updateMetadata(newComposedId)
+            .flatMap(any -> messageIdDAO.updateMetadata(composedMessageId, updatedFlags)
                 .thenReturn(Pair.of(oldComposedId.getFlags(), newComposedId)))
             .single();
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -37,6 +37,7 @@ import org.apache.james.backends.cassandra.init.configuration.CassandraConsisten
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -339,7 +340,17 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
     }
 
     private Mono<Pair<Flags, ComposedMessageIdWithMetaData>> updateFlags(ComposedMessageIdWithMetaData oldComposedId, ComposedMessageIdWithMetaData newComposedId) {
-        return imapUidDAO.updateMetadata(newComposedId, oldComposedId.getModSeq())
+        ComposedMessageId composedMessageId = newComposedId.getComposedMessageId();
+        ModSeq previousModseq = oldComposedId.getModSeq();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .messageId(composedMessageId.getMessageId())
+            .modSeq(newComposedId.getModSeq())
+            .oldFlags(oldComposedId.getFlags())
+            .newFlags(newComposedId.getFlags())
+            .uid(composedMessageId.getUid())
+            .build();
+
+        return imapUidDAO.updateMetadata(composedMessageId, updatedFlags, previousModseq)
             .filter(FunctionalUtils.identityPredicate())
             .flatMap(any -> messageIdDAO.updateMetadata(newComposedId)
                 .thenReturn(Pair.of(oldComposedId.getFlags(), newComposedId)))

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
@@ -23,6 +23,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.addAll;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.removeAll;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
@@ -74,6 +75,7 @@ import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UpdatedFlags;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.PreparedStatement;
@@ -85,12 +87,15 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Update;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class CassandraMessageIdToImapUidDAO {
     private static final String MOD_SEQ_CONDITION = "modSeqCondition";
+    private static final String ADDED_USERS_FLAGS = "added_user_flags";
+    private static final String REMOVED_USERS_FLAGS = "removed_user_flags";
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
     private final BlobId.Factory blobIdFactory;
@@ -201,7 +206,8 @@ public class CassandraMessageIdToImapUidDAO {
             .and(set(RECENT, bindMarker(RECENT)))
             .and(set(SEEN, bindMarker(SEEN)))
             .and(set(USER, bindMarker(USER)))
-            .and(set(USER_FLAGS, bindMarker(USER_FLAGS)))
+            .and(addAll(USER_FLAGS, bindMarker(ADDED_USERS_FLAGS)))
+            .and(removeAll(USER_FLAGS, bindMarker(REMOVED_USERS_FLAGS)))
             .where(eq(MESSAGE_ID, bindMarker(MESSAGE_ID)))
             .and(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
             .and(eq(IMAP_UID, bindMarker(IMAP_UID)));
@@ -290,29 +296,70 @@ public class CassandraMessageIdToImapUidDAO {
                 .setString(HEADER_CONTENT, metadata.getHeaderContent().get().asString()));
     }
 
-    public Mono<Boolean> updateMetadata(ComposedMessageIdWithMetaData composedMessageIdWithMetaData, ModSeq oldModSeq) {
-        ComposedMessageId composedMessageId = composedMessageIdWithMetaData.getComposedMessageId();
-        Flags flags = composedMessageIdWithMetaData.getFlags();
-        return cassandraAsyncExecutor.executeReturnApplied(updateBoundStatement(composedMessageIdWithMetaData, composedMessageId, flags, oldModSeq));
+    public Mono<Boolean> updateMetadata(ComposedMessageId id, UpdatedFlags updatedFlags, ModSeq previousModeq) {
+        return cassandraAsyncExecutor.executeReturnApplied(updateBoundStatement(id, updatedFlags, previousModeq));
     }
 
-    private BoundStatement updateBoundStatement(ComposedMessageIdWithMetaData composedMessageIdWithMetaData, ComposedMessageId composedMessageId, Flags flags,
-                                                ModSeq oldModSeq) {
+    private BoundStatement updateBoundStatement(ComposedMessageId id, UpdatedFlags updatedFlags, ModSeq previousModeq) {
         final BoundStatement boundStatement = update.bind()
-            .setLong(MOD_SEQ, composedMessageIdWithMetaData.getModSeq().asLong())
-            .setBool(ANSWERED, flags.contains(Flag.ANSWERED))
-            .setBool(DELETED, flags.contains(Flag.DELETED))
-            .setBool(DRAFT, flags.contains(Flag.DRAFT))
-            .setBool(FLAGGED, flags.contains(Flag.FLAGGED))
-            .setBool(RECENT, flags.contains(Flag.RECENT))
-            .setBool(SEEN, flags.contains(Flag.SEEN))
-            .setBool(USER, flags.contains(Flag.USER))
-            .setSet(USER_FLAGS, ImmutableSet.copyOf(flags.getUserFlags()))
-            .setUUID(MESSAGE_ID, ((CassandraMessageId) composedMessageId.getMessageId()).get())
-            .setUUID(MAILBOX_ID, ((CassandraId) composedMessageId.getMailboxId()).asUuid())
-            .setLong(IMAP_UID, composedMessageId.getUid().asLong());
+            .setLong(MOD_SEQ, updatedFlags.getModSeq().asLong())
+            .setUUID(MESSAGE_ID, ((CassandraMessageId) id.getMessageId()).get())
+            .setUUID(MAILBOX_ID, ((CassandraId) id.getMailboxId()).asUuid())
+            .setLong(IMAP_UID, id.getUid().asLong());
+
+        if (updatedFlags.isChanged(Flag.ANSWERED)) {
+            boundStatement.setBool(ANSWERED, updatedFlags.isModifiedToSet(Flag.ANSWERED));
+        } else {
+            boundStatement.unset(ANSWERED);
+        }
+        if (updatedFlags.isChanged(Flag.DRAFT)) {
+            boundStatement.setBool(DRAFT, updatedFlags.isModifiedToSet(Flag.DRAFT));
+        } else {
+            boundStatement.unset(DRAFT);
+        }
+        if (updatedFlags.isChanged(Flag.FLAGGED)) {
+            boundStatement.setBool(FLAGGED, updatedFlags.isModifiedToSet(Flag.FLAGGED));
+        } else {
+            boundStatement.unset(FLAGGED);
+        }
+        if (updatedFlags.isChanged(Flag.DELETED)) {
+            boundStatement.setBool(DELETED, updatedFlags.isModifiedToSet(Flag.DELETED));
+        } else {
+            boundStatement.unset(DELETED);
+        }
+        if (updatedFlags.isChanged(Flag.RECENT)) {
+            boundStatement.setBool(RECENT, updatedFlags.getNewFlags().contains(Flag.RECENT));
+        } else {
+            boundStatement.unset(RECENT);
+        }
+        if (updatedFlags.isChanged(Flag.SEEN)) {
+            boundStatement.setBool(SEEN, updatedFlags.isModifiedToSet(Flag.SEEN));
+        } else {
+            boundStatement.unset(SEEN);
+        }
+        if (updatedFlags.isChanged(Flag.USER)) {
+            boundStatement.setBool(USER, updatedFlags.isModifiedToSet(Flag.USER));
+        } else {
+            boundStatement.unset(USER);
+        }
+        Sets.SetView<String> removedFlags = Sets.difference(
+            ImmutableSet.copyOf(updatedFlags.getOldFlags().getUserFlags()),
+            ImmutableSet.copyOf(updatedFlags.getNewFlags().getUserFlags()));
+        Sets.SetView<String> addedFlags = Sets.difference(
+            ImmutableSet.copyOf(updatedFlags.getNewFlags().getUserFlags()),
+            ImmutableSet.copyOf(updatedFlags.getOldFlags().getUserFlags()));
+        if (addedFlags.isEmpty()) {
+            boundStatement.unset(ADDED_USERS_FLAGS);
+        } else {
+            boundStatement.setSet(ADDED_USERS_FLAGS, addedFlags);
+        }
+        if (removedFlags.isEmpty()) {
+            boundStatement.unset(REMOVED_USERS_FLAGS);
+        } else {
+            boundStatement.setSet(REMOVED_USERS_FLAGS, removedFlags);
+        }
         if (cassandraConfiguration.isMessageWriteStrongConsistency()) {
-            return boundStatement.setLong(MOD_SEQ_CONDITION, oldModSeq.asLong());
+            return boundStatement.setLong(MOD_SEQ_CONDITION, previousModeq.asLong());
         }
         return boundStatement;
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -623,7 +623,7 @@ public class CassandraMessageMapper implements MessageMapper {
         return imapUidDAO.updateMetadata(composedMessageId, updatedFlags, previousModseq)
             .flatMap(success -> {
                 if (success) {
-                    return messageIdDAO.updateMetadata(newMetadata).thenReturn(true);
+                    return messageIdDAO.updateMetadata(composedMessageId, updatedFlags).thenReturn(true);
                 } else {
                     return Mono.just(false);
                 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -604,12 +604,23 @@ public class CassandraMessageMapper implements MessageMapper {
 
     private Mono<Boolean> updateFlags(ComposedMessageIdWithMetaData oldMetadata, Flags newFlags, ModSeq newModSeq) {
         ComposedMessageIdWithMetaData newMetadata = ComposedMessageIdWithMetaData.builder()
-                .composedMessageId(oldMetadata.getComposedMessageId())
-                .modSeq(newModSeq)
-                .flags(newFlags)
-                .threadId(oldMetadata.getThreadId())
-                .build();
-        return imapUidDAO.updateMetadata(newMetadata, oldMetadata.getModSeq())
+            .composedMessageId(oldMetadata.getComposedMessageId())
+            .modSeq(newModSeq)
+            .flags(newFlags)
+            .threadId(oldMetadata.getThreadId())
+            .build();
+
+        ComposedMessageId composedMessageId = newMetadata.getComposedMessageId();
+        ModSeq previousModseq = oldMetadata.getModSeq();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .messageId(composedMessageId.getMessageId())
+            .modSeq(newMetadata.getModSeq())
+            .oldFlags(oldMetadata.getFlags())
+            .newFlags(newMetadata.getFlags())
+            .uid(composedMessageId.getUid())
+            .build();
+
+        return imapUidDAO.updateMetadata(composedMessageId, updatedFlags, previousModseq)
             .flatMap(success -> {
                 if (success) {
                     return messageIdDAO.updateMetadata(newMetadata).thenReturn(true);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.util.streams.Limit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,12 +119,21 @@ class CassandraMessageIdDAOTest {
 
         testee.delete(mailboxId, messageUid).block();
 
-        testee.updateMetadata(ComposedMessageIdWithMetaData.builder()
-                .composedMessageId(new ComposedMessageId(mailboxId, messageId, messageUid))
-                .flags(new Flags(org.apache.james.mailbox.cassandra.table.Flag.ANSWERED))
-                .modSeq(ModSeq.of(2))
-                .threadId(ThreadId.fromBaseMessageId(messageId))
-                .build())
+        ComposedMessageIdWithMetaData metadata = ComposedMessageIdWithMetaData.builder()
+            .composedMessageId(new ComposedMessageId(mailboxId, messageId, messageUid))
+            .flags(new Flags(Flag.ANSWERED))
+            .modSeq(ModSeq.of(2))
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .build();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(metadata.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(metadata.getFlags())
+            .build();
+
+        testee.updateMetadata(metadata.getComposedMessageId(), updatedFlags)
             .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
@@ -224,7 +234,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -257,7 +276,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -290,7 +318,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -323,7 +360,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -356,7 +402,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -389,7 +444,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -422,7 +486,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -455,7 +528,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);
@@ -490,7 +572,16 @@ class CassandraMessageIdDAOTest {
                 .modSeq(ModSeq.of(2))
                 .threadId(ThreadId.fromBaseMessageId(messageId))
                 .build();
-        testee.updateMetadata(expectedComposedMessageId).block();
+        UpdatedFlags updatedFlags = UpdatedFlags.builder()
+            .uid(messageUid)
+            .messageId(messageId)
+            .modSeq(expectedComposedMessageId.getModSeq())
+            .oldFlags(new Flags())
+            .newFlags(expectedComposedMessageId.getFlags())
+            .build();
+
+        testee.updateMetadata(expectedComposedMessageId.getComposedMessageId(), updatedFlags)
+            .block();
 
         Optional<CassandraMessageMetadata> message = testee.retrieve(mailboxId, messageUid).block();
         assertThat(message.get().getComposedMessageId()).isEqualTo(expectedComposedMessageId);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -135,7 +135,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("INSERT INTO messageV3"));
+                    .whenQueryStartsWith("UPDATE messageV3"));
 
             try {
                 message1.setUid(mapperProvider.generateMessageUid());

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -315,7 +315,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("INSERT INTO messageIdTable"));
+                    .whenQueryStartsWith("UPDATE messageIdTable"));
 
             try {
                 messageMapper.add(benwaInboxMailbox, message1);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -223,7 +223,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("INSERT INTO messageV3"));
+                    .whenQueryStartsWith("UPDATE messageV3"));
 
             try {
                 messageMapper.add(benwaInboxMailbox, message1);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -260,7 +260,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
 
     private boolean interestingFlags(UpdatedFlags updated) {
         boolean result;
-        final Iterator<Flags.Flag> it = updated.systemFlagIterator();
+        final Iterator<Flags.Flag> it = updated.modifiedSystemFlags().iterator();
         if (it.hasNext()) {
             final Flags.Flag flag = it.next();
             if (flag.equals(uninterestingFlag)) {
@@ -428,7 +428,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
             // See IMAP-287
             List<UpdatedFlags> uflags = updated.getUpdatedFlags();
             for (UpdatedFlags u : uflags) {
-                Iterator<Flag> flags = u.systemFlagIterator();
+                Iterator<Flag> flags = u.modifiedSystemFlags().iterator();
 
                 while (flags.hasNext()) {
                     if (Flag.RECENT.equals(flags.next())) {

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/ConsistencyTasksIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/ConsistencyTasksIntegrationTest.java
@@ -363,7 +363,7 @@ class ConsistencyTasksIntegrationTest {
         TestingSessionProbe testingProbe = server.getProbe(TestingSessionProbe.class);
         testingProbe.getTestingSession().registerScenario(fail()
             .forever()
-            .whenQueryStartsWith("INSERT INTO messageIdTable"));
+            .whenQueryStartsWith("UPDATE messageIdTable"));
 
         smtpMessageSender.connect(LOCALHOST_IP, server.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .sendMessageWithHeaders(ALICE.asString(), BOB.asString(), MESSAGE);
@@ -375,7 +375,7 @@ class ConsistencyTasksIntegrationTest {
         // When we run solveInconsistenciesTask
         testingProbe.getTestingSession().registerScenario(executeNormally()
             .forever()
-            .whenQueryStartsWith("INSERT INTO messageIdTable"));
+            .whenQueryStartsWith("UPDATE messageIdTable"));
 
         String solveInconsistenciesTaskId = with()
             .queryParam("task", "SolveInconsistencies")

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -21,8 +21,8 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 
 import static com.datastax.driver.core.DataType.blob;
 import static com.datastax.driver.core.DataType.cint;
-import static com.datastax.driver.core.DataType.list;
-import static com.datastax.driver.core.DataType.map;
+import static com.datastax.driver.core.DataType.frozenList;
+import static com.datastax.driver.core.DataType.frozenMap;
 import static com.datastax.driver.core.DataType.text;
 import static com.datastax.driver.core.DataType.timestamp;
 import static com.datastax.driver.core.DataType.uuid;
@@ -37,10 +37,8 @@ import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 
 public interface CassandraMailQueueViewModule {
 
-    Double NO_READ_REPAIR = 0.0;
-
     interface EnqueuedMailsTable {
-        String TABLE_NAME = "enqueuedMailsV3";
+        String TABLE_NAME = "enqueuedMailsV4";
 
         String QUEUE_NAME = "queueName";
         String TIME_RANGE_START = "timeRangeStart";
@@ -109,14 +107,14 @@ public interface CassandraMailQueueViewModule {
             .addColumn(EnqueuedMailsTable.STATE, text())
             .addColumn(EnqueuedMailsTable.HEADER_BLOB_ID, text())
             .addColumn(EnqueuedMailsTable.BODY_BLOB_ID, text())
-            .addColumn(EnqueuedMailsTable.ATTRIBUTES, map(text(), blob()))
+            .addColumn(EnqueuedMailsTable.ATTRIBUTES, frozenMap(text(), blob()))
             .addColumn(EnqueuedMailsTable.ERROR_MESSAGE, text())
             .addColumn(EnqueuedMailsTable.SENDER, text())
-            .addColumn(EnqueuedMailsTable.RECIPIENTS, list(text()))
+            .addColumn(EnqueuedMailsTable.RECIPIENTS, frozenList(text()))
             .addColumn(EnqueuedMailsTable.REMOTE_HOST, text())
             .addColumn(EnqueuedMailsTable.REMOTE_ADDR, text())
             .addColumn(EnqueuedMailsTable.LAST_UPDATED, timestamp())
-            .addColumn(EnqueuedMailsTable.PER_RECIPIENT_SPECIFIC_HEADERS, list(TupleType.of(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE, text(), text(), text()))))
+            .addColumn(EnqueuedMailsTable.PER_RECIPIENT_SPECIFIC_HEADERS, frozenList(TupleType.of(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE, text(), text(), text()))))
 
         .table(BrowseStartTable.TABLE_NAME)
         .comment("this table allows to find the starting point of iteration from the table: "

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -19,6 +19,27 @@ Change list:
  - [Rework message denormalization](#rework-message-denormalization)
  - [Adding threadId column to message metadata tables](#adding-threadid-column-to-message-metadata-tables)
 
+### Changes to the enqueuedMails DAO
+
+Date 06/08/2021
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-3629
+
+Concerned product: Distributed James
+
+In order to avoid uses of non frozen Cassandra collection by the MailQueue component,
+we introduced a new table, enqueuedMailsv4, not suffering from these pitfalls.
+
+Pre existing table, enqueuedMailsV3 is no longer read and can be dropped.
+
+To avoid data loss (only noticeable when browsing the mailqueue email, no email
+in flight in the mailqueue will be lost, they will just be non-browseable) do your
+rolling upgrade with an empty mailqueue. 
+
+To achieve an empty mailqueue, start a James server with SMTP and JMAP ports not exposed:
+they will consume existing mails without creating new ones.
+
+
 ### Adding the threadId to the ElasticSearch index
 
 Date 22/07/2021


### PR DESCRIPTION
Taken from https://docs.datastax.com/en/landing_page/doc/landing_page/dataModel.html#dataModel__checkTableStructure

This includes:

 - Avoid usage of non frozen collections if possible (and easily doable)
 - Avoid insertion of tombstone when working with non frozen collections
 - Preparing statements for Applicable flags thanks to refined Cassandra collection knowledge.