### PR TITLE
JAMES-3601 Do not update browse start when not needed

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
@@ -127,7 +127,11 @@ public class CassandraMailQueueBrowser {
 
     Flux<EnqueuedItemWithSlicingContext> browseReferences(MailQueueName queueName) {
         return browseStartDao.findBrowseStart(queueName)
-            .flatMapMany(this::allSlicesStartingAt)
+            .flatMapMany(browseStart -> browseReferences(queueName, browseStart));
+    }
+
+    Flux<EnqueuedItemWithSlicingContext> browseReferences(MailQueueName queueName, Instant browseStart) {
+        return allSlicesStartingAt(browseStart)
             .flatMapSequential(slice -> browseSlice(queueName, slice));
     }
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
@@ -43,7 +43,7 @@ public class CassandraMailQueueViewTestFactory {
 
         CassandraMailQueueBrowser cassandraMailQueueBrowser = new CassandraMailQueueBrowser(browseStartDao, deletedMailsDao, enqueuedMailsDao, mimeMessageStoreFactory, configuration, clock);
         CassandraMailQueueMailStore cassandraMailQueueMailStore = new CassandraMailQueueMailStore(enqueuedMailsDao, browseStartDao, contentStartDAO, configuration, clock);
-        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, contentStartDAO, enqueuedMailsDao, cassandraMailQueueBrowser, configuration);
+        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, contentStartDAO, enqueuedMailsDao, cassandraMailQueueBrowser, configuration, clock);
 
         return new CassandraMailQueueView.Factory(
             cassandraMailQueueMailStore,


### PR DESCRIPTION
A common mis-configuration of the Distributed mailqueue is to attempt to
update the browse start too often, which results in attempts to update the
browse start while we are already in the last slice.

Repeatedly trying to needlessly update the browse start can seriously undermine
application performance as browsing the mail queue is no cheap task.

Hopefully prior to attempt to update the browse start, we can ensure the browse start is not the current slice.
Thus mis-configurations are mitigated and will not result in hammering browse start update of the current slice
(mis-configuration however can result in suboptimal concurrently triggered browse start updates when switching
slices, operators should still ensure their "updateBrowseStartPace" are adequate, but failures to do so becomes
less problematic)