### PR TITLE
JAMES-3140 CassandraBlobStoreDependenciesModule should only be bound …

### DIFF
--- a/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -44,7 +44,6 @@ import org.apache.james.modules.event.JMAPEventBusModule;
 import org.apache.james.modules.event.RabbitMQEventBusModule;
 import org.apache.james.modules.eventstore.CassandraEventStoreModule;
 import org.apache.james.modules.mailbox.BlobStoreAPIModule;
-import org.apache.james.modules.mailbox.CassandraBlobStoreDependenciesModule;
 import org.apache.james.modules.mailbox.CassandraDeletedMessageVaultModule;
 import org.apache.james.modules.mailbox.CassandraMailboxModule;
 import org.apache.james.modules.mailbox.CassandraQuotaMailingModule;
@@ -134,7 +133,6 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
             .toInstance(ImmutableSet.of());
 
     public static final Module CASSANDRA_SERVER_CORE_MODULE = Modules.combine(
-        new CassandraBlobStoreDependenciesModule(),
         new CassandraDomainListModule(),
         new CassandraDLPConfigurationStoreModule(),
         new CassandraEventStoreModule(),


### PR DESCRIPTION
…when using the Cassandra blobStore

S3 users no longer need to create Cassandra
 Blob Store tables, helping keeping counts
 of table low (too many tables comes at a
 performance price)