### PR TITLE
JAMES-2625 Remove stacktrace upon ClosedChannelException

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelUpstreamHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelUpstreamHandler.java
@@ -242,7 +242,7 @@ public class BasicChannelUpstreamHandler extends SimpleChannelUpstreamHandler {
                     transport.writeResponse(Response.DISCONNECT, session);
                 }
                 if (e.getCause() instanceof ClosedChannelException) {
-                    LOGGER.info("Unable to process request", e.getCause());
+                    LOGGER.info("Channel closed before we could send in flight messages to the users (ClosedChannelException): {}", e.getCause().getMessage());
                 } else {
                     LOGGER.error("Unable to process request", e.getCause());
                 }


### PR DESCRIPTION
This stacktrace is especially annoying when behind a load balancer
doing port checks: connecting and disconnecting straight away, then the
banner can not be sent to the client.

These checks were encountered with for instance F5 Big Ip load
balancers.