### PR TITLE
[UPGRADE] JSOUP 1.14.1 -> 1.14.2 to address CVE-2021-37714

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2577,7 +2577,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.14.1</version>
+                <version>1.14.2</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37714

jsoup is a Java library for working with HTML. Those using jsoup versions
prior to 1.14.2 to parse untrusted HTML or XML may be vulnerable to DOS
attacks. If the parser is run on user supplied input, an attacker may supply
content that causes the parser to get stuck (loop indefinitely until
cancelled), to complete more slowly than usual, or to throw an unexpected
exception. This effect may support a denial of service attack. The issue is
patched in version 1.14.2. There are a few available workarounds. Users may
rate limit input parsing, limit the size of inputs based on system resources,
and/or implement thread watchdogs to cap and timeout parse runtimes.