### PR TITLE
JAMES-3611 Use fuzzing to strengthen SearchUtil::getBaseSubject

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/SearchUtil.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/SearchUtil.java
@@ -328,7 +328,7 @@ public class SearchUtil {
             return subject;
         }
         String subj = subject;
-        while (subj.charAt(0) == OPEN_SQUARE_BRACKED) {
+        while (!subj.isEmpty() && subj.charAt(0) == OPEN_SQUARE_BRACKED) {
             int length = subj.length();
             subj = removeBlob(subject);
             int i = 0;
@@ -337,7 +337,7 @@ public class SearchUtil {
             } else {
                 return subject;
             }
-            while (subj.charAt(i) == WS) {
+            while (i < subj.length() && subj.charAt(i) == WS) {
                 i++;
             }
             subj = subj.substring(i);
@@ -382,7 +382,7 @@ public class SearchUtil {
             } else {
                 return subject;
             }
-            while (subj.charAt(subString) == WS) {
+            while (subString < subj.length() && subj.charAt(subString) == WS) {
                 subString++;
             }
 
@@ -392,7 +392,7 @@ public class SearchUtil {
              * = 1; } else { subString = 0; }
              */
 
-            if (subj.charAt(subString) == COLON) {
+            if (subString < subj.length() && subj.charAt(subString) == COLON) {
                 subString++;
             } else {
                 return subject;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/SearchUtilTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/SearchUtilTest.java
@@ -47,6 +47,18 @@ class SearchUtilTest {
     }
 
     @Test
+    void fwdShouldNotCrash() {
+        String subject = "fwd";
+        assertThat(SearchUtil.getBaseSubject(subject)).isEqualTo("fwd");
+    }
+
+    @Test
+    void fwShouldNotCrash() {
+        String subject = "[fw:]]";
+        assertThat(SearchUtil.getBaseSubject(subject)).isEqualTo("]");
+    }
+
+    @Test
     void getBaseSubjectShouldNotFailWhenEmpty() {
         String subject = "";
         assertThat(SearchUtil.getBaseSubject(subject)).isEqualTo("");


### PR DESCRIPTION
```
import java.util.Base64;

import org.apache.james.mailbox.store.search.SearchUtil;

import com.code_intelligence.jazzer.api.FuzzedDataProvider;

public class Fuzzed {
    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
        final byte[] bytes = fuzzedDataProvider.consumeString(128).getBytes();
        final String b64 = new String(Base64.getEncoder().encode(bytes));

        try {
            SearchUtil.getBaseSubject(new String(bytes));
        } catch (Exception e) {
            throw new RuntimeException(b64, e);
        }
    }
}
```

Cc @quantranhong1999 