### PR TITLE
JAMES-3642 Fix Buggy behavior with Android Email mobile application

### DIFF
--- a/protocols/imap/pom.xml
+++ b/protocols/imap/pom.xml
@@ -45,7 +45,13 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>apache-james-mailbox-store</artifactId>
+            <artifactId>apache-james-mailbox-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-memory</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -568,7 +568,6 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
                 
             }
             searchQuery.andCriteria(SearchQuery.uid(nRanges));
-            searchQuery.andCriteria(SearchQuery.modSeqGreaterThan(changedSince));
             try (Stream<MessageUid> uids = Flux.from(mailbox.search(searchQuery.build(), session)).toStream()) {
                 uids.forEach(vanishedUids::remove);
             }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import javax.mail.Flags;
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -299,7 +299,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
                     //          expunges have not happened, or happen only toward the end of the
                     //          mailbox.
                     //
-                    respondVanished(mailboxSession, mailbox, ranges, modSeq, metaData, responder);
+                    respondVanished(selected, ranges, modSeq, metaData, responder);
                 }
                 taggedOk(responder, request, metaData, HumanReadableText.SELECT);
             } else {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -112,7 +112,7 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
             if (vanished) {
                 // TODO: From the QRESYNC RFC it seems ok to send the VANISHED responses after the FETCH Responses. 
                 //       If we do so we could prolly save one mailbox access which should give use some more speed up
-                respondVanished(mailboxSession, mailbox, ranges, changedSince, metaData.get(), responder);
+                respondVanished(session.getSelected(), ranges, changedSince, metaData.get(), responder);
             }
             processMessageRanges(session, mailbox, ranges, fetch, useUids, mailboxSession, responder);
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
@@ -128,7 +128,7 @@ class SelectProcessorTest {
     }
 
     @Test
-    void vanishedResponsesShouldBeSentWheDeletes() throws Exception {
+    void vanishedResponsesShouldBeSentWhenDeletes() throws Exception {
         FakeImapSession session = new FakeImapSession();
         session.authenticated();
         session.setMailboxSession(mailboxSession);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
@@ -1,0 +1,173 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.mail.Flags;
+import javax.mail.util.SharedByteArrayInputStream;
+
+import org.apache.james.core.Username;
+import org.apache.james.imap.api.ImapConfiguration;
+import org.apache.james.imap.api.ImapConstants;
+import org.apache.james.imap.api.ImapMessage;
+import org.apache.james.imap.api.Tag;
+import org.apache.james.imap.api.message.IdRange;
+import org.apache.james.imap.api.message.UidRange;
+import org.apache.james.imap.api.process.ImapProcessor;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.decode.main.OutputStreamImapResponseWriter;
+import org.apache.james.imap.encode.FakeImapSession;
+import org.apache.james.imap.encode.base.ImapResponseComposerImpl;
+import org.apache.james.imap.encode.main.DefaultImapEncoderFactory;
+import org.apache.james.imap.encode.main.DefaultLocalizer;
+import org.apache.james.imap.main.ResponseEncoder;
+import org.apache.james.imap.message.request.AbstractMailboxSelectionRequest;
+import org.apache.james.imap.message.request.SelectRequest;
+import org.apache.james.imap.message.response.UnpooledStatusResponseFactory;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class SelectProcessorTest {
+    private static final Username BOB = Username.of("bob");
+
+    private SelectProcessor testee;
+    private InMemoryMailboxManager mailboxManager;
+    private MailboxSession mailboxSession;
+    private UidValidity uidValidity;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        InMemoryIntegrationResources integrationResources = InMemoryIntegrationResources.defaultResources();
+
+        mailboxManager = integrationResources.getMailboxManager();
+        testee = new SelectProcessor(new ImapProcessor() {
+            @Override
+            public void process(ImapMessage message, Responder responder, ImapSession session) {
+
+            }
+
+            @Override
+            public void configure(ImapConfiguration imapConfiguration) {
+
+            }
+        }, mailboxManager,
+            integrationResources.getEventBus(),
+            new UnpooledStatusResponseFactory(),
+            new RecordingMetricFactory());
+
+        mailboxSession = mailboxManager.createSystemSession(Username.of("bob"));
+        mailboxManager.createMailbox(MailboxPath.inbox(BOB), mailboxSession);
+        uidValidity = mailboxManager.getMailbox(MailboxPath.inbox(BOB), mailboxSession).getMailboxEntity().getUidValidity();
+    }
+
+    @Test
+    void vanishedResponsesShouldNotBeSentWhenNoDeletes() throws Exception {
+        FakeImapSession session = new FakeImapSession();
+        session.authenticated();
+        session.setMailboxSession(mailboxSession);
+        EnableProcessor.getEnabledCapabilities(session)
+            .add(ImapConstants.SUPPORTS_QRESYNC);
+
+        MessageManager mailbox = mailboxManager.getMailbox(MailboxPath.inbox(BOB), mailboxSession);
+        MessageManager.AppendCommand appendCommand = MessageManager.AppendCommand
+            .builder()
+            .withFlags(new Flags(Flags.Flag.SEEN))
+            .notRecent()
+            .build(new SharedByteArrayInputStream("header: value\r\n\r\nbody".getBytes()));
+        mailbox.appendMessage(appendCommand, mailboxSession);
+        mailbox.appendMessage(appendCommand, mailboxSession);
+        mailbox.appendMessage(appendCommand, mailboxSession);
+        mailbox.appendMessage(appendCommand, mailboxSession);
+        mailbox.appendMessage(appendCommand, mailboxSession);
+
+        UidRange[] uidRanges = null;
+        IdRange[] sequences = null;
+        SelectRequest message = new SelectRequest("INBOX", false,
+            AbstractMailboxSelectionRequest.ClientSpecifiedUidValidity.valid(uidValidity),
+            4L, uidRanges, uidRanges, sequences, new Tag("AA"));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        testee.process(message,
+            new ResponseEncoder(
+                new DefaultImapEncoderFactory(new DefaultLocalizer(), true).buildImapEncoder(),
+                new ImapResponseComposerImpl(new OutputStreamImapResponseWriter(outputStream))),
+            session);
+
+        assertThat(new String(outputStream.toByteArray()))
+            .doesNotContain("* VANISHED (EARLIER) 1:4");
+    }
+
+    @Test
+    void vanishedResponsesShouldBeSentWheDeletes() throws Exception {
+        FakeImapSession session = new FakeImapSession();
+        session.authenticated();
+        session.setMailboxSession(mailboxSession);
+        EnableProcessor.getEnabledCapabilities(session)
+            .add(ImapConstants.SUPPORTS_QRESYNC);
+
+        MessageManager mailbox = mailboxManager.getMailbox(MailboxPath.inbox(BOB), mailboxSession);
+        MessageManager.AppendCommand appendCommand = MessageManager.AppendCommand
+            .builder()
+            .withFlags(new Flags(Flags.Flag.SEEN))
+            .notRecent()
+            .build(new SharedByteArrayInputStream("header: value\r\n\r\nbody".getBytes()));
+        mailbox.appendMessage(appendCommand, mailboxSession);
+
+        MessageManager.AppendResult msg2 = mailbox.appendMessage(appendCommand, mailboxSession);
+
+        mailbox.appendMessage(appendCommand, mailboxSession);
+
+        MessageManager.AppendResult msg4 = mailbox.appendMessage(appendCommand, mailboxSession);
+
+        mailbox.appendMessage(appendCommand, mailboxSession);
+
+        mailbox.delete(ImmutableList.of(msg2.getId().getUid(), msg4.getId().getUid()), mailboxSession);
+
+        UidRange[] uidRanges = null;
+        IdRange[] sequences = null;
+        SelectRequest message = new SelectRequest("INBOX", false,
+            AbstractMailboxSelectionRequest.ClientSpecifiedUidValidity.valid(uidValidity),
+            4L, uidRanges, uidRanges, sequences, new Tag("AA"));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        testee.process(message,
+            new ResponseEncoder(
+                new DefaultImapEncoderFactory(new DefaultLocalizer(), true).buildImapEncoder(),
+                new ImapResponseComposerImpl(new OutputStreamImapResponseWriter(outputStream))),
+            session);
+
+        assertThat(new String(outputStream.toByteArray()))
+            .contains("* VANISHED (EARLIER) 2,4");
+    }
+}


### PR DESCRIPTION
### Actual behaviour

```
GIVEN Samsung Email mobile application
AND connected to an IMAP account located on an IMAP James server
AND load you emails (swap down if needed)
WHEN Refresh your emails (swap down a second time)
THEN the email account is rendered empty, only emails received since are displayed
```

Another refresh restores the original email list....

### Explanation

The second refresh uses QRESYNC SELECT command with the last known modification sequence modifier.

Thus James needs to compute the vanished responses (messages deletes since the last known modseq).

As James do not store expunges, we should interate the supplied range and identify the missing items, for which we will send vanished responses.

But James specifically filters out old messages from the liveness search, which results in all messages prior to the last known modification sequence to be considered deleted, effectively removing them from client cahe.

### The fix

Remove this buggy modseq condition: we should not answer that all old messages are deleted!

Also to avoid a full scan we can detect the deletions from the UID <-> MSN mapping of the mailbox we just selected (yeah).

### Alternative

We could add a projection table tracking expunged messages - along with the modseq.

However we should store all the history of deletions - otherwize some values as last known modseq would be rejected, and no client behaviour is specified in the spec if so.

Also storing even more data have a bitter-sweat taste to me...