### PR TITLE
JAMES-1808 if (character > 128) should be changed to if (character >=…

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
@@ -228,7 +228,7 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
                 buffer.write(BYTE_BACK_SLASH);
             }
             // 7-bit ASCII only
-            if (character > 128) {
+            if (character >= 128) {
                 buffer.write(BYTE_QUESTION);
             } else {
                 buffer.write((byte) character);

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/ImapResponseComposerImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/ImapResponseComposerImplTest.java
@@ -1,0 +1,47 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.encode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.imap.encode.base.ByteImapResponseWriter;
+import org.apache.james.imap.encode.base.ImapResponseComposerImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ImapResponseComposerImplTest {
+    private ByteImapResponseWriter writer;
+    private ImapResponseComposer composer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new ByteImapResponseWriter();
+        composer = new ImapResponseComposerImpl(writer);
+    }
+
+    @Test
+    void encodeShouldHandleQuotedChar128() throws Exception {
+        Character c = 128;
+        composer.quote(c.toString());
+        composer.end();
+
+        assertThat(writer.getString()).isEqualTo(" \"?\"\r\n");
+    }
+}


### PR DESCRIPTION
… 128)

Not doing so results in (byte) character overflowing to -128:

org.opentest4j.AssertionFailedError:
expected: " "?"
"
but was : " "�"
"