### PR TITLE
JAMES-3646 FileMailRepository shoud reject URL outside of James root

### DIFF
--- a/server/container/core/src/main/java/org/apache/james/server/core/filesystem/FileSystemImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/filesystem/FileSystemImpl.java
@@ -54,4 +54,11 @@ public class FileSystemImpl implements FileSystem {
             throw new FileNotFoundException(e.getMessage());
         }
     }
+
+    @Override
+    public File getFileWithinBaseDir(String fileURL) throws FileNotFoundException, IOException {
+        final File file = getFile(fileURL);
+        resourceLoader.validate(file);
+        return file;
+    }
 }

--- a/server/container/core/src/main/java/org/apache/james/server/core/filesystem/ResourceFactory.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/filesystem/ResourceFactory.java
@@ -19,6 +19,7 @@
 package org.apache.james.server.core.filesystem;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -31,6 +32,16 @@ public class ResourceFactory {
 
     public ResourceFactory(JamesDirectoriesProvider directoryProvider) {
         this.directoryProvider = directoryProvider;
+    }
+
+    public void validate(File file) throws IOException {
+        String canonicalPath = file.getCanonicalPath();
+        if (!canonicalPath.startsWith(directoryProvider.getAbsoluteDirectory())
+            && !canonicalPath.startsWith(directoryProvider.getRootDirectory())
+            && !canonicalPath.startsWith(directoryProvider.getVarDirectory())) {
+
+            throw new IOException(canonicalPath + " jail break outside of " + directoryProvider.getRootDirectory());
+        }
     }
     
     public Resource getResource(String fileURL) {

--- a/server/container/filesystem-api/src/main/java/org/apache/james/filesystem/api/FileSystem.java
+++ b/server/container/filesystem-api/src/main/java/org/apache/james/filesystem/api/FileSystem.java
@@ -82,6 +82,17 @@ public interface FileSystem {
     File getFile(String fileURL) throws FileNotFoundException;
 
     /**
+     * Similar to getFile but enforces the file to be within baseDir
+     */
+    default File getFileWithinBaseDir(String fileURL) throws FileNotFoundException, IOException {
+        File file = getFile(fileURL);
+        if (file.getCanonicalPath().startsWith(getBasedir().getCanonicalPath())) {
+            return file;
+        }
+        throw new IOException(fileURL + " jail break outside of " + getBasedir().getCanonicalPath());
+    }
+
+    /**
      * Return the base folder used by the application
      */
     File getBasedir() throws FileNotFoundException;

--- a/server/container/filesystem-api/src/main/java/org/apache/james/filesystem/api/FileSystem.java
+++ b/server/container/filesystem-api/src/main/java/org/apache/james/filesystem/api/FileSystem.java
@@ -89,7 +89,7 @@ public interface FileSystem {
         if (file.getCanonicalPath().startsWith(getBasedir().getCanonicalPath())) {
             return file;
         }
-        throw new IOException(fileURL + " jail break outside of " + getBasedir().getCanonicalPath());
+        throw new IOException(fileURL + " -> " + file.getCanonicalPath() + " jail break outside of " + getBasedir().getCanonicalPath());
     }
 
     /**

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/context/JamesServerApplicationContext.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/context/JamesServerApplicationContext.java
@@ -18,6 +18,9 @@
  ****************************************************************/
 package org.apache.james.container.spring.context;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.james.container.spring.resource.DefaultJamesResourceLoader;
 import org.apache.james.container.spring.resource.JamesResourceLoader;
 import org.apache.james.server.core.JamesServerResourceLoader;
@@ -38,6 +41,11 @@ public class JamesServerApplicationContext extends ClassPathXmlApplicationContex
 
     public JamesServerApplicationContext(String[] configs) {
         super(configs);
+    }
+
+    @Override
+    public void validate(File file) throws IOException {
+        resourceLoader.validate(file);
     }
 
     /**

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/context/web/JamesServerWebApplicationContext.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/context/web/JamesServerWebApplicationContext.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.container.spring.context.web;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Objects;
 
 import org.apache.james.container.spring.resource.DefaultJamesResourceLoader;
@@ -77,6 +79,11 @@ public class JamesServerWebApplicationContext extends XmlWebApplicationContext i
     private String absoluteDirectory;
     private String varDirectory;
     private String confDirectory;
+
+    @Override
+    public void validate(File file) throws IOException {
+        resourceLoader.validate(file);
+    }
 
     @Override
     public Resource getResource(String fileURL) {

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/filesystem/FileSystemImpl.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/filesystem/FileSystemImpl.java
@@ -61,4 +61,11 @@ public class FileSystemImpl implements FileSystem, ApplicationContextAware {
         this.resourceLoader = (JamesResourceLoader) context;
     }
 
+    @Override
+    public File getFileWithinBaseDir(String fileURL) throws IOException {
+        File file = getFile(fileURL);
+        resourceLoader.validate(file);
+        return file;
+    }
+
 }

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/filesystem/ResourceLoaderFileSystem.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/filesystem/ResourceLoaderFileSystem.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.james.container.spring.resource.JamesResourceLoader;
 import org.apache.james.filesystem.api.FileSystem;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
@@ -51,6 +52,18 @@ public class ResourceLoaderFileSystem implements FileSystem, ResourceLoaderAware
             return loader.getResource(".").getFile();
         } catch (IOException e) {
             throw new FileNotFoundException("Could not access base directory");
+        }
+    }
+
+
+    @Override
+    public File getFileWithinBaseDir(String fileURL) throws IOException {
+        File file = getFile(fileURL);
+        if (loader instanceof JamesResourceLoader) {
+            ((JamesResourceLoader) loader).validate(file);
+            return file;
+        } else {
+            return FileSystem.super.getFileWithinBaseDir(fileURL);
         }
     }
 

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/resource/DefaultJamesResourceLoader.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/resource/DefaultJamesResourceLoader.java
@@ -19,6 +19,7 @@
 package org.apache.james.container.spring.resource;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.filesystem.api.JamesDirectoriesProvider;
@@ -38,6 +39,17 @@ public class DefaultJamesResourceLoader extends DefaultResourceLoader implements
 
     public DefaultJamesResourceLoader(JamesDirectoriesProvider jamesDirectoriesProvider) {
         this.jamesDirectoriesProvider = jamesDirectoriesProvider;
+    }
+
+    @Override
+    public void validate(File file) throws IOException {
+        String canonicalPath = file.getCanonicalPath();
+        if (!canonicalPath.startsWith(jamesDirectoriesProvider.getAbsoluteDirectory())
+            && !canonicalPath.startsWith(jamesDirectoriesProvider.getRootDirectory())
+            && !canonicalPath.startsWith(jamesDirectoriesProvider.getVarDirectory())) {
+
+            throw new IOException(canonicalPath + " jail break outside of " + jamesDirectoriesProvider.getRootDirectory());
+        }
     }
     
     /**

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/resource/JamesResourceLoader.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/resource/JamesResourceLoader.java
@@ -18,6 +18,9 @@
  ****************************************************************/
 package org.apache.james.container.spring.resource;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.james.filesystem.api.JamesDirectoriesProvider;
 import org.springframework.core.io.ResourceLoader;
 
@@ -26,5 +29,8 @@ import org.springframework.core.io.ResourceLoader;
  * important Directories, which are in use by JAMES.
  */
 public interface JamesResourceLoader extends ResourceLoader, JamesDirectoriesProvider {
+    default void validate(File file) throws IOException {
+
+    }
 
 }

--- a/server/data/data-library/src/main/java/org/apache/james/repository/file/AbstractFileRepository.java
+++ b/server/data/data-library/src/main/java/org/apache/james/repository/file/AbstractFileRepository.java
@@ -146,8 +146,8 @@ public abstract class AbstractFileRepository implements Configurable {
         }
 
         try {
-            baseDirectory = fileSystem.getFile(destination);
-        } catch (FileNotFoundException e) {
+            baseDirectory = fileSystem.getFileWithinBaseDir(destination);
+        } catch (IOException e) {
             throw new ConfigurationException("Unable to acces destination " + destination, e);
         }
 


### PR DESCRIPTION
An attacker could use webAdmin REST API to create folders in arbitrary
locations if it is not the case.