### PR TITLE
JAMES-3647 Adopt eclipse-temurin:11-jre-focal docker image

### DIFF
--- a/server/apps/cassandra-app/pom.xml
+++ b/server/apps/cassandra-app/pom.xml
@@ -348,7 +348,7 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>apache/james</image>

--- a/server/apps/distributed-app/pom.xml
+++ b/server/apps/distributed-app/pom.xml
@@ -396,7 +396,7 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>apache/james</image>

--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -280,7 +280,7 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>apache/james</image>

--- a/server/apps/jpa-smtp-app/pom.xml
+++ b/server/apps/jpa-smtp-app/pom.xml
@@ -243,7 +243,7 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>apache/james</image>

--- a/server/apps/memory-app/pom.xml
+++ b/server/apps/memory-app/pom.xml
@@ -271,7 +271,7 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>apache/james</image>


### PR DESCRIPTION
DEPRECATION NOTICE of adoptopenjdk:

This image is officially deprecated in favor of the eclipse-temurin image,
and will receive no further updates after 2021-08-01 (Aug 01, 2021). Please
adjust your usage accordingly.

https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&ordering=last_updated&name=11