### PR TITLE
[Documentation] Fix missing content-type in upgrade schema version co…

### DIFF
--- a/docs/modules/servers/pages/distributed/operate/webadmin.adoc
+++ b/docs/modules/servers/pages/distributed/operate/webadmin.adoc
@@ -3765,7 +3765,7 @@ Response codes:
 ==== Upgrading to a specific version
 
 ....
-curl -XPOST http://ip:port/cassandra/version/upgrade -d '3'
+curl -XPOST -H "Content-Type: application/json http://ip:port/cassandra/version/upgrade -d '3'
 ....
 
 Will schedule the run of the migrations you need to reach schema version

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -2042,7 +2042,7 @@ Response codes:
 ### Upgrading to a specific version
 
 ```
-curl -XPOST http://ip:port/cassandra/version/upgrade -d '3'
+curl -XPOST -H "Content-Type: application/json http://ip:port/cassandra/version/upgrade -d '3'
 ```
 
 Will schedule the run of the migrations you need to reach schema version 3.


### PR DESCRIPTION
…mmand

If the content type is not specified with curl, application/x-www-form-urlencoded is the default one, and then the request fails.