### PR TITLE
JAMES-3647 Adopt eclipse-temurin:11-jre-focal docker image

### DIFF
--- a/examples/custom-james-assembly/pom.xml
+++ b/examples/custom-james-assembly/pom.xml
@@ -54,7 +54,7 @@
                 <version>2.7.1</version>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>apache/james</image>

--- a/server/mailet/mock-smtp-server/pom.xml
+++ b/server/mailet/mock-smtp-server/pom.xml
@@ -124,7 +124,7 @@
                 <version>2.7.0</version>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jre-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>linagora/mock-smtp-server</image>

--- a/src/site/Dockerfile
+++ b/src/site/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM adoptopenjdk:11-jdk-hotspot
+FROM eclipse-temurin:11-jdk-focal
 
 # Install git
 RUN apt-get update


### PR DESCRIPTION
Some update of  https://github.com/apache/james-project/pull/647