### PR TITLE
Upgrade S3 client and Netty

### DIFF
--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -81,17 +81,17 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.65.Final</version>
+            <version>4.1.68.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.1.65.Final</version>
+            <version>4.1.68.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.65.Final</version>
+            <version>4.1.68.Final</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor.addons</groupId>

--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Blob :: S3</name>
 
     <properties>
-        <s3-sdk.version>2.17.9</s3-sdk.version>
+        <s3-sdk.version>2.17.39</s3-sdk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fixes:
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37136 (DoS)
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37137 (DoS)