### PR TITLE
JAMES-3150 Better handle massive deletions as part of BloomFilterGCAl…

### DIFF
--- a/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
+++ b/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
+import java.util.Collection;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.blob.api.BlobId;
@@ -125,6 +126,11 @@ public class AESBlobStoreDAO implements BlobStoreDAO {
     @Override
     public Publisher<Void> delete(BucketName bucketName, BlobId blobId) {
         return underlying.delete(bucketName, blobId);
+    }
+
+    @Override
+    public Publisher<Void> delete(BucketName bucketName, Collection<BlobId> blobIds) {
+        return underlying.delete(bucketName, blobIds);
     }
 
     @Override

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStoreDAO.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStoreDAO.java
@@ -21,6 +21,7 @@ package org.apache.james.blob.api;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 
 import org.reactivestreams.Publisher;
 
@@ -87,6 +88,8 @@ public interface BlobStoreDAO {
      *  otherwise an IOObjectStoreException in its error channel
      */
     Publisher<Void> delete(BucketName bucketName, BlobId blobId);
+
+    Publisher<Void> delete(BucketName bucketName, Collection<BlobId> blobIds);
 
     /**
      * Remove a bucket based on its BucketName

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreDAO.java
@@ -23,6 +23,7 @@ import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -177,6 +178,13 @@ public class CassandraBlobStoreDAO implements BlobStoreDAO {
             return bucketDAO.deletePosition(bucketName, blobId)
                 .then(bucketDAO.deleteParts(bucketName, blobId));
         }
+    }
+
+    @Override
+    public Publisher<Void> delete(BucketName bucketName, Collection<BlobId> blobIds) {
+        return Flux.fromIterable(blobIds)
+            .flatMap(id -> delete(bucketName, id), DEFAULT_CONCURRENCY)
+            .then();
     }
 
     @Override

--- a/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStoreDAO.java
+++ b/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStoreDAO.java
@@ -22,6 +22,7 @@ package org.apache.james.blob.memory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.blob.api.BlobId;
@@ -103,6 +104,13 @@ public class MemoryBlobStoreDAO implements BlobStoreDAO {
                 blobs.remove(bucketName, blobId);
             }
         });
+    }
+
+    @Override
+    public Publisher<Void> delete(BucketName bucketName, Collection<BlobId> blobIds) {
+        return Flux.fromIterable(blobIds)
+            .flatMap(id -> delete(bucketName, id))
+            .then();
     }
 
     @Override

--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -262,6 +263,16 @@ public class S3BlobStoreDAO implements BlobStoreDAO, Startable, Closeable {
             .then()
             .onErrorResume(NoSuchBucketException.class, e -> Mono.empty())
             .publishOn(Schedulers.parallel());
+    }
+
+    @Override
+    public Publisher<Void> delete(BucketName bucketName, Collection<BlobId> blobIds) {
+        return deleteObjects(bucketName,
+            blobIds.stream()
+                .map(BlobId::asString)
+                .map(id -> ObjectIdentifier.builder().key(id).build())
+                .collect(ImmutableList.toImmutableList()))
+            .then();
     }
 
     @Override

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithmContract.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithmContract.java
@@ -23,10 +23,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.awaitility.Durations.TEN_SECONDS;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -48,6 +50,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -231,7 +234,7 @@ public interface BloomFilterGCAlgorithmContract {
         BlobStoreDAO blobStoreDAO = mock(BlobStoreDAO.class);
         BlobId blobId = GENERATION_AWARE_BLOB_ID_FACTORY.randomId();
         when(blobStoreDAO.listBlobs(DEFAULT_BUCKET)).thenReturn(Flux.just(blobId));
-        when(blobStoreDAO.delete(DEFAULT_BUCKET, blobId)).thenThrow(new RuntimeException("test"));
+        when(blobStoreDAO.delete(ArgumentMatchers.eq(DEFAULT_BUCKET), any(Collection.class))).thenReturn(Mono.error(new RuntimeException("test")));
 
         CLOCK.setInstant(NOW.plusMonths(2).toInstant());
 


### PR DESCRIPTION
…gorithm

Before we were deleting 128 objjects in parrallel.

This approach proved to be slow: we took 25 hours for 35M deletions...

With this proposed changeset we delete 1000 blobs per requests,
16 in parallel, using a S3 API to delete several objects at
once.