### PR TITLE
JAMES-1436 SwitchableLineBasedFrameDecoder: clean up cumulation buffer [BACKPORT]

### DIFF
--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
@@ -58,6 +58,7 @@ public class SwitchableLineBasedFrameDecoder extends AllButStartTlsLineBasedChan
         this.framingEnabled = false;
         if (this.cumulation != null && this.cumulation.readable()) {
             final ChannelBuffer spareBytes = this.cumulation.readBytes(this.cumulation.readableBytes());
+            this.cumulation = null;
             Channels.fireMessageReceived(ctx, spareBytes);
         }
     }

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -44,6 +44,7 @@ import org.apache.james.utils.TestIMAPClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -146,7 +147,7 @@ class IMAPServerTest {
                 .contains("\r\n" + _65K_MESSAGE + ")\r\n");
         }
 
-        @Test
+        @RepeatedTest(200)
         void largeAppendsShouldWork() throws Exception {
             assertThatCode(() ->
                 testIMAPClient.connect("127.0.0.1", port)


### PR DESCRIPTION
Thanks https://github.com/jtconsol for the report.

If data remains in the cumulation buffer after say a APPEND, we flush it, as it avoids
APPEND to wait indefinitly for data. However this did let the cumulation buffer in a
non usable state causing following commands to fail.

We should this set the cumulation buffer to null to no longer use it (and allocate a new one)
in order to prevent failures in follow up message processing.