### PR TITLE
MAILBOX-333 Avoid overQuotaMailing failures when no size limit

### DIFF
--- a/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/subscribers/QuotaThresholdNotice.java
+++ b/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/subscribers/QuotaThresholdNotice.java
@@ -199,7 +199,7 @@ public class QuotaThresholdNotice {
         scopes.put("usedCount", countQuota.getUsed().asLong());
         scopes.put("hasCountLimit", countQuota.getLimit().isLimited());
         if (countQuota.getLimit().isLimited()) {
-            scopes.put("limitCount", sizeQuota.getLimit().asLong());
+            scopes.put("limitCount", countQuota.getLimit().asLong());
         }
 
         return scopes;

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/subscribers/QuotaThresholdNoticeTest.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/subscribers/QuotaThresholdNoticeTest.java
@@ -186,6 +186,64 @@ class QuotaThresholdNoticeTest {
     }
 
     @Test
+    void generateReportShouldGenerateAHumanReadableMessageWhenNoCountQuota() throws Exception {
+        QuotaThresholdChange sizeThresholdChange = new QuotaThresholdChange(_80, NOW);
+        QuotaThresholdChange countThresholdChange = new QuotaThresholdChange(_80, NOW);
+
+        assertThat(QuotaThresholdNotice.builder()
+            .withConfiguration(DEFAULT_CONFIGURATION)
+            .sizeQuota(Sizes._82_PERCENT)
+            .countQuota(Quota.<QuotaCountLimit, QuotaCountUsage>builder()
+                .used(QuotaCountUsage.count(92))
+                .computedLimit(QuotaCountLimit.unlimited())
+                .build())
+            .sizeThreshold(HistoryEvolution.higherThresholdReached(sizeThresholdChange, NotAlreadyReachedDuringGracePeriod))
+            .countThreshold(HistoryEvolution.higherThresholdReached(countThresholdChange, NotAlreadyReachedDuringGracePeriod))
+            .build()
+            .get()
+            .generateReport(fileSystem))
+            .isEqualTo("You receive this email because you recently exceeded a threshold related to the quotas of your email account.\n" +
+                "\n" +
+                "You currently occupy more than 80 % of the total size allocated to you.\n" +
+                "You currently occupy 82 bytes on a total of 100 bytes allocated to you.\n" +
+                "\n" +
+                "You currently occupy more than 80 % of the total message count allocated to you.\n" +
+                "You currently have 92 messages.\n" +
+                "\n" +
+                "You need to be aware that actions leading to exceeded quotas will be denied. This will result in a degraded service.\n" +
+                "To mitigate this issue you might reach your administrator in order to increase your configured quota. You might also delete some non important emails.");
+    }
+
+    @Test
+    void generateReportShouldGenerateAHumanReadableMessageWhenNoSizeQuota() throws Exception {
+        QuotaThresholdChange sizeThresholdChange = new QuotaThresholdChange(_80, NOW);
+        QuotaThresholdChange countThresholdChange = new QuotaThresholdChange(_80, NOW);
+
+        assertThat(QuotaThresholdNotice.builder()
+            .withConfiguration(DEFAULT_CONFIGURATION)
+            .countQuota(Counts._92_PERCENT)
+            .sizeQuota(Quota.<QuotaSizeLimit, QuotaSizeUsage>builder()
+                .used(QuotaSizeUsage.size(82))
+                .computedLimit(QuotaSizeLimit.unlimited())
+                .build())
+            .sizeThreshold(HistoryEvolution.higherThresholdReached(sizeThresholdChange, NotAlreadyReachedDuringGracePeriod))
+            .countThreshold(HistoryEvolution.higherThresholdReached(countThresholdChange, NotAlreadyReachedDuringGracePeriod))
+            .build()
+            .get()
+            .generateReport(fileSystem))
+            .isEqualTo("You receive this email because you recently exceeded a threshold related to the quotas of your email account.\n" +
+                "\n" +
+                "You currently occupy more than 80 % of the total size allocated to you.\n" +
+                "You currently occupy 82 bytes.\n" +
+                "\n" +
+                "You currently occupy more than 80 % of the total message count allocated to you.\n" +
+                "You currently have 92 messages on a total of 100 allowed for you.\n" +
+                "\n" +
+                "You need to be aware that actions leading to exceeded quotas will be denied. This will result in a degraded service.\n" +
+                "To mitigate this issue you might reach your administrator in order to increase your configured quota. You might also delete some non important emails.");
+    }
+
+    @Test
     void generateReportShouldOmitCountPartWhenNone() throws Exception {
         QuotaThresholdChange sizeThresholdChange = new QuotaThresholdChange(_80, NOW);
 


### PR DESCRIPTION
```
java.lang.IllegalStateException: null
	at java.base/java.util.Optional.orElseThrow(Optional.java:408)
	at org.apache.james.core.quota.QuotaSizeLimit.asLong(QuotaSizeLimit.java:52)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdNotice.computeScopes(QuotaThresholdNotice.java:202)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdNotice.renderTemplate(QuotaThresholdNotice.java:169)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdNotice.generateSubject(QuotaThresholdNotice.java:146)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdNotice.generateMimeMessage(QuotaThresholdNotice.java:140)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdMailer.sendNotice(QuotaThresholdMailer.java:78)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdMailer.lambda$handleEvent$0(QuotaThresholdMailer.java:70)
	at com.github.fge.lambdas.consumers.ConsumerChainer.doAccept(ConsumerChainer.java:20)
	at com.github.fge.lambdas.consumers.ThrowingConsumer.accept(ThrowingConsumer.java:22)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdMailer.handleEvent(QuotaThresholdMailer.java:70)
	at org.apache.james.mailbox.quota.mailing.subscribers.QuotaThresholdMailer.handle(QuotaThresholdMailer.java:57)
	at org.apache.james.eventsourcing.ReactiveSubscriberWrapper.handle(Subscriber.scala:43)
```