### PR TITLE
JAMES-3656 Ignore failures in non essential feature prior delivery

### DIFF
--- a/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/resources/mailetcontainer.xml
+++ b/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/resources/mailetcontainer.xml
@@ -60,8 +60,12 @@
             <mailet match="All" class="RemoveMimeHeader">
                 <name>bcc</name>
             </mailet>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>rrt-error</errorProcessor>
             </mailet>

--- a/mpt/impl/smtp/cassandra/src/test/resources/mailetcontainer.xml
+++ b/mpt/impl/smtp/cassandra/src/test/resources/mailetcontainer.xml
@@ -63,8 +63,12 @@
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>rrt-error</errorProcessor>
             </mailet>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="RemoteDelivery">
                 <outgoingQueue>outgoing</outgoingQueue>
                 <delayTime>5 minutes</delayTime>

--- a/server/apps/cassandra-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/cassandra-app/sample-configuration/mailetcontainer.xml
@@ -87,10 +87,16 @@
         </processor>
 
         <processor state="local-delivery" enableJmx="true">
-            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="All" class="Sieve"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="AddDeliveredToHeader"/>
-            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="LocalDelivery"/>
         </processor>
 

--- a/server/apps/cassandra-app/src/test/resources/mailetcontainer.xml
+++ b/server/apps/cassandra-app/src/test/resources/mailetcontainer.xml
@@ -95,10 +95,16 @@
             <mailet match="IsMarkedAsSpam" class="WithStorageDirective">
                 <targetFolderName>Spam</targetFolderName>
             </mailet>
-            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="All" class="Sieve"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="AddDeliveredToHeader"/>
-            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="LocalDelivery"/>
         </processor>
 

--- a/server/apps/distributed-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/distributed-app/sample-configuration/mailetcontainer.xml
@@ -87,10 +87,16 @@
         </processor>
 
         <processor state="local-delivery" enableJmx="true">
-            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="All" class="Sieve"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="AddDeliveredToHeader"/>
-            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="LocalDelivery"/>
         </processor>
 

--- a/server/apps/distributed-app/src/test/resources/mailetcontainer.xml
+++ b/server/apps/distributed-app/src/test/resources/mailetcontainer.xml
@@ -94,8 +94,12 @@
 
 
         <processor state="local-delivery" enableJmx="true">
-            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="LocalDelivery"/>
         </processor>
 

--- a/server/apps/memory-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/memory-app/sample-configuration/mailetcontainer.xml
@@ -87,10 +87,16 @@
         </processor>
 
         <processor state="local-delivery" enableJmx="true">
-            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="All" class="Sieve"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="AddDeliveredToHeader"/>
-            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="LocalDelivery"/>
         </processor>
 

--- a/server/apps/memory-app/src/test/resources/mailetcontainer.xml
+++ b/server/apps/memory-app/src/test/resources/mailetcontainer.xml
@@ -106,10 +106,16 @@
             <mailet match="IsMarkedAsSpam" class="WithStorageDirective">
                 <targetFolderName>Spam</targetFolderName>
             </mailet>
-            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="All" class="Sieve"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="AddDeliveredToHeader"/>
-            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="LocalDelivery"/>
         </processor>
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/mailetcontainer.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/mailetcontainer.xml
@@ -65,11 +65,15 @@
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>rrt-error</errorProcessor>
             </mailet>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="mdn-matcher" class="org.apache.james.jmap.mailet.ExtractMDNOriginalJMAPMessageId" >
                 <onMailetException>ignore</onMailetException>
             </mailet>
-            <mailet match="RecipientIsLocal" class="Sieve"/>
+            <mailet match="RecipientIsLocal" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="RecipientIsLocal" class="SpamAssassin">
                 <onMailetException>ignore</onMailetException>
                 <spamdHost>localhost</spamdHost>
@@ -78,7 +82,9 @@
             <mailet match="IsMarkedAsSpam" class="WithStorageDirective">
                 <targetFolderName>Spam</targetFolderName>
             </mailet>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="RecipientIsLocal" class="LocalDelivery"/>
             <mailet match="HostIsLocal" class="ToProcessor">
                 <processor>local-address-error</processor>

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/mailetcontainer.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/mailetcontainer.xml
@@ -61,11 +61,15 @@
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>error</errorProcessor>
             </mailet>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="mdn-matcher" class="org.apache.james.jmap.mailet.ExtractMDNOriginalJMAPMessageId" >
                 <onMailetException>ignore</onMailetException>
             </mailet>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="RecipientIsLocal" class="LocalDelivery"/>
 
             <mailet match="relay-allowed" class="RemoteDelivery">

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/mailetcontainer.xml
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/mailetcontainer.xml
@@ -62,9 +62,15 @@
                 <name>bcc</name>
             </mailet>
             <mailet match="All" class="RecipientRewriteTable" />
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="RecipientIsLocal" class="Sieve"/>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="RecipientIsLocal" class="LocalDelivery"/>
             <mailet match="HostIsLocal" class="ToProcessor">
                 <processor>local-address-error</processor>

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/mailetcontainer.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/mailetcontainer.xml
@@ -62,9 +62,15 @@
                 <name>bcc</name>
             </mailet>
             <mailet match="All" class="RecipientRewriteTable" />
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="RecipientIsLocal" class="Sieve"/>
-            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="RecipientIsLocal" class="LocalDelivery"/>
             <mailet match="HostIsLocal" class="ToProcessor">
                 <processor>local-address-error</processor>


### PR DESCRIPTION
https://ci-builds.apache.org/job/james/job/ApacheJames/job/master/281/testReport/junit/org.apache.james/WithCassandraPassThroughBlobStoreMutableTest/oneHundredMailsShouldBeWellReceived_GuiceJamesServer_/

This master build did fail because JMAP filtering failed for one of the emails.

This test sends 100 emails to a single recipient. Single recipients have their filters on a single Primary Key, and filters are managed by a Cassandra Lightweight transaction (refer to JAMES-3435 for background regarding LightWeight transactions in the project). Apparently this is enough to create contention!


```
05:02:05.113 [ERROR] o.a.j.m.i.ProcessorImpl - Exception calling org.apache.james.jmap.mailet.filter.JMAPFiltering: Cassandra timeout during read query at consistency SERIAL (1 responses were required but only 0 replica responded)
com.datastax.driver.core.exceptions.ReadTimeoutException: Cassandra timeout during read query at consistency SERIAL (1 responses were required but only 0 replica responded)
	at com.datastax.driver.core.exceptions.ReadTimeoutException.copy(ReadTimeoutException.java:124)
```

This results in one email not making it to its destination...

```
org.awaitility.core.ConditionTimeoutException: 
Assertion condition defined as a lambda expression in org.apache.james.utils.TestIMAPClient 
expected: 100L
but was : 99L within 10 seconds.
```

There is little things we can do regarding LWT performance (since Cassandra 3.11.10 even SERIAL reads implies to commit an empty update!).

However, as 'filtering' is (in my opinion at least) not critical - my philosophy would be "don't loose emails - even if that means some features could not be run...".

As such I propose to ignore errors arising upon JMAPFiltering - this would also make the above mentioned test stable.
