### PR TITLE
JAMES-3660 Cassandra mailbox creation unstable when high concurency

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -95,6 +95,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -164,7 +165,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         mailboxManager.endProcessingRequest(session);
     }
 
-    @Test
+    @RepeatedTest(10)
     protected void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
         MailboxSession session = mailboxManager.createSystemSession(USER_1);
         String mailboxName = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z";
@@ -186,6 +187,21 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         assertThat(mailboxId.isPresent()).isTrue();
         assertThat(mailboxId.get()).isEqualTo(retrievedMailbox.getId());
+    }
+
+    @Test
+    void createShouldSucceedWhenSubFolderExists() throws Exception {
+        session = mailboxManager.createSystemSession(USER_1);
+        mailboxManager.startProcessingRequest(session);
+
+        MailboxId parentId = mailboxManager.createMailbox(MailboxPath.forUser(USER_1, "name"), session).get();
+        MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "name.subfolder");
+        Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, session);
+        MessageManager retrievedMailbox = mailboxManager.getMailbox(mailboxPath, session);
+
+        assertThat(mailboxId.isPresent()).isTrue();
+        assertThat(mailboxId.get()).isEqualTo(retrievedMailbox.getId());
+        assertThat(mailboxManager.getMailbox(MailboxPath.forUser(USER_1, "name"), session).getId()).isEqualTo(parentId);
     }
 
     @Nested

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -89,7 +89,6 @@ import org.apache.james.mailbox.store.quota.QuotaComponents;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.user.SubscriptionMapper;
 import org.apache.james.mailbox.store.user.model.Subscription;
-import org.apache.james.util.FunctionalUtils;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -397,9 +396,7 @@ public class StoreMailboxManager implements MailboxManager {
         List<MailboxId> mailboxIds = new ArrayList<>();
         MailboxMapper mapper = mailboxSessionMapperFactory.getMailboxMapper(mailboxSession);
         locker.executeWithLock(mailboxPath, () ->
-            block(mapper.pathExists(mailboxPath)
-                .filter(FunctionalUtils.identityPredicate().negate())
-                .flatMap(any -> mapper.executeReactive(mapper.create(mailboxPath, UidValidity.generate())
+            block(mapper.executeReactive(mapper.create(mailboxPath, UidValidity.generate())
                     .doOnNext(mailbox -> mailboxIds.add(mailbox.getMailboxId()))
                     .flatMap(mailbox ->
                         // notify listeners
@@ -416,8 +413,7 @@ public class StoreMailboxManager implements MailboxManager {
                             return Mono.error(e);
                         }
                         return Mono.empty();
-                    }))
-                .then()), MailboxPathLocker.LockType.Write);
+                    })), MailboxPathLocker.LockType.Write);
 
         return mailboxIds;
     }


### PR DESCRIPTION
org.apache.james.mailbox.cassandra.CassandraMailboxManagerTest$WithBatchSize.creatingConcurrentlyMailboxesWithSameParentShouldNotFail

tests is enough to trigger instability on the Apache CI

https://ci-builds.apache.org/job/james/job/ApacheJames/job/PR-685/1/

In short, the LWT usage is enough to create contention.

Looking closer at the issue, StoreMailboxManager does numerous defensive SERIAL reads (doing empty paxos commits) which ends up further degrading performance and increase contention.

I believe removing these defensive reads would make our code more stable.

It resulted in faster (x2) test for gConcurrentlyMailboxesWithSameParentShouldNotFail