### PR TITLE
JAMES-3658 LocalResourcesImpl should public constructor

### DIFF
--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/LocalResourcesImpl.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/LocalResourcesImpl.java
@@ -55,7 +55,7 @@ public class LocalResourcesImpl implements LocalResources {
     private final RecipientRewriteTable recipientRewriteTable;
 
     @Inject
-    LocalResourcesImpl(UsersRepository localUsers, DomainList domains, RecipientRewriteTable recipientRewriteTable) {
+    public LocalResourcesImpl(UsersRepository localUsers, DomainList domains, RecipientRewriteTable recipientRewriteTable) {
         this.localUsers = localUsers;
         this.domains = domains;
         this.recipientRewriteTable = recipientRewriteTable;


### PR DESCRIPTION
In order to easier for reusable