### PR TITLE
JAMES-2344 UserQuotaRootResolver should allow linking QuotaRoot for o…

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/quota/UserQuotaRootResolver.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/quota/UserQuotaRootResolver.java
@@ -25,4 +25,11 @@ public interface UserQuotaRootResolver extends QuotaRootResolver {
 
     QuotaRoot forUser(Username username);
 
+    /**
+     * When the username might not point to a user entity, and an extra translation step is required
+     * for the quota root.
+     */
+    default QuotaRoot forMailAddress(Username username) {
+        return forUser(username);
+    }
 }

--- a/mailbox/plugin/quota-search-scanning/src/main/java/org/apache/james/quota/search/scanning/ClauseConverter.java
+++ b/mailbox/plugin/quota-search-scanning/src/main/java/org/apache/james/quota/search/scanning/ClauseConverter.java
@@ -94,7 +94,7 @@ public class ClauseConverter {
 
     private double retrieveUserRatio(Username username) {
         try {
-            QuotaRoot quotaRoot = quotaRootResolver.forUser(username);
+            QuotaRoot quotaRoot = quotaRootResolver.forMailAddress(username);
             QuotaManager.Quotas quotas = quotaManager.getQuotas(quotaRoot);
             Quota<QuotaSizeLimit, QuotaSizeUsage> storageQuota = quotas.getStorageQuota();
             Quota<QuotaCountLimit, QuotaCountUsage> messageQuota = quotas.getMessageQuota();

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserQuotaService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserQuotaService.java
@@ -80,7 +80,10 @@ public class UserQuotaService {
     }
 
     public QuotaDetailsDTO getQuota(Username username) throws MailboxException {
-        QuotaRoot quotaRoot = userQuotaRootResolver.forUser(username);
+        return getQuota(userQuotaRootResolver.forUser(username));
+    }
+
+    private QuotaDetailsDTO getQuota(QuotaRoot quotaRoot) throws MailboxException {
         QuotaManager.Quotas quotas = quotaManager.getQuotas(quotaRoot);
         QuotaDetailsDTO.Builder quotaDetails = QuotaDetailsDTO.builder()
             .occupation(quotas.getStorageQuota(),
@@ -144,7 +147,7 @@ public class UserQuotaService {
             .stream()
             .map(Throwing.function(user -> UsersQuotaDetailsDTO.builder()
                 .user(user)
-                .detail(getQuota(user))
+                .detail(getQuota(userQuotaRootResolver.forMailAddress(user)))
                 .build()))
             .collect(ImmutableList.toImmutableList());
     }


### PR DESCRIPTION
…ther entity than users

 -> forUser is to be used when the username is strictly linked to a user
 -> forMailAddress is to be used when the username could reference another entity than a user.