### PR TITLE
[PERFORMANCE] Limit context switches

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -134,7 +134,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
                 .map(metadata::asMailboxMessage);
         }
         return messageDAOV3.retrieveMessage(metadata.getComposedMessageId(), fetchType)
-            .switchIfEmpty(messageDAO.retrieveMessage(metadata.getComposedMessageId(), fetchType))
+            .switchIfEmpty(Mono.defer(() -> messageDAO.retrieveMessage(metadata.getComposedMessageId(), fetchType)))
             .map(messageRepresentation -> Pair.of(metadata.getComposedMessageId(), messageRepresentation))
             .flatMap(messageRepresentation -> attachmentLoader.addAttachmentToMessage(messageRepresentation, fetchType));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -346,13 +346,18 @@ public class CassandraMessageMapper implements MessageMapper {
 
     @Override
     public MessageMetaData add(Mailbox mailbox, MailboxMessage message) throws MailboxException {
+        return block(addReactive(mailbox, message));
+    }
+
+    @Override
+    public Mono<MessageMetaData> addReactive(Mailbox mailbox, MailboxMessage message) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
-        return block(addUidAndModseq(message, mailboxId)
+        return addUidAndModseq(message, mailboxId)
             .flatMap(Throwing.function((MailboxMessage messageWithUidAndModSeq) ->
                 save(mailbox, messageWithUidAndModSeq)
                     .thenReturn(messageWithUidAndModSeq)))
-            .map(MailboxMessage::metaData));
+            .map(MailboxMessage::metaData);
     }
 
     private Mono<MailboxMessage> addUidAndModseq(MailboxMessage message, CassandraId mailboxId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -265,7 +265,7 @@ public class CassandraMessageMapper implements MessageMapper {
                 .map(metadata::asMailboxMessage);
         }
         return messageDAOV3.retrieveMessage(metadata.getComposedMessageId(), fetchType)
-            .switchIfEmpty(messageDAO.retrieveMessage(metadata.getComposedMessageId(), fetchType))
+            .switchIfEmpty(Mono.defer(() -> messageDAO.retrieveMessage(metadata.getComposedMessageId(), fetchType)))
             .map(messageRepresentation -> Pair.of(metadata.getComposedMessageId(), messageRepresentation))
             .flatMap(messageRepresentation -> attachmentLoader.addAttachmentToMessage(messageRepresentation, fetchType));
     }
@@ -313,7 +313,7 @@ public class CassandraMessageMapper implements MessageMapper {
     private Mono<SimpleMailboxMessage> expungeOne(ComposedMessageIdWithMetaData metaData) {
         return delete(metaData)
             .then(messageDAOV3.retrieveMessage(metaData, FetchType.Metadata)
-                .switchIfEmpty(messageDAO.retrieveMessage(metaData, FetchType.Metadata)))
+                .switchIfEmpty(Mono.defer(() -> messageDAO.retrieveMessage(metaData, FetchType.Metadata))))
             .map(pair -> pair.toMailboxMessage(metaData, ImmutableList.of()));
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactory.java
@@ -51,6 +51,7 @@ import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mime4j.dom.Message;
+import org.apache.james.util.ReactorUtils;
 import org.apache.james.util.html.HtmlTextExtractor;
 import org.apache.james.util.mime.MessageContentExtractor;
 import org.apache.james.util.mime.MessageContentExtractor.MessageContent;
@@ -158,7 +159,8 @@ public class MessageFullViewFactory implements MessageViewFactory<MessageFullVie
     }
 
     private Mono<MessageFastViewPrecomputedProperties> computeProjection(MessageContent messageContent, Supplier<Boolean> hasAttachments) {
-        return Mono.justOrEmpty(mainTextContent(messageContent))
+        return Mono.fromCallable(() -> mainTextContent(messageContent))
+            .handle(ReactorUtils.publishIfPresent())
             .map(Preview::compute)
             .defaultIfEmpty(Preview.EMPTY)
             .map(extractedPreview -> MessageFastViewPrecomputedProperties.builder()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListener.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListener.java
@@ -44,7 +44,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class ComputeMessageFastViewProjectionListener implements EventListener.ReactiveGroupEventListener {
     public static class ComputeMessageFastViewProjectionListenerGroup extends Group {
@@ -90,9 +89,8 @@ public class ComputeMessageFastViewProjectionListener implements EventListener.R
     private Mono<Void> handleAddedEvent(Added addedEvent, MailboxSession session) {
         return Flux.from(messageIdManager.getMessagesReactive(addedEvent.getMessageIds(), FetchGroup.FULL_CONTENT, session))
             .flatMap(Throwing.function(messageResult -> Mono.fromCallable(
-                () -> Pair.of(messageResult.getMessageId(), computeFastViewPrecomputedProperties(messageResult)))
-                    .subscribeOn(Schedulers.parallel())), DEFAULT_CONCURRENCY)
-            .publishOn(Schedulers.elastic())
+                () -> Pair.of(messageResult.getMessageId(),
+                    computeFastViewPrecomputedProperties(messageResult)))), DEFAULT_CONCURRENCY)
             .flatMap(message -> messageFastViewProjection.store(message.getKey(), message.getValue()), DEFAULT_CONCURRENCY)
             .then();
     }


### PR DESCRIPTION
Before: 10.22% of time is spent in Unsafe.park/unpark, after it is 9.12%.

We also have a little performance enhancement (not reaching system limit...)

Before

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                     126470 (OK=126470 KO=0     )
> min response time                                      6 (OK=6      KO=-     )
> max response time                                   6958 (OK=6958   KO=-     )
> mean response time                                    57 (OK=57     KO=-     )
> std deviation                                        139 (OK=139    KO=-     )
> response time 50th percentile                         28 (OK=28     KO=-     )
> response time 75th percentile                         61 (OK=61     KO=-     )
> response time 95th percentile                        174 (OK=174    KO=-     )
> response time 99th percentile                        400 (OK=400    KO=-     )
> mean requests/sec                                 173.01 (OK=173.01 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                        126097 (100%)
> 800 ms < t < 1200 ms                                 211 (  0%)
> t > 1200 ms                                          162 (  0%)
> failed                                                 0 (  0%)
================================================================================
```

After

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                     127502 (OK=127502 KO=0     )
> min response time                                      5 (OK=5      KO=-     )
> max response time                                   3355 (OK=3355   KO=-     )
> mean response time                                    43 (OK=43     KO=-     )
> std deviation                                         84 (OK=84     KO=-     )
> response time 50th percentile                         18 (OK=18     KO=-     )
> response time 75th percentile                         42 (OK=42     KO=-     )
> response time 95th percentile                        136 (OK=136    KO=-     )
> response time 99th percentile                        342 (OK=342    KO=-     )
> mean requests/sec                                  174.9 (OK=174.9  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                        127238 (100%)
> 800 ms < t < 1200 ms                                 173 (  0%)
> t > 1200 ms                                           91 (  0%)
> failed                                                 0 (  0%)
================================================================================
```