### PR TITLE
JAMES-3666 Fix DSNBounce exception when no Date header is present

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -23,7 +23,6 @@ import static org.apache.james.transport.mailets.remote.delivery.Bouncer.DELIVER
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -361,7 +360,7 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
     private String getDateHeader(Mail originalMail) throws MessagingException {
         String[] date = originalMail.getMessage().getHeader(RFC2822Headers.DATE);
         if (date == null) {
-            return dateFormatter.format(LocalDateTime.now());
+            return dateFormatter.format(ZonedDateTime.now());
         }
         return date[0];
     }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -216,6 +216,7 @@ public class DSNBounceTest {
                 .recipient("recipient@domain.com")
                 .lastUpdated(Date.from(Instant.parse("2016-09-08T14:25:52.000Z")))
                 .build();
+            mail.getMessage().removeHeader(RFC2822Headers.DATE);
 
             dsnBounce.service(mail);
 


### PR DESCRIPTION
When the DSNBounce mailet processes a mail without a Date header, it fails with the exception

`java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: OffsetSeconds`

because the LocalDateTime used to construct the new date does not include timezone information required by the date formatter.

The fix is to construct the new date via ZonedDateTime instead.

There is actually a unit test for this, but the MimeMessageBuilder adds a Date header by default if not specified. The test fix is to explicitly remove the Date header after building.