### PR TITLE
JAMES-3539 Fix a dependency conflict

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/PushServerExtension.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/PushServerExtension.scala
@@ -1,0 +1,95 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ************************************************************** */
+
+package org.apache.james.jmap.rfc8621.contract
+
+import java.net.URL
+import java.time.Clock
+import java.util.UUID
+
+import org.junit.jupiter.api.`extension`.{AfterEachCallback, BeforeEachCallback, ExtensionContext, ParameterContext, ParameterResolver}
+import org.mockserver.configuration.ConfigurationProperties
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.mockserver.model.NottableString.{not, string}
+
+class PushServerExtension extends BeforeEachCallback with AfterEachCallback with ParameterResolver {
+  var mockServer: ClientAndServer = _
+
+  override def afterEach(extensionContext: ExtensionContext): Unit = mockServer.close()
+
+  override def supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
+    parameterContext.getParameter.getType eq classOf[ClientAndServer]
+
+  override def resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): AnyRef =
+    mockServer
+
+  override def beforeEach(extensionContext: ExtensionContext): Unit = {
+    mockServer = startClientAndServer(0)
+    ConfigurationProperties.logLevel("WARN")
+    MockPushServer.appendSpec(mockServer)
+  }
+
+  def getBaseUrl: URL = new URL(s"http://127.0.0.1:${mockServer.getLocalPort}")
+}
+
+object MockPushServer {
+  def appendSpec(mockServer: ClientAndServer): Unit = {
+    mockServer
+      .when(request.withHeader(not("TTL")))
+      .respond(response.withStatusCode(400).withBody("missing TTL header"))
+
+    mockServer
+      .when(request.withHeader(not("Content-type")))
+      .respond(response.withStatusCode(400).withBody("Content-type is missing or invalid"))
+
+    mockServer
+      .when(request.withHeader(string("Content-type"), not("application/json charset=utf-8")))
+      .respond(response.withStatusCode(400).withBody("Content-type is missing or invalid"))
+
+    mockServer
+      .when(request
+        .withPath("/push")
+        .withMethod("POST")
+        .withHeader(string("Content-type"), string("application/json charset=utf-8"))
+        .withHeader(string("Urgency"))
+        .withHeader(string("Topic"))
+        .withHeader(string("TTL")))
+      .respond(response
+        .withStatusCode(201)
+        .withHeader("Location", String.format("https://push.example.net/message/%s", UUID.randomUUID))
+        .withHeader("Date", Clock.systemUTC.toString)
+        .withBody(UUID.randomUUID.toString))
+
+    mockServer
+      .when(request
+        .withPath("/push")
+        .withMethod("POST")
+        .withHeader(string("Content-type"), string("application/json charset=utf-8"))
+        .withHeader(string("Content-Encoding"))
+        .withHeader(string("TTL")))
+      .respond(response
+        .withStatusCode(201)
+        .withHeader("Location", String.format("https://push.example.net/message/%s", UUID.randomUUID))
+        .withHeader("Date", Clock.systemUTC.toString)
+        .withBody(UUID.randomUUID.toString))
+  }
+}

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/pom.xml
@@ -43,12 +43,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-jmap-rfc-8621</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>james-server-memory-app</artifactId>
             <scope>test</scope>

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryPushSubscriptionSetMethodTest.java
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryPushSubscriptionSetMethodTest.java
@@ -22,11 +22,11 @@ package org.apache.james.jmap.rfc8621.memory;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.jmap.rfc8621.contract.PushServerExtension;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionProbeModule;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionSetMethodContract;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.apache.james.jmap.pushsubscription.PushServerExtension;
 
 public class MemoryPushSubscriptionSetMethodTest implements PushSubscriptionSetMethodContract {
     @RegisterExtension

--- a/server/protocols/jmap-rfc-8621-integration-tests/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/pom.xml
@@ -44,12 +44,6 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>${james.groupId}</groupId>
-                <artifactId>james-server-jmap-rfc-8621</artifactId>
-                <version>${project.version}</version>
-                <type>test-jar</type>
-            </dependency>
-            <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>james-server-guice-jmap</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
One of the weirdest things I have seen so far.

Solves https://ci-builds.apache.org/job/james/job/ApacheJames/job/master/332/

```
Error Message

Different value found in node "methodResponses[0][1].sent.k1546.textBody", expected: <string> but was: <missing>.

Stacktrace

java.lang.AssertionError: Different value found in node "methodResponses[0][1].sent.k1546.textBody", expected: <string> but was: <missing>.
```

Under the hood javax.mail was not able to handle `message/disposition-notification` content type.

I don't know why the build on https://github.com/apache/james-project/pull/724 was :green_apple: ...