### PR TITLE
JAMES-3600 Fix check Content-Length when ProvisioningTest

### DIFF
--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -95,7 +96,7 @@ public abstract class ProvisioningTest {
         .when()
             .post("/jmap")
         .then()
-            .header("Content-Length", "2735")
+            .header("Content-Length", notNullValue())
             .statusCode(200)
             .body(NAME, equalTo("mailboxes"))
             .body(ARGUMENTS + ".list", hasSize(6))


### PR DESCRIPTION
The test case `ProvisioningTest.provisionMailboxesShouldNotDuplicateMailboxByName` some times pass, some times fail.
Because the Content-Length is not a `2735` for all repeat tests. 

Example: 
- If the `id` in response is 9 => length =1
- If the `id` in response is 10 => length =2


I checked other JUnit tests that have validated content length in https://github.com/apache/james-project/pull/494.
But I don't think the risk from them. So, I just only fix this JUnit test
