### PR TITLE
JAMES-3667 Add a WebAdmin route for verifying a user password.

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/operate/webadmin.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/operate/webadmin.adoc
@@ -473,6 +473,23 @@ Response codes:
 
 This also can be used to create a new user.
 
+
+=== Verifying a user password
+
+....
+curl -XPOST http://ip:port/users/usernameToBeUsed/verify \
+  -d '{"password":"passwordToBeVerified"}' \
+  -H "Content-Type: application/json"
+....
+
+Response codes:
+
+- 204: The user's password was correct
+- 401: Wrong password or user does not exist
+- 400: The user name or the payload is invalid
+
+This intentionally treats non-existing users as unauthenticated, to prevent a username oracle attack.
+
 === Testing a user existence
 
 ....

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/dto/VerifyUserRequest.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/dto/VerifyUserRequest.java
@@ -1,0 +1,39 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+public class VerifyUserRequest {
+
+    private final String password;
+
+    @JsonCreator
+    public VerifyUserRequest(@JsonProperty("password") String password) {
+        Preconditions.checkNotNull(password);
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/UserService.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/UserService.java
@@ -65,6 +65,10 @@ public class UserService {
         }
     }
 
+    public boolean verifyUser(Username username, String password) throws UsersRepositoryException {
+        return usersRepository.test(username, password);
+    }
+
     public boolean userExists(Username username) throws UsersRepositoryException {
         return usersRepository.contains(username);
     }

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/UserRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/UserRoutesTest.java
@@ -776,6 +776,48 @@ class UserRoutesTest {
                 .body("message", is("Invalid arguments supplied in the user request"));
         }
 
+        @Test
+        void verifyShouldReturnOkWhenUserPasswordMatches() {
+            with()
+                .body("{\"password\":\"password\"}")
+                .put(USERNAME_WITH_DOMAIN.asString());
+
+            given()
+                .body("{\"password\":\"password\"}")
+            .when()
+                .post(USERNAME_WITH_DOMAIN.asString() + "/verify")
+            .then()
+                .statusCode(HttpStatus.NO_CONTENT_204);
+        }
+
+        @Test
+        void verifyShouldReturnUnauthorizedWhenUserPasswordDoesntMatch() {
+            with()
+                .body("{\"password\":\"password\"}")
+                .put(USERNAME_WITH_DOMAIN.asString());
+
+            given()
+                .body("{\"password\":\"false\"}")
+            .when()
+                .post(USERNAME_WITH_DOMAIN.asString() + "/verify")
+            .then()
+                .statusCode(HttpStatus.UNAUTHORIZED_401);
+        }
+
+        @Test
+        void verifyShouldReturnUnauthorizedWhenUserDoesNotExist() {
+            with()
+                .body("{\"password\":\"password\"}")
+                .put(USERNAME_WITH_DOMAIN.asString());
+
+            given()
+                .body("{\"password\":\"password\"}")
+            .when()
+                .post("/NOTusername@domain/verify")
+            .then()
+                .statusCode(HttpStatus.UNAUTHORIZED_401);
+        }
+
         @Nested
         class IllegalCharacterErrorHandlingTest implements UserRoutesContract.IllegalCharactersErrorHandlingContract {
 
@@ -926,6 +968,48 @@ class UserRoutesTest {
                 .put(USERNAME_WITHOUT_DOMAIN.asString())
             .then()
                 .statusCode(HttpStatus.NO_CONTENT_204);
+        }
+
+        @Test
+        void verifyShouldReturnOkWhenUserPasswordMatches() {
+            with()
+                .body("{\"password\":\"password\"}")
+                .put(USERNAME_WITHOUT_DOMAIN.asString());
+
+            given()
+                .body("{\"password\":\"password\"}")
+            .when()
+                .post(USERNAME_WITHOUT_DOMAIN.asString() + "/verify")
+            .then()
+                .statusCode(HttpStatus.NO_CONTENT_204);
+        }
+
+        @Test
+        void verifyShouldReturnUnauthorizedWhenUserPasswordDoesntMatch() {
+            with()
+                .body("{\"password\":\"password\"}")
+                .put(USERNAME_WITHOUT_DOMAIN.asString());
+
+            given()
+                .body("{\"password\":\"false\"}")
+            .when()
+                .post(USERNAME_WITHOUT_DOMAIN.asString() + "/verify")
+            .then()
+                .statusCode(HttpStatus.UNAUTHORIZED_401);
+        }
+
+        @Test
+        void verifyShouldReturnUnauthorizedWhenUserDoesNotExist() {
+            with()
+                .body("{\"password\":\"password\"}")
+                .put(USERNAME_WITHOUT_DOMAIN.asString());
+
+            given()
+                .body("{\"password\":\"password\"}")
+            .when()
+                .post("/NOTusername/verify")
+            .then()
+                .statusCode(HttpStatus.UNAUTHORIZED_401);
         }
 
         @Nested


### PR DESCRIPTION
Extend the WebAdmin interface with a route to verify a username/password combination:

curl -XPOST http://ip:port/users/usernameToBeUsed \
-d '{"password":"passwordToBeVerified"}' \
-H "Content-Type: application/json"

The route reports 204 on success and 401 on failure. There is intentionally no distinction for non-existing users, to prevent a username oracle attack through this route.

Adding such a feature is useful for integrating James with 3rd party services, e.g. a web admin GUI.

T-Shirt size M.