### PR TITLE
JAMES-3668 Extra system properties from configuration file

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -1,0 +1,5 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever

--- a/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -168,6 +168,8 @@ public class CassandraJamesServerMain implements JamesServerMain {
     );
 
     public static void main(String[] args) throws Exception {
+        ExtraProperties.initialize();
+
         CassandraJamesServerConfiguration configuration = CassandraJamesServerConfiguration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/index.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/index.adoc
@@ -56,6 +56,7 @@ By omitting these files, no extra behaviour is added.
 ** xref:configure/vault.adoc[*deletedMessageVault.properties*] allows to configure the DeletedMessageVault link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/deletedMessageVault.properties[example]
 ** xref:configure/listeners.adoc[*listeners.xml*] enables configuration of Mailbox Listeners link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/listeners.xml[example]
 ** xref:configure/extensions.adoc[*extensions.properties*] allows to extend James behaviour by loading your extensions in it link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/extensions.properties[example]
+** xref:configure/jvm.adoc[*jvm.properties*] lets you specify additional system properties without cluttering your command line
 ** xref:configure/spam.adoc[This page] documents Anti-Spam setup with SpamAssassin.
 ** xref:configure/remote-delivery-error-handling.adoc[This page] proposes a simple strategy for RemoteDelivery error handling.
 ** xref:configure/collecting-contacts.adoc[This page] documents contact collection

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
@@ -1,0 +1,9 @@
+= Distributed James Server &mdash; jvm.properties
+:navtitle: jvm.properties
+
+This file may contain any additional system properties for tweaking JVM execution. When you normally would add a command line option `-Dmy.property=whatever`, you can put it in this file as `my.property=whatever` instead. These properties will be added as system properties on server start.
+
+Note that in some rare cases this might not work,
+when a property affects very early JVM start behaviour.
+
+For testing purposes, you may specify a different file path via the command line option `-Dextra.props=/some/other/jvm.properties`.

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -1,0 +1,5 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever

--- a/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -167,6 +167,8 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
             new DistributedTaskSerializationModule());
 
     public static void main(String[] args) throws Exception {
+        ExtraProperties.initialize();
+
         CassandraRabbitMQJamesConfiguration configuration = CassandraRabbitMQJamesConfiguration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -1,0 +1,5 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever

--- a/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesServerMain.java
+++ b/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesServerMain.java
@@ -160,6 +160,8 @@ public class DistributedPOP3JamesServerMain implements JamesServerMain {
             new DistributedTaskSerializationModule());
 
     public static void main(String[] args) throws Exception {
+        ExtraProperties.initialize();
+
         DistributedPOP3JamesConfiguration configuration = DistributedPOP3JamesConfiguration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -1,0 +1,5 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever

--- a/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -98,6 +98,8 @@ public class JPAJamesServerMain implements JamesServerMain {
         new MailetProcessingModule(), JPA_SERVER_MODULE, PROTOCOLS);
 
     public static void main(String[] args) throws Exception {
+        ExtraProperties.initialize();
+
         JPAJamesConfiguration configuration = JPAJamesConfiguration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -1,0 +1,5 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever

--- a/server/apps/jpa-smtp-app/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/apps/jpa-smtp-app/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -63,6 +63,8 @@ public class JPAJamesServerMain implements JamesServerMain {
         new ElasticSearchMetricReporterModule());
 
     public static void main(String[] args) throws Exception {
+        ExtraProperties.initialize();
+
         JPAJamesConfiguration configuration = JPAJamesConfiguration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -1,0 +1,5 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever

--- a/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -137,6 +137,8 @@ public class MemoryJamesServerMain implements JamesServerMain {
         new DKIMMailetModule());
 
     public static void main(String[] args) throws Exception {
+        ExtraProperties.initialize();
+
         Configuration configuration = Configuration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/container/guice/common/src/main/java/org/apache/james/ExtraProperties.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/ExtraProperties.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class ExtraProperties {
+
+    public static final String OVERRIDE_PROPERTY = "extra.props";
+    public static final String DEFAULT_PATH = "conf/jvm.properties";
+
+    public static void initialize() {
+        String propsPath = System.getProperty(OVERRIDE_PROPERTY, DEFAULT_PATH);
+        try (FileInputStream in = new FileInputStream(propsPath)) {
+            System.getProperties().load(in);
+        } catch (FileNotFoundException e) {
+            if (!DEFAULT_PATH.equals(propsPath)) {
+                JamesServerMain.LOGGER.warn("Could not find extra system properties file {}", propsPath);
+            }
+        } catch (IOException e) {
+            JamesServerMain.LOGGER.warn(
+                    "Failed to load extra system properties from file {} : {}", propsPath, e.getMessage());
+        }
+    }
+}

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -151,6 +151,23 @@
 
             </subsection>
 
+            <subsection name="jvm.properties">
+
+                <p>This configuration file is only relevant when using Guice.</p>
+
+                <p>It may contain any additional system properties for tweaking JVM execution.
+                    When you normally would add a command line option <code>-Dmy.property=whatever</code>,
+                    you can put it in this file as <code>my.property=whatever</code> instead.
+                    These properties will be added as system properties on server start.</p>
+
+                <p>Note that in some rare cases this might not work,
+                    when a property affects very early JVM start behaviour.</p>
+
+                <p>For testing purposes, you may specify a different file path via the
+                    command line option <code>-Dextra.props=/some/other/jvm.properties</code>.</p>
+
+            </subsection>
+
         </section>
 
     </body>


### PR DESCRIPTION
Many aspects of JVM execution for James can be tweaked by system properties. However, a lot of them will clutter the command line and can become difficult to manage.

The solution is to read a properties file and set the contents as system properties. Since this can affect various class initializations, it should be done as soon as possible, e.g. immediately as first line of the server main() method.

This proposal adds a small utility class for this purpose. It will read a configuration file "conf/jvm.properties" if present, otherwise do nothing. The location of the file may be overridden by a system property "extra.props" for quick testing.