### PR TITLE
JAMES-3669 Delay on authentication failure

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/usersrepository.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/usersrepository.adoc
@@ -36,6 +36,9 @@ recipient local part than as login for different protocols.
 |user's name. Allow a user to access to the https://tools.ietf.org/html/rfc4616#section-2[impersonation command],
 acting on the behalf of any user.
 
+| verifyFailureDelay
+| Delay after a failed authentication attempt with an invalid user name or password. Duration string defaulting to seconds, e.g. `2`, `2s`, `2000ms`. Default `0s` (disabled).
+
 |===
 
 == Configuring a LDAP

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersRepositoryImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersRepositoryImpl.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.user.lib;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Iterator;
 import java.util.Optional;
 
@@ -40,6 +41,7 @@ import org.apache.james.user.api.InvalidUsernameException;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.user.api.model.User;
+import org.apache.james.util.DurationParser;
 import org.reactivestreams.Publisher;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,7 @@ public class UsersRepositoryImpl<T extends UsersDAO> implements UsersRepository,
     protected final T usersDAO;
     private boolean virtualHosting;
     private Optional<Username> administratorId;
+    private long verifyFailureDelay;
     private UserEntityValidator validator;
 
     @Inject
@@ -72,6 +75,9 @@ public class UsersRepositoryImpl<T extends UsersDAO> implements UsersRepository,
         virtualHosting = configuration.getBoolean("enableVirtualHosting", usersDAO.getDefaultVirtualHostingValue());
         administratorId = Optional.ofNullable(configuration.getString("administratorId"))
             .map(Username::of);
+        verifyFailureDelay = Optional.ofNullable(configuration.getString("verifyFailureDelay"))
+            .map(string -> DurationParser.parse(string, ChronoUnit.SECONDS).toMillis())
+            .orElse(0L);
     }
 
     public void setEnableVirtualHosting(boolean virtualHosting) {
@@ -144,12 +150,22 @@ public class UsersRepositoryImpl<T extends UsersDAO> implements UsersRepository,
 
     @Override
     public boolean test(Username name, String password) throws UsersRepositoryException {
-        return usersDAO.getUserByName(name)
+        boolean isVerified = usersDAO.getUserByName(name)
             .map(x -> x.verifyPassword(password))
             .orElseGet(() -> {
                 LOGGER.info("Could not retrieve user {}. Password is unverified.", name);
                 return false;
             });
+
+        if (!isVerified && verifyFailureDelay > 0L) {
+            try {
+                Thread.sleep(verifyFailureDelay);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+
+        return isVerified;
     }
 
     @Override

--- a/src/site/xdoc/server/config-users.xml
+++ b/src/site/xdoc/server/config-users.xml
@@ -54,13 +54,15 @@
 
     <subsection name="General configuration">
 
-      <p>All Users Repositories provide at least these two options</p>
+      <p>All Users Repositories provide at least these three options</p>
 
       <dl>
         <dt><strong>enableVirtualHosting</strong></dt>
         <dd>true or false. Add domain support for users (default: false, except for Cassandra Users Repository)</dd>
         <dt><strong>administratorId</strong></dt>
         <dd>user's name. Allow a user to access to the <a href="https://tools.ietf.org/html/rfc4616#section-2">impersonation command</a>, acting on the behalf of any user.</dd>
+        <dt><strong>verifyFailureDelay</strong></dt>
+        <dd>2, 2s, 2000ms, default 0s (disabled). Delay after a failed authentication attempt with an invalid user name or password.</dd>
       </dl>
 
     </subsection>


### PR DESCRIPTION
For standalone James installations, there should be some basic protection against people/bots abusing James as a password oracle for brute-force/dictionary attacks. This needs to be enforced in a central location, so it affects all of the various protocols supported by James.

This proposal adds an option verifyFailureDelay to usersrepository.xml, which delays the response if someone tries to authenticate with a non-existing user or wrong password. There is intentionally no distinction between these two cases, so it also covers username guessing attacks.

Introducing this feature should not affect existing James installations, so the default is 0 delay/disabled.

T-Shirt size S.