### PR TITLE
JAMES-3670 : Configurable restore location for deleted messages

### DIFF
--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
@@ -40,7 +40,7 @@ import org.apache.james.task.Task;
 import org.apache.james.vault.DeletedMessage;
 import org.apache.james.vault.DeletedMessageContentNotFoundException;
 import org.apache.james.vault.DeletedMessageVault;
-import org.apache.james.vault.RetentionConfiguration;
+import org.apache.james.vault.VaultConfiguration;
 import org.apache.james.vault.metadata.DeletedMessageMetadataVault;
 import org.apache.james.vault.metadata.DeletedMessageWithStorageInformation;
 import org.apache.james.vault.metadata.StorageInformation;
@@ -72,21 +72,21 @@ public class BlobStoreDeletedMessageVault implements DeletedMessageVault {
     private final BlobStoreDAO blobStoreDAO;
     private final BucketNameGenerator nameGenerator;
     private final Clock clock;
-    private final RetentionConfiguration retentionConfiguration;
+    private final VaultConfiguration vaultConfiguration;
     private final BlobStoreVaultGarbageCollectionTask.Factory taskFactory;
 
     @Inject
     public BlobStoreDeletedMessageVault(MetricFactory metricFactory, DeletedMessageMetadataVault messageMetadataVault,
                                         BlobStore blobStore, BlobStoreDAO blobStoreDAO, BucketNameGenerator nameGenerator,
                                         Clock clock,
-                                        RetentionConfiguration retentionConfiguration) {
+                                        VaultConfiguration vaultConfiguration) {
         this.metricFactory = metricFactory;
         this.messageMetadataVault = messageMetadataVault;
         this.blobStore = blobStore;
         this.blobStoreDAO = blobStoreDAO;
         this.nameGenerator = nameGenerator;
         this.clock = clock;
-        this.retentionConfiguration = retentionConfiguration;
+        this.vaultConfiguration = vaultConfiguration;
         this.taskFactory = new BlobStoreVaultGarbageCollectionTask.Factory(this);
     }
 
@@ -181,7 +181,7 @@ public class BlobStoreDeletedMessageVault implements DeletedMessageVault {
 
     ZonedDateTime getBeginningOfRetentionPeriod() {
         ZonedDateTime now = ZonedDateTime.now(clock);
-        return now.minus(retentionConfiguration.getRetentionPeriod());
+        return now.minus(vaultConfiguration.getRetentionPeriod());
     }
 
     @VisibleForTesting

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
@@ -120,7 +120,7 @@ class DeletedMessageVaultHookTest {
                 .blobIdFactory(new HashBlobId.Factory())
                 .defaultBucketName()
                 .passthrough(), blobStoreDAO, new BucketNameGenerator(clock), clock,
-            RetentionConfiguration.DEFAULT);
+            VaultConfiguration.DEFAULT);
 
         DeletedMessageConverter deletedMessageConverter = new DeletedMessageConverter();
 

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
@@ -47,7 +47,7 @@ import org.apache.james.utils.UpdatableTickingClock;
 import org.apache.james.vault.DeletedMessageVault;
 import org.apache.james.vault.DeletedMessageVaultContract;
 import org.apache.james.vault.DeletedMessageVaultSearchContract;
-import org.apache.james.vault.RetentionConfiguration;
+import org.apache.james.vault.VaultConfiguration;
 import org.apache.james.vault.memory.metadata.MemoryDeletedMessageMetadataVault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +71,7 @@ class BlobStoreDeletedMessageVaultTest implements DeletedMessageVaultContract, D
                 .blobIdFactory(new HashBlobId.Factory())
                 .defaultBucketName()
                 .passthrough(),
-            blobStoreDAO, new BucketNameGenerator(clock), clock, RetentionConfiguration.DEFAULT);
+            blobStoreDAO, new BucketNameGenerator(clock), clock, VaultConfiguration.DEFAULT);
     }
 
     @Override

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/vault.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/vault.adoc
@@ -29,4 +29,7 @@ to get some examples and hints.
 
 | retentionPeriod
 | Deleted messages stored in the Deleted Messages Vault are expired after this period (default: 1 year). It can be expressed in *y* years, *d* days, *h* hours, ...
+
+| restoreLocation
+| Messages restored from the Deleted Messages Vault are placed in a mailbox with this name (default: ``Restored-Messages``). The mailbox will be created if it does not exist yet.
 |===

--- a/server/apps/distributed-pop3-app/sample-configuration/deletedMessageVault.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/deletedMessageVault.properties
@@ -2,3 +2,7 @@
 # Retention period for your deleted messages into the vault, after which they expire and can be potentially cleaned up
 # Optional, default 1y
 # retentionPeriod=1y
+
+# Mailbox that will contain messages restored from the vault, will be created if it does not exist yet
+# Optional, default 'Restored-Messages' ; must be set to INBOX for POP3
+restoreLocation=INBOX

--- a/server/container/guice/mailbox-plugin-deleted-messages-vault/src/main/java/org/apache/james/modules/vault/DeletedMessageVaultConfigurationModule.java
+++ b/server/container/guice/mailbox-plugin-deleted-messages-vault/src/main/java/org/apache/james/modules/vault/DeletedMessageVaultConfigurationModule.java
@@ -25,7 +25,7 @@ import javax.inject.Singleton;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.james.utils.PropertiesProvider;
-import org.apache.james.vault.RetentionConfiguration;
+import org.apache.james.vault.VaultConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,8 +33,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Provides;
 
-public class DeletedMessageVaultRetentionModule extends AbstractModule {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeletedMessageVaultRetentionModule.class);
+public class DeletedMessageVaultConfigurationModule extends AbstractModule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeletedMessageVaultConfigurationModule.class);
 
     @Override
     protected void configure() {
@@ -43,13 +43,13 @@ public class DeletedMessageVaultRetentionModule extends AbstractModule {
 
     @Provides
     @Singleton
-    RetentionConfiguration providesRetentionConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException, org.apache.commons.configuration2.ex.ConfigurationException {
+    VaultConfiguration providesVaultConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException, org.apache.commons.configuration2.ex.ConfigurationException {
         try {
             Configuration configuration = propertiesProvider.getConfiguration("deletedMessageVault");
-            return RetentionConfiguration.from(configuration);
+            return VaultConfiguration.from(configuration);
         } catch (FileNotFoundException e) {
-            LOGGER.warn("Error encountered while retrieving Deleted message vault configuration. Using default RetentionTime (1 year) instead.");
-            return RetentionConfiguration.DEFAULT;
+            LOGGER.warn("Error encountered while retrieving Deleted message vault configuration. Using default RetentionTime (1 year) and RestoreLocation (Restored-Messages) instead.");
+            return VaultConfiguration.DEFAULT;
         }
     }
 }

--- a/server/container/guice/mailbox-plugin-deleted-messages-vault/src/main/java/org/apache/james/modules/vault/DeletedMessageVaultModule.java
+++ b/server/container/guice/mailbox-plugin-deleted-messages-vault/src/main/java/org/apache/james/modules/vault/DeletedMessageVaultModule.java
@@ -29,7 +29,7 @@ import com.google.inject.Scopes;
 public class DeletedMessageVaultModule extends AbstractModule {
     @Override
     protected void configure() {
-        install(new DeletedMessageVaultRetentionModule());
+        install(new DeletedMessageVaultConfigurationModule());
         install(new VaultTaskSerializationModule());
 
         bind(BucketNameGenerator.class).in(Scopes.SINGLETON);

--- a/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/main/java/org/apache/james/webadmin/vault/routes/RestoreService.java
+++ b/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/main/java/org/apache/james/webadmin/vault/routes/RestoreService.java
@@ -30,7 +30,6 @@ import java.util.function.Predicate;
 import javax.inject.Inject;
 
 import org.apache.james.core.Username;
-import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
@@ -42,6 +41,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.vault.DeletedMessage;
 import org.apache.james.vault.DeletedMessageContentNotFoundException;
 import org.apache.james.vault.DeletedMessageVault;
+import org.apache.james.vault.VaultConfiguration;
 import org.apache.james.vault.search.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,11 +64,14 @@ class RestoreService {
 
     private final DeletedMessageVault deletedMessageVault;
     private final MailboxManager mailboxManager;
+    private final VaultConfiguration vaultConfiguration;
 
     @Inject
-    RestoreService(DeletedMessageVault deletedMessageVault, MailboxManager mailboxManager) {
+    RestoreService(DeletedMessageVault deletedMessageVault, MailboxManager mailboxManager,
+                   VaultConfiguration vaultConfiguration) {
         this.deletedMessageVault = deletedMessageVault;
         this.mailboxManager = mailboxManager;
+        this.vaultConfiguration = vaultConfiguration;
     }
 
     Flux<RestoreResult> restore(Username usernameToRestore, Query searchQuery) throws MailboxException {
@@ -109,7 +112,7 @@ class RestoreService {
     }
 
     private MessageManager restoreMailboxManager(MailboxSession session) throws MailboxException {
-        MailboxPath restoreMailbox = MailboxPath.forUser(session.getUser(), DefaultMailboxes.RESTORED_MESSAGES);
+        MailboxPath restoreMailbox = MailboxPath.forUser(session.getUser(), vaultConfiguration.getRestoreLocation());
         try {
             return mailboxManager.getMailbox(restoreMailbox, session);
         } catch (MailboxNotFoundException e) {

--- a/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
@@ -111,7 +111,7 @@ import org.apache.james.utils.UpdatableTickingClock;
 import org.apache.james.vault.DeletedMessage;
 import org.apache.james.vault.DeletedMessageVault;
 import org.apache.james.vault.DeletedMessageZipper;
-import org.apache.james.vault.RetentionConfiguration;
+import org.apache.james.vault.VaultConfiguration;
 import org.apache.james.vault.blob.BlobStoreDeletedMessageVault;
 import org.apache.james.vault.blob.BlobStoreVaultGarbageCollectionTaskAdditionalInformationDTO;
 import org.apache.james.vault.blob.BucketNameGenerator;
@@ -191,14 +191,14 @@ class DeletedMessagesVaultRoutesTest {
         clock = new UpdatableTickingClock(OLD_DELETION_DATE.toInstant());
         vault = spy(new BlobStoreDeletedMessageVault(new RecordingMetricFactory(), new MemoryDeletedMessageMetadataVault(),
             blobStore, blobStoreDAO, new BucketNameGenerator(clock), clock,
-            RetentionConfiguration.DEFAULT));
+            VaultConfiguration.DEFAULT));
         InMemoryIntegrationResources inMemoryResource = InMemoryIntegrationResources.defaultResources();
         mailboxManager = spy(inMemoryResource.getMailboxManager());
 
         taskManager = new MemoryTaskManager(new Hostname("foo"));
         JsonTransformer jsonTransformer = new JsonTransformer();
 
-        RestoreService vaultRestore = new RestoreService(vault, mailboxManager);
+        RestoreService vaultRestore = new RestoreService(vault, mailboxManager, VaultConfiguration.DEFAULT);
         blobExporting = spy(new NoopBlobExporting());
         zipper = new DeletedMessageZipper();
         exportService = new ExportService(blobExporting, blobStore, zipper, vault);

--- a/src/site/xdoc/server/config-vault.xml
+++ b/src/site/xdoc/server/config-vault.xml
@@ -57,6 +57,13 @@
                         It can be expressed in <b>y</b> years, <b>d</b> days, <b>h</b> hours, ...
                     </dd>
                 </dl>
+                <dl>
+                    <dt><strong>restoreLocation</strong></dt>
+                    <dd>
+                        Messages restored from the Deleted Messages Vault are placed in a mailbox with this name (default: <code>Restored-Messages</code>>).
+                        The mailbox will be created if it does not exist yet.
+                    </dd>
+                </dl>
 
             </subsection>
         </section>


### PR DESCRIPTION
James should have an option to specify which mailbox receives any restored messages from the Deleted Messages Vault, i.e. something other than the default of 'Restored-Messages'.

This is necessary to use the Deleted Messages Vault in combination with POP3, since POP3 users cannot access any other mailboxes than 'INBOX'.

The solution is to add an extra configuration option 'restoreLocation' within deletedMessagesVault.properties, which can be injected into the RestoreService for this purpose.

T-Shirt size S.