### PR TITLE
JAMES-3671 : Glowroot instrumentation for POP3 protocol

### DIFF
--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/AbstractPOP3CommandHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/AbstractPOP3CommandHandler.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.pop3.core;
+
+import org.apache.james.protocols.api.Request;
+import org.apache.james.protocols.api.Response;
+import org.apache.james.protocols.api.handler.CommandHandler;
+import org.apache.james.protocols.pop3.POP3Session;
+
+public abstract class AbstractPOP3CommandHandler implements CommandHandler<POP3Session> {
+    
+    public abstract Response onCommand(POP3Session session, Request request);
+
+}

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/CapaCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/CapaCmdHandler.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.api.handler.ExtensibleHandler;
 import org.apache.james.protocols.api.handler.WiringException;
 import org.apache.james.protocols.pop3.POP3Response;
@@ -41,7 +40,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * This handler is used to handle CAPA commands
  */
-public class CapaCmdHandler implements CommandHandler<POP3Session>, ExtensibleHandler, CapaCapability {    
+public class CapaCmdHandler extends AbstractPOP3CommandHandler implements ExtensibleHandler, CapaCapability {
     private List<CapaCapability> caps;
     private static final Collection<String> COMMANDS = ImmutableSet.of("CAPA");
     private static final Set<String> CAPS = ImmutableSet.of("PIPELINING");

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/DeleCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/DeleCmdHandler.java
@@ -29,7 +29,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
@@ -40,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles DELE command
  */
-public class DeleCmdHandler implements CommandHandler<POP3Session> {
+public class DeleCmdHandler extends AbstractPOP3CommandHandler {
     private static final Collection<String> COMMANDS = ImmutableSet.of("DELE");
 
     private static final Response SYNTAX_ERROR = new POP3Response(POP3Response.ERR_RESPONSE, "Usage: DELE [mail number]").immutable();

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/ListCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/ListCmdHandler.java
@@ -29,7 +29,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
@@ -41,7 +40,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles LIST command
  */
-public class ListCmdHandler implements CommandHandler<POP3Session> {
+public class ListCmdHandler extends AbstractPOP3CommandHandler {
 
     private static final Collection<String> COMMANDS = ImmutableSet.of("LIST");
 

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/NoopCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/NoopCmdHandler.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.util.MDCBuilder;
@@ -38,7 +37,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles NOOP command
  */
-public class NoopCmdHandler implements CommandHandler<POP3Session> {
+public class NoopCmdHandler extends AbstractPOP3CommandHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(NoopCmdHandler.class);
     private static final Collection<String> COMMANDS = ImmutableSet.of("NOOP");
 

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/QuitCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/QuitCmdHandler.java
@@ -29,7 +29,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.mailbox.Mailbox;
@@ -43,7 +42,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles QUIT command
  */
-public class QuitCmdHandler implements CommandHandler<POP3Session> {
+public class QuitCmdHandler extends AbstractPOP3CommandHandler {
     private static final Collection<String> COMMANDS = ImmutableSet.of("QUIT");
     private static final Logger LOGGER = LoggerFactory.getLogger(QuitCmdHandler.class);
     private static final Response SIGN_OFF;

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/RetrCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/RetrCmdHandler.java
@@ -30,7 +30,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.POP3StreamResponse;
@@ -46,7 +45,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles RETR command
  */
-public class RetrCmdHandler implements CommandHandler<POP3Session> {
+public class RetrCmdHandler extends AbstractPOP3CommandHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RetrCmdHandler.class);
     private static final Collection<String> COMMANDS = ImmutableSet.of("RETR");
     @VisibleForTesting

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/RsetCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/RsetCmdHandler.java
@@ -30,7 +30,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
@@ -43,7 +42,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles RSET command
  */
-public class RsetCmdHandler implements CommandHandler<POP3Session> {
+public class RsetCmdHandler extends AbstractPOP3CommandHandler {
     private static final Collection<String> COMMANDS = ImmutableSet.of("RSET");
     private static final Logger LOGGER = LoggerFactory.getLogger(RsetCmdHandler.class);
 

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/StatCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/StatCmdHandler.java
@@ -29,7 +29,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
@@ -43,7 +42,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles STAT command
  */
-public class StatCmdHandler implements CommandHandler<POP3Session> {
+public class StatCmdHandler extends AbstractPOP3CommandHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(StatCmdHandler.class);
     private static final Collection<String> COMMANDS = ImmutableSet.of("STAT");
 

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/StlsCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/StlsCmdHandler.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.POP3StartTlsResponse;
@@ -42,7 +41,7 @@ import com.google.common.collect.ImmutableSet;
  * Handler which offer STARTTLS implementation for POP3. STARTTLS is started
  * with the STSL command
  */
-public class StlsCmdHandler implements CommandHandler<POP3Session>, CapaCapability {
+public class StlsCmdHandler extends AbstractPOP3CommandHandler implements CapaCapability {
     private static final Logger LOGGER = LoggerFactory.getLogger(StlsCmdHandler.class);
     private static final Collection<String> COMMANDS = ImmutableSet.of("STLS");
     private static final Set<String> CAPS = ImmutableSet.of("STLS");

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/UidlCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/UidlCmdHandler.java
@@ -31,7 +31,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
@@ -45,7 +44,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles UIDL command
  */
-public class UidlCmdHandler implements CommandHandler<POP3Session>, CapaCapability {
+public class UidlCmdHandler extends AbstractPOP3CommandHandler implements CapaCapability {
     private static final Logger LOGGER = LoggerFactory.getLogger(UidlCmdHandler.class);
     private static final Collection<String> COMMANDS = ImmutableSet.of("UIDL");
     private static final Set<String> CAPS = ImmutableSet.of("UIDL");

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/UserCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/UserCmdHandler.java
@@ -28,7 +28,6 @@ import org.apache.james.core.Username;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
-import org.apache.james.protocols.api.handler.CommandHandler;
 import org.apache.james.protocols.pop3.POP3Response;
 import org.apache.james.protocols.pop3.POP3Session;
 import org.apache.james.util.MDCBuilder;
@@ -40,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Handles USER command
  */
-public class UserCmdHandler implements CommandHandler<POP3Session>, CapaCapability {
+public class UserCmdHandler extends AbstractPOP3CommandHandler implements CapaCapability {
     private static final Logger LOGGER = LoggerFactory.getLogger(UserCmdHandler.class);
     private static final Collection<String> COMMANDS = ImmutableSet.of("USER");
     private static final Set<String> CAPS = ImmutableSet.of("USER");

--- a/server/apps/cassandra-app/src/main/glowroot/plugins/pop3.json
+++ b/server/apps/cassandra-app/src/main/glowroot/plugins/pop3.json
@@ -1,0 +1,19 @@
+{
+  "name": "POP3 Plugin",
+  "id": "pop3",
+  "instrumentation": [
+    {
+      "className": "org.apache.james.protocols.pop3.core.AbstractPOP3CommandHandler",
+      "methodName": "onCommand",
+      "methodParameterTypes": [
+        ".."
+      ],
+      "captureKind": "transaction",
+      "transactionType": "POP3",
+      "transactionNameTemplate": "POP3 Command: {{this.class.name}}",
+      "alreadyInTransactionBehavior": "capture-trace-entry",
+      "traceEntryMessageTemplate": "{{this.class.name}}.{{methodName}}",
+      "timerName": "pop3Timer"
+    }
+  ]
+}

--- a/server/apps/distributed-app/src/main/glowroot/plugins/pop3.json
+++ b/server/apps/distributed-app/src/main/glowroot/plugins/pop3.json
@@ -1,0 +1,19 @@
+{
+  "name": "POP3 Plugin",
+  "id": "pop3",
+  "instrumentation": [
+    {
+      "className": "org.apache.james.protocols.pop3.core.AbstractPOP3CommandHandler",
+      "methodName": "onCommand",
+      "methodParameterTypes": [
+        ".."
+      ],
+      "captureKind": "transaction",
+      "transactionType": "POP3",
+      "transactionNameTemplate": "POP3 Command: {{this.class.name}}",
+      "alreadyInTransactionBehavior": "capture-trace-entry",
+      "traceEntryMessageTemplate": "{{this.class.name}}.{{methodName}}",
+      "timerName": "pop3Timer"
+    }
+  ]
+}

--- a/server/apps/distributed-pop3-app/src/main/glowroot/plugins/pop3.json
+++ b/server/apps/distributed-pop3-app/src/main/glowroot/plugins/pop3.json
@@ -1,0 +1,19 @@
+{
+  "name": "POP3 Plugin",
+  "id": "pop3",
+  "instrumentation": [
+    {
+      "className": "org.apache.james.protocols.pop3.core.AbstractPOP3CommandHandler",
+      "methodName": "onCommand",
+      "methodParameterTypes": [
+        ".."
+      ],
+      "captureKind": "transaction",
+      "transactionType": "POP3",
+      "transactionNameTemplate": "POP3 Command: {{this.class.name}}",
+      "alreadyInTransactionBehavior": "capture-trace-entry",
+      "traceEntryMessageTemplate": "{{this.class.name}}.{{methodName}}",
+      "timerName": "pop3Timer"
+    }
+  ]
+}

--- a/server/apps/jpa-app/src/main/glowroot/plugins/pop3.json
+++ b/server/apps/jpa-app/src/main/glowroot/plugins/pop3.json
@@ -1,0 +1,19 @@
+{
+  "name": "POP3 Plugin",
+  "id": "pop3",
+  "instrumentation": [
+    {
+      "className": "org.apache.james.protocols.pop3.core.AbstractPOP3CommandHandler",
+      "methodName": "onCommand",
+      "methodParameterTypes": [
+        ".."
+      ],
+      "captureKind": "transaction",
+      "transactionType": "POP3",
+      "transactionNameTemplate": "POP3 Command: {{this.class.name}}",
+      "alreadyInTransactionBehavior": "capture-trace-entry",
+      "traceEntryMessageTemplate": "{{this.class.name}}.{{methodName}}",
+      "timerName": "pop3Timer"
+    }
+  ]
+}

--- a/server/apps/jpa-smtp-app/src/main/glowroot/plugins/pop3.json
+++ b/server/apps/jpa-smtp-app/src/main/glowroot/plugins/pop3.json
@@ -1,0 +1,19 @@
+{
+  "name": "POP3 Plugin",
+  "id": "pop3",
+  "instrumentation": [
+    {
+      "className": "org.apache.james.protocols.pop3.core.AbstractPOP3CommandHandler",
+      "methodName": "onCommand",
+      "methodParameterTypes": [
+        ".."
+      ],
+      "captureKind": "transaction",
+      "transactionType": "POP3",
+      "transactionNameTemplate": "POP3 Command: {{this.class.name}}",
+      "alreadyInTransactionBehavior": "capture-trace-entry",
+      "traceEntryMessageTemplate": "{{this.class.name}}.{{methodName}}",
+      "timerName": "pop3Timer"
+    }
+  ]
+}

--- a/server/apps/memory-app/src/main/glowroot/plugins/pop3.json
+++ b/server/apps/memory-app/src/main/glowroot/plugins/pop3.json
@@ -1,0 +1,19 @@
+{
+  "name": "POP3 Plugin",
+  "id": "pop3",
+  "instrumentation": [
+    {
+      "className": "org.apache.james.protocols.pop3.core.AbstractPOP3CommandHandler",
+      "methodName": "onCommand",
+      "methodParameterTypes": [
+        ".."
+      ],
+      "captureKind": "transaction",
+      "transactionType": "POP3",
+      "transactionNameTemplate": "POP3 Command: {{this.class.name}}",
+      "alreadyInTransactionBehavior": "capture-trace-entry",
+      "traceEntryMessageTemplate": "{{this.class.name}}.{{methodName}}",
+      "timerName": "pop3Timer"
+    }
+  ]
+}


### PR DESCRIPTION
For better analysis capability in POP3 related issues, James should have glowroot support for this protocol as well.

This is considerably easier with a minor refactoring, making all POP3 command handlers extend an AbstractPOP3CommandHandler which unifies their onCommand methods.

On this basis we can provide a simple glowroot plugin (pop3.json) for each James app variant.

T-Shirt size S.