### PR TITLE
JAMES-3674 : Support password salting and hash scheme upgrading

### DIFF
--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/CassandraRecomputeCurrentQuotasServiceTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/CassandraRecomputeCurrentQuotasServiceTest.java
@@ -48,7 +48,6 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.cassandra.CassandraUsersDAO;
 import org.apache.james.user.cassandra.CassandraUsersRepositoryModule;
 import org.apache.james.user.lib.UsersRepositoryImpl;
-import org.apache.james.user.lib.model.Algorithm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -77,7 +76,7 @@ public class CassandraRecomputeCurrentQuotasServiceTest implements RecomputeCurr
         CassandraCluster cassandra = cassandraCluster.getCassandraCluster();
         CassandraMailboxSessionMapperFactory mapperFactory = CassandraTestSystemFixture.createMapperFactory(cassandra);
 
-        CassandraUsersDAO usersDAO = new CassandraUsersDAO(new Algorithm.DefaultFactory(), cassandra.getConf());
+        CassandraUsersDAO usersDAO = new CassandraUsersDAO(cassandra.getConf());
         usersRepository = new UsersRepositoryImpl(NO_DOMAIN_LIST, usersDAO);
         usersRepository.setEnableVirtualHosting(false);
 

--- a/mpt/impl/managesieve/cassandra/src/test/java/org/apache/james/mpt/managesieve/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/managesieve/cassandra/src/test/java/org/apache/james/mpt/managesieve/cassandra/host/CassandraHostSystem.java
@@ -34,7 +34,6 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.cassandra.CassandraUsersDAO;
 import org.apache.james.user.cassandra.CassandraUsersRepositoryModule;
 import org.apache.james.user.lib.UsersRepositoryImpl;
-import org.apache.james.user.lib.model.Algorithm;
 import org.apache.james.util.Host;
 
 public class CassandraHostSystem extends JamesManageSieveHostSystem {
@@ -66,7 +65,7 @@ public class CassandraHostSystem extends JamesManageSieveHostSystem {
 
     @Override
     protected UsersRepository createUsersRepository() {
-        CassandraUsersDAO usersDAO = new CassandraUsersDAO(new Algorithm.DefaultFactory(), cassandra.getConf());
+        CassandraUsersDAO usersDAO = new CassandraUsersDAO(cassandra.getConf());
         UsersRepositoryImpl usersRepository = new UsersRepositoryImpl(NO_DOMAIN_LIST, usersDAO);
         usersRepository.setEnableVirtualHosting(false);
         return usersRepository;

--- a/server/apps/cassandra-app/sample-configuration/usersrepository.xml
+++ b/server/apps/cassandra-app/sample-configuration/usersrepository.xml
@@ -21,7 +21,7 @@
 <!-- Read https://james.apache.org/server/config-users.html for further details -->
 
 <usersrepository name="LocalUsers">
-    <algorithm>SHA-512</algorithm>
+    <algorithm>SHA-512/salted</algorithm>
     <enableVirtualHosting>true</enableVirtualHosting>    
     <enableForwarding>true</enableForwarding>
 </usersrepository>

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/usersrepository.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/usersrepository.adoc
@@ -39,8 +39,11 @@ acting on the behalf of any user.
 | verifyFailureDelay
 | Delay after a failed authentication attempt with an invalid user name or password. Duration string defaulting to seconds, e.g. `2`, `2s`, `2000ms`. Default `0s` (disabled).
 
+| algorithm
+| use a specific hash algorithm to compute passwords, with optional mode `plain` (default) or `salted`; e.g. `SHA-512` (default),  `SHA-512/plain`, `SHA-512/salted`
+
 | hashingMode
-| change the way password hashes are computed: plain (default), salted, legacy, legacy_salted
+| specify the hashing mode to use if there is none recorded in the database: `plain` (default) for newer installations or `legacy` for older ones
 
 |===
 

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/usersrepository.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/usersrepository.adoc
@@ -39,6 +39,9 @@ acting on the behalf of any user.
 | verifyFailureDelay
 | Delay after a failed authentication attempt with an invalid user name or password. Duration string defaulting to seconds, e.g. `2`, `2s`, `2000ms`. Default `0s` (disabled).
 
+| hashingMode
+| change the way password hashes are computed: plain (default), salted, legacy, legacy_salted
+
 |===
 
 == Configuring a LDAP

--- a/server/apps/distributed-app/sample-configuration/usersrepository.xml
+++ b/server/apps/distributed-app/sample-configuration/usersrepository.xml
@@ -21,7 +21,7 @@
 <!-- Read https://james.apache.org/server/config-users.html for further details -->
 
 <usersrepository name="LocalUsers">
-    <algorithm>SHA-512</algorithm>
+    <algorithm>SHA-512/salted</algorithm>
     <enableVirtualHosting>true</enableVirtualHosting>    
     <enableForwarding>true</enableForwarding>
 </usersrepository>

--- a/server/apps/distributed-pop3-app/sample-configuration/usersrepository.xml
+++ b/server/apps/distributed-pop3-app/sample-configuration/usersrepository.xml
@@ -21,7 +21,7 @@
 <!-- Read https://james.apache.org/server/config-users.html for further details -->
 
 <usersrepository name="LocalUsers">
-    <algorithm>SHA-512</algorithm>
+    <algorithm>SHA-512/salted</algorithm>
     <enableVirtualHosting>true</enableVirtualHosting>    
     <enableForwarding>true</enableForwarding>
 </usersrepository>

--- a/server/apps/jpa-app/sample-configuration/usersrepository.xml
+++ b/server/apps/jpa-app/sample-configuration/usersrepository.xml
@@ -21,7 +21,7 @@
 <!-- Read https://james.apache.org/server/config-users.html for further details -->
 
 <usersrepository name="LocalUsers">
-    <algorithm>SHA-512</algorithm>
+    <algorithm>SHA-512/salted</algorithm>
     <enableVirtualHosting>true</enableVirtualHosting>    
     <enableForwarding>true</enableForwarding>
 </usersrepository>

--- a/server/apps/jpa-smtp-app/sample-configuration/usersrepository.xml
+++ b/server/apps/jpa-smtp-app/sample-configuration/usersrepository.xml
@@ -22,7 +22,7 @@
 
 <usersrepository name="LocalUsers" class="org.apache.james.user.jpa.JPAUsersRepository">
     <destination URL="file://users/"/>
-    <algorithm>SHA-512</algorithm>
+    <algorithm>SHA-512/salted</algorithm>
     <enableVirtualHosting>true</enableVirtualHosting>
     <enableForwarding>true</enableForwarding>
 </usersrepository>

--- a/server/apps/memory-app/sample-configuration/usersrepository.xml
+++ b/server/apps/memory-app/sample-configuration/usersrepository.xml
@@ -21,7 +21,7 @@
 <!-- Read https://james.apache.org/server/config-users.html for further details -->
 
 <usersrepository name="LocalUsers">
-    <algorithm>SHA-512</algorithm>
+    <algorithm>SHA-512/salted</algorithm>
     <enableVirtualHosting>true</enableVirtualHosting>    
     <enableForwarding>true</enableForwarding>
 </usersrepository>

--- a/server/container/guice/data-cassandra/src/main/java/org/apache/james/modules/data/CassandraUsersRepositoryModule.java
+++ b/server/container/guice/data-cassandra/src/main/java/org/apache/james/modules/data/CassandraUsersRepositoryModule.java
@@ -19,23 +19,17 @@
 
 package org.apache.james.modules.data;
 
-import java.util.Optional;
-
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.cassandra.CassandraUsersDAO;
 import org.apache.james.user.lib.UsersDAO;
 import org.apache.james.user.lib.UsersRepositoryImpl;
-import org.apache.james.user.lib.model.Algorithm;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
 import com.google.inject.Scopes;
-import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
@@ -56,15 +50,5 @@ public class CassandraUsersRepositoryModule extends AbstractModule {
         return InitilizationOperationBuilder
             .forClass(UsersRepositoryImpl.class)
             .init(() -> usersRepository.configure(configurationProvider.getConfiguration("usersrepository")));
-    }
-
-    @Provides
-    @Singleton
-    Algorithm.Factory provideAlgorithmFactory(ConfigurationProvider configurationProvider) throws ConfigurationException {
-        return Optional.ofNullable(configurationProvider.getConfiguration("usersrepository")
-            .getString("hashingMode", null))
-            .map(Algorithm.HashingMode::parse)
-            .orElse(Algorithm.HashingMode.DEFAULT)
-            .getFactory();
     }
 }

--- a/server/container/guice/data-cassandra/src/main/java/org/apache/james/modules/data/CassandraUsersRepositoryModule.java
+++ b/server/container/guice/data-cassandra/src/main/java/org/apache/james/modules/data/CassandraUsersRepositoryModule.java
@@ -19,9 +19,11 @@
 
 package org.apache.james.modules.data;
 
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.cassandra.CassandraRepositoryConfiguration;
 import org.apache.james.user.cassandra.CassandraUsersDAO;
 import org.apache.james.user.lib.UsersDAO;
 import org.apache.james.user.lib.UsersRepositoryImpl;
@@ -29,7 +31,9 @@ import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
@@ -43,6 +47,13 @@ public class CassandraUsersRepositoryModule extends AbstractModule {
         bind(UsersRepository.class).to(new TypeLiteral<UsersRepositoryImpl<CassandraUsersDAO>>() {});
         Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
         cassandraDataDefinitions.addBinding().toInstance(org.apache.james.user.cassandra.CassandraUsersRepositoryModule.MODULE);
+    }
+
+    @Provides
+    @Singleton
+    public CassandraRepositoryConfiguration provideConfiguration(ConfigurationProvider configurationProvider) throws ConfigurationException {
+        return CassandraRepositoryConfiguration.from(
+            configurationProvider.getConfiguration("usersrepository"));
     }
 
     @ProvidesIntoSet

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraRepositoryConfiguration.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraRepositoryConfiguration.java
@@ -1,0 +1,57 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.user.cassandra;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.user.lib.model.Algorithm;
+import org.apache.james.user.lib.model.Algorithm.HashingMode;
+
+public class CassandraRepositoryConfiguration {
+    public static final String DEFAULT_ALGORITHM = "SHA-512";
+    public static final String DEFAULT_HASHING_MODE = HashingMode.PLAIN.name();
+
+    public static final CassandraRepositoryConfiguration DEFAULT = new CassandraRepositoryConfiguration(
+        Algorithm.of(DEFAULT_ALGORITHM), HashingMode.parse(DEFAULT_HASHING_MODE)
+    );
+
+    private final Algorithm preferredAlgorithm;
+    private final HashingMode fallbackHashingMode;
+
+    public CassandraRepositoryConfiguration(Algorithm preferredAlgorithm, HashingMode fallbackHashingMode) {
+        this.preferredAlgorithm = preferredAlgorithm;
+        this.fallbackHashingMode = fallbackHashingMode;
+    }
+
+    public Algorithm getPreferredAlgorithm() {
+        return preferredAlgorithm;
+    }
+
+    public HashingMode getFallbackHashingMode() {
+        return fallbackHashingMode;
+    }
+
+    public static CassandraRepositoryConfiguration from(HierarchicalConfiguration<ImmutableNode> config) throws ConfigurationException {
+        return new CassandraRepositoryConfiguration(
+            Algorithm.of(config.getString("algorithm", DEFAULT_ALGORITHM)),
+            HashingMode.parse(config.getString("hashingMode", DEFAULT_HASHING_MODE)));
+    }
+}

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
@@ -44,18 +44,19 @@ import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.user.api.model.User;
 import org.apache.james.user.lib.UsersDAO;
 import org.apache.james.user.lib.model.Algorithm;
+import org.apache.james.user.lib.model.Algorithm.HashingMode;
 import org.apache.james.user.lib.model.DefaultUser;
 import org.reactivestreams.Publisher;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 
 import reactor.core.publisher.Mono;
 
 public class CassandraUsersDAO implements UsersDAO {
-    private static final String DEFAULT_ALGO_VALUE = "SHA-512";
 
     private final CassandraAsyncExecutor executor;
     private final PreparedStatement getUserStatement;
@@ -65,8 +66,11 @@ public class CassandraUsersDAO implements UsersDAO {
     private final PreparedStatement listStatement;
     private final PreparedStatement insertStatement;
 
+    private final Algorithm preferredAlgorithm;
+    private final HashingMode fallbackHashingMode;
+
     @Inject
-    public CassandraUsersDAO(Session session) {
+    public CassandraUsersDAO(Session session, CassandraRepositoryConfiguration configuration) {
         this.executor = new CassandraAsyncExecutor(session);
         this.getUserStatement = prepareGetUserStatement(session);
         this.updateUserStatement = prepareUpdateUserStatement(session);
@@ -79,6 +83,13 @@ public class CassandraUsersDAO implements UsersDAO {
             .value(PASSWORD, bindMarker(PASSWORD))
             .value(ALGORITHM, bindMarker(ALGORITHM))
             .ifNotExists());
+        this.preferredAlgorithm = configuration.getPreferredAlgorithm();
+        this.fallbackHashingMode = configuration.getFallbackHashingMode();
+    }
+
+    @VisibleForTesting
+    public CassandraUsersDAO(Session session) {
+        this(session, CassandraRepositoryConfiguration.DEFAULT);
     }
 
     private PreparedStatement prepareListStatement(Session session) {
@@ -123,7 +134,7 @@ public class CassandraUsersDAO implements UsersDAO {
             getUserStatement.bind()
                 .setString(NAME, name.asString()))
             .map(row -> new DefaultUser(Username.of(row.getString(NAME)), row.getString(PASSWORD),
-                Algorithm.of(row.getString(ALGORITHM))));
+                Algorithm.of(row.getString(ALGORITHM), fallbackHashingMode), preferredAlgorithm));
     }
 
     @Override
@@ -183,7 +194,7 @@ public class CassandraUsersDAO implements UsersDAO {
 
     @Override
     public void addUser(Username username, String password) throws UsersRepositoryException {
-        DefaultUser user = new DefaultUser(username, Algorithm.of(DEFAULT_ALGO_VALUE));
+        DefaultUser user = new DefaultUser(username, preferredAlgorithm, preferredAlgorithm);
         user.setPassword(password);
         boolean executed = executor.executeReturnApplied(
             insertStatement.bind()

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
@@ -57,7 +57,6 @@ import reactor.core.publisher.Mono;
 public class CassandraUsersDAO implements UsersDAO {
     private static final String DEFAULT_ALGO_VALUE = "SHA-512";
 
-    private final Algorithm.Factory algorithmFactory;
     private final CassandraAsyncExecutor executor;
     private final PreparedStatement getUserStatement;
     private final PreparedStatement updateUserStatement;
@@ -67,8 +66,7 @@ public class CassandraUsersDAO implements UsersDAO {
     private final PreparedStatement insertStatement;
 
     @Inject
-    public CassandraUsersDAO(Algorithm.Factory algorithmFactory, Session session) {
-        this.algorithmFactory = algorithmFactory;
+    public CassandraUsersDAO(Session session) {
         this.executor = new CassandraAsyncExecutor(session);
         this.getUserStatement = prepareGetUserStatement(session);
         this.updateUserStatement = prepareUpdateUserStatement(session);
@@ -125,7 +123,7 @@ public class CassandraUsersDAO implements UsersDAO {
             getUserStatement.bind()
                 .setString(NAME, name.asString()))
             .map(row -> new DefaultUser(Username.of(row.getString(NAME)), row.getString(PASSWORD),
-                algorithmFactory.of(row.getString(ALGORITHM))));
+                Algorithm.of(row.getString(ALGORITHM))));
     }
 
     @Override
@@ -185,7 +183,7 @@ public class CassandraUsersDAO implements UsersDAO {
 
     @Override
     public void addUser(Username username, String password) throws UsersRepositoryException {
-        DefaultUser user = new DefaultUser(username, algorithmFactory.of(DEFAULT_ALGO_VALUE));
+        DefaultUser user = new DefaultUser(username, Algorithm.of(DEFAULT_ALGO_VALUE));
         user.setPassword(password);
         boolean executed = executor.executeReturnApplied(
             insertStatement.bind()

--- a/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableTest.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableTest.java
@@ -67,7 +67,7 @@ class CassandraRecipientRewriteTableTest implements RecipientRewriteTableContrac
     public void createRecipientRewriteTable() {
         recipientRewriteTable = new CassandraRecipientRewriteTable(recipientRewriteTableDAO, mappingsSourcesDAO);
         recipientRewriteTable.setUsersRepository(new UsersRepositoryImpl<>(new SimpleDomainList(),
-            new CassandraUsersDAO(new Algorithm.DefaultFactory(), cassandraCluster.getCassandraCluster().getConf())));
+            new CassandraUsersDAO(cassandraCluster.getCassandraCluster().getConf())));
     }
 
     @Override

--- a/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraStepdefs.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraStepdefs.java
@@ -67,7 +67,7 @@ public class CassandraStepdefs {
             new CassandraRecipientRewriteTableDAO(cassandra.getConf()),
             new CassandraMappingsSourcesDAO(cassandra.getConf()));
         rrt.setUsersRepository(new UsersRepositoryImpl<>(RecipientRewriteTableFixture.domainListForCucumberTests(),
-            new CassandraUsersDAO(new Algorithm.DefaultFactory(), cassandra.getConf())));
+            new CassandraUsersDAO(cassandra.getConf())));
         rrt.setDomainList(RecipientRewriteTableFixture.domainListForCucumberTests());
         return rrt;
     }

--- a/server/data/data-cassandra/src/test/java/org/apache/james/user/cassandra/CassandraUsersRepositoryTest.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/user/cassandra/CassandraUsersRepositoryTest.java
@@ -89,7 +89,7 @@ class CassandraUsersRepositoryTest {
     }
 
     private static UsersRepositoryImpl<CassandraUsersDAO> getUsersRepository(DomainList domainList, boolean enableVirtualHosting, Optional<Username> administrator) throws Exception {
-        CassandraUsersDAO usersDAO = new CassandraUsersDAO(new Algorithm.DefaultFactory(), cassandraCluster.getCassandraCluster().getConf());
+        CassandraUsersDAO usersDAO = new CassandraUsersDAO(cassandraCluster.getCassandraCluster().getConf());
         BaseHierarchicalConfiguration configuration = new BaseHierarchicalConfiguration();
         configuration.addProperty("enableVirtualHosting", String.valueOf(enableVirtualHosting));
         administrator.ifPresent(username -> configuration.addProperty("administratorId", username.asString()));

--- a/server/data/data-jpa/src/main/java/org/apache/james/user/jpa/model/JPAUser.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/user/jpa/model/JPAUser.java
@@ -34,6 +34,7 @@ import javax.persistence.Version;
 
 import org.apache.james.core.Username;
 import org.apache.james.user.api.model.User;
+import org.apache.james.user.lib.model.Algorithm;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.HashFunction;
@@ -57,14 +58,18 @@ public class JPAUser implements User {
      * @return not null
      */
     @VisibleForTesting
-    static String hashPassword(String password, String alg) {
-        return chooseHashFunction(alg).apply(password);
+    static String hashPassword(String password, String nullableSalt, String nullableAlgorithm) {
+        Algorithm algorithm = Algorithm.of(Optional.ofNullable(nullableAlgorithm).orElse("SHA-512"));
+        String credentials = password;
+        if (algorithm.isSalted() && nullableSalt != null) {
+            credentials = nullableSalt + password;
+        }
+        return chooseHashFunction(algorithm.getName()).apply(credentials);
     }
 
     interface PasswordHashFunction extends Function<String, String> {}
 
-    private static PasswordHashFunction chooseHashFunction(String nullableAlgorithm) {
-        String algorithm = Optional.ofNullable(nullableAlgorithm).orElse("SHA-512");
+    private static PasswordHashFunction chooseHashFunction(String algorithm) {
         switch (algorithm) {
             case "NONE":
                 return password -> password;
@@ -115,7 +120,7 @@ public class JPAUser implements User {
         super();
         this.name = userName;
         this.alg = alg;
-        this.password = hashPassword(password, alg);
+        this.password = hashPassword(password, userName, alg);
     }
 
     @Override
@@ -129,7 +134,7 @@ public class JPAUser implements User {
         if (newPass == null) {
             result = false;
         } else {
-            password = hashPassword(newPass, alg);
+            password = hashPassword(newPass, name, alg);
             result = true;
         }
         return result;
@@ -141,7 +146,7 @@ public class JPAUser implements User {
         if (pass == null) {
             result = password == null;
         } else {
-            result = password != null && password.equals(hashPassword(pass, alg));
+            result = password != null && password.equals(hashPassword(pass, name, alg));
         }
         return result;
     }

--- a/server/data/data-jpa/src/test/java/org/apache/james/user/jpa/model/JPAUserTest.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/user/jpa/model/JPAUserTest.java
@@ -28,36 +28,46 @@ class JPAUserTest {
     @Test
     void hashPasswordShouldBeNoopWhenNone() {
         //I doubt the expected result was the author intent
-        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, "NONE")).isEqualTo("baeMiqu7");
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, "NONE")).isEqualTo("baeMiqu7");
     }
 
     @Test
     void hashPasswordShouldHashWhenMD5() {
-        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, "MD5")).isEqualTo("702000e50c9fd3755b8fc20ecb07d1ac");
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, "MD5")).isEqualTo("702000e50c9fd3755b8fc20ecb07d1ac");
     }
 
     @Test
     void hashPasswordShouldHashWhenSHA1() {
-        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, "SHA1")).isEqualTo("05dbbaa7b4bcae245f14d19ae58ef1b80adf3363");
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, "SHA1")).isEqualTo("05dbbaa7b4bcae245f14d19ae58ef1b80adf3363");
     }
 
     @Test
     void hashPasswordShouldHashWhenSHA256() {
-        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, "SHA-256")).isEqualTo("6d06c72a578fe0b78ede2393b07739831a287774dcad0b18bc4bde8b0c948b82");
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, "SHA-256")).isEqualTo("6d06c72a578fe0b78ede2393b07739831a287774dcad0b18bc4bde8b0c948b82");
     }
 
     @Test
     void hashPasswordShouldHashWhenSHA512() {
-        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, "SHA-512")).isEqualTo("f9cc82d1c04bb2ce0494a51f7a21d07ac60b6f79a8a55397f454603acac29d8589fdfd694d5c01ba01a346c76b090abca9ad855b5b0c92c6062ad6d93cdc0d03");
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, "SHA-512")).isEqualTo("f9cc82d1c04bb2ce0494a51f7a21d07ac60b6f79a8a55397f454603acac29d8589fdfd694d5c01ba01a346c76b090abca9ad855b5b0c92c6062ad6d93cdc0d03");
     }
 
     @Test
     void hashPasswordShouldSha512WhenRandomString() {
-        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, "random")).isEqualTo("f9cc82d1c04bb2ce0494a51f7a21d07ac60b6f79a8a55397f454603acac29d8589fdfd694d5c01ba01a346c76b090abca9ad855b5b0c92c6062ad6d93cdc0d03");
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, "random")).isEqualTo("f9cc82d1c04bb2ce0494a51f7a21d07ac60b6f79a8a55397f454603acac29d8589fdfd694d5c01ba01a346c76b090abca9ad855b5b0c92c6062ad6d93cdc0d03");
     }
 
     @Test
-    void hashPasswordShouldMD5WhenNull() {
-        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null)).isEqualTo("f9cc82d1c04bb2ce0494a51f7a21d07ac60b6f79a8a55397f454603acac29d8589fdfd694d5c01ba01a346c76b090abca9ad855b5b0c92c6062ad6d93cdc0d03");
+    void hashPasswordShouldSha512WhenNull() {
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, null)).isEqualTo("f9cc82d1c04bb2ce0494a51f7a21d07ac60b6f79a8a55397f454603acac29d8589fdfd694d5c01ba01a346c76b090abca9ad855b5b0c92c6062ad6d93cdc0d03");
+    }
+
+    @Test
+    void hashPasswordShouldHashWithNullSalt() {
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, null, "SHA-512/salted")).isEqualTo("f9cc82d1c04bb2ce0494a51f7a21d07ac60b6f79a8a55397f454603acac29d8589fdfd694d5c01ba01a346c76b090abca9ad855b5b0c92c6062ad6d93cdc0d03");
+    }
+
+    @Test
+    void hashPasswordShouldHashWithSalt() {
+        Assertions.assertThat(JPAUser.hashPassword(RANDOM_PASSWORD, "salt", "SHA-512/salted")).isEqualTo("b7941dcdc380ec414623834919f7d5cbe241a2b6a23be79a61cd9f36178382901b8d83642b743297ac72e5de24e4111885dd05df06e14e47c943c05fdd1ff15a");
     }
 }

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/model/Algorithm.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/model/Algorithm.java
@@ -20,70 +20,71 @@
 package org.apache.james.user.lib.model;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
 public class Algorithm {
 
     public enum HashingMode {
-        LEGACY(LEGACY_FACTORY),
-        DEFAULT(DEFAULT_FACTORY);
+        PLAIN,
+        SALTED,
+        LEGACY,
+        LEGACY_SALTED;
 
         public static HashingMode parse(String value) {
             return Arrays.stream(values())
                 .filter(aValue -> value.equalsIgnoreCase(aValue.toString()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unsuported value for HashingMode: " + value + ". Should be one of " + ImmutableList.copyOf(values())));
-        }
-
-        private final Factory factory;
-
-        HashingMode(Factory factory) {
-            this.factory = factory;
-        }
-
-        public Factory getFactory() {
-            return factory;
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported value for HashingMode: " + value + ". Should be one of " + ImmutableList.copyOf(values())));
         }
     }
 
-    public interface Factory {
-        Algorithm of(String rawValue);
+    public static Algorithm of(String algorithmName) {
+        return Algorithm.of(algorithmName, HashingMode.PLAIN);
     }
 
-    public static class LegacyFactory implements Factory {
-        @Override
-        public Algorithm of(String rawValue) {
-            return new Algorithm(rawValue, LEGACY);
+    public static Algorithm of(String algorithmName, String fallbackHashingMode) {
+        return Algorithm.of(algorithmName, HashingMode.parse(fallbackHashingMode));
+    }
+
+    public static Algorithm of(String algorithmName, HashingMode fallbackHashingMode) {
+        List<String> spec = Splitter.on('/').splitToList(algorithmName);
+        if (spec.size() == 1) {
+            return new Algorithm(algorithmName, fallbackHashingMode);
+        } else {
+            return new Algorithm(spec.get(0), HashingMode.parse(spec.get(1)));
         }
     }
-
-    public static class DefaultFactory implements Factory {
-        @Override
-        public Algorithm of(String rawValue) {
-            return new Algorithm(rawValue, !LEGACY);
-        }
-    }
-
-    private static final boolean LEGACY = true;
-    public static final Factory LEGACY_FACTORY = new LegacyFactory();
-    public static final Factory DEFAULT_FACTORY = new DefaultFactory();
 
     private final String rawValue;
-    private final boolean legacy;
+    private final HashingMode hashingMode;
 
-    private Algorithm(String rawValue, boolean legacy) {
+    private Algorithm(String rawValue, HashingMode hashingMode) {
         this.rawValue = rawValue;
-        this.legacy = legacy;
+        this.hashingMode = hashingMode;
     }
 
     public String asString() {
+        return rawValue + "/" + hashingMode.name().toLowerCase();
+    }
+
+    public String getName() {
         return rawValue;
     }
 
+    public String getHashingMode() {
+        return hashingMode.name();
+    }
+
     public boolean isLegacy() {
-        return legacy;
+        return hashingMode == HashingMode.LEGACY || hashingMode == HashingMode.LEGACY_SALTED;
+    }
+
+    public boolean isSalted() {
+        return hashingMode == HashingMode.SALTED || hashingMode == HashingMode.LEGACY_SALTED;
     }
 
     @Override
@@ -92,13 +93,13 @@ public class Algorithm {
             Algorithm that = (Algorithm) o;
 
             return Objects.equals(this.rawValue, that.rawValue)
-                && Objects.equals(this.legacy, that.legacy);
+                && Objects.equals(this.hashingMode, that.hashingMode);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(rawValue, legacy);
+        return Objects.hash(rawValue, hashingMode);
     }
 }

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/model/DefaultUser.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/model/DefaultUser.java
@@ -76,7 +76,8 @@ public class DefaultUser implements User, Serializable {
     @Override
     public boolean verifyPassword(String pass) {
         try {
-            String hashGuess = DigestUtil.digestString(pass, algorithm);
+            String credentials = algorithm.isSalted() ? userName.asString() + pass : pass;
+            String hashGuess = DigestUtil.digestString(credentials, algorithm);
             return hashedPassword.equals(hashGuess);
         } catch (NoSuchAlgorithmException nsae) {
             throw new RuntimeException("Security error: " + nsae);
@@ -86,7 +87,8 @@ public class DefaultUser implements User, Serializable {
     @Override
     public boolean setPassword(String newPass) {
         try {
-            hashedPassword = DigestUtil.digestString(newPass, algorithm);
+            String newCredentials = algorithm.isSalted() ? userName.asString() + newPass : newPass;
+            hashedPassword = DigestUtil.digestString(newCredentials, algorithm);
             return true;
         } catch (NoSuchAlgorithmException nsae) {
             throw new RuntimeException("Security error: " + nsae);

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/util/DigestUtil.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/util/DigestUtil.java
@@ -77,7 +77,7 @@ public class DigestUtil {
             digestFile(args[args.length - 1], alg);
         } else {
             try {
-                String hash = digestString(args[args.length - 1], Algorithm.DEFAULT_FACTORY.of(alg));
+                String hash = digestString(args[args.length - 1], Algorithm.of(alg));
                 System.out.println("Hash is: " + hash);
             } catch (NoSuchAlgorithmException nsae) {
                 System.out.println("No such algorithm available");
@@ -141,7 +141,7 @@ public class DigestUtil {
         ByteArrayOutputStream bos;
 
         try {
-            md = MessageDigest.getInstance(algorithm.asString());
+            md = MessageDigest.getInstance(algorithm.getName());
             byte[] digest = md.digest(pass.getBytes(ISO_8859_1));
             bos = new ByteArrayOutputStream();
             OutputStream encodedStream = MimeUtility.encode(bos, "base64");

--- a/server/data/data-library/src/test/java/org/apache/james/user/lib/UsersRepositoryContract.java
+++ b/server/data/data-library/src/test/java/org/apache/james/user/lib/UsersRepositoryContract.java
@@ -567,14 +567,14 @@ public interface UsersRepositoryContract {
 
         @Test
         default void updateUserShouldThrowWhenUserDoesNotBelongToDomainList(TestSystem testSystem) {
-            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.userWithUnknownDomain, Algorithm.of("hasAlg"))))
+            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.userWithUnknownDomain, Algorithm.of("hasAlg"), Algorithm.of("hasAlg"))))
                 .isInstanceOf(InvalidUsernameException.class)
                 .hasMessage("Domain does not exist in DomainList");
         }
 
         @Test
         default void updateUserShouldNotThrowInvalidUsernameExceptionWhenInvalidUser(TestSystem testSystem) {
-            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.invalidUsername, Algorithm.of("hasAlg"))))
+            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.invalidUsername, Algorithm.of("hasAlg"), Algorithm.of("hasAlg"))))
                 .isNotInstanceOf(InvalidUsernameException.class);
         }
 

--- a/server/data/data-library/src/test/java/org/apache/james/user/lib/UsersRepositoryContract.java
+++ b/server/data/data-library/src/test/java/org/apache/james/user/lib/UsersRepositoryContract.java
@@ -567,14 +567,14 @@ public interface UsersRepositoryContract {
 
         @Test
         default void updateUserShouldThrowWhenUserDoesNotBelongToDomainList(TestSystem testSystem) {
-            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.userWithUnknownDomain, Algorithm.DEFAULT_FACTORY.of("hasAlg"))))
+            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.userWithUnknownDomain, Algorithm.of("hasAlg"))))
                 .isInstanceOf(InvalidUsernameException.class)
                 .hasMessage("Domain does not exist in DomainList");
         }
 
         @Test
         default void updateUserShouldNotThrowInvalidUsernameExceptionWhenInvalidUser(TestSystem testSystem) {
-            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.invalidUsername, Algorithm.DEFAULT_FACTORY.of("hasAlg"))))
+            assertThatThrownBy(() -> testee().updateUser(new DefaultUser(testSystem.invalidUsername, Algorithm.of("hasAlg"))))
                 .isNotInstanceOf(InvalidUsernameException.class);
         }
 

--- a/server/data/data-library/src/test/java/org/apache/james/user/lib/model/AlgorithmTest.java
+++ b/server/data/data-library/src/test/java/org/apache/james/user/lib/model/AlgorithmTest.java
@@ -19,9 +19,6 @@
 
 package org.apache.james.user.lib.model;
 
-import static org.apache.james.user.lib.model.Algorithm.DEFAULT_FACTORY;
-import static org.apache.james.user.lib.model.Algorithm.LEGACY_FACTORY;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -36,16 +33,110 @@ class AlgorithmTest {
     @Test
     void ofShouldParseRawHash() {
         SoftAssertions.assertSoftly(softly-> {
-            softly.assertThat(DEFAULT_FACTORY.of("SHA-1").asString()).isEqualTo("SHA-1");
-            softly.assertThat(DEFAULT_FACTORY.of("SHA-1").isLegacy()).isFalse();
+            softly.assertThat(Algorithm.of("SHA-1").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1").asString()).isEqualTo("SHA-1/plain");
+            softly.assertThat(Algorithm.of("SHA-1").isLegacy()).isFalse();
+            softly.assertThat(Algorithm.of("SHA-1").isSalted()).isFalse();
+        });
+    }
+
+    @Test
+    void ofShouldParseRawHashWithFallback() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1", "plain").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1", "plain").asString()).isEqualTo("SHA-1/plain");
+            softly.assertThat(Algorithm.of("SHA-1", "plain").isLegacy()).isFalse();
+            softly.assertThat(Algorithm.of("SHA-1", "plain").isSalted()).isFalse();
         });
     }
 
     @Test
     void ofShouldParseLegacy() {
         SoftAssertions.assertSoftly(softly-> {
-            softly.assertThat(LEGACY_FACTORY.of("SHA-1").asString()).isEqualTo("SHA-1");
-            softly.assertThat(LEGACY_FACTORY.of("SHA-1").isLegacy()).isTrue();
+            softly.assertThat(Algorithm.of("SHA-1/legacy").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1/legacy").asString()).isEqualTo("SHA-1/legacy");
+            softly.assertThat(Algorithm.of("SHA-1/legacy").isLegacy()).isTrue();
+            softly.assertThat(Algorithm.of("SHA-1/legacy").isSalted()).isFalse();
+        });
+    }
+
+    @Test
+    void ofShouldParseLegacyWithFallback() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1", "legacy").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1", "legacy").asString()).isEqualTo("SHA-1/legacy");
+            softly.assertThat(Algorithm.of("SHA-1", "legacy").isLegacy()).isTrue();
+            softly.assertThat(Algorithm.of("SHA-1", "legacy").isSalted()).isFalse();
+        });
+    }
+
+    @Test
+    void ofShouldParseLegacyIgnoringFallback() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1/legacy", "plain").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1/legacy", "plain").asString()).isEqualTo("SHA-1/legacy");
+            softly.assertThat(Algorithm.of("SHA-1/legacy", "plain").isLegacy()).isTrue();
+            softly.assertThat(Algorithm.of("SHA-1/legacy", "plain").isSalted()).isFalse();
+        });
+    }
+
+    @Test
+    void ofShouldParseSalted() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1/salted").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1/salted").asString()).isEqualTo("SHA-1/salted");
+            softly.assertThat(Algorithm.of("SHA-1/salted").isLegacy()).isFalse();
+            softly.assertThat(Algorithm.of("SHA-1/salted").isSalted()).isTrue();
+        });
+    }
+
+    @Test
+    void ofShouldParseSaltedWithFallback() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1", "salted").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1", "salted").asString()).isEqualTo("SHA-1/salted");
+            softly.assertThat(Algorithm.of("SHA-1", "salted").isLegacy()).isFalse();
+            softly.assertThat(Algorithm.of("SHA-1", "salted").isSalted()).isTrue();
+        });
+    }
+
+    @Test
+    void ofShouldParseSaltedIgnoringFallback() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1/salted", "plain").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1/salted", "plain").asString()).isEqualTo("SHA-1/salted");
+            softly.assertThat(Algorithm.of("SHA-1/salted", "plain").isLegacy()).isFalse();
+            softly.assertThat(Algorithm.of("SHA-1/salted", "plain").isSalted()).isTrue();
+        });
+    }
+
+    @Test
+    void ofShouldParseLegacySalted() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted").asString()).isEqualTo("SHA-1/legacy_salted");
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted").isLegacy()).isTrue();
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted").isSalted()).isTrue();
+        });
+    }
+
+    @Test
+    void ofShouldParseLegacySaltedWithFallback() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1", "legacy_salted").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1", "legacy_salted").asString()).isEqualTo("SHA-1/legacy_salted");
+            softly.assertThat(Algorithm.of("SHA-1", "legacy_salted").isLegacy()).isTrue();
+            softly.assertThat(Algorithm.of("SHA-1", "legacy_salted").isSalted()).isTrue();
+        });
+    }
+
+    @Test
+    void ofShouldParseLegacySaltedIgnoringFallback() {
+        SoftAssertions.assertSoftly(softly-> {
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted", "plain").getName()).isEqualTo("SHA-1");
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted", "plain").asString()).isEqualTo("SHA-1/legacy_salted");
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted", "plain").isLegacy()).isTrue();
+            softly.assertThat(Algorithm.of("SHA-1/legacy_salted", "plain").isSalted()).isTrue();
         });
     }
 }

--- a/server/data/data-library/src/test/java/org/apache/james/user/lib/model/DefaultUserTest.java
+++ b/server/data/data-library/src/test/java/org/apache/james/user/lib/model/DefaultUserTest.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.user.lib.model;
+
+import org.apache.james.core.Username;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.james.user.lib.model.Algorithm.HashingMode.LEGACY;
+import static org.apache.james.user.lib.model.Algorithm.HashingMode.PLAIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultUserTest {
+
+    private DefaultUser user;
+
+    @Before
+    public void setUp() {
+        user = new DefaultUser(
+                Username.of("joe"),
+                "5en6G6MezRroT3XKqkdPOmY/", // SHA-1 legacy hash of "secret"
+                Algorithm.of("SHA-1", LEGACY),
+                Algorithm.of("SHA-256", PLAIN));
+    }
+
+    @Test
+    public void shouldYieldVerifyAlgorithm() {
+        assertThat(user.getHashAlgorithm().asString()).isEqualTo("SHA-1/legacy");
+        assertThat(user.getHashAlgorithm().getHashingMode()).isEqualToIgnoringCase(LEGACY.name());
+    }
+
+    @Test
+    public void shouldVerifyPasswordUsingVerifyAlgorithm() {
+        assertThat(user.verifyPassword("secret")).isTrue();
+        assertThat(user.verifyPassword("secret2")).isFalse();
+    }
+
+    @Test
+    public void shouldSetPasswordUsingUpdateAlgorithm() {
+        user.setPassword("secret2");
+        assertThat(user.getHashAlgorithm().asString()).isEqualTo("SHA-256/plain");
+        assertThat(user.getHashAlgorithm().getHashingMode()).isEqualToIgnoringCase(PLAIN.name());
+
+        assertThat(user.verifyPassword("secret2")).isTrue();
+        assertThat(user.verifyPassword("secret")).isFalse();
+    }
+}

--- a/server/data/data-library/src/test/java/org/apache/james/user/lib/util/DigestUtilTest.java
+++ b/server/data/data-library/src/test/java/org/apache/james/user/lib/util/DigestUtilTest.java
@@ -19,13 +19,12 @@
 
 package org.apache.james.user.lib.util;
 
-import static org.apache.james.user.lib.model.Algorithm.DEFAULT_FACTORY;
-import static org.apache.james.user.lib.model.Algorithm.LEGACY_FACTORY;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.apache.james.user.lib.model.Algorithm;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,7 +41,7 @@ class DigestUtilTest {
     @ParameterizedTest
     @MethodSource("sha1LegacyTestBed")
     void testSha1Legacy(String password, String expectedHash) throws Exception {
-        assertThat(DigestUtil.digestString(Optional.ofNullable(password).orElse(""), LEGACY_FACTORY.of("SHA-1")))
+        assertThat(DigestUtil.digestString(Optional.ofNullable(password).orElse(""), Algorithm.of("SHA-1", "legacy")))
             .isEqualTo(expectedHash);
     }
 
@@ -57,7 +56,7 @@ class DigestUtilTest {
     @ParameterizedTest
     @MethodSource("sha512LegacyTestBed")
     void testSha512Legacy(String password, String expectedHash) throws Exception {
-        assertThat(DigestUtil.digestString(password, LEGACY_FACTORY.of("SHA-512")))
+        assertThat(DigestUtil.digestString(password, Algorithm.of("SHA-512", "legacy")))
             .isEqualTo(expectedHash);
     }
 
@@ -72,7 +71,7 @@ class DigestUtilTest {
     @ParameterizedTest
     @MethodSource("sha1TestBed")
     void testSha1(String password, String expectedHash) throws Exception {
-        assertThat(DigestUtil.digestString(Optional.ofNullable(password).orElse(""), DEFAULT_FACTORY.of("SHA-1")))
+        assertThat(DigestUtil.digestString(Optional.ofNullable(password).orElse(""), Algorithm.of("SHA-1")))
             .isEqualTo(expectedHash);
     }
 
@@ -87,7 +86,7 @@ class DigestUtilTest {
     @ParameterizedTest
     @MethodSource("sha512TestBed")
     void testSha512(String password, String expectedHash) throws Exception {
-        assertThat(DigestUtil.digestString(password, DEFAULT_FACTORY.of("SHA-512")))
+        assertThat(DigestUtil.digestString(password, Algorithm.of("SHA-512")))
             .isEqualTo(expectedHash);
     }
 }

--- a/server/data/data-memory/src/main/java/org/apache/james/user/memory/MemoryUsersDAO.java
+++ b/server/data/data-memory/src/main/java/org/apache/james/user/memory/MemoryUsersDAO.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.user.memory;
 
+import static org.apache.james.user.lib.model.Algorithm.HashingMode.PLAIN;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -45,7 +47,7 @@ public class MemoryUsersDAO implements UsersDAO, Configurable {
 
     @Override
     public void configure(HierarchicalConfiguration<ImmutableNode> config) {
-        algo = Algorithm.of(config.getString("algorithm", "SHA-512"), config.getString("hashingMode", "plain"));
+        algo = Algorithm.of(config.getString("algorithm", "SHA-512"), config.getString("hashingMode", PLAIN.name()));
     }
 
     public void clear() {
@@ -54,7 +56,7 @@ public class MemoryUsersDAO implements UsersDAO, Configurable {
 
     @Override
     public void addUser(Username username, String password) {
-        DefaultUser user = new DefaultUser(username, algo);
+        DefaultUser user = new DefaultUser(username, algo, algo);
         user.setPassword(password);
         userByName.put(username.asString(), user);
     }

--- a/server/data/data-memory/src/main/java/org/apache/james/user/memory/MemoryUsersDAO.java
+++ b/server/data/data-memory/src/main/java/org/apache/james/user/memory/MemoryUsersDAO.java
@@ -37,21 +37,15 @@ import org.apache.james.user.lib.model.DefaultUser;
 public class MemoryUsersDAO implements UsersDAO, Configurable {
     private final Map<String, User> userByName;
     private Algorithm algo;
-    private Algorithm.Factory hashFactory;
 
     MemoryUsersDAO() {
         this.userByName = new HashMap<>();
-        this.hashFactory = Algorithm.DEFAULT_FACTORY;
-        this.algo = hashFactory.of("SHA-512");
+        this.algo = Algorithm.of("SHA-512");
     }
 
     @Override
     public void configure(HierarchicalConfiguration<ImmutableNode> config) {
-        hashFactory = Optional.ofNullable(config.getString("hashingMode", null))
-            .map(Algorithm.HashingMode::parse)
-            .orElse(Algorithm.HashingMode.DEFAULT)
-            .getFactory();
-        algo = hashFactory.of(config.getString("algorithm", "SHA-512"));
+        algo = Algorithm.of(config.getString("algorithm", "SHA-512"), config.getString("hashingMode", "plain"));
     }
 
     public void clear() {

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -23,6 +23,24 @@ Change list:
  - [Changes to the enqueuedMails DAO](#changes-to-the-enqueuedmails-dao)
  - [Restructure maximum quotas definition](#restructure-maximum-quotas-definition)
 
+### Support salted passwords
+
+Date: 24/11/2021
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-3674
+
+With this update, the password algorithm may include an option to salt the password hash with the user name, for increased security against rainbow table cracking. To use this feature, update your usersrepository.xml :
+```
+<algorithm>SHA-512/salted</algorithm>
+```
+
+Whenever users change their password, James will update the respective database entry with a salted hash.
+
+Note that `plain` hashing mode is the default. If you were using `legacy` mode and want to keep it for some reason, you must specify this option explicitly:
+```
+<algorithm>SHA-512/legacy</algorithm>
+```
+
 ### MailDir removal
 
 Date 19/09/2021


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/JAMES-3674 for a general description. This comes in two commits for clarification:
1. Extend `Algorithm.HashingMode` with new options `salted` and `legacy_salted`, and renaming `default` to `plain` now that there are multiple options. Remove the implicit factory mechanism in favor of an explicit second parameter, i.e.`Algorithm.of(algorithmName, hashingMode)`. Then have `DefaultUser` include the username when the selected algorithm requires salting.
2. Introduce a `CassandraUsersRepository` to pass configuration options to the user DAO. Extend the latter to remember the preferred algorithm and hashing mode from the configuration, and use them when hashing new passwords. But add an explicit `hashingmode` colum next to `algorithm` and `password` in the user table, and use them together during verification. Add a new configuration option `hashingModeFallback` to use when the `hashingmode` column is `null`, which avoids a costly migration solution and reduces upgrading to a single CQL command (see upgrade-instructions.md).

Note that this only works for Cassandra. I believe it should be easy to do something similar for JPA, but I have never used it and do not feel comfortable with touching that part of the code base. Obviously does not apply to LDAP.