### PR TITLE
JAMES-3225 Force a dependency cleanup on the build phase in the Jenki…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
         stage('Build') {
             steps {
                 echo 'Building'
-                sh 'mvn -U -B -e clean install -DskipTests -T1C ${MVN_SHOW_TIMESTAMPS}'
+                sh 'mvn -U -B -e dependency:purge-local-repository clean install -DskipTests -T1C ${MVN_SHOW_TIMESTAMPS}'
             }
         }
 


### PR DESCRIPTION
We have more and more corrupted maven packages in the local repo on some workers it seems lately, crashing builds very quickly. The goal here is to force the update of maven packages to avoid corruptions.