### PR TITLE
JAMES-3534 Identity/destroy should not fail for identities whose alias is deleted

### DIFF
--- a/server/container/guice/common/src/main/java/org/apache/james/utils/DataProbeImpl.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/DataProbeImpl.java
@@ -119,6 +119,12 @@ public class DataProbeImpl implements GuiceProbe, DataProbe {
     }
 
     @Override
+    public void removeUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception {
+        MappingSource source = MappingSource.fromUser(fromUser, fromDomain);
+        recipientRewriteTable.removeAliasMapping(source, toAddress);
+    }
+
+    @Override
     public void addDomainAliasMapping(String aliasDomain, String deliveryDomain) throws Exception {
         recipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(deliveryDomain));
     }

--- a/server/data/data-api/src/main/java/org/apache/james/probe/DataProbe.java
+++ b/server/data/data-api/src/main/java/org/apache/james/probe/DataProbe.java
@@ -75,6 +75,8 @@ public interface DataProbe {
 
     void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
 
+    void removeUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
+
     void addDomainAliasMapping(String aliasDomain, String deliveryDomain) throws Exception;
 
     void addGroupAliasMapping(String fromGroup, String toAddress) throws Exception;


### PR DESCRIPTION
After writing the test and having a look again at the delete API logic, I realize that we don't need to change any logic to the destroy case.
Still the test for sure.