### PR TITLE
[PERFORMANCE] MessageUid::compareTo should not box values

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageUid.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageUid.java
@@ -45,7 +45,7 @@ public class MessageUid implements Comparable<MessageUid> {
     
     @Override
     public int compareTo(MessageUid o) {
-        return Long.valueOf(uid).compareTo(o.uid);
+        return Long.compare(uid, o.uid);
     }
 
     public long asLong() {


### PR DESCRIPTION
This extra boxing was using 10% of CPU resources for IMAP.

![Screenshot from 2021-11-28 11-35-55](https://user-images.githubusercontent.com/6928740/143732909-b24fef5d-e3cf-4dc7-a916-1e6052e64d1e.png)
