### PR TITLE
JAMES-3679 Set mailbox recent gc_grace_second to zero

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMailboxRecentsModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMailboxRecentsModule.java
@@ -34,6 +34,7 @@ public interface CassandraMailboxRecentsModule {
             " is a SELECT optimisation.")
         .options(options -> options
             .compactionOptions(SchemaBuilder.sizedTieredStategy())
+            .gcGraceSeconds(0)
             .caching(SchemaBuilder.KeyCaching.ALL,
                 SchemaBuilder.rows(CassandraConstants.DEFAULT_CACHED_ROW_PER_PARTITION)))
         .statement(statement -> statement


### PR DESCRIPTION
This prevents (most of) tombstones warnings when reading this
table and the underlying data model is resilient to
deletions not applied (as all entries are removed on SELECT).