### PR TITLE
JAMES-3680 SMTP/LMTP authentication configuration reworked

### DIFF
--- a/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/resources/smtpserver.xml
+++ b/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/resources/smtpserver.xml
@@ -34,7 +34,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -57,10 +60,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -84,10 +87,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/mpt/impl/smtp/cassandra/src/test/resources/smtpserver.xml
+++ b/mpt/impl/smtp/cassandra/src/test/resources/smtpserver.xml
@@ -34,7 +34,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -57,10 +60,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -84,10 +87,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/protocols/lmtp/src/main/java/org/apache/james/protocols/lmtp/LMTPConfiguration.java
+++ b/protocols/lmtp/src/main/java/org/apache/james/protocols/lmtp/LMTPConfiguration.java
@@ -37,7 +37,7 @@ public abstract class LMTPConfiguration extends ProtocolConfigurationImpl implem
     }
 
     @Override
-    public boolean isAuthAnnounced(String remoteIP) {
+    public boolean isAuthAnnounced(String remoteIP, boolean tlsStarted) {
         return false;
     }
 

--- a/protocols/lmtp/src/main/java/org/apache/james/protocols/lmtp/LMTPConfiguration.java
+++ b/protocols/lmtp/src/main/java/org/apache/james/protocols/lmtp/LMTPConfiguration.java
@@ -37,7 +37,7 @@ public abstract class LMTPConfiguration extends ProtocolConfigurationImpl implem
     }
 
     @Override
-    public boolean isAuthRequired(String remoteIP) {
+    public boolean isAuthAnnounced(String remoteIP) {
         return false;
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfiguration.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfiguration.java
@@ -53,7 +53,7 @@ public interface SMTPConfiguration extends ProtocolConfiguration {
      * @param remoteIP the remote IP address in String form
      * @return whether SMTP authentication is on
      */
-    boolean isAuthRequired(String remoteIP);
+    boolean isAuthAnnounced(String remoteIP);
     
     /**
      * Returns whether the remote server needs to send a HELO/EHLO

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfiguration.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfiguration.java
@@ -53,7 +53,7 @@ public interface SMTPConfiguration extends ProtocolConfiguration {
      * @param remoteIP the remote IP address in String form
      * @return whether SMTP authentication is on
      */
-    boolean isAuthAnnounced(String remoteIP);
+    boolean isAuthAnnounced(String remoteIP, boolean tlsStarted);
     
     /**
      * Returns whether the remote server needs to send a HELO/EHLO

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfigurationImpl.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfigurationImpl.java
@@ -54,7 +54,7 @@ public class SMTPConfigurationImpl extends ProtocolConfigurationImpl implements 
      * Return <code>false</code>
      */
     @Override
-    public boolean isAuthAnnounced(String remoteIP) {
+    public boolean isAuthAnnounced(String remoteIP, boolean tlsStarted) {
         return false;
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfigurationImpl.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPConfigurationImpl.java
@@ -54,7 +54,7 @@ public class SMTPConfigurationImpl extends ProtocolConfigurationImpl implements 
      * Return <code>false</code>
      */
     @Override
-    public boolean isAuthRequired(String remoteIP) {
+    public boolean isAuthAnnounced(String remoteIP) {
         return false;
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSession.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSession.java
@@ -68,7 +68,7 @@ public interface SMTPSession extends ProtocolSession {
      *
      * @return authentication required or not
      */
-    boolean isAuthSupported();
+    boolean isAuthAnnounced();
 
     
     /**

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSessionImpl.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSessionImpl.java
@@ -65,8 +65,8 @@ public class SMTPSessionImpl extends ProtocolSessionImpl implements SMTPSession 
     }
 
     @Override
-    public boolean isAuthSupported() {
-        return getConfiguration().isAuthRequired(getRemoteAddress().getAddress().getHostAddress());
+    public boolean isAuthAnnounced() {
+        return getConfiguration().isAuthAnnounced(getRemoteAddress().getAddress().getHostAddress());
     }
 
     @Override

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSessionImpl.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSessionImpl.java
@@ -66,7 +66,7 @@ public class SMTPSessionImpl extends ProtocolSessionImpl implements SMTPSession 
 
     @Override
     public boolean isAuthAnnounced() {
-        return getConfiguration().isAuthAnnounced(getRemoteAddress().getAddress().getHostAddress());
+        return getConfiguration().isAuthAnnounced(getRemoteAddress().getAddress().getHostAddress(), isTLSStarted());
     }
 
     @Override

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
@@ -53,7 +53,7 @@ public abstract class AbstractAuthRequiredToRelayRcptHook implements RcptHook {
         if (!session.isRelayingAllowed()) {
             Domain toDomain = rcpt.getDomain();
             if (!isLocalDomain(toDomain)) {
-                if (session.isAuthSupported()) {
+                if (session.isAuthAnnounced()) {
                     return AUTH_REQUIRED;
                 } else {
                     return RELAYING_DENIED;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
@@ -466,7 +466,7 @@ public class AuthCmdHandler
 
     @Override
     public List<String> getImplementedEsmtpFeatures(SMTPSession session) {
-        if (session.isAuthSupported()) {
+        if (session.isAuthAnnounced()) {
             return ESMTP_FEATURES;
         } else {
             return Collections.emptyList();

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
@@ -138,7 +138,7 @@ public class DNSRBLHandlerTest {
             }
 
             @Override
-            public boolean isAuthSupported() {
+            public boolean isAuthAnnounced() {
                 return false;
             }
 

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
@@ -55,7 +55,7 @@ public class ResolvableEhloHeloHandlerTest {
             HashMap<AttachmentKey<?>, Object> map = new HashMap<>();
 
             @Override
-            public boolean isAuthSupported() {
+            public boolean isAuthAnnounced() {
                 return authRequired;
             }
 

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/BaseFakeSMTPSession.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/BaseFakeSMTPSession.java
@@ -78,7 +78,7 @@ public class BaseFakeSMTPSession implements SMTPSession {
     }
 
     @Override
-    public boolean isAuthSupported() {
+    public boolean isAuthAnnounced() {
         throw new UnsupportedOperationException("Unimplemented Stub Method");
     }
 

--- a/server/apps/cassandra-app/sample-configuration/smtpserver.xml
+++ b/server/apps/cassandra-app/sample-configuration/smtpserver.xml
@@ -45,7 +45,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -82,7 +84,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -120,7 +124,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/cassandra-app/sample-configuration/smtpserver.xml
+++ b/server/apps/cassandra-app/sample-configuration/smtpserver.xml
@@ -47,6 +47,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +87,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
@@ -126,6 +128,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->

--- a/server/apps/cassandra-app/src/test/resources/smtpserver.xml
+++ b/server/apps/cassandra-app/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -59,7 +61,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -86,7 +90,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/apps/cassandra-app/src/test/resources/smtpserver.xml
+++ b/server/apps/cassandra-app/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -63,6 +64,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -92,6 +94,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/cli-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/apps/cli-integration-tests/src/test/resources/smtpserver.xml
@@ -61,7 +61,7 @@
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
-            <announce>true</announce>
+            <announce>always</announce>
             <requireSSL>false</requireSSL>
         </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
@@ -89,7 +89,7 @@
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
-            <announce>true</announce>
+            <announce>always</announce>
             <requireSSL>false</requireSSL>
         </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>

--- a/server/apps/cli-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/apps/cli-integration-tests/src/test/resources/smtpserver.xml
@@ -33,7 +33,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -57,10 +60,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>true</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -85,10 +88,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>true</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/demo/smtpserver.xml
+++ b/server/apps/demo/smtpserver.xml
@@ -33,7 +33,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -58,7 +61,10 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -84,7 +90,10 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/smtp.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/smtp.adoc
@@ -54,20 +54,35 @@ this case, if no body is present, the value "localhost" will be used.
 | connectionLimitPerIP
 | Set the maximum simultaneous incoming connections per IP for this service.
 
-| handler.authRequired
-| This is an optional tag with a boolean body.  If true, then the server will
-require authentication before delivering mail to non-local email addresses.  If this tag is absent, or the value
+| authRequired
+| (deprecated) use auth.announce instead.
+
+This is an optional tag with a boolean body.  If true, then the server will
+announce authentication after HELO command.  If this tag is absent, or the value
 is false then the client will not be prompted for authentication.  Only simple user/password authentication is
-supported at this time. supported values:
+supported at this time. Supported values:
 
-* true: required but announced only to not authorizedAddresses
-* false: don't use AUTH
-* announce: like true, but always announce AUTH capability to clients
+ * true: announced only to not authorizedAddresses
 
-The correct behaviour per RFC value would be false or announce
-but we still support true for backward compatibility and because
-some webmail client fails when AUTH is announced but no authentication
-information has been provided
+ * false: don't announce AUTH. If absent, *authorizedAddresses* are set to a wilcard to accept all remote hosts.
+
+ * announce: like true, but always announce AUTH capability to clients
+
+Please note that emails are only relayed if, and only if, the user did authenticate, or is in an authorized network,
+regardless of this option.
+
+| auth.announce
+| This is an optional tag.  Possible values are:
+
+* never: Don't announce auth. If absent, *authorizedAddresses* are set to a wilcard to accept all remote hosts.
+This is the default behaviour.
+
+* always: always announce AUTH capability to clients.
+
+* forUnauthorizedAddresses: announced only to not authorizedAddresses
+
+Please note that emails are only relayed if, and only if, the user did authenticate, or is in an authorized network,
+regardless of this option.
 
 | authorizedAddresses
 | Authorize specific addresses/networks.

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/smtp.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/smtp.adoc
@@ -83,6 +83,10 @@ regardless of this option.
 Please note that emails are only relayed if, and only if, the user did authenticate, or is in an authorized network,
 regardless of this option.
 
+| auth.requireSSL
+| This is an optional tag, defaults to true. If true, authentication is not advertised via capabilities on unencrypted
+channels.
+
 | authorizedAddresses
 | Authorize specific addresses/networks.
 

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/smtp.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/smtp.adoc
@@ -74,8 +74,7 @@ regardless of this option.
 | auth.announce
 | This is an optional tag.  Possible values are:
 
-* never: Don't announce auth. If absent, *authorizedAddresses* are set to a wilcard to accept all remote hosts.
-This is the default behaviour.
+* never: Don't announce auth.
 
 * always: always announce AUTH capability to clients.
 

--- a/server/apps/distributed-app/sample-configuration/smtpserver.xml
+++ b/server/apps/distributed-app/sample-configuration/smtpserver.xml
@@ -45,7 +45,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -82,7 +84,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -120,7 +124,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/distributed-app/sample-configuration/smtpserver.xml
+++ b/server/apps/distributed-app/sample-configuration/smtpserver.xml
@@ -47,6 +47,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +87,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
@@ -126,6 +128,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->

--- a/server/apps/distributed-app/src/test/resources/smtpserver.xml
+++ b/server/apps/distributed-app/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -56,10 +58,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -83,10 +84,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/apps/distributed-app/src/test/resources/smtpserver.xml
+++ b/server/apps/distributed-app/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <authorizedAddresses>0.0.0.0/0.0.0.0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -61,6 +62,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -87,6 +89,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/distributed-app/src/test/resources/smtpserver.xml
+++ b/server/apps/distributed-app/src/test/resources/smtpserver.xml
@@ -36,6 +36,7 @@
         <auth>
             <announce>never</announce>
         </auth>
+        <authorizedAddresses>0.0.0.0/0.0.0.0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>

--- a/server/apps/distributed-pop3-app/sample-configuration/smtpserver.xml
+++ b/server/apps/distributed-pop3-app/sample-configuration/smtpserver.xml
@@ -35,7 +35,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -62,7 +64,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -90,7 +94,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/distributed-pop3-app/sample-configuration/smtpserver.xml
+++ b/server/apps/distributed-pop3-app/sample-configuration/smtpserver.xml
@@ -37,6 +37,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -66,6 +67,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
@@ -96,6 +98,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->

--- a/server/apps/distributed-pop3-app/src/test/resources/smtpserver.xml
+++ b/server/apps/distributed-pop3-app/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -56,10 +58,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -83,10 +84,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/apps/distributed-pop3-app/src/test/resources/smtpserver.xml
+++ b/server/apps/distributed-pop3-app/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -60,6 +61,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +88,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/jpa-app/sample-configuration/smtpserver.xml
+++ b/server/apps/jpa-app/sample-configuration/smtpserver.xml
@@ -45,7 +45,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -82,7 +84,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -120,7 +124,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/jpa-app/sample-configuration/smtpserver.xml
+++ b/server/apps/jpa-app/sample-configuration/smtpserver.xml
@@ -47,6 +47,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +87,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
@@ -126,6 +128,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->

--- a/server/apps/jpa-app/src/test/resources/smtpserver.xml
+++ b/server/apps/jpa-app/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -56,10 +58,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -83,10 +84,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/apps/jpa-app/src/test/resources/smtpserver.xml
+++ b/server/apps/jpa-app/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -60,6 +61,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +88,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/jpa-smtp-app/sample-configuration/smtpserver.xml
+++ b/server/apps/jpa-smtp-app/sample-configuration/smtpserver.xml
@@ -45,7 +45,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -82,7 +84,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -120,7 +124,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/jpa-smtp-app/sample-configuration/smtpserver.xml
+++ b/server/apps/jpa-smtp-app/sample-configuration/smtpserver.xml
@@ -47,6 +47,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +87,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
@@ -126,6 +128,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->

--- a/server/apps/jpa-smtp-app/src/test/resources/smtpserver.xml
+++ b/server/apps/jpa-smtp-app/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -56,10 +58,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -83,10 +84,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/apps/jpa-smtp-app/src/test/resources/smtpserver.xml
+++ b/server/apps/jpa-smtp-app/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -60,6 +61,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +88,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/memory-app/sample-configuration/smtpserver.xml
+++ b/server/apps/memory-app/sample-configuration/smtpserver.xml
@@ -45,7 +45,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -82,7 +84,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -120,7 +124,9 @@
         <!--
            Authorize only local users
         -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/memory-app/sample-configuration/smtpserver.xml
+++ b/server/apps/memory-app/sample-configuration/smtpserver.xml
@@ -47,6 +47,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +87,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
@@ -126,6 +128,7 @@
         -->
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>true</requireSSL>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->

--- a/server/apps/memory-app/src/test/resources/smtpserver.xml
+++ b/server/apps/memory-app/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -56,10 +58,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -83,10 +84,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/apps/memory-app/src/test/resources/smtpserver.xml
+++ b/server/apps/memory-app/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -60,6 +61,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +88,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/apps/spring-app/src/main/resources/smtpserver.xml
+++ b/server/apps/spring-app/src/main/resources/smtpserver.xml
@@ -84,22 +84,22 @@
          
         <!-- Set the maximum simultaneous incoming connections per IP for this service -->
         <connectionLimitPerIP>0</connectionLimitPerIP>
-         
-        <!--  Uncomment this if you want to require SMTP authentication.
+
+       <auth>
+           <!--  Uncomment this if you want to require SMTP authentication.
 
                supported values:
-               true: required but announced only to not authorizedAddresses
-               false: don't use AUTH
-               announce: like true, but always announce AUTH capability to clients
+               forUnauthorizedAddresses:  announced only to not authorizedAddresses
+               never: don't announce AUTH
+               always: always announce AUTH capability to clients
 
                The correct behaviour per RFC value would be false or announce
                but we still support true for backward compatibility and because
                some webmail client fails when AUTH is announced but no authentication
                information has been provided
           -->
-        <!--
-        <authRequired>true</authRequired>
-         -->
+         <!-- <announce>forUnauthorizedAddresses</announce> -->
+       </auth>
 
 <!-- CHECKME! -->
         <!--  Uncomment this if you want to authorize specific addresses/networks.

--- a/server/apps/spring-app/src/test/resources/smtpserver.xml
+++ b/server/apps/spring-app/src/test/resources/smtpserver.xml
@@ -36,7 +36,9 @@
     <connectionLimit> 0 </connectionLimit>
     <connectionLimitPerIP> 0 </connectionLimitPerIP>
     <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-    <authRequired>true</authRequired>
+    <auth>
+      <announce>forUnauthorizedAddresses</announce>
+    </auth>
     <verifyIdentity>true</verifyIdentity>
     <maxmessagesize>0</maxmessagesize>
     <addressBracketsEnforcement>true</addressBracketsEnforcement>

--- a/server/apps/spring-app/src/test/resources/smtpserver.xml
+++ b/server/apps/spring-app/src/test/resources/smtpserver.xml
@@ -38,6 +38,7 @@
     <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
     <auth>
       <announce>forUnauthorizedAddresses</announce>
+      <requireSSL>false</requireSSL>
     </auth>
     <verifyIdentity>true</verifyIdentity>
     <maxmessagesize>0</maxmessagesize>

--- a/server/apps/webadmin-cli/src/test/resources/smtpserver.xml
+++ b/server/apps/webadmin-cli/src/test/resources/smtpserver.xml
@@ -33,7 +33,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -57,10 +60,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -85,10 +88,10 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SmtpGuiceProbe.java
+++ b/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SmtpGuiceProbe.java
@@ -18,7 +18,7 @@
  ****************************************************************/
 package org.apache.james.modules.protocols;
 
-import static org.apache.james.smtpserver.netty.SMTPServer.AuthenticationRequired.REQUIRED;
+import static org.apache.james.smtpserver.netty.SMTPServer.AuthenticationAnnounceMode.FOR_UNAUTHORIZED_ADDRESSES;
 
 import java.net.InetSocketAddress;
 import java.util.function.Function;
@@ -65,7 +65,7 @@ public class SmtpGuiceProbe implements GuiceProbe {
     }
 
     public Port getSmtpAuthRequiredPort() {
-        return getPort(server -> ((SMTPServer) server).getAuthRequired().equals(REQUIRED));
+        return getPort(server -> ((SMTPServer) server).getAuthRequired().equals(FOR_UNAUTHORIZED_ADDRESSES));
     }
 
     private Port getPort(Predicate<? super AbstractConfigurableAsyncServer> filter) {

--- a/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SmtpGuiceProbe.java
+++ b/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SmtpGuiceProbe.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.modules.protocols;
 
+import static org.apache.james.smtpserver.netty.SMTPServer.AuthenticationRequired.REQUIRED;
+
 import java.net.InetSocketAddress;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -63,7 +65,7 @@ public class SmtpGuiceProbe implements GuiceProbe {
     }
 
     public Port getSmtpAuthRequiredPort() {
-        return getPort(server -> ((SMTPServer) server).getAuthRequired() == SMTPServer.AUTH_REQUIRED);
+        return getPort(server -> ((SMTPServer) server).getAuthRequired().equals(REQUIRED));
     }
 
     private Port getPort(Predicate<? super AbstractConfigurableAsyncServer> filter) {

--- a/server/mailet/integration-testing/src/main/resources/smtpserver.xml
+++ b/server/mailet/integration-testing/src/main/resources/smtpserver.xml
@@ -37,6 +37,9 @@
 {{#hasAuthorizedAddresses}}
         <authorizedAddresses>{{authorizedAddresses}}</authorizedAddresses>
 {{/hasAuthorizedAddresses}}
+        <auth>
+            <requireSSL>false</requireSSL>
+        </auth>
         <verifyIdentity>{{verifyIdentity}}</verifyIdentity>
         <maxmessagesize>{{maxmessagesize}}</maxmessagesize>
         <addressBracketsEnforcement>{{bracketEnforcement}}</addressBracketsEnforcement>

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
@@ -100,7 +100,7 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
                 .putProcessor(CommonProcessors.bounces()))
             .withSmtpConfiguration(SmtpConfiguration.builder()
                 .doNotVerifyIdentity()
-                .build())
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -128,6 +128,8 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(directResolutionTransport())
                 .putProcessor(CommonProcessors.bounces()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -154,6 +156,8 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(transport())
                 .putProcessor(CommonProcessors.bounces()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -182,6 +186,8 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(transport())
                 .putProcessor(CommonProcessors.bounces()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -219,6 +225,8 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
                     .addMailet(MailetConfiguration.remoteDeliveryBuilder()
                         .matcher(All.class)))
                 .putProcessor(CommonProcessors.bounces()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
@@ -91,6 +91,7 @@ class GatewayRemoteDeliveryIntegrationTest {
             .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
             .withSmtpConfiguration(SmtpConfiguration.builder()
                 .doNotVerifyIdentity()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0")
                 .build())
             .build(temporaryFolder);
         jamesServer.start();
@@ -113,6 +114,8 @@ class GatewayRemoteDeliveryIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
             .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -134,6 +137,8 @@ class GatewayRemoteDeliveryIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
             .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -156,6 +161,8 @@ class GatewayRemoteDeliveryIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
             .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -179,6 +186,8 @@ class GatewayRemoteDeliveryIntegrationTest {
             .withBase(SMTP_AND_IMAP_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
             .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -206,6 +215,8 @@ class GatewayRemoteDeliveryIntegrationTest {
             .withBase(SMTP_AND_IMAP_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
             .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 
@@ -237,6 +248,8 @@ class GatewayRemoteDeliveryIntegrationTest {
                     .addMailet(MailetConfiguration.remoteDeliveryBuilderNoBounces()
                         .matcher(All.class)
                         .addProperty("gateway", gatewayProperty))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/MailetErrorsTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/MailetErrorsTest.java
@@ -35,6 +35,7 @@ import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
@@ -96,6 +97,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(ErrorMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -116,6 +119,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(NoClassDefFoundErrorMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -137,6 +142,8 @@ class MailetErrorsTest {
                         .mailet(OneRuntimeExceptionMailet.class)
                         .addProperty("onMailetException", "propagate"))
                     .addMailet(MailetConfiguration.TO_TRANSPORT)))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         jamesServer.getProbe(DataProbeImpl.class).fluent()
@@ -167,6 +174,8 @@ class MailetErrorsTest {
                     .addMailetsFrom(CommonProcessors.transport()))
                 .putProcessor(errorProcessor())
                 .putProcessor(CommonProcessors.root()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         jamesServer.getProbe(DataProbeImpl.class).fluent()
@@ -203,6 +212,8 @@ class MailetErrorsTest {
                     .addMailetsFrom(CommonProcessors.transport()))
                 .putProcessor(errorProcessor())
                 .putProcessor(CommonProcessors.root()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         jamesServer.getProbe(DataProbeImpl.class).fluent()
@@ -232,6 +243,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(NoClassDefFoundErrorMatcher.class)
                         .mailet(Null.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -255,6 +268,8 @@ class MailetErrorsTest {
                     .addMailetsFrom(CommonProcessors.transport()))
                 .putProcessor(errorProcessor())
                 .putProcessor(CommonProcessors.root()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         jamesServer.getProbe(DataProbeImpl.class).fluent()
@@ -292,6 +307,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(RuntimeExceptionMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -317,6 +334,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", CUSTOM_REPOSITORY.asString()))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -341,6 +360,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", CUSTOM_REPOSITORY.asString()))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -362,6 +383,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(RuntimeErrorMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -384,6 +407,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(ErrorMailet.class)
                         .addProperty("onMailetException", CUSTOM_PROCESSOR))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -407,6 +432,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(RuntimeExceptionMailet.class)
                         .addProperty("onMailetException", CUSTOM_PROCESSOR))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -433,6 +460,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", CUSTOM_REPOSITORY.asString()))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -459,6 +488,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", CUSTOM_REPOSITORY.asString()))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -479,6 +510,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(ErrorMatcher.class)
                         .mailet(NoopMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -499,6 +532,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(RuntimeExceptionMatcher.class)
                         .mailet(NoopMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -521,6 +556,8 @@ class MailetErrorsTest {
                         .matcher(ErrorMatcher.class)
                         .mailet(NoopMailet.class)
                         .addProperty("onMatchException", CUSTOM_PROCESSOR))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -543,6 +580,8 @@ class MailetErrorsTest {
                         .matcher(RuntimeExceptionMatcher.class)
                         .mailet(NoopMailet.class)
                         .addProperty("onMatchException", CUSTOM_PROCESSOR))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -569,6 +608,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", CUSTOM_REPOSITORY.asString()))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -595,6 +636,8 @@ class MailetErrorsTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", CUSTOM_REPOSITORY.asString()))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -621,6 +664,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(Null.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -647,6 +692,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(Null.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -677,6 +724,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(ErrorMatcher.class)
                         .mailet(Null.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -707,6 +756,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(RuntimeExceptionMatcher.class)
                         .mailet(Null.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -737,6 +788,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(ErrorMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
@@ -767,6 +820,8 @@ class MailetErrorsTest {
                     .addMailet(MailetConfiguration.builder()
                         .matcher(All.class)
                         .mailet(RuntimeExceptionMailet.class))))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
         MailRepositoryProbeImpl probe = jamesServer.getProbe(MailRepositoryProbeImpl.class);

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryDKIMIntegrationTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryDKIMIntegrationTest.java
@@ -46,6 +46,7 @@ import org.apache.james.jdkim.mailets.MockPublicKeyRecordRetriever;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.mock.smtp.server.model.Mail;
 import org.apache.james.mock.smtp.server.testing.MockSmtpServerExtension;
 import org.apache.james.mock.smtp.server.testing.MockSmtpServerExtension.DockerMockSmtp;
@@ -138,6 +139,8 @@ class RemoteDeliveryDKIMIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(directResolutionTransport(MailetConfiguration.remoteDeliveryBuilder()
                     .addProperty("mail.smtp.allow8bitmime", "true")))
@@ -179,6 +182,8 @@ class RemoteDeliveryDKIMIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(directResolutionTransport(MailetConfiguration.remoteDeliveryBuilder()
                     .addProperty("mail.smtp.allow8bitmime", "true")))
@@ -221,6 +226,8 @@ class RemoteDeliveryDKIMIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(directResolutionTransport(MailetConfiguration.remoteDeliveryBuilder()))
                 .putProcessor(CommonProcessors.bounces()))

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryErrorHandlingTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryErrorHandlingTest.java
@@ -39,6 +39,7 @@ import org.apache.james.dnsservice.api.InMemoryDNSService;
 import org.apache.james.mailets.TemporaryJamesServer;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.mock.smtp.server.model.SMTPCommand;
 import org.apache.james.mock.smtp.server.testing.MockSmtpServerExtension;
@@ -97,6 +98,8 @@ class RemoteDeliveryErrorHandlingTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(Modules.combine(MemoryJamesServerMain.SMTP_ONLY_MODULE, MemoryJamesServerMain.WEBADMIN_TESTING))
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .withMailetContainer(TemporaryJamesServer.simpleMailetContainerConfiguration()
                 .putProcessor(ProcessorConfiguration.transport()
                     .addMailet(BCC_STRIPPER)

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryErrorTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryErrorTest.java
@@ -42,6 +42,7 @@ import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.mock.smtp.server.ConfigurationClient;
 import org.apache.james.mock.smtp.server.model.Mail;
 import org.apache.james.mock.smtp.server.model.SMTPCommand;
@@ -134,6 +135,8 @@ class RemoteDeliveryErrorTest {
                 .putProcessor(CommonProcessors.error())
                 .putProcessor(directResolutionTransport())
                 .putProcessor(CommonProcessors.bounces()))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryForwardIntegrationTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryForwardIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.james.core.Domain;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.mock.smtp.server.testing.MockSmtpServerExtension;
 import org.apache.james.mock.smtp.server.testing.MockSmtpServerExtension.DockerMockSmtp;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
@@ -84,6 +85,8 @@ class RemoteDeliveryForwardIntegrationTest {
 
         jamesServer = TemporaryJamesServer.builder()
             .withMailetContainer(mailetContainer)
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(tempDir);
         jamesServer.start();
         webAdminApi = WebAdminUtils.spec(jamesServer.getProbe(WebAdminGuiceProbe.class).getWebAdminPort());

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryOnSuccessTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/mailets/RemoteDeliveryOnSuccessTest.java
@@ -40,6 +40,7 @@ import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.mock.smtp.server.ConfigurationClient;
 import org.apache.james.mock.smtp.server.model.SMTPCommand;
@@ -102,6 +103,8 @@ class RemoteDeliveryOnSuccessTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_AND_IMAP_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .withMailetContainer(MailetContainer.builder()
                 .putProcessor(CommonProcessors.simpleRoot())
                 .putProcessor(CommonProcessors.error())

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/smtp/dsn/DSNLocalIntegrationTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/smtp/dsn/DSNLocalIntegrationTest.java
@@ -92,6 +92,8 @@ class DSNLocalIntegrationTest {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_AND_IMAP_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .withMailetContainer(MailetContainer.builder()
                 .putProcessor(CommonProcessors.simpleRoot())
                 .putProcessor(CommonProcessors.error())

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/smtp/dsn/DSNRelayTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/smtp/dsn/DSNRelayTest.java
@@ -98,7 +98,8 @@ class DSNRelayTest {
                 .addHook(DSNEhloHook.class.getName())
                 .addHook(DSNMailParameterHook.class.getName())
                 .addHook(DSNRcptParameterHook.class.getName())
-                .addHook(DSNMessageHook.class.getName()))
+                .addHook(DSNMessageHook.class.getName())
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/smtp/dsn/DSNRemoteIntegrationTest.java
+++ b/server/mailet/remote-delivery-integration-testing/src/test/java/org/apache/james/smtp/dsn/DSNRemoteIntegrationTest.java
@@ -147,7 +147,8 @@ class DSNRemoteIntegrationTest {
                 .addHook(DSNEhloHook.class.getName())
                 .addHook(DSNMailParameterHook.class.getName())
                 .addHook(DSNRcptParameterHook.class.getName())
-                .addHook(DSNMessageHook.class.getName()))
+                .addHook(DSNMessageHook.class.getName())
+                .withAutorizedAddresses("0.0.0.0/0.0.0.0"))
             .build(temporaryFolder);
         jamesServer.start();
 

--- a/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>

--- a/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
@@ -56,10 +58,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -83,10 +84,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -60,6 +61,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -86,6 +88,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
@@ -36,6 +36,7 @@
         <authRequired>false</authRequired>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
@@ -34,7 +34,9 @@
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <authRequired>false</authRequired>
-        <verifyIdentity>false</verifyIdentity>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -87,17 +87,11 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
 
     public static class AuthenticationConfiguration {
         public static AuthenticationConfiguration parse(HierarchicalConfiguration<ImmutableNode> configuration) {
-            return Optional.ofNullable(configuration.configurationAt("auth"))
-                .map(authConfiguration -> parse(configuration, authConfiguration))
-                .orElseGet(() -> new AuthenticationConfiguration(fallbackAuthenticationAnnounceMode(configuration), false));
-        }
-
-        private static AuthenticationConfiguration parse(HierarchicalConfiguration<ImmutableNode> configuration, HierarchicalConfiguration<ImmutableNode> authConfiguration) {
             return new AuthenticationConfiguration(
-                Optional.ofNullable(authConfiguration.getString("announce", null))
+                Optional.ofNullable(configuration.getString("auth.announce", null))
                     .map(AuthenticationAnnounceMode::parse)
                     .orElseGet(() -> fallbackAuthenticationAnnounceMode(configuration)),
-                Optional.ofNullable(authConfiguration.getBoolean("requireSSL", null))
+                Optional.ofNullable(configuration.getBoolean("auth.requireSSL", null))
                     .orElse(false));
         }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -169,12 +169,6 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
                 .map(AuthenticationAnnounceMode::parse)
                 .orElseGet(() -> AuthenticationAnnounceMode.parseFallback(configuration.getString("authRequired", "false")));
 
-            if (authRequired != NEVER) {
-                LOGGER.info("This SMTP server requires authentication.");
-            } else {
-                LOGGER.info("This SMTP server does not require authentication.");
-            }
-
             authorizedAddresses = configuration.getString("authorizedAddresses", null);
 
             // get the message size limit from the conf file and multiply

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -237,10 +237,6 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
             return SMTPServer.this.heloEhloEnforcement;
         }
 
-        public String getSMTPGreeting() {
-            return SMTPServer.this.smtpGreeting;
-        }
-
         @Override
         public boolean useAddressBracketsEnforcement() {
             return SMTPServer.this.addressBracketsEnforcement;

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -257,11 +257,10 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
             if (SMTPServer.this.authRequired == ANNOUNCE) {
                 return true;
             }
-            boolean authRequired = SMTPServer.this.authRequired != DISABLED;
-            if (authorizedNetworks != null) {
-                authRequired = authRequired && !SMTPServer.this.authorizedNetworks.matchInetNetwork(remoteIP);
+            if (SMTPServer.this.authRequired == DISABLED) {
+                return false;
             }
-            return authRequired;
+            return !SMTPServer.this.authorizedNetworks.matchInetNetwork(remoteIP);
         }
 
         /**

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -147,6 +147,7 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
                 networks.add(addr);
             }
             authorizedNetworks = new NetMatcher(networks, dns);
+            LOGGER.info("Authorized addresses: {}", authorizedNetworks);
         }
         SMTPProtocol transport = new SMTPProtocol(getProtocolHandlerChain(), theConfigData) {
 
@@ -175,27 +176,6 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
             }
 
             authorizedAddresses = configuration.getString("authorizedAddresses", null);
-            if (authRequired == NEVER && authorizedAddresses == null) {
-                /*
-                 * if SMTP AUTH is not required then we will use
-                 * authorizedAddresses to determine whether or not to relay
-                 * e-mail. Therefore if SMTP AUTH is not required, we will not
-                 * relay e-mail unless the sending IP address is authorized.
-                 * 
-                 * Since this is a change in behavior for James v2, create a
-                 * default authorizedAddresses network of 0.0.0.0/0, which
-                 * matches all possible addresses, thus preserving the current
-                 * behavior.
-                 * 
-                 * James v3 should require the <authorizedAddresses> element.
-                 */
-                authorizedAddresses = "0.0.0.0/0.0.0.0";
-            }
-
-          
-            if (authorizedNetworks != null) {
-                LOGGER.info("Authorized addresses: {}", authorizedNetworks);
-            }
 
             // get the message size limit from the conf file and multiply
             // by 1024, to put it in bytes

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -235,11 +235,10 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
 
         @Override
         public boolean isRelayingAllowed(String remoteIP) {
-            boolean relayingAllowed = false;
             if (authorizedNetworks != null) {
-                relayingAllowed = SMTPServer.this.authorizedNetworks.matchInetNetwork(remoteIP);
+                return SMTPServer.this.authorizedNetworks.matchInetNetwork(remoteIP);
             }
-            return relayingAllowed;
+            return false;
         }
 
         @Override

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -147,12 +147,7 @@ public class SMTPServerTest {
                 throw new UnknownHostException();
             }
 
-            if ("128.0.0.1".equals(host) || "192.168.0.1".equals(host) || "127.0.0.1".equals(host) || "127.0.0.0".equals(
-                    host) || "255.0.0.0".equals(host) || "255.255.255.255".equals(host)) {
-                return InetAddress.getByName(host);
-            }
-
-            throw new UnsupportedOperationException("getByName not implemented in mock for host: " + host);
+            return InetAddress.getByName(host);
         }
 
         @Override

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPTestConfiguration.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPTestConfiguration.java
@@ -135,6 +135,7 @@ public class SMTPTestConfiguration extends BaseHierarchicalConfiguration {
         addProperty("tls.[@startTLS]", startTLS);
         addProperty("tls.keystore", "test_keystore");
         addProperty("tls.secret", "jamestest");
+        addProperty("auth.requireSSL", false);
         addProperty("verifyIdentity", verifyIdentity);
 
         // add the rbl handler

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceAlways.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceAlways.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+    <smtpserver enabled="true">
+        <bind>0.0.0.0:0</bind>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <auth>
+            <announce>always</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
+        <verifyIdentity>true</verifyIdentity>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
+
+

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceNever.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceNever.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+    <smtpserver enabled="true">
+        <bind>0.0.0.0:0</bind>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <auth>
+            <announce>never</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
+        <verifyIdentity>false</verifyIdentity>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
+
+

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeMatching.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeMatching.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+    <smtpserver enabled="true">
+        <bind>0.0.0.0:0</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <connectiontimeout>360</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
+        <authorizedAddresses>0.0.0.0/0.0.0.0</authorizedAddresses>
+        <verifyIdentity>true</verifyIdentity>
+        <maxmessagesize>0</maxmessagesize>
+        <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
+
+

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeNotMatching.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeNotMatching.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+    <smtpserver enabled="true">
+        <bind>0.0.0.0:0</bind>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
+        <authorizedAddresses>192.168.0.1</authorizedAddresses>
+        <verifyIdentity>true</verifyIdentity>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
+
+

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-dsn.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-dsn.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-dsn.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-dsn.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-noauth.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-noauth.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-smtp-lmtp.html#SMTP_Configuration for further details -->
+
+    <smtpserver enabled="true">
+        <bind>0.0.0.0:0</bind>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <verifyIdentity>false</verifyIdentity>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
+
+

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-requireSSL.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-requireSSL.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-smtp-lmtp.html#SMTP_Configuration for further details -->
+
+    <smtpserver enabled="true">
+        <bind>0.0.0.0:0</bind>
+        <tls socketTLS="false" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+            <algorithm>SunX509</algorithm>
+        </tls>
+        <auth>
+            <announce>always</announce>
+            <requireSSL>true</requireSSL>
+        </auth>
+        <verifyIdentity>true</verifyIdentity>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
+
+

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/smtpserver.xml
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/smtpserver.xml
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/smtpserver.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/smtpserver.xml
@@ -33,7 +33,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <authRequired>false</authRequired>
+        <auth>
+            <announce>never</announce>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
@@ -57,10 +59,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>
@@ -85,10 +86,9 @@
         <connectiontimeout>360</connectiontimeout>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
+        <auth>
+            <announce>forUnauthorizedAddresses</announce>
+        </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/smtpserver.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/smtpserver.xml
@@ -35,6 +35,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>never</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <verifyIdentity>false</verifyIdentity>
@@ -61,6 +62,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->
@@ -88,6 +90,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <auth>
             <announce>forUnauthorizedAddresses</announce>
+            <requireSSL>false</requireSSL>
         </auth>
         <authorizedAddresses>0.0.0.0/0</authorizedAddresses>
         <!-- Trust authenticated users -->

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -91,8 +91,7 @@
         <dt><strong>auth.announce</strong></dt>
         <dd>This is an optional tag.  Possible values are:<br/>
 
-            * never: Don't announce auth. If absent, *authorizedAddresses* are set to a wilcard to accept all remote hosts.
-            This is the default behaviour.<br/>
+            * never: Don't announce auth.<br/>
 
             * always: always announce AUTH capability to clients.<br/>
 

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -99,6 +99,9 @@
 
             Please note that emails are only relayed if, and only if, the user did authenticate, or is in an authorized network,
             regardless of this option.</dd>
+      <dt><strong>auth.requireSSL</strong></dt>
+      <dd>This is an optional tag, defaults to true. If true, authentication is not advertised via capabilities on unencrypted
+          channels.</dd>
       <dt><strong>handler.authorizedAddresses</strong></dt>
       <dd>Authorize specific addresses/networks.
                If you use SMTP AUTH, addresses that match those specified here will

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -76,19 +76,30 @@
       <dd>Set the maximum simultaneous incoming connections for this service.</dd>
       <dt><strong>handler.connectionLimitPerIP</strong></dt>
       <dd>Set the maximum simultaneous incoming connections per IP for this service.</dd>
-      <dt><strong>handler.authRequired</strong></dt>
-      <dd>This is an optional tag with a boolean body.  If true, then the server will 
-      require authentication before delivering mail to non-local email addresses.  If this tag is absent, or the value 
-      is false then the client will not be prompted for authentication.  Only simple user/password authentication is
-      supported at this time. supported values:
-               true: required but announced only to not authorizedAddresses
-               false: don't use AUTH
-               announce: like true, but always announce AUTH capability to clients
+        <dt><strong>authRequired</strong></dt>
+        <dd>(deprecated) use auth.announce instead.
+            This is an optional tag with a boolean body.  If true, then the server will
+            announce authentication. If this tag is absent, or the value
+            is false then the client will not be prompted for authentication.  Only simple user/password authentication is
+            supported at this time. supported values:
+            true: announced only to not authorizedAddresses
+            false: don't announce AUTH. If absent, *authorizedAddresses* are set to a wilcard to accept all remote hosts.
+            announce: like true, but always announce AUTH capability to clients
 
-               The correct behaviour per RFC value would be false or announce
-               but we still support true for backward compatibility and because
-               some webmail client fails when AUTH is announced but no authentication
-               information has been provided</dd>
+            Please note that emails are only relayed if, and only if, the user did authenticate, or is in an authorized network,
+            regardless of this option.</dd>
+        <dt><strong>auth.announce</strong></dt>
+        <dd>This is an optional tag.  Possible values are:<br/>
+
+            * never: Don't announce auth. If absent, *authorizedAddresses* are set to a wilcard to accept all remote hosts.
+            This is the default behaviour.<br/>
+
+            * always: always announce AUTH capability to clients.<br/>
+
+            * forUnauthorizedAddresses: announced only to not authorizedAddresses<br/>
+
+            Please note that emails are only relayed if, and only if, the user did authenticate, or is in an authorized network,
+            regardless of this option.</dd>
       <dt><strong>handler.authorizedAddresses</strong></dt>
       <dd>Authorize specific addresses/networks.
                If you use SMTP AUTH, addresses that match those specified here will


### PR DESCRIPTION
We reworked SMTP/LMTP configuration to improve security and better explicit the configuration effects.

We added a new setting within SMTP/LMTP configuration to avoid advertising authentication on unencrypted channels. 
For security reasons, it is enabled by default, which is a breaking change. To disable it:

```xml
    <smtpserver enabled="true">
        <jmxName>smtpserver-global</jmxName>
        <bind>0.0.0.0:25</bind>
        <!--- ... -->
        <auth>
            <announce>never</announce>
            <requireSSL>false</requireSSL>
        </auth>
        <!--- ... -->
    </smtpserver>
```

Also, `requireAuth` setting, which was misleading, had been renamed to `auth.announce`. This change did not affect
backward compatibility and `requireAuth` is still read as a fallback.

 - `<requireAuth>false</requireAuth>` can now be specified with `<auth><announce>never</announce></auth>`
 - `<requireAuth>announce</requireAuth>` can now be specified with `<auth><announce>always</announce></auth>`
 - `<requireAuth>true</requireAuth>` can now be specified with `<auth><announce>forUnauthorizedAddresses</announce></auth>`

Finally, an implicit wildcard value `0.0.0.0/0.0.0.0` was specified as authorizedAddresses (for James 2.3 backward 
compatibility) when `<requireAuth>false</requireAuth>` or (equivalent) `<auth><announce>never</announce></auth>`. 
This behaviour could result in a user believing she disabled authentication, but would ultimately result in an 
open relay, which is unsecure, and why we no longer apply this implicit value - BTW this happened once to us at Linagora. Users relying on James as an open relay will need to specify `authorizedAddresses` explicitly:

```xml
    <smtpserver enabled="true">
        <jmxName>smtpserver-global</jmxName>
        <bind>0.0.0.0:25</bind>
        <!--- ... -->
        <auth>
            <announce>never</announce>
        </auth>
        <authorizedAddresses>0.0.0.0/0.0.0.0</authorizedAddresses>
        <!--- ... -->
    </smtpserver>
```

## Work remaining

To feel fully confident about this work I would like to have the time to test it manually with `telnet` and `openssl s_client`.