### PR TITLE
JAMES-3681 : RemoteDelivery must use correct properties for SMTPS

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
@@ -211,31 +211,37 @@ public class RemoteDeliveryConfiguration {
     }
 
     public Properties createFinalJavaxProperties() {
-        Properties props = createFinalJavaxPropertiesNoSSL();
-        props.put("mail.smtp.ssl.enable", String.valueOf(isSSLEnable));
+        Properties props = createFinalJavaxProperties("smtp");
+        props.put("mail.smtp.ssl.enable", "false");
         return props;
     }
 
-    public Properties createFinalJavaxPropertiesNoSSL() {
+    public Properties createFinalJavaxPropertiesWithSSL() {
+        Properties props = createFinalJavaxProperties("smtps");
+        props.put("mail.smtps.ssl.enable", "true");
+        return props;
+    }
+    
+    private Properties createFinalJavaxProperties(String protocol) {
         Properties props = new Properties();
         props.put("mail.debug", "false");
         // Reactivated: javamail 1.3.2 should no more have problems with "250 OK" messages
         // (WAS "false": Prevents problems encountered with 250 OK Messages)
-        props.put("mail.smtp.ehlo", "true");
-        props.put("mail.smtp.timeout", String.valueOf(smtpTimeout));
-        props.put("mail.smtp.connectiontimeout", String.valueOf(connectionTimeout));
-        props.put("mail.smtp.sendpartial", String.valueOf(sendPartial));
-        props.put("mail.smtp.localhost", heloNameProvider.getHeloName());
-        props.put("mail.smtp.starttls.enable", String.valueOf(startTLS));
+        props.put("mail." + protocol + ".ehlo", "true");
+        props.put("mail." + protocol + ".timeout", String.valueOf(smtpTimeout));
+        props.put("mail." + protocol + ".connectiontimeout", String.valueOf(connectionTimeout));
+        props.put("mail." + protocol + ".sendpartial", String.valueOf(sendPartial));
+        props.put("mail." + protocol + ".localhost", heloNameProvider.getHeloName());
+        props.put("mail." + protocol + ".starttls.enable", String.valueOf(startTLS));
         if (isBindUsed()) {
             // undocumented JavaMail 1.2 feature, smtp transport will use
             // our socket factory, which will also set the local address
-            props.put("mail.smtp.socketFactory.class", RemoteDeliverySocketFactory.class);
+            props.put("mail." + protocol + ".socketFactory.class", RemoteDeliverySocketFactory.class);
             // Don't fallback to the standard socket factory on error, do throw an exception
-            props.put("mail.smtp.socketFactory.fallback", "false");
+            props.put("mail." + protocol + ".socketFactory.fallback", "false");
         }
         if (authUser != null) {
-            props.put("mail.smtp.auth", "true");
+            props.put("mail." + protocol + ".auth", "true");
         }
         props.putAll(javaxAdditionalProperties);
         return props;

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfigurationTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfigurationTest.java
@@ -772,7 +772,7 @@ public class RemoteDeliveryConfigurationTest {
         String helo = "domain.com";
         int connectionTimeout = 1856;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "true")
+            .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "false")
             .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "true")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, String.valueOf(connectionTimeout))
             .setProperty(RemoteDeliveryConfiguration.START_TLS, "true")
@@ -783,7 +783,7 @@ public class RemoteDeliveryConfigurationTest {
 
 
         assertThat(properties)
-            .containsOnly(MapEntry.entry("mail.smtp.ssl.enable", "true"),
+            .containsOnly(MapEntry.entry("mail.smtp.ssl.enable", "false"),
                 MapEntry.entry("mail.smtp.sendpartial", "true"),
                 MapEntry.entry("mail.smtp.ehlo", "true"),
                 MapEntry.entry("mail.smtp.connectiontimeout", String.valueOf(connectionTimeout)),
@@ -798,7 +798,7 @@ public class RemoteDeliveryConfigurationTest {
         String helo = "domain.com";
         int connectionTimeout = 1856;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "true")
+            .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "false")
             .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "true")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, String.valueOf(connectionTimeout))
             .setProperty(RemoteDeliveryConfiguration.START_TLS, "true")
@@ -812,7 +812,7 @@ public class RemoteDeliveryConfigurationTest {
 
 
         assertThat(properties)
-            .containsOnly(MapEntry.entry("mail.smtp.ssl.enable", "true"),
+            .containsOnly(MapEntry.entry("mail.smtp.ssl.enable", "false"),
                 MapEntry.entry("mail.smtp.sendpartial", "true"),
                 MapEntry.entry("mail.smtp.ehlo", "true"),
                 MapEntry.entry("mail.smtp.connectiontimeout", String.valueOf(connectionTimeout)),
@@ -821,5 +821,53 @@ public class RemoteDeliveryConfigurationTest {
                 MapEntry.entry("mail.debug", "false"),
                 MapEntry.entry("mail.smtp.starttls.enable", "true"),
                 MapEntry.entry("mail.smtp.auth", "true"));
+    }
+
+    @Test
+    void createFinalJavaxPropertiesWithSSLShouldProvidePropertiesWithMinimalConfiguration() {
+        String helo = "domain.com";
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "true")
+            .setProperty(RemoteDeliveryConfiguration.HELO_NAME, helo)
+            .build();
+
+        Properties properties = new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).createFinalJavaxPropertiesWithSSL();
+
+
+        assertThat(properties)
+            .containsOnly(MapEntry.entry("mail.smtps.ssl.enable", "true"),
+                MapEntry.entry("mail.smtps.sendpartial", "false"),
+                MapEntry.entry("mail.smtps.ehlo", "true"),
+                MapEntry.entry("mail.smtps.connectiontimeout", "60000"),
+                MapEntry.entry("mail.smtps.localhost", helo),
+                MapEntry.entry("mail.smtps.timeout", "180000"),
+                MapEntry.entry("mail.debug", "false"),
+                MapEntry.entry("mail.smtps.starttls.enable", "false"));
+    }
+
+    @Test
+    void createFinalJavaxPropertiesWithSSLShouldProvidePropertiesWithFullConfigurationWithoutGateway() {
+        String helo = "domain.com";
+        int connectionTimeout = 1856;
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "true")
+            .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "true")
+            .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, String.valueOf(connectionTimeout))
+            .setProperty(RemoteDeliveryConfiguration.START_TLS, "false")
+            .setProperty(RemoteDeliveryConfiguration.HELO_NAME, helo)
+            .build();
+
+        Properties properties = new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).createFinalJavaxPropertiesWithSSL();
+
+
+        assertThat(properties)
+            .containsOnly(MapEntry.entry("mail.smtps.ssl.enable", "true"),
+                MapEntry.entry("mail.smtps.sendpartial", "true"),
+                MapEntry.entry("mail.smtps.ehlo", "true"),
+                MapEntry.entry("mail.smtps.connectiontimeout", String.valueOf(connectionTimeout)),
+                MapEntry.entry("mail.smtps.localhost", helo),
+                MapEntry.entry("mail.smtps.timeout", "180000"),
+                MapEntry.entry("mail.debug", "false"),
+                MapEntry.entry("mail.smtps.starttls.enable", "false"));
     }
 }


### PR DESCRIPTION
Java Mail annoyingly wants its properties to use mail.smtp**s**.x prefix instead of mail.smtp.x when using an SMTPS session, and ignores the regular properties in this case. 