### PR TITLE
solve the problem when sending messages with Chinese subjects by some clients, subject displayed are as garbled codes

### DIFF
--- a/server/container/core/src/main/java/org/apache/james/server/core/MailHeaders.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailHeaders.java
@@ -19,16 +19,15 @@
 
 package org.apache.james.server.core;
 
+import org.apache.mailet.base.RFC2822Headers;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetHeaders;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Enumeration;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.InternetHeaders;
-
-import org.apache.mailet.base.RFC2822Headers;
 
 /**
  * This interface defines a container for mail headers. Each header must use
@@ -67,7 +66,7 @@ public class MailHeaders extends InternetHeaders implements Serializable, Clonea
      */
     public MailHeaders(InputStream in) throws MessagingException {
         super();
-        load(in);
+        load(in, true);
     }
 
     /**

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
@@ -19,10 +19,6 @@
 
 package org.apache.james.smtpserver;
 
-import java.io.IOException;
-
-import javax.inject.Inject;
-
 import org.apache.commons.configuration2.Configuration;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -33,6 +29,10 @@ import org.apache.james.queue.api.MailQueueFactory;
 import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.mail.Message;
+import java.io.IOException;
 
 /**
  * Queue the message
@@ -70,6 +70,8 @@ public class SendMailHandler implements JamesMessageHook {
         LOGGER.debug("sending mail");
 
         try {
+            Message message = mail.getMessage();
+            message.setSubject(mail.getMessage().getSubject());
             queue.enQueue(mail);
             LOGGER.info("Successfully spooled mail {} from {} on {} for {}", mail.getName(), mail.getMaybeSender(), session.getRemoteAddress().getAddress(), mail.getRecipients());
         } catch (Exception me) {


### PR DESCRIPTION
When I send an email, Chinese subject, by wps excel, the subject displayed as "?????", which are garbled codes. So I changed the two java files here, and the problem is solved.

![image](https://user-images.githubusercontent.com/457313/147586561-5c06e2ab-20f3-4137-828e-936a0484bbf6.png)
