### PR TITLE
[UPGRADE] Upgrade jackson 2.12.4 -> 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
         <cucumber.version>2.4.0</cucumber.version>
 
         <pax-logging-api.version>1.6.4</pax-logging-api.version>
-        <jackson.version>2.12.4</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <feign.version>11.6</feign.version>
         <feign-form.version>3.8.0</feign-form.version>
         <jjwt.version>0.11.2</jjwt.version>


### PR DESCRIPTION
Solves https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698

Denial of Service (DoS)

Affected versions of this package are vulnerable to
Denial of Service (DoS) when using JDK serialization
to serialize and deserialize JsonNode values. It is
possible for the attacker to send a 4-byte length
payload, with a value of Integer.MAX_VALUE , that
will eventually cause large buffer allocation and
out of heap memory.