### PR TITLE
[UPGRADE] Upgrade log4j 2.17.0 -> 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
         <apache-mime4j.version>0.8.6</apache-mime4j.version>
         <apache.openjpa.version>3.1.2</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.activation.groupId>javax.activation</javax.activation.groupId>
         <javax.activation.artifactId>activation</javax.activation.artifactId>


### PR DESCRIPTION
Solves CVE-2021-44832 (Score 6.6)

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832

Apache Log4j2 versions 2.0-beta7 through 2.17.0
(excluding security fix releases 2.3.2 and 2.12.4)
are vulnerable to a remote code execution (RCE)
attack when a configuration uses a JDBC Appender
with a JNDI LDAP data source URI when an attacker
has control of the target LDAP server. This issue
is fixed by limiting JNDI data source names to the
java protocol in Log4j2 versions 2.17.1, 2.12.4,
and 2.3.2.