### PR TITLE
[SITE] Fill the security page following recent CVE announces

### DIFF
--- a/src/site/xdoc/server/feature-security.xml
+++ b/src/site/xdoc/server/feature-security.xml
@@ -49,19 +49,75 @@
   </section>
 
     <section name="Reported vulnerabilities">
-        <subsection name="Apache James 3.0.0">
-            <p>The Apache James Server version 3.0.0 is vulnerable to Java deserialization issues.</p>
+        <subsection name="Reporting vulnerabilities">
+            We follow the standard procedures within the ASF regarding
+            <a href="https://apache.org/security/committers.html#vulnerability-handling">vulnerability handling</a>.
+        </subsection>
+        <subsection name="CVE-2021-38542: Apache James vulnerable to STARTTLS command injection (IMAP and POP3)">
+            <p>Apache James prior to release 3.6.1 is vulnerable to a buffering attack relying on the use of the STARTTLS
+                command. This can result in Man-in -the-middle command injection attacks, leading potentially to leakage
+                of sensible information.</p>
+
+            <p><b>Severity</b>: Moderate</p>
+
+            <p>This issue is being tracked as <a href="https://issues.apache.org/jira/browse/JAMES-1862">JAMES-1862</a></p>
+
+            <p><b>Mitigation</b>: We recommend to upgrade to Apache James 3.6.1, which fixes this vulnerability.</p>
+
+            <p>Furthermore, we recommend, if possible to dis-activate STARTTLS and rely solely on explicit TLS for mail protocols, including SMTP, IMAP and POP3.</p>
+
+            <p>Read more <a href="https://nostarttls.secvuln.info/">about STARTTLS security here</a>.</p>
+        </subsection>
+        <subsection name="CVE-2021-40110: Apache James IMAP vulnerable to a ReDoS">
+            <p>Using Jazzer fuzzer, we identified that an IMAP user can craft IMAP LIST commands to orchestrate a Denial
+                Of Service using a vulnerable Regular expression. This affected Apache James prior to 3.6.1</p>
+
+            <p><b>Severity</b>: Moderate</p>
+
+            <p>This issue is being tracked as <a href="https://issues.apache.org/jira/browse/JAMES-3635">JAMES-3635</a></p>
+
+            <p><b>Mitigation</b>: We recommend to upgrade to Apache James 3.6.1, which enforce the use of RE2J regular
+                expression engine to execute regex in linear time without back-tracking.</p>
+        </subsection>
+        <subsection name="CVE-2021-40111: Apache James IMAP parsing Denial Of Service">
+            <p>While fuzzing with Jazzer the IMAP parsing stack we discover that crafted APPEND and STATUS IMAP command
+                could be used to trigger infinite loops resulting in expensive CPU computations and OutOfMemory exceptions.
+                This can be used for a Denial Of Service attack. The IMAP user needs to be authenticated to exploit this
+                vulnerability. This affected Apache James prior to version 3.6.1.</p>
+
+            <p><b>Severity</b>: Moderate</p>
+
+            <p>This issue is being tracked as <a href="https://issues.apache.org/jira/browse/JAMES-3634">JAMES-3634</a></p>
+
+            <p><b>Mitigation</b>: We recommend to upgrade to Apache James 3.6.1, which enforce the use of RE2J regular
+                expression engine to execute regex in linear time without back-tracking.</p>
+        </subsection>
+        <subsection name="CVE-2021-40525: Apache James: Sieve file storage vulnerable to path traversal attacks ">
+            <p>Apache James ManagedSieve implementation alongside with the file storage for sieve scripts is vulnerable
+                to path traversal, allowing reading and writing any file. </p>
+
+            <p><b>Severity</b>: Moderate</p>
+
+            <p>This issue is being tracked as <a href="https://issues.apache.org/jira/browse/JAMES-3646">JAMES-3646</a></p>
+
+            <p><b>Mitigation</b>:This vulnerability had been patched in Apache
+                James 3.6.1 and higher. We recommend the upgrade.<br/><br/>
+                This could also be mitigated by ensuring manageSieve is disabled, which is the case by default.<br/><br/>
+                Distributed and Cassandra based products are also not impacted.</p>
+        </subsection>
+        <subsection name="CVE-2017-12628 Priviledge escalation using JMX">
+            <p>The Apache James Server prior version 3.0.1 is vulnerable to Java deserialization issues.</p>
             <p>One can use this for privilege escalation.</p>
             <p>This issue can be mitigated by:</p>
             <ul>
-                <li>Upgrading to James 3.0.1</li>
+                <li>Upgrading to James 3.0.1 onward</li>
                 <li>Using a recent JRE (Exploit could not be reproduced on OpenJdk 8 u141)</li>
                 <li>Exposing JMX socket only to localhost (default behaviour)</li>
                 <li>Possibly running James in a container</li>
+                <li>Disabling JMX all-together (Guice only)</li>
             </ul>
             <p>Read more <a href="http://james.apache.org//james/update/2017/10/20/james-3.0.1.html">here</a>.</p>
         </subsection>
-
     </section>
   
 </body>


### PR DESCRIPTION
 - Adds a Reporting vulnerabilities section
 - CVE-2021-38542: Apache James vulnerable to STARTTLS command injection (IMAP and POP3)
 - CVE-2021-40110: Apache James IMAP vulnerable to a ReDoS
 - CVE-2021-40111: Apache James IMAP parsing Denial Of Service
 - CVE-2021-40525: Apache James: Sieve file storage
  vulnerable to path traversal attacks
 - Add details for CVE-2017-12628