### PR TITLE
JAMES-3687 Demonstrate issues with deletes of delayed mails

### DIFF
--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
@@ -143,6 +143,20 @@ public class ActiveMQMailQueueBlobTest implements DelayedManageableMailQueueCont
     }
 
     @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeleted() {
+
+    }
+
+    @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeletedWhenMixedWithOtherEmails() {
+
+    }
+
+    @Test
     void computeNextDeliveryTimestampShouldReturnLongMaxWhenOverflow() {
         long deliveryTimestamp = mailQueue.computeNextDeliveryTimestamp(ChronoUnit.FOREVER.getDuration());
 

--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
@@ -134,4 +134,18 @@ public class ActiveMQMailQueueTest implements DelayedManageableMailQueueContract
     public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
 
     }
+
+    @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeleted() {
+
+    }
+
+    @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeletedWhenMixedWithOtherEmails() {
+
+    }
 }

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedManageableMailQueueContract.java
@@ -93,7 +93,8 @@ public interface DelayedManageableMailQueueContract extends DelayedMailQueueCont
             .subscribeOn(Schedulers.elastic())
             .subscribe(item -> names.add(item.getMail().getName()));
 
-       Awaitility.await().untilAsserted(() -> assertThat(names).contains("def"));
+       Awaitility.await()
+           .untilAsserted(() -> assertThat(names).contains("def"));
         assertThat(names).containsExactly("def");
     }
 
@@ -123,7 +124,8 @@ public interface DelayedManageableMailQueueContract extends DelayedMailQueueCont
             .subscribeOn(Schedulers.elastic())
             .subscribe(item -> names.add(item.getMail().getName()));
 
-       Awaitility.await().untilAsserted(() -> assertThat(names).contains("ghi"));
+       Awaitility.await()
+           .untilAsserted(() -> assertThat(names).contains("ghi"));
         assertThat(names).containsExactly("def", "ghi");
     }
 

--- a/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSCacheableMailQueueTest.java
+++ b/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSCacheableMailQueueTest.java
@@ -123,4 +123,18 @@ public class JMSCacheableMailQueueTest implements DelayedManageableMailQueueCont
     public void enQueueShouldAcceptMailWithDuplicatedNames() {
 
     }
+
+    @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeleted() {
+
+    }
+
+    @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeletedWhenMixedWithOtherEmails() {
+
+    }
 }

--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
@@ -238,4 +238,18 @@ public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricCo
     @Override
     public void flushShouldPreserveBrowseOrder() {
     }
+
+    @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeleted() {
+
+    }
+
+    @Test
+    @Override
+    @Disabled("JAMES-3687 Delayed deletes are buggy")
+    public void delayedEmailsShouldBeDeletedWhenMixedWithOtherEmails() {
+
+    }
 }


### PR DESCRIPTION
 - The Pulsar mail queue currently do not delete delayed emails

 Explanation: the sequenceId of the mail is reset when
 moved from the scheduled topic to the out topic, thus
 bypassing deletes emitted while it was sitting in the
 scheduled queue.

 (this mechanism exist to prevent deletions to apply on
 future emails)

 We would likely need the sequence to be backed by some
 applicative metadata - like a timestamp?

  - Second problem: filter removal based on sequence number

 Goal: Prevent uncontrolled growth by removing
 meaningless deletion filters

 Assumptions: emails are ordered

 Pitfall: delayed messages are out of order.

 Please note that the JMS mailqueue is buggy regarding
 delayed messages being deleted, I used the memory implementation as a reference.