### PR TITLE
JAMES-3704 Improve mail diagnostics on system edge

### DIFF
--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -84,7 +84,8 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
             // 46 is "."
             // Stream terminated
             if (line.length == 3 && line[0] == 46) {
-                try (Closeable closeable = SMTPMDCContextFactory.forSession(session).build()) {
+                String mailName = MailImpl.getId();
+                try (Closeable closeable = SMTPMDCContextFactory.forSession(session).addToContext("mail", mailName).build()) {
                     out.flush();
                     out.close();
 
@@ -92,7 +93,7 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
                     MaybeSender sender = session.getAttachment(SMTPSession.SENDER, State.Transaction).orElse(MaybeSender.nullSender());
 
                     MailImpl mail = MailImpl.builder()
-                        .name(MailImpl.getId())
+                        .name(mailName)
                         .sender(sender)
                         .addRecipients(recipientCollection)
                         .build();


### PR DESCRIPTION
Adds mail specific MDC fields during initial hooks/spooling, as well as during remote delivery. (The latter runs in a different thread pool and thus looses the mailet container MDC).