### PR TITLE
JAMES-3705 Refactoring POP3 handlers to be more extensible

### DIFF
--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/RetrCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/RetrCmdHandler.java
@@ -98,7 +98,7 @@ public class RetrCmdHandler extends AbstractPOP3CommandHandler {
 
                 String uid = data.getUid();
                 if (!deletedUidList.contains(uid)) {
-                    InputStream content = session.getUserMailbox().getMessage(uid);
+                    InputStream content = getMessageContent(session, data);
 
                     if (content != null) {
                         InputStream in = new CRLFTerminatedInputStream(new ExtraDotInputStream(content));
@@ -119,6 +119,10 @@ public class RetrCmdHandler extends AbstractPOP3CommandHandler {
             return POP3Response.ERR;
         }
         return response;
+    }
+    
+    protected InputStream getMessageContent(POP3Session session, MessageMetaData data) throws IOException {
+        return session.getUserMailbox().getMessage(data.getUid());
     }
 
     @Override

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/TopCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/TopCmdHandler.java
@@ -119,7 +119,7 @@ public class TopCmdHandler extends RetrCmdHandler implements CapaCapability {
                 String uid = data.getUid();
                 if (!deletedUidList.contains(uid)) {
 
-                    InputStream message = new CountingBodyInputStream(new ExtraDotInputStream(new CRLFTerminatedInputStream(session.getUserMailbox().getMessage(uid))), lines);
+                    InputStream message = new CountingBodyInputStream(new ExtraDotInputStream(new CRLFTerminatedInputStream(getMessageContent(session, data))), lines);
                     return new POP3StreamResponse(POP3Response.OK_RESPONSE, "Message follows", message);
 
                 } else {


### PR DESCRIPTION
A minor refactoring to make the POP3 RETR/TOP handlers more easily extensible: Retrieve the message content via a separate protected method.