### PR TITLE
JAMES-3715 Tests and fix for IMAP partial Fetch

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchResponseBuilder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchResponseBuilder.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.mail.Flags;
@@ -275,7 +274,7 @@ public final class FetchResponseBuilder {
         if (firstOctet == null) {
             return fullResult;
         }
-        final long numberOfOctetsAsLong = Objects.requireNonNullElse(numberOfOctets, Long.MAX_VALUE);
+        final Optional<Long> numberOfOctetsAsLong = Optional.ofNullable(numberOfOctets);
         final long firstOctetAsLong = firstOctet;
         return new PartialFetchBodyElement(fullResult, firstOctetAsLong, numberOfOctetsAsLong);
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/fetch/PartialFetchBodyElementTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/fetch/PartialFetchBodyElementTest.java
@@ -23,9 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.apache.james.imap.message.response.FetchResponse.BodyElement;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class PartialFetchBodyElementTest {
@@ -34,7 +35,7 @@ class PartialFetchBodyElementTest {
     BodyElement mockBodyElement;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         mockBodyElement = mock(BodyElement.class);
         when(mockBodyElement.getName()).thenReturn("Name");
     }
@@ -42,7 +43,7 @@ class PartialFetchBodyElementTest {
     @Test
     void testSizeShouldBeNumberOfOctetsWhenSizeMoreWhenStartIsZero() throws Exception {
         final long moreThanNumberOfOctets = NUMBER_OF_OCTETS + 1;
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, NUMBER_OF_OCTETS);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, Optional.of(NUMBER_OF_OCTETS));
         when(mockBodyElement.size()).thenReturn(moreThanNumberOfOctets);
 
         assertThat(element.size()).describedAs("Size is more than number of octets so should be number of octets").isEqualTo(NUMBER_OF_OCTETS);
@@ -51,7 +52,7 @@ class PartialFetchBodyElementTest {
     @Test
     void testSizeShouldBeSizeWhenNumberOfOctetsMoreWhenStartIsZero() throws Exception {
         final long lessThanNumberOfOctets = NUMBER_OF_OCTETS - 1;
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, NUMBER_OF_OCTETS);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, Optional.of(NUMBER_OF_OCTETS));
         when(mockBodyElement.size()).thenReturn(lessThanNumberOfOctets);
 
         assertThat(element.size()).describedAs("Size is less than number of octets so should be size").isEqualTo(lessThanNumberOfOctets);
@@ -60,7 +61,7 @@ class PartialFetchBodyElementTest {
     @Test
     void testWhenStartPlusNumberOfOctetsIsMoreThanSizeSizeShouldBeSizeMinusStart() throws Exception {
         final long size = 60;
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, NUMBER_OF_OCTETS);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, Optional.of(NUMBER_OF_OCTETS));
         when(mockBodyElement.size()).thenReturn(size);
 
         assertThat(element.size()).describedAs("Size is less than number of octets so should be size").isEqualTo(50);
@@ -70,7 +71,7 @@ class PartialFetchBodyElementTest {
     void testWhenStartPlusNumberOfOctetsIsLessThanSizeSizeShouldBeNumberOfOctetsMinusStart()
         throws Exception {
         final long size = 100;
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, NUMBER_OF_OCTETS);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, Optional.of(NUMBER_OF_OCTETS));
         when(mockBodyElement.size()).thenReturn(size);
 
         assertThat(element.size()).describedAs("Size is less than number of octets so should be size").isEqualTo(90);
@@ -79,16 +80,16 @@ class PartialFetchBodyElementTest {
     @Test
     void testSizeShouldBeZeroWhenStartIsMoreThanSize() throws Exception {
         final long size = 100;
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 1000, NUMBER_OF_OCTETS);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 1000, Optional.of(NUMBER_OF_OCTETS));
         when(mockBodyElement.size()).thenReturn(size);
 
-        assertThat(element.size()).describedAs("Size is less than number of octets so should be size").isEqualTo(0);
+        assertThat(element.size()).describedAs("Size is less than number of octets so should be size").isZero();
     }
 
     @Test
     void testSizeShouldBeNumberOfOctetsWhenStartMoreThanOctets() throws Exception {
         final long size = 2000;
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 1000, NUMBER_OF_OCTETS);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 1000, Optional.of(NUMBER_OF_OCTETS));
         when(mockBodyElement.size()).thenReturn(size);
 
         assertThat(element.size()).describedAs("Content size is less than start. Size should be zero.").isEqualTo(NUMBER_OF_OCTETS);
@@ -96,19 +97,17 @@ class PartialFetchBodyElementTest {
 
     @Test
     void testSizeShouldBeNumberOfOctetsWhenSizeMoreWhenStartIsZeroAndNoLimitSpecified() throws Exception {
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, Long.MAX_VALUE);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, Optional.empty());
         when(mockBodyElement.size()).thenReturn(NUMBER_OF_OCTETS);
 
         assertThat(element.size()).describedAs("Size is more than number of octets so should be number of octets")
             .isEqualTo(NUMBER_OF_OCTETS);
     }
 
-    @Disabled("JAMES-3715 A bug due to usage of Long.MAX to represent a value that is absent prevents this" +
-        "from working decently. Returns 9223372036854775807L which cannot be parsed nor handled by IMAP clients.")
     @Test
     void testWhenStartPlusNumberOfOctetsIsMoreThanSizeSizeShouldBeSizeMinusStartAndNoLimitSpecified() throws Exception {
         final long size = 60;
-        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, Long.MAX_VALUE);
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, Optional.empty());
         when(mockBodyElement.size()).thenReturn(size);
 
         assertThat(element.size()).describedAs("Size is less than number of octets so should be size").isEqualTo(50);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/fetch/PartialFetchBodyElementTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/fetch/PartialFetchBodyElementTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.james.imap.message.response.FetchResponse.BodyElement;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class PartialFetchBodyElementTest {
@@ -39,8 +40,7 @@ class PartialFetchBodyElementTest {
     }
 
     @Test
-    void testSizeShouldBeNumberOfOctetsWhenSizeMoreWhenStartIsZero()
-            throws Exception {
+    void testSizeShouldBeNumberOfOctetsWhenSizeMoreWhenStartIsZero() throws Exception {
         final long moreThanNumberOfOctets = NUMBER_OF_OCTETS + 1;
         PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, NUMBER_OF_OCTETS);
         when(mockBodyElement.size()).thenReturn(moreThanNumberOfOctets);
@@ -49,8 +49,7 @@ class PartialFetchBodyElementTest {
     }
 
     @Test
-    void testSizeShouldBeSizeWhenNumberOfOctetsMoreWhenStartIsZero()
-            throws Exception {
+    void testSizeShouldBeSizeWhenNumberOfOctetsMoreWhenStartIsZero() throws Exception {
         final long lessThanNumberOfOctets = NUMBER_OF_OCTETS - 1;
         PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, NUMBER_OF_OCTETS);
         when(mockBodyElement.size()).thenReturn(lessThanNumberOfOctets);
@@ -59,8 +58,7 @@ class PartialFetchBodyElementTest {
     }
 
     @Test
-    void testWhenStartPlusNumberOfOctetsIsMoreThanSizeSizeShouldBeSizeMinusStart()
-            throws Exception {
+    void testWhenStartPlusNumberOfOctetsIsMoreThanSizeSizeShouldBeSizeMinusStart() throws Exception {
         final long size = 60;
         PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, NUMBER_OF_OCTETS);
         when(mockBodyElement.size()).thenReturn(size);
@@ -70,7 +68,7 @@ class PartialFetchBodyElementTest {
 
     @Test
     void testWhenStartPlusNumberOfOctetsIsLessThanSizeSizeShouldBeNumberOfOctetsMinusStart()
-            throws Exception {
+        throws Exception {
         final long size = 100;
         PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, NUMBER_OF_OCTETS);
         when(mockBodyElement.size()).thenReturn(size);
@@ -88,12 +86,31 @@ class PartialFetchBodyElementTest {
     }
 
     @Test
-    void testSizeShouldBeNumberOfOctetsWhenStartMoreThanOctets()
-            throws Exception {
+    void testSizeShouldBeNumberOfOctetsWhenStartMoreThanOctets() throws Exception {
         final long size = 2000;
         PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 1000, NUMBER_OF_OCTETS);
         when(mockBodyElement.size()).thenReturn(size);
 
         assertThat(element.size()).describedAs("Content size is less than start. Size should be zero.").isEqualTo(NUMBER_OF_OCTETS);
+    }
+
+    @Test
+    void testSizeShouldBeNumberOfOctetsWhenSizeMoreWhenStartIsZeroAndNoLimitSpecified() throws Exception {
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 0, Long.MAX_VALUE);
+        when(mockBodyElement.size()).thenReturn(NUMBER_OF_OCTETS);
+
+        assertThat(element.size()).describedAs("Size is more than number of octets so should be number of octets")
+            .isEqualTo(NUMBER_OF_OCTETS);
+    }
+
+    @Disabled("JAMES-3715 A bug due to usage of Long.MAX to represent a value that is absent prevents this" +
+        "from working decently. Returns 9223372036854775807L which cannot be parsed nor handled by IMAP clients.")
+    @Test
+    void testWhenStartPlusNumberOfOctetsIsMoreThanSizeSizeShouldBeSizeMinusStartAndNoLimitSpecified() throws Exception {
+        final long size = 60;
+        PartialFetchBodyElement element = new PartialFetchBodyElement(mockBodyElement, 10, Long.MAX_VALUE);
+        when(mockBodyElement.size()).thenReturn(size);
+
+        assertThat(element.size()).describedAs("Size is less than number of octets so should be size").isEqualTo(50);
     }
 }

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -204,8 +204,6 @@ class IMAPServerTest {
                 .contains("* 1 FETCH (FLAGS (\\Recent \\Seen) BODY[]<8> {12}\r\nvalue\r\n\r\nBOD)\r\n");
         }
 
-        @Disabled("JAMES-3715 A bug due to usage of Long.MAX to represent a value that is absent prevents this" +
-            "from working decently.")
         @Test
         void fetchShouldRetrieveMessageWhenOffsetAndNoLimitSpecified() throws Exception {
             testIMAPClient.connect("127.0.0.1", port)

--- a/server/testing/src/main/java/org/apache/james/utils/TestIMAPClient.java
+++ b/server/testing/src/main/java/org/apache/james/utils/TestIMAPClient.java
@@ -220,7 +220,7 @@ public class TestIMAPClient extends ExternalResource implements Closeable, After
         return imapClient.getReplyString();
     }
 
-    private String readFirstMessageInMailbox(String parameters) throws IOException {
+    public String readFirstMessageInMailbox(String parameters) throws IOException {
         imapClient.fetch("1:1", parameters);
         return imapClient.getReplyString();
     }


### PR DESCRIPTION
1. Introduces unit tests for IMAP partial fetch. Those are not working properly after the Netty 4 migration cf https://github.com/apache/james-project/pull/886#issuecomment-1048862314

2. I discovered a bug where a ridicoulously high size is reproded for partial fetches with an offset and no limit (close to Long.MAX) that IMAP clients are not able to handle. This is due to the use of Long.MAX_VALUE to represent absence and causes mis-calculations down the line. Fixed with the use of Optionals...