### PR TITLE
JAMES-3715 Add tests for IMAP COMPRESS transport layer

### DIFF
--- a/server/protocols/protocols-imap4/pom.xml
+++ b/server/protocols/protocols-imap4/pom.xml
@@ -143,6 +143,12 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jzlib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerCompress.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerCompress.xml
@@ -1,0 +1,14 @@
+
+<imapserver enabled="true">
+    <jmxName>imapserver</jmxName>
+    <bind>0.0.0.0:0</bind>
+    <compress>true</compress>
+    <connectionBacklog>200</connectionBacklog>
+    <connectionLimit>0</connectionLimit>
+    <connectionLimitPerIP>0</connectionLimitPerIP>
+    <idleTimeInterval>120</idleTimeInterval>
+    <idleTimeIntervalUnit>SECONDS</idleTimeIntervalUnit>
+    <enableIdle>true</enableIdle>
+    <inMemorySizeLimit>65536</inMemorySizeLimit> <!-- 64 KB -->
+    <plainAuthDisallowed>false</plainAuthDisallowed>
+</imapserver>


### PR DESCRIPTION
Commons-net do not look like it supports compression thus I resorted
to use javax.mail

Compression is one of the untested features that broke during the
Netty 4 upgrade thus I take this opportunity to add more tests.

CF https://github.com/apache/james-project/pull/886#issuecomment-1050804710