### PR TITLE
[UPGRADE] scala maven plugin change recompileMode: incremental -> all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2938,8 +2938,7 @@
                     <artifactId>scala-maven-plugin</artifactId>
                     <version>4.5.6</version>
                     <configuration>
-                        <fork>false</fork>
-                        <recompileMode>incremental</recompileMode>
+                        <recompileMode>all</recompileMode>
                         <source>${target.jdk}</source>
                         <target>${target.jdk}</target>
                         <args>


### PR DESCRIPTION
When running maven (`mvn clean install`), The new version of scala maven plugin (v4.5.6) take more time than older version we used before (v.3.4.6) (https://github.com/apache/james-project/pull/826/commits/c2288511de79d1282081f39aba34e23213041317)

It comes from `incremental compilation` (https://davidb.github.io/scala-maven-plugin/example_incremental.html)
```
The incremental compilation is enabled by default after scala-maven-plugin v4.0.0, and the "recompileMode" configuration option is set to "incremental" by default.
```

=> Change suggestion: `<recompileMode>incremental</recompileMode>` -> `<recompileMode>all</recompileMode>`

### Result
- Command: `mvn clean install -Dmaven.javadoc.skip=true -DskipTests -T11`
- Env 1: My PC - CPU AMD 5600G - 6 core 12 threads
    - Before: Total time:  05:26 min (Wall Clock)
    - After: Total time:  03:47 min (Wall Clock)
    - 
- Env 2: My Laptop - CPU Intel 8250u - 4 core 8 thread
    - Before: Total time:  12:09 min (Wall Clock)
    - After: Total time:  08:28 min (Wall Clock)

![image](https://user-images.githubusercontent.com/81145350/155834796-40bd1ace-6db2-4f57-ba7a-af11f78ade40.png)
