### PR TITLE
JAMES-3715 Graceful shutdown for Netty servers

### DIFF
--- a/mpt/impl/smtp/cassandra-pulsar/src/test/resources/smtpserver.xml
+++ b/mpt/impl/smtp/cassandra-pulsar/src/test/resources/smtpserver.xml
@@ -43,6 +43,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -70,6 +71,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -97,6 +99,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/resources/smtpserver.xml
+++ b/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/resources/smtpserver.xml
@@ -47,6 +47,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -74,6 +75,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -101,6 +103,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/mpt/impl/smtp/cassandra/src/test/resources/smtpserver.xml
+++ b/mpt/impl/smtp/cassandra/src/test/resources/smtpserver.xml
@@ -47,6 +47,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -74,6 +75,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -101,6 +103,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/protocols/netty/src/test/java/org/apache/james/protocols/netty/NettyServerTest.java
+++ b/protocols/netty/src/test/java/org/apache/james/protocols/netty/NettyServerTest.java
@@ -26,8 +26,6 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.james.protocols.api.Encryption;
 import org.apache.james.protocols.api.Protocol;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class NettyServerTest {

--- a/server/apps/cassandra-app/src/test/resources/imapserver.xml
+++ b/server/apps/cassandra-app/src/test/resources/imapserver.xml
@@ -36,6 +36,7 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -51,5 +52,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/apps/cassandra-app/src/test/resources/lmtpserver.xml
+++ b/server/apps/cassandra-app/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/apps/cassandra-app/src/test/resources/managesieveserver.xml
+++ b/server/apps/cassandra-app/src/test/resources/managesieveserver.xml
@@ -57,6 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <gracefulShutdown>false</gracefulShutdown>
   
    </managesieveserver>
 

--- a/server/apps/cassandra-app/src/test/resources/pop3server.xml
+++ b/server/apps/cassandra-app/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/apps/cassandra-app/src/test/resources/smtpserver.xml
+++ b/server/apps/cassandra-app/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -77,6 +78,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -108,6 +110,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/cli-integration-tests/src/test/resources/imapserver.xml
+++ b/server/apps/cli-integration-tests/src/test/resources/imapserver.xml
@@ -35,6 +35,7 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -50,5 +51,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/apps/cli-integration-tests/src/test/resources/lmtpserver.xml
+++ b/server/apps/cli-integration-tests/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/apps/cli-integration-tests/src/test/resources/managesieveserver.xml
+++ b/server/apps/cli-integration-tests/src/test/resources/managesieveserver.xml
@@ -57,7 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
-  
+        <gracefulShutdown>false</gracefulShutdown>
    </managesieveserver>
 
 </managesieveservers>

--- a/server/apps/cli-integration-tests/src/test/resources/pop3server.xml
+++ b/server/apps/cli-integration-tests/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/apps/cli-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/apps/cli-integration-tests/src/test/resources/smtpserver.xml
@@ -47,6 +47,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -82,6 +83,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -117,6 +119,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/distributed-app/src/test/resources/imapserver.xml
+++ b/server/apps/distributed-app/src/test/resources/imapserver.xml
@@ -36,6 +36,7 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -51,5 +52,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/apps/distributed-app/src/test/resources/lmtpserver.xml
+++ b/server/apps/distributed-app/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/apps/distributed-app/src/test/resources/managesieveserver.xml
+++ b/server/apps/distributed-app/src/test/resources/managesieveserver.xml
@@ -57,6 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <gracefulShutdown>false</gracefulShutdown>
   
    </managesieveserver>
 

--- a/server/apps/distributed-app/src/test/resources/pop3server.xml
+++ b/server/apps/distributed-app/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/apps/distributed-app/src/test/resources/smtpserver.xml
+++ b/server/apps/distributed-app/src/test/resources/smtpserver.xml
@@ -47,6 +47,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -75,6 +76,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -103,6 +105,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/distributed-pop3-app/src/test/resources/lmtpserver.xml
+++ b/server/apps/distributed-pop3-app/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/apps/distributed-pop3-app/src/test/resources/pop3server.xml
+++ b/server/apps/distributed-pop3-app/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/apps/distributed-pop3-app/src/test/resources/smtpserver.xml
+++ b/server/apps/distributed-pop3-app/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -74,6 +75,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -102,6 +104,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/jpa-app/src/test/resources/imapserver.xml
+++ b/server/apps/jpa-app/src/test/resources/imapserver.xml
@@ -36,6 +36,7 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -51,5 +52,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/apps/jpa-app/src/test/resources/lmtpserver.xml
+++ b/server/apps/jpa-app/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/apps/jpa-app/src/test/resources/managesieveserver.xml
+++ b/server/apps/jpa-app/src/test/resources/managesieveserver.xml
@@ -57,6 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <gracefulShutdown>false</gracefulShutdown>
   
    </managesieveserver>
 

--- a/server/apps/jpa-app/src/test/resources/pop3server.xml
+++ b/server/apps/jpa-app/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/apps/jpa-app/src/test/resources/smtpserver.xml
+++ b/server/apps/jpa-app/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -74,6 +75,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -102,6 +104,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/jpa-smtp-app/src/test/resources/smtpserver.xml
+++ b/server/apps/jpa-smtp-app/src/test/resources/smtpserver.xml
@@ -45,6 +45,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -72,6 +73,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -99,6 +101,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/memory-app/src/test/resources/imapserver.xml
+++ b/server/apps/memory-app/src/test/resources/imapserver.xml
@@ -36,6 +36,7 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -51,5 +52,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/apps/memory-app/src/test/resources/lmtpserver.xml
+++ b/server/apps/memory-app/src/test/resources/lmtpserver.xml
@@ -39,6 +39,7 @@
                 <splitExecution>true</splitExecution>
             </handler>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/apps/memory-app/src/test/resources/managesieveserver.xml
+++ b/server/apps/memory-app/src/test/resources/managesieveserver.xml
@@ -57,6 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <gracefulShutdown>false</gracefulShutdown>
   
    </managesieveserver>
 

--- a/server/apps/memory-app/src/test/resources/pop3server.xml
+++ b/server/apps/memory-app/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/apps/memory-app/src/test/resources/smtpserver.xml
+++ b/server/apps/memory-app/src/test/resources/smtpserver.xml
@@ -45,6 +45,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -72,6 +73,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -99,6 +101,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/smtp-pulsar-cassandra-app/src/test/resources/smtpserver.xml
+++ b/server/apps/smtp-pulsar-cassandra-app/src/test/resources/smtpserver.xml
@@ -42,6 +42,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -69,6 +70,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -96,6 +98,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/apps/spring-app/src/test/resources/imapserver.xml
+++ b/server/apps/spring-app/src/test/resources/imapserver.xml
@@ -68,7 +68,8 @@
        <!-- Set the maximum simultaneous incoming connections per IP for this service -->
        <connectionLimitPerIP>0</connectionLimitPerIP>
 
-        <plainAuthDisallowed>false</plainAuthDisallowed>
+       <plainAuthDisallowed>false</plainAuthDisallowed>
+       <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 
 </imapservers>

--- a/server/apps/spring-app/src/test/resources/managesieveserver.xml
+++ b/server/apps/spring-app/src/test/resources/managesieveserver.xml
@@ -57,6 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <gracefulShutdown>false</gracefulShutdown>
   
    </managesieveserver>
 

--- a/server/apps/spring-app/src/test/resources/pop3server.xml
+++ b/server/apps/spring-app/src/test/resources/pop3server.xml
@@ -73,6 +73,7 @@
            <!-- know what you are doing -->
            <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
        </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
 
     </pop3server>
 

--- a/server/apps/spring-app/src/test/resources/smtpserver.xml
+++ b/server/apps/spring-app/src/test/resources/smtpserver.xml
@@ -47,6 +47,7 @@
     <handlerchain enableJmx="true">
       <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
       <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>       
-    </handlerchain>            
+    </handlerchain>
+    <gracefulShutdown>false</gracefulShutdown>
   </smtpserver>
 </smtpservers>

--- a/server/apps/webadmin-cli/src/test/resources/imapserver.xml
+++ b/server/apps/webadmin-cli/src/test/resources/imapserver.xml
@@ -35,6 +35,7 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -50,5 +51,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/apps/webadmin-cli/src/test/resources/lmtpserver.xml
+++ b/server/apps/webadmin-cli/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/apps/webadmin-cli/src/test/resources/managesieveserver.xml
+++ b/server/apps/webadmin-cli/src/test/resources/managesieveserver.xml
@@ -57,6 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <gracefulShutdown>false</gracefulShutdown>
   
    </managesieveserver>
 

--- a/server/apps/webadmin-cli/src/test/resources/pop3server.xml
+++ b/server/apps/webadmin-cli/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/apps/webadmin-cli/src/test/resources/smtpserver.xml
+++ b/server/apps/webadmin-cli/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -74,6 +75,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -102,6 +104,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/mailet/integration-testing/src/main/resources/imapserver.xml
+++ b/server/mailet/integration-testing/src/main/resources/imapserver.xml
@@ -36,5 +36,6 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/mailet/integration-testing/src/main/resources/smtpserver.xml
+++ b/server/mailet/integration-testing/src/main/resources/smtpserver.xml
@@ -52,6 +52,7 @@
             <handler class="{{hookFqcn}}"/>
             {{/hooks}}
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -95,6 +96,7 @@
             <handler class="{{hookFqcn}}"/>
             {{/hooks}}
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/imapserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/imapserver.xml
@@ -36,5 +36,6 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/imapserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/imapserver.xml
@@ -36,6 +36,7 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -51,5 +52,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/lmtpserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/pop3server.xml
+++ b/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-draft-integration-testing/rabbitmq-jmap-draft-integration-testing/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -73,6 +74,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -100,6 +102,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/smtpserver.xml
@@ -46,6 +46,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/protocols/protocols-imap4/src/test/resources/imapServer.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServer.xml
@@ -11,4 +11,5 @@
     <inMemorySizeLimit>64K</inMemorySizeLimit>
     <literalSizeLimit>128K</literalSizeLimit>
     <plainAuthDisallowed>false</plainAuthDisallowed>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerNoLimits.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerNoLimits.xml
@@ -10,4 +10,5 @@
     <enableIdle>true</enableIdle>
     <inMemorySizeLimit>65536</inMemorySizeLimit> <!-- 64 KB -->
     <plainAuthDisallowed>false</plainAuthDisallowed>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthAllowed.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthAllowed.xml
@@ -8,4 +8,5 @@
         <algorithm>SunX509</algorithm>
     </tls>
     <plainAuthDisallowed>false</plainAuthDisallowed>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthDisabled.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthDisabled.xml
@@ -10,4 +10,5 @@
     <auth>
         <plainAuthEnabled>false</plainAuthEnabled>
     </auth>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthDisallowed.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthDisallowed.xml
@@ -8,4 +8,5 @@
         <algorithm>SunX509</algorithm>
     </tls>
     <plainAuthDisallowed>true</plainAuthDisallowed>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthEnabledWithoutRequireSSL.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerPlainAuthEnabledWithoutRequireSSL.xml
@@ -11,4 +11,5 @@
         <plainAuthEnabled>true</plainAuthEnabled>
     </auth>
     <plainAuthDisallowed>false</plainAuthDisallowed>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsFalseAndStartSSLIsFalse.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsFalseAndStartSSLIsFalse.xml
@@ -11,4 +11,5 @@
         <plainAuthEnabled>true</plainAuthEnabled>
         <requireSSL>false</requireSSL>
     </auth>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsFalseAndStartSSLIsTrue.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsFalseAndStartSSLIsTrue.xml
@@ -11,4 +11,5 @@
         <plainAuthEnabled>true</plainAuthEnabled>
         <requireSSL>false</requireSSL>
     </auth>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsTrueAndStartSSLIsFalse.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsTrueAndStartSSLIsFalse.xml
@@ -11,4 +11,5 @@
         <plainAuthEnabled>true</plainAuthEnabled>
         <requireSSL>true</requireSSL>
     </auth>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsTrueAndStartSSLIsTrue.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerRequireSSLIsTrueAndStartSSLIsTrue.xml
@@ -11,4 +11,5 @@
         <plainAuthEnabled>true</plainAuthEnabled>
         <requireSSL>true</requireSSL>
     </auth>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslDefaultJKS.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslDefaultJKS.xml
@@ -7,4 +7,5 @@
         <secret>123456</secret>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslJKS.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslJKS.xml
@@ -8,4 +8,5 @@
         <secret>123456</secret>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslJKSBadPassword.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslJKSBadPassword.xml
@@ -8,4 +8,5 @@
         <secret>badbad</secret>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslJKSNotFound.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslJKSNotFound.xml
@@ -8,4 +8,5 @@
         <secret>123456</secret>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslNoKeys.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslNoKeys.xml
@@ -4,4 +4,5 @@
     <bind>0.0.0.0:0</bind>
     <tls socketTLS="false" startTLS="true">
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEM.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEM.xml
@@ -7,4 +7,5 @@
         <certificates>certs.self-signed.csr</certificates>
         <secret>123456</secret>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMBadPass.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMBadPass.xml
@@ -7,4 +7,5 @@
         <certificates>certs.self-signed.csr</certificates>
         <secret>badbad</secret>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMExtraPass.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMExtraPass.xml
@@ -7,4 +7,5 @@
         <certificates>certs.self-signed.csr</certificates>
         <secret>123456</secret>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMMissingPass.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMMissingPass.xml
@@ -6,4 +6,5 @@
         <privateKey>private.key</privateKey>
         <certificates>certs.self-signed.csr</certificates>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMNoPass.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPEMNoPass.xml
@@ -6,4 +6,5 @@
         <privateKey>private.nopass.key</privateKey>
         <certificates>certs.self-signed.csr</certificates>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPKCS12.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPKCS12.xml
@@ -8,4 +8,5 @@
         <secret>123456</secret>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPKCS12MissingPassword.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPKCS12MissingPassword.xml
@@ -6,4 +6,5 @@
         <keystoreType>PKCS12</keystoreType>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerSslPKCS12WrongPassword.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerSslPKCS12WrongPassword.xml
@@ -7,4 +7,5 @@
         <secret>badbad</secret>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
     </tls>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerStartTLS.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerStartTLS.xml
@@ -16,4 +16,5 @@
     <inMemorySizeLimit>64K</inMemorySizeLimit>
     <literalSizeLimit>128K</literalSizeLimit>
     <plainAuthDisallowed>false</plainAuthDisallowed>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-imap4/src/test/resources/oauth.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/oauth.xml
@@ -10,4 +10,5 @@
         <plainAuthEnabled>true</plainAuthEnabled>
         <requireSSL>true</requireSSL>
     </auth>
+    <gracefulShutdown>false</gracefulShutdown>
 </imapserver>

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
@@ -263,6 +263,8 @@ public abstract class AbstractConfigurableAsyncServer extends AbstractAsyncServe
             LOGGER.info("TLS enabled with auth {} using truststore {}", clientAuth, truststore);
         }
 
+        Optional.ofNullable(config.getBoolean("gracefulShutdown", null)).ifPresent(this::setGracefulShutdown);
+
         doConfigure(config);
 
     }

--- a/server/protocols/protocols-lmtp/src/test/resources/lmtp.xml
+++ b/server/protocols/protocols-lmtp/src/test/resources/lmtp.xml
@@ -30,5 +30,6 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 </lmtpservers>

--- a/server/protocols/protocols-lmtp/src/test/resources/lmtpdsn.xml
+++ b/server/protocols/protocols-lmtp/src/test/resources/lmtpdsn.xml
@@ -35,5 +35,6 @@
             <handler class="org.apache.james.smtpserver.dsn.DSNRcptParameterHook"/>
             <handler class="org.apache.james.smtpserver.dsn.DSNMessageHook"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 </lmtpservers>

--- a/server/protocols/protocols-lmtp/src/test/resources/lmtpmailet.xml
+++ b/server/protocols/protocols-lmtp/src/test/resources/lmtpmailet.xml
@@ -30,5 +30,6 @@
         <handlerchain coreHandlersPackage="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader">
             <handler class="org.apache.james.lmtpserver.MailetContainerCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 </lmtpservers>

--- a/server/protocols/protocols-lmtp/src/test/resources/lmtpnormaldsn.xml
+++ b/server/protocols/protocols-lmtp/src/test/resources/lmtpnormaldsn.xml
@@ -35,5 +35,6 @@
             <handler class="org.apache.james.smtpserver.dsn.DSNRcptParameterHook"/>
             <handler class="org.apache.james.smtpserver.dsn.DSNMessageHook"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 </lmtpservers>

--- a/server/protocols/protocols-pop3-distributed/src/test/resources/pop3server.xml
+++ b/server/protocols/protocols-pop3-distributed/src/test/resources/pop3server.xml
@@ -12,4 +12,5 @@
     <handlerchain>
         <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
     </handlerchain>
+    <gracefulShutdown>false</gracefulShutdown>
 </pop3server>

--- a/server/protocols/protocols-pop3/src/test/resources/pop3server.xml
+++ b/server/protocols/protocols-pop3/src/test/resources/pop3server.xml
@@ -12,4 +12,5 @@
     <handlerchain>
         <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
     </handlerchain>
+    <gracefulShutdown>false</gracefulShutdown>
 </pop3server>

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -259,6 +259,7 @@ public class SMTPServerTest {
         smtpServer.setDnsService(dnsServer);
         smtpServer.setFileSystem(fileSystem);
         smtpServer.setProtocolHandlerLoader(chain);
+        smtpServer.setGracefulShutdown(false);
     }
 
     protected void init(SMTPTestConfiguration testConfiguration) throws Exception {

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-advancedSecurity.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-advancedSecurity.xml
@@ -17,4 +17,5 @@
     <handlerchain>
         <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
     </handlerchain>
+    <gracefulShutdown>false</gracefulShutdown>
 </smtpserver>

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceAlways.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceAlways.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceNever.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceNever.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeMatching.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeMatching.xml
@@ -43,6 +43,7 @@
         <handlerchain>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeNotMatching.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-authAnnounceSometimeNotMatching.xml
@@ -37,6 +37,7 @@
         <handlerchain>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-dsn.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-dsn.xml
@@ -48,6 +48,7 @@
             <handler class="org.apache.james.smtpserver.dsn.DSNMessageHook"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-no-plain.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-no-plain.xml
@@ -39,6 +39,7 @@
         <handlerchain>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-noauth.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-noauth.xml
@@ -34,6 +34,7 @@
         <handlerchain>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-requireSSL.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-requireSSL.xml
@@ -38,6 +38,7 @@
         <handlerchain>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 
 

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/imapserver.xml
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/imapserver.xml
@@ -36,5 +36,6 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/smtpserver.xml
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/smtpserver.xml
@@ -47,6 +47,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/lmtpserver.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/lmtpserver.xml
@@ -36,6 +36,7 @@
         <handlerchain>
             <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </lmtpserver>
 
 </lmtpservers>

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/managesieveserver.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/managesieveserver.xml
@@ -57,7 +57,7 @@
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
-  
+       <gracefulShutdown>false</gracefulShutdown>
    </managesieveserver>
 
 </managesieveservers>

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/pop3server.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/pop3server.xml
@@ -38,5 +38,6 @@
         <handlerchain>
             <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </pop3server>
 </pop3servers>

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/smtpserver.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/smtpserver.xml
@@ -47,6 +47,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
@@ -76,6 +77,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
@@ -105,6 +107,7 @@
             <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
+        <gracefulShutdown>false</gracefulShutdown>
     </smtpserver>
 </smtpservers>
 


### PR DESCRIPTION
Waits ongoing tasks being executed on Netty servers for a few seconds
before releasing underlying resources (like DB connections).

Especially on top of Cassandra components, this is a good first step
to minimize risks of shutdowns to cause inconsistencies.

The Netty4 migration enabled us to easily write such resilient
behaviour while it was not implemented for the previously existing
Netty 3 code. CF https://github.com/apache/james-project/pull/886