### PR TITLE
[Clean code] Pretty name of maven submodule

### DIFF
--- a/backends-common/cassandra/pom.xml
+++ b/backends-common/cassandra/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-backends-cassandra</artifactId>
-    <name>Apache James Cassandra backend</name>
+    <name>Apache James :: Backends Common :: Cassandra</name>
 
     <properties>
         <cassandra.driver.version>3.11.0</cassandra.driver.version>

--- a/backends-common/elasticsearch-v7/pom.xml
+++ b/backends-common/elasticsearch-v7/pom.xml
@@ -26,6 +26,7 @@
     </parent>
 
     <artifactId>apache-james-backends-es-v7</artifactId>
+    <name>Apache James :: Backends Common :: ES-V7</name>
 
     <dependencies>
         <dependency>

--- a/backends-common/jpa/pom.xml
+++ b/backends-common/jpa/pom.xml
@@ -26,6 +26,7 @@
     </parent>
 
     <artifactId>apache-james-backends-jpa</artifactId>
+    <name>Apache James :: Backends Common :: JPA</name>
 
     <dependencies>
         <dependency>

--- a/backends-common/pom.xml
+++ b/backends-common/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>james-backends-common</artifactId>
     <packaging>pom</packaging>
 
-    <name>Apache JAMES backends common</name>
+    <name>Apache James :: Backends Common</name>
     <description>Apache James Backends: common utils to access backends</description>
     <inceptionYear>2015</inceptionYear>
 

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-backends-pulsar</artifactId>
-    <name>Apache James Pulsar backend</name>
+    <name>Apache James :: Backends Common :: Pulsar</name>
 
     <dependencies>
         <dependency>

--- a/backends-common/rabbitmq/pom.xml
+++ b/backends-common/rabbitmq/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-backends-rabbitmq</artifactId>
-    <name>Apache James RabbitMQ backend</name>
+    <name>Apache James :: Backends Common :: RabbitMQ</name>
 
     <dependencies>
         <dependency>

--- a/event-sourcing/event-sourcing-core/pom.xml
+++ b/event-sourcing/event-sourcing-core/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>event-sourcing-core</artifactId>
 
-    <name>Apache James :: Event sourcing :: core</name>
+    <name>Apache James :: Event sourcing :: Core</name>
     <description>James Event Sourcing system</description>
 
     <dependencies>

--- a/event-sourcing/event-sourcing-pojo/pom.xml
+++ b/event-sourcing/event-sourcing-pojo/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>event-sourcing-pojo</artifactId>
 
-    <name>Apache James :: Event sourcing :: pojo</name>
+    <name>Apache James :: Event sourcing :: Pojo</name>
     <description>James event sourcing types</description>
 
     <dependencies>

--- a/mailet/ai/pom.xml
+++ b/mailet/ai/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>apache-mailet-ai</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: AI Mailets</name>
+    <name>Apache James :: Mailet :: AI</name>
     <description>Collects mail processors making use of artificial intelligence (AI) methods.</description>
     <url>http://james.apache.org/mailet/ai</url>
     <inceptionYear>2011</inceptionYear>

--- a/mailet/amqp/pom.xml
+++ b/mailet/amqp/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>apache-mailet-amqp</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: AMQP Mailet</name>
+    <name>Apache James :: Mailet :: AMQP</name>
     <description>Provides a mailet forwarding mail attributes over AMQP</description>
     <inceptionYear>2021</inceptionYear>
 

--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>apache-mailet-api</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Mailet API</name>
+    <name>Apache James :: Mailet :: API</name>
     <description>The Apache Mailet API is a flexible specification for mail processing agents.</description>
     <url>http://james.apache.org/mailet/api/</url>
     <inceptionYear>2007</inceptionYear>

--- a/mailet/base/pom.xml
+++ b/mailet/base/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>apache-mailet-base</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Basic Mailet Toolkit</name>
+    <name>Apache James :: Mailet :: Basic Toolkit</name>
     <description>Apache James Basic Mailet Toolkit is a collection of utilities and lightweight framework
         aimed at developers and testers of mailets. This toolkit is extensively used elsewhere in
         James.</description>

--- a/mailet/crypto/pom.xml
+++ b/mailet/crypto/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>apache-mailet-crypto</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Crypto Mailets</name>
+    <name>Apache James :: Mailet :: Crypto</name>
     <description>Apache James Cryptographic Mailets is a collection of mailets which use cryptography.
         This includes matching signatures, decrypting, encrypting and signing.</description>
     <url>http://james.apache.org/mailet/crypto/</url>

--- a/mailet/icalendar/pom.xml
+++ b/mailet/icalendar/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>apache-mailet-icalendar</artifactId>
 
-    <name>Apache James :: ICalendar Mailets</name>
+    <name>Apache James :: Mailet :: ICalendar</name>
 
     <dependencies>
         <dependency>

--- a/mailet/mailetdocs-maven-plugin/pom.xml
+++ b/mailet/mailetdocs-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>mailetdocs-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
-    <name>Apache James :: Mailetdocs Maven Plugin</name>
+    <name>Apache James :: Mailet :: Docs Maven Plugin</name>
     <description>This plugin generates documentation for Mailets by collating
         information available from implementation source.</description>
     <url>http://james.apache.org/mailet/maven-mailetdocs-plugin/</url>

--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>apache-mailet</artifactId>
     <packaging>pom</packaging>
 
-    <name>Apache James :: Mailets parent and aggregator</name>
+    <name>Apache James :: Mailet</name>
     <description>Apache James Mailets parent and aggregator</description>
     <url>http://james.apache.org/mailet/</url>
     <inceptionYear>2008</inceptionYear>

--- a/mailet/standard/pom.xml
+++ b/mailet/standard/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>apache-mailet-standard</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Standard Mailets</name>
+    <name>Apache James :: Mailet :: Standard</name>
     <description>Apache James Standard Mailets is a rich collection of general purpose mailets
         with limited dependencies. These mailets can be used in any mailet container.</description>
     <url>http://james.apache.org/mailet/standard/</url>

--- a/mpt/all/pom.xml
+++ b/mpt/all/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <artifactId>apache-james-mpt-all</artifactId>
     <packaging>pom</packaging>
-    <name>Apache James MPT All</name>
+    <name>Apache James :: MPT :: All</name>
 
     <description>This module assembles distributions 
 MPT is a functional test framework specialised for the ASCII line-base protocols common in mail.</description>

--- a/mpt/app/pom.xml
+++ b/mpt/app/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>apache-james-mpt-app</artifactId>
 
-    <name>Apache James MPT Application</name>
+    <name>Apache James :: MPT :: Application</name>
     <description>Apache James Mail Protocol Tester (MPT) is a library providing a framework for the 
 scriptable functional testing of ASCII based line protocols. This application provides easy executable
 interfaces to the MPT library.</description>

--- a/mpt/core/pom.xml
+++ b/mpt/core/pom.xml
@@ -26,7 +26,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>apache-james-mpt-core</artifactId>
-    <name>Apache James MPT Core</name>
+    <name>Apache James :: MPT :: Core</name>
     <description>Apache James Mail Protocol Tester (MPT) is a library providing a framework for the 
       scriptable functional testing of ASCII based line protocols.</description>
     <url>http://james.apache.org/mpt/main</url>

--- a/mpt/impl/imap-mailbox/cassandra/pom.xml
+++ b/mpt/impl/imap-mailbox/cassandra/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-cassandra</artifactId>
-    <name>Apache James MPT Imap Mailbox - Cassandra</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: Cassandra</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/core/pom.xml
+++ b/mpt/impl/imap-mailbox/core/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-core</artifactId>
-    <name>Apache James MPT Imap Mailbox Core</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: Core</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/cyrus/pom.xml
+++ b/mpt/impl/imap-mailbox/cyrus/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-cyrus</artifactId>
-    <name>Apache James MPT Imap Mailbox - Cyrus</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: Cyrus</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/elasticsearch/pom.xml
+++ b/mpt/impl/imap-mailbox/elasticsearch/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-elasticsearch</artifactId>
-    <name>Apache James MPT Imap Mailbox - ElasticSearch</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: ElasticSearch</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/external-james/pom.xml
+++ b/mpt/impl/imap-mailbox/external-james/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-external-james</artifactId>
-    <name>Apache James MPT Imap Mailbox - External James</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: External James</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/inmemory/pom.xml
+++ b/mpt/impl/imap-mailbox/inmemory/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-inmemory</artifactId>
-    <name>Apache James MPT Imap Mailbox - InMemory</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: InMemory</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/jpa/pom.xml
+++ b/mpt/impl/imap-mailbox/jpa/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-jpa</artifactId>
-    <name>Apache James MPT Imap Mailbox - JPA</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: JPA</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/lucenesearch/pom.xml
+++ b/mpt/impl/imap-mailbox/lucenesearch/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-jpa-lucene</artifactId>
-    <name>Apache James MPT Imap Mailbox - LuceneSearch</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: LuceneSearch</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/imap-mailbox/pom.xml
+++ b/mpt/impl/imap-mailbox/pom.xml
@@ -30,7 +30,7 @@
 
     <artifactId>apache-james-mpt-imapmailbox</artifactId>
     <packaging>pom</packaging>
-    <name>Apache James MPT Imap Mailbox</name>
+    <name>Apache James :: MPT :: Imap Mailbox</name>
 
     <modules>
         <module>cassandra</module>

--- a/mpt/impl/imap-mailbox/rabbitmq/pom.xml
+++ b/mpt/impl/imap-mailbox/rabbitmq/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mpt-imapmailbox-rabbitmq</artifactId>
-    <name>Apache James MPT Imap Mailbox - RabbitMQ EventBus</name>
+    <name>Apache James :: MPT :: Imap Mailbox :: RabbitMQ EventBus</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/managesieve/cassandra/pom.xml
+++ b/mpt/impl/managesieve/cassandra/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>apache-james-mpt-managesieve-cassandra</artifactId>
 
-    <name>Apache James MPT ManageSieve Cassandra</name>
+    <name>Apache James :: MPT :: ManageSieve :: Cassandra</name>
 
 
     <dependencies>

--- a/mpt/impl/managesieve/core/pom.xml
+++ b/mpt/impl/managesieve/core/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>apache-james-mpt-managesieve-core</artifactId>
 
-    <name>Apache James MPT ManageSieve Core</name>
+    <name>Apache James :: MPT :: ManageSieve :: Core</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/managesieve/file/pom.xml
+++ b/mpt/impl/managesieve/file/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>apache-james-mpt-managesieve-file</artifactId>
 
-    <name>Apache James MPT ManageSieve File</name>
+    <name>Apache James :: MPT :: ManageSieve :: File</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/managesieve/pom.xml
+++ b/mpt/impl/managesieve/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>apache-james-mpt-managesieve</artifactId>
     <packaging>pom</packaging>
 
-    <name>Apache James MPT ManageSieve</name>
+    <name>Apache James :: MPT :: ManageSieve</name>
 
     <modules>
         <module>cassandra</module>

--- a/mpt/impl/smtp/cassandra-pulsar/pom.xml
+++ b/mpt/impl/smtp/cassandra-pulsar/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>apache-james-mpt-smtp-cassandra-pulsar</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James MPT SMTP Cassandra</name>
+    <name>Apache James :: MPT :: SMTP :: Cassandra - Pulsar</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/smtp/cassandra-rabbitmq-object-storage/pom.xml
+++ b/mpt/impl/smtp/cassandra-rabbitmq-object-storage/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>apache-james-mpt-smtp-cassandra-rabbitmq-object-storage</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James MPT SMTP Cassandra RabbitMQ Object Storage</name>
+    <name>Apache James :: MPT :: SMTP :: Cassandra - RabbitMQ - Object Storage</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/smtp/cassandra/pom.xml
+++ b/mpt/impl/smtp/cassandra/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>apache-james-mpt-smtp-cassandra</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James MPT SMTP Cassandra</name>
+    <name>Apache James :: MPT :: SMTP :: Cassandra</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/smtp/core/pom.xml
+++ b/mpt/impl/smtp/core/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>apache-james-mpt-smtp-core</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James MPT SMTP Core</name>
+    <name>Apache James :: MPT :: SMTP :: Core</name>
 
     <dependencies>
         <dependency>

--- a/mpt/impl/smtp/pom.xml
+++ b/mpt/impl/smtp/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>apache-james-mpt-smtp</artifactId>
     <packaging>pom</packaging>
-    <name>Apache James MPT SMTP</name>
+    <name>Apache James :: MPT :: SMTP</name>
 
     <modules>
         <module>cassandra</module>

--- a/mpt/mavenplugin/pom.xml
+++ b/mpt/mavenplugin/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>mpt-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
-    <name>Apache James MPT Maven2 Plugin</name>
+    <name>Apache James :: MPT :: Maven2 Plugin</name>
     <description>Apache James Mail Protocol Tester (MPT) is a library providing a framework for the 
 scriptable functional testing of ASCII based line protocols. This Maven2 Plugin  is an easy interface
 to the library requiring no extra coding.</description>

--- a/mpt/pom.xml
+++ b/mpt/pom.xml
@@ -30,7 +30,7 @@
 
     <packaging>pom</packaging>
 
-    <name>Apache James MPT</name>
+    <name>Apache James :: MPT</name>
     <description>Functional test framework specialised for the ASCII line-base protocols common in mail.</description>
     <url>http://james.apache.org/mpt/</url>
     <inceptionYear>2008</inceptionYear>

--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>james-server-jpa-app</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Server :: JPA - guice injection</name>
+    <name>Apache James :: Server :: JPA - Application</name>
     <description>An advanced email server - JPA backend with guice injection</description>
 
     <properties>

--- a/server/container/guice/testing/custom-mailets-implementation/pom.xml
+++ b/server/container/guice/testing/custom-mailets-implementation/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>custom-mailets-implementation</artifactId>
+    <name>Apache James :: Server :: Guice :: Mailet :: Custom testing mailets :: implement</name>
 
     <dependencies>
         <dependency>

--- a/server/container/guice/testing/dependency/pom.xml
+++ b/server/container/guice/testing/dependency/pom.xml
@@ -28,8 +28,8 @@
 
     <artifactId>james-server-guice-custom-mailets-dependency</artifactId>
 
-    <name>Apache James :: Server :: Guice :: Mailet :: Custom testing mailets :: dependency</name>
-    <description>Dependency not part of James classpath that custom mailets can depends on</description>
+    <name>Apache James :: Server :: Guice :: Mailet :: Custom testing mailets :: Dependency</name>
+    <description>Dependency not part of James classpath that custom mailets can depend on</description>
 
     <dependencies>
         <dependency>

--- a/server/container/guice/utils/pom.xml
+++ b/server/container/guice/utils/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>james-server-guice-utils</artifactId>
-
+    <name>Apache James :: Server :: Guice :: Utils</name>
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/server/mailet/integration-testing/pom.xml
+++ b/server/mailet/integration-testing/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>james-server-mailets-integration-testing</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Server :: Mailets Integration Testing</name>
+    <name>Apache James :: Server :: Mailet :: Integration Testing</name>
 
     <dependencies>
         <dependency>

--- a/server/mailet/rate-limiter/pom.xml
+++ b/server/mailet/rate-limiter/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>james-server-rate-limiter</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Server :: Mailets :: Rate limiter</name>
+    <name>Apache James :: Server :: Mailet :: Rate limiter</name>
     <description>Rate limiting for Apache James email processing</description>
 
     <dependencies>

--- a/server/protocols/jmap/pom.xml
+++ b/server/protocols/jmap/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>james-server-jmap</artifactId>
+    <name>Apache James :: Server :: JMAP</name>
 
     <dependencies>
         <dependency>

--- a/server/protocols/protocols-pop3-distributed/pom.xml
+++ b/server/protocols/protocols-pop3-distributed/pom.xml
@@ -28,8 +28,7 @@
     </parent>
 
     <artifactId>james-server-protocols-pop3-distributed</artifactId>
-
-    <name>POP3 distributed server</name>
+    <name>Apache James :: Server :: POP3 :: Distributed</name>
     <description>Distributed friendly implementation of a POP3 server. The use of messageId as an identifier enables
         to use safely Cassandra multi-datacenters set up</description>
 

--- a/server/protocols/webadmin/webadmin-pop3/pom.xml
+++ b/server/protocols/webadmin/webadmin-pop3/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>james-server-webadmin-pop3</artifactId>
-    <name>POP3 :: WebAdmin</name>
+    <name>Apache James :: Server :: WebAdmin :: POP3</name>
     <description>Expose task to fix inconsistencies of POP3Metadata</description>
 
     <dependencies>

--- a/third-party/pom.xml
+++ b/third-party/pom.xml
@@ -28,8 +28,7 @@
 
     <artifactId>third-party</artifactId>
     <packaging>pom</packaging>
-
-    <name>Apache JAMES third party</name>
+    <name>Apache James :: Third Party</name>
     <description>Common utilities for integrating with third party software</description>
     <inceptionYear>2018</inceptionYear>
 


### PR DESCRIPTION
Making name of maven modules is more pretty in the log, IDE

![image](https://user-images.githubusercontent.com/81145350/156164644-2a79f83e-b252-4b3c-b509-57c89d154a80.png)
![image](https://user-images.githubusercontent.com/81145350/156164676-737a8fd6-d99a-4dad-9920-4f1ef4042f35.png)
