### PR TITLE
JAMES-3719 Reactive textual content extraction with Apache Tika

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import org.apache.james.mailbox.model.ContentType;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public interface TextExtractor {
     default boolean applicable(ContentType contentType) {
@@ -33,7 +34,8 @@ public interface TextExtractor {
     ParsedContent extractContent(InputStream inputStream, ContentType contentType) throws Exception;
 
     default Mono<ParsedContent> extractContentReactive(InputStream inputStream, ContentType contentType) {
-        return Mono.fromCallable(() -> extractContent(inputStream, contentType));
+        return Mono.fromCallable(() -> extractContent(inputStream, contentType))
+            .subscribeOn(Schedulers.elastic());
     }
 
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
@@ -23,8 +23,14 @@ import java.io.InputStream;
 
 import org.apache.james.mailbox.model.ContentType;
 
+import reactor.core.publisher.Mono;
+
 public interface TextExtractor {
 
     ParsedContent extractContent(InputStream inputStream, ContentType contentType) throws Exception;
+
+    default Mono<ParsedContent> extractContentReactive(InputStream inputStream, ContentType contentType) {
+        return Mono.fromCallable(() -> extractContent(inputStream, contentType));
+    }
 
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
@@ -26,6 +26,9 @@ import org.apache.james.mailbox.model.ContentType;
 import reactor.core.publisher.Mono;
 
 public interface TextExtractor {
+    default boolean applicable(ContentType contentType) {
+        return true;
+    }
 
     ParsedContent extractContent(InputStream inputStream, ContentType contentType) throws Exception;
 

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndex.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndex.java
@@ -155,23 +155,22 @@ public class ElasticSearchListeningMessageSearchIndex extends ListeningMessageSe
         RoutingKey from = routingKeyFactory.from(mailbox.getMailboxId());
         DocumentId id = indexIdFor(mailbox.getMailboxId(), message.getUid());
 
-        return Mono.fromCallable(() -> generateIndexedJson(mailbox, message, session))
+        return generateIndexedJson(mailbox, message, session)
             .flatMap(jsonContent -> elasticSearchIndexer.index(id, jsonContent, from))
             .then();
     }
 
-    private String generateIndexedJson(Mailbox mailbox, MailboxMessage message, MailboxSession session) throws JsonProcessingException {
-        try {
-            return messageToElasticSearchJson.convertToJson(message);
-        } catch (Exception e) {
-            LOGGER.warn("Indexing mailbox {}-{} of user {} on message {} without attachments ",
-                mailbox.getName(),
-                mailbox.getMailboxId().serialize(),
-                session.getUser().asString(),
-                message.getUid(),
-                e);
-            return messageToElasticSearchJson.convertToJsonWithoutAttachment(message);
-        }
+    private Mono<String> generateIndexedJson(Mailbox mailbox, MailboxMessage message, MailboxSession session) {
+        return messageToElasticSearchJson.convertToJson(message)
+            .onErrorResume(e -> {
+                LOGGER.warn("Indexing mailbox {}-{} of user {} on message {} without attachments ",
+                    mailbox.getName(),
+                    mailbox.getMailboxId().serialize(),
+                    session.getUser().asString(),
+                    message.getUid(),
+                    e);
+                return messageToElasticSearchJson.convertToJsonWithoutAttachment(message);
+            });
     }
 
     @Override

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessage.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessage.java
@@ -39,6 +39,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import reactor.core.publisher.Mono;
+
 public class IndexableMessage {
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
@@ -62,7 +64,7 @@ public class IndexableMessage {
         private Builder() {
         }
 
-        public IndexableMessage build() {
+        public Mono<IndexableMessage> build() {
             Preconditions.checkNotNull(message.getMailboxId());
             Preconditions.checkNotNull(textExtractor);
             Preconditions.checkNotNull(indexAttachments);
@@ -95,73 +97,77 @@ public class IndexableMessage {
             return this;
         }
 
-        private IndexableMessage instantiateIndexedMessage() throws IOException, MimeException {
+        private Mono<IndexableMessage> instantiateIndexedMessage() throws IOException, MimeException {
             String messageId = SearchUtil.getSerializedMessageIdIfSupportedByUnderlyingStorageOrNull(message);
             String threadId = SearchUtil.getSerializedThreadIdIfSupportedByUnderlyingStorageOrNull(message);
-            MimePart parsingResult = new MimePartParser(message, textExtractor).parse();
 
-            Optional<String> bodyText = parsingResult.locateFirstTextBody();
-            Optional<String> bodyHtml = parsingResult.locateFirstHtmlBody();
+            return new MimePartParser(message, textExtractor).parse()
+                .asMimePart(textExtractor)
+                .map(parsingResult -> {
 
-            boolean hasAttachment = MessageAttachmentMetadata.hasNonInlinedAttachment(message.getAttachments());
-            List<MimePart> attachments = setFlattenedAttachments(parsingResult, indexAttachments);
+                    Optional<String> bodyText = parsingResult.locateFirstTextBody();
+                    Optional<String> bodyHtml = parsingResult.locateFirstHtmlBody();
 
-            HeaderCollection headerCollection = parsingResult.getHeaderCollection();
-            ZonedDateTime internalDate = getSanitizedInternalDate(message, zoneId);
+                    boolean hasAttachment = MessageAttachmentMetadata.hasNonInlinedAttachment(message.getAttachments());
+                    List<MimePart> attachments = setFlattenedAttachments(parsingResult, indexAttachments);
 
-            List<HeaderCollection.Header> headers = headerCollection.getHeaders();
-            Subjects subjects = Subjects.from(headerCollection.getSubjectSet());
-            EMailers from = EMailers.from(headerCollection.getFromAddressSet());
-            EMailers to = EMailers.from(headerCollection.getToAddressSet());
-            EMailers cc = EMailers.from(headerCollection.getCcAddressSet());
-            EMailers bcc = EMailers.from(headerCollection.getBccAddressSet());
-            String sentDate = DATE_TIME_FORMATTER.format(headerCollection.getSentDate().orElse(internalDate));
-            Optional<String> mimeMessageID = headerCollection.getMessageID();
+                    HeaderCollection headerCollection = parsingResult.getHeaderCollection();
+                    ZonedDateTime internalDate = getSanitizedInternalDate(message, zoneId);
 
-            long uid = message.getUid().asLong();
-            String mailboxId = message.getMailboxId().serialize();
-            ModSeq modSeq = message.getModSeq();
-            long size = message.getFullContentOctets();
-            String date = DATE_TIME_FORMATTER.format(getSanitizedInternalDate(message, zoneId));
-            String mediaType = message.getMediaType();
-            String subType = message.getSubType();
-            boolean isAnswered = message.isAnswered();
-            boolean isDeleted = message.isDeleted();
-            boolean isDraft = message.isDraft();
-            boolean isFlagged = message.isFlagged();
-            boolean isRecent = message.isRecent();
-            boolean isUnRead = !message.isSeen();
-            String[] userFlags = message.createFlags().getUserFlags();
+                    List<HeaderCollection.Header> headers = headerCollection.getHeaders();
+                    Subjects subjects = Subjects.from(headerCollection.getSubjectSet());
+                    EMailers from = EMailers.from(headerCollection.getFromAddressSet());
+                    EMailers to = EMailers.from(headerCollection.getToAddressSet());
+                    EMailers cc = EMailers.from(headerCollection.getCcAddressSet());
+                    EMailers bcc = EMailers.from(headerCollection.getBccAddressSet());
+                    String sentDate = DATE_TIME_FORMATTER.format(headerCollection.getSentDate().orElse(internalDate));
+                    Optional<String> mimeMessageID = headerCollection.getMessageID();
 
-            return new IndexableMessage(
-                    attachments,
-                    bcc,
-                    bodyHtml,
-                    bodyText,
-                    cc,
-                    date,
-                    from,
-                    hasAttachment,
-                    headers,
-                    isAnswered,
-                    isDeleted,
-                    isDraft,
-                    isFlagged,
-                    isRecent,
-                    isUnRead,
-                    mailboxId,
-                    mediaType,
-                    messageId,
-                    threadId,
-                    modSeq,
-                    sentDate,
-                    size,
-                    subjects,
-                    subType,
-                    to,
-                    uid,
-                    userFlags,
-                    mimeMessageID);
+                    long uid = message.getUid().asLong();
+                    String mailboxId = message.getMailboxId().serialize();
+                    ModSeq modSeq = message.getModSeq();
+                    long size = message.getFullContentOctets();
+                    String date = DATE_TIME_FORMATTER.format(getSanitizedInternalDate(message, zoneId));
+                    String mediaType = message.getMediaType();
+                    String subType = message.getSubType();
+                    boolean isAnswered = message.isAnswered();
+                    boolean isDeleted = message.isDeleted();
+                    boolean isDraft = message.isDraft();
+                    boolean isFlagged = message.isFlagged();
+                    boolean isRecent = message.isRecent();
+                    boolean isUnRead = !message.isSeen();
+                    String[] userFlags = message.createFlags().getUserFlags();
+
+                    return new IndexableMessage(
+                        attachments,
+                        bcc,
+                        bodyHtml,
+                        bodyText,
+                        cc,
+                        date,
+                        from,
+                        hasAttachment,
+                        headers,
+                        isAnswered,
+                        isDeleted,
+                        isDraft,
+                        isFlagged,
+                        isRecent,
+                        isUnRead,
+                        mailboxId,
+                        mediaType,
+                        messageId,
+                        threadId,
+                        modSeq,
+                        sentDate,
+                        size,
+                        subjects,
+                        subType,
+                        to,
+                        uid,
+                        userFlags,
+                        mimeMessageID);
+                });
         }
 
         private List<MimePart> setFlattenedAttachments(MimePart parsingResult, IndexAttachments indexAttachments) {

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartContainerBuilder.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartContainerBuilder.java
@@ -22,7 +22,6 @@ package org.apache.james.mailbox.elasticsearch.v7.json;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
-import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.model.ContentType.MediaType;
 import org.apache.james.mailbox.model.ContentType.SubType;
 import org.apache.james.mime4j.stream.Field;
@@ -30,8 +29,6 @@ import org.apache.james.mime4j.stream.Field;
 public interface MimePartContainerBuilder {
 
     MimePart.ParsedMimePart build();
-
-    MimePartContainerBuilder using(TextExtractor textExtractor);
 
     MimePartContainerBuilder addToHeaders(Field field);
 

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartContainerBuilder.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartContainerBuilder.java
@@ -29,7 +29,7 @@ import org.apache.james.mime4j.stream.Field;
 
 public interface MimePartContainerBuilder {
 
-    MimePart build();
+    MimePart.ParsedMimePart build();
 
     MimePartContainerBuilder using(TextExtractor textExtractor);
 
@@ -37,7 +37,7 @@ public interface MimePartContainerBuilder {
 
     MimePartContainerBuilder addBodyContent(InputStream bodyContent);
 
-    MimePartContainerBuilder addChild(MimePart mimePart);
+    MimePartContainerBuilder addChild(MimePart.ParsedMimePart mimePart);
 
     MimePartContainerBuilder addFileName(String fileName);
 

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartParser.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartParser.java
@@ -50,7 +50,7 @@ public class MimePartParser {
     private final TextExtractor textExtractor;
     private final MimeTokenStream stream;
     private final Deque<MimePartContainerBuilder> builderStack;
-    private MimePart result;
+    private MimePart.ParsedMimePart result;
     private MimePartContainerBuilder currentlyBuildMimePart;
 
     public MimePartParser(Message message, TextExtractor textExtractor) {
@@ -63,7 +63,7 @@ public class MimePartParser {
             new DefaultBodyDescriptorBuilder(null, FIELD_PARSER, DecodeMonitor.SILENT));
     }
 
-    public MimePart parse() throws IOException, MimeException {
+    public MimePart.ParsedMimePart parse() throws IOException, MimeException {
         stream.parse(message.getFullContent());
         for (EntityState state = stream.getState(); state != EntityState.T_END_OF_STREAM; state = stream.next()) {
             processMimePart(stream, state);
@@ -107,7 +107,7 @@ public class MimePartParser {
     }
     
     private void closeMimePart() {
-        MimePart bodyMimePart = currentlyBuildMimePart.using(textExtractor).build();
+        MimePart.ParsedMimePart bodyMimePart = currentlyBuildMimePart.using(textExtractor).build();
         if (!builderStack.isEmpty()) {
             builderStack.peek().addChild(bodyMimePart);
         } else {

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartParser.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartParser.java
@@ -78,7 +78,7 @@ public class MimePartParser {
                 stackCurrent();
                 break;
             case T_START_HEADER:
-                currentlyBuildMimePart = MimePart.builder();
+                currentlyBuildMimePart = MimePart.builder(textExtractor::applicable);
                 break;
             case T_FIELD:
                 currentlyBuildMimePart.addToHeaders(stream.getField());
@@ -107,7 +107,7 @@ public class MimePartParser {
     }
     
     private void closeMimePart() {
-        MimePart.ParsedMimePart bodyMimePart = currentlyBuildMimePart.using(textExtractor).build();
+        MimePart.ParsedMimePart bodyMimePart = currentlyBuildMimePart.build();
         if (!builderStack.isEmpty()) {
             builderStack.peek().addChild(bodyMimePart);
         } else {

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/RootMimePartContainerBuilder.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/RootMimePartContainerBuilder.java
@@ -33,10 +33,10 @@ public class RootMimePartContainerBuilder implements MimePartContainerBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RootMimePartContainerBuilder.class);
 
-    private MimePart rootMimePart;
+    private MimePart.ParsedMimePart rootMimePart;
 
     @Override
-    public MimePart build() {
+    public MimePart.ParsedMimePart build() {
         return rootMimePart;
     }
 
@@ -57,7 +57,7 @@ public class RootMimePartContainerBuilder implements MimePartContainerBuilder {
     }
 
     @Override
-    public MimePartContainerBuilder addChild(MimePart mimePart) {
+    public MimePartContainerBuilder addChild(MimePart.ParsedMimePart mimePart) {
         if (rootMimePart == null) {
             rootMimePart = mimePart;
         } else {

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/RootMimePartContainerBuilder.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/json/RootMimePartContainerBuilder.java
@@ -22,7 +22,6 @@ package org.apache.james.mailbox.elasticsearch.v7.json;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
-import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.model.ContentType.MediaType;
 import org.apache.james.mailbox.model.ContentType.SubType;
 import org.apache.james.mime4j.stream.Field;
@@ -38,10 +37,6 @@ public class RootMimePartContainerBuilder implements MimePartContainerBuilder {
     @Override
     public MimePart.ParsedMimePart build() {
         return rootMimePart;
-    }
-
-    @Override public MimePartContainerBuilder using(TextExtractor textExtractor) {
-        return this;
     }
 
     @Override

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessageTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessageTest.java
@@ -56,6 +56,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import reactor.core.publisher.Mono;
+
 class IndexableMessageTest {
     static final MessageUid MESSAGE_UID = MessageUid.of(154);
 
@@ -108,7 +110,8 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
-                .build();
+                .build()
+                .block();
 
         // Then
         assertThat(indexableMessage.getHasAttachment()).isTrue();
@@ -140,7 +143,8 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.NO)
-                .build();
+                .build()
+                .block();
 
         // Then
         assertThat(indexableMessage.getHasAttachment()).isFalse();
@@ -170,7 +174,8 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.NO)
-                .build();
+                .build()
+                .block();
 
         // Then
         assertThat(indexableMessage.getAttachments()).isEmpty();
@@ -200,7 +205,8 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
-                .build();
+                .build()
+                .block();
 
         // Then
         assertThat(indexableMessage.getAttachments()).isNotEmpty();
@@ -226,10 +232,10 @@ class IndexableMessageTest {
             .thenReturn(MESSAGE_UID);
 
         TextExtractor textExtractor = mock(TextExtractor.class);
-        when(textExtractor.extractContent(any(), any()))
-            .thenReturn(new ParsedContent(Optional.of("first attachment content"), ImmutableMap.of()))
-            .thenThrow(new RuntimeException("second cannot be parsed"))
-            .thenReturn(new ParsedContent(Optional.of("third attachment content"), ImmutableMap.of()));
+        when(textExtractor.extractContentReactive(any(), any()))
+            .thenReturn(Mono.just(new ParsedContent(Optional.of("first attachment content"), ImmutableMap.of())))
+            .thenReturn(Mono.error(new RuntimeException("second cannot be parsed")))
+            .thenReturn(Mono.just(new ParsedContent(Optional.of("third attachment content"), ImmutableMap.of())));
 
         // When
         IndexableMessage indexableMessage = IndexableMessage.builder()
@@ -237,7 +243,8 @@ class IndexableMessageTest {
                 .extractor(textExtractor)
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
-                .build();
+                .build()
+                .block();
 
         // Then
         String NO_TEXTUAL_BODY = "The textual body is not present";
@@ -273,7 +280,8 @@ class IndexableMessageTest {
                 .extractor(textExtractor)
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
-                .build();
+                .build()
+                .block();
 
         // Then
         assertThat(indexableMessage.getMessageId()).isNull();
@@ -306,7 +314,8 @@ class IndexableMessageTest {
             .extractor(textExtractor)
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.YES)
-            .build();
+            .build()
+            .block();
 
         // Then
         assertThat(indexableMessage.getThreadId()).isNull();
@@ -336,7 +345,8 @@ class IndexableMessageTest {
                 .extractor(textExtractor)
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
-                .build();
+                .build()
+                .block();
 
         // Then
         assertThat(indexableMessage.getMessageId()).isNull();
@@ -368,7 +378,8 @@ class IndexableMessageTest {
             .extractor(textExtractor)
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.YES)
-            .build();
+            .build()
+            .block();
 
         // Then
         assertThat(indexableMessage.getThreadId()).isNull();
@@ -401,7 +412,8 @@ class IndexableMessageTest {
             .extractor(new DefaultTextExtractor())
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.NO)
-            .build();
+            .build()
+            .block();
 
         // Then
         assertThat(indexableMessage.getThreadId()).isEqualTo("42");

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessageTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/IndexableMessageTest.java
@@ -232,6 +232,7 @@ class IndexableMessageTest {
             .thenReturn(MESSAGE_UID);
 
         TextExtractor textExtractor = mock(TextExtractor.class);
+        when(textExtractor.applicable(any())).thenReturn(true);
         when(textExtractor.extractContentReactive(any(), any()))
             .thenReturn(Mono.just(new ParsedContent(Optional.of("first attachment content"), ImmutableMap.of())))
             .thenReturn(Mono.error(new RuntimeException("second cannot be parsed")))

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MessageToElasticSearchJsonTest.java
@@ -107,7 +107,7 @@ class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
-        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail))
+        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail).block())
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/spamMail.json"));
     }
@@ -129,7 +129,7 @@ class MessageToElasticSearchJsonTest {
         mail.setUid(UID);
         mail.setModSeq(MOD_SEQ);
 
-        assertThatJson(messageToElasticSearchJson.convertToJson(mail))
+        assertThatJson(messageToElasticSearchJson.convertToJson(mail).block())
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/inlined-mixed.json"));
     }
@@ -151,7 +151,7 @@ class MessageToElasticSearchJsonTest {
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
 
-        String actual = messageToElasticSearchJson.convertToJson(spamMail);
+        String actual = messageToElasticSearchJson.convertToJson(spamMail).block();
         assertThatJson(actual)
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/invalidCharset.json"));
@@ -173,7 +173,7 @@ class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         htmlMail.setModSeq(MOD_SEQ);
         htmlMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(htmlMail))
+        assertThatJson(messageToElasticSearchJson.convertToJson(htmlMail).block())
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/htmlMail.json"));
     }
@@ -194,7 +194,7 @@ class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         pgpSignedMail.setModSeq(MOD_SEQ);
         pgpSignedMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(pgpSignedMail))
+        assertThatJson(messageToElasticSearchJson.convertToJson(pgpSignedMail).block())
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/pgpSignedMail.json"));
     }
@@ -215,7 +215,7 @@ class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         mail.setModSeq(MOD_SEQ);
         mail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(mail))
+        assertThatJson(messageToElasticSearchJson.convertToJson(mail).block())
             .when(IGNORING_ARRAY_ORDER).when(IGNORING_VALUES)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/mail.json"));
     }
@@ -236,7 +236,7 @@ class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         recursiveMail.setModSeq(MOD_SEQ);
         recursiveMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(recursiveMail))
+        assertThatJson(messageToElasticSearchJson.convertToJson(recursiveMail).block())
             .when(IGNORING_ARRAY_ORDER).when(IGNORING_VALUES)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMail.json"));
     }
@@ -257,7 +257,7 @@ class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         mailWithNoInternalDate.setModSeq(MOD_SEQ);
         mailWithNoInternalDate.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(mailWithNoInternalDate))
+        assertThatJson(messageToElasticSearchJson.convertToJson(mailWithNoInternalDate).block())
             .when(IGNORING_ARRAY_ORDER)
             .when(IGNORING_VALUES)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMail.json"));
@@ -283,7 +283,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"),
             IndexAttachments.YES);
-        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate);
+        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate).block();
 
         // Then
         assertThatJson(convertToJson)
@@ -312,7 +312,7 @@ class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"),
             IndexAttachments.NO);
-        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate);
+        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate).block();
 
         // Then
         assertThatJson(convertToJson)
@@ -388,7 +388,7 @@ class MessageToElasticSearchJsonTest {
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
 
-        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail))
+        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail).block())
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(
                 ClassLoaderUtils.getSystemResourceAsString("eml/nonTextual.json", StandardCharsets.UTF_8));
@@ -414,7 +414,7 @@ class MessageToElasticSearchJsonTest {
                 new DefaultTextExtractor(),
                 ZoneId.of("Europe/Paris"),
                 IndexAttachments.NO);
-        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message);
+        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message).block();
 
         // Then
         assertThatJson(convertToJsonWithoutAttachment)
@@ -443,9 +443,7 @@ class MessageToElasticSearchJsonTest {
                 new JsoupTextExtractor(),
                 ZoneId.of("Europe/Paris"),
                 IndexAttachments.NO);
-        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message);
-
-        System.out.println(convertToJsonWithoutAttachment);
+        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message).block();
 
         // Then
         assertThatJson(convertToJsonWithoutAttachment)

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.model.ContentType.MediaType;
 import org.apache.james.mailbox.model.ContentType.SubType;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,9 @@ class MimePartTest {
             .addBodyContent(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)))
             .addMediaType(MediaType.of("text"))
             .addSubType(SubType.of("plain"))
-            .build();
+            .build()
+            .asMimePart((in, contentType) -> ParsedContent.empty())
+            .block();
 
         assertThat(mimePart.getTextualBody()).contains(body);
     }

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/json/MimePartTest.java
@@ -32,7 +32,7 @@ class MimePartTest {
 
     @Test
     void buildShouldWorkWhenTextualContentFromParserIsEmpty() {
-        MimePart.builder()
+        MimePart.builder(contentType -> true)
             .addBodyContent(new ByteArrayInputStream(new byte[] {}))
             .addMediaType(MediaType.of("text"))
             .addSubType(SubType.of("plain"))
@@ -42,7 +42,7 @@ class MimePartTest {
     @Test
     void buildShouldWorkWhenTextualContentFromParserIsNonEmpty() {
         String body = "text";
-        MimePart mimePart = MimePart.builder()
+        MimePart mimePart = MimePart.builder(contentType -> true)
             .addBodyContent(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)))
             .addMediaType(MediaType.of("text"))
             .addSubType(SubType.of("plain"))

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
@@ -36,10 +36,14 @@ import org.apache.james.mailbox.model.ContentType;
  * Costs less calculations that TikaTextExtractor, but result is not that good.
  */
 public class DefaultTextExtractor implements TextExtractor {
+    @Override
+    public boolean applicable(ContentType contentType) {
+        return contentType != null && contentType.asString().startsWith("text/");
+    }
 
     @Override
     public ParsedContent extractContent(InputStream inputStream, ContentType contentType) throws Exception {
-        if (contentType != null && contentType.asString().startsWith("text/")) {
+        if (applicable(contentType)) {
             Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
             return new ParsedContent(Optional.ofNullable(IOUtils.toString(inputStream, charset)), new HashMap<>());
         } else {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
@@ -30,6 +30,9 @@ import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.model.ContentType;
 
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
 /**
  * A default text extractor that is directly based on the input file provided.
  * 
@@ -48,6 +51,17 @@ public class DefaultTextExtractor implements TextExtractor {
             return new ParsedContent(Optional.ofNullable(IOUtils.toString(inputStream, charset)), new HashMap<>());
         } else {
             return new ParsedContent(Optional.empty(), new HashMap<>());
+        }
+    }
+
+    @Override
+    public Mono<ParsedContent> extractContentReactive(InputStream inputStream, ContentType contentType) {
+        if (applicable(contentType)) {
+            Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
+            return Mono.fromCallable(() -> new ParsedContent(Optional.ofNullable(IOUtils.toString(inputStream, charset)), new HashMap<>()))
+                .subscribeOn(Schedulers.elastic());
+        } else {
+            return Mono.just(new ParsedContent(Optional.empty(), new HashMap<>()));
         }
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/JsoupTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/JsoupTextExtractor.java
@@ -45,6 +45,14 @@ public class JsoupTextExtractor implements TextExtractor {
     private static final MimeType TEXT_PLAIN = MimeType.of("text/plain");
 
     @Override
+    public boolean applicable(ContentType contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        return contentType.mimeType().equals(TEXT_HTML) || contentType.mimeType().equals(TEXT_PLAIN);
+    }
+
+    @Override
     public ParsedContent extractContent(InputStream inputStream, ContentType contentType) throws Exception {
         if (inputStream == null || contentType == null) {
             return ParsedContent.empty();

--- a/mailbox/tika/pom.xml
+++ b/mailbox/tika/pom.xml
@@ -64,8 +64,16 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/ContentTypeFilteringTextExtractor.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/ContentTypeFilteringTextExtractor.java
@@ -41,6 +41,11 @@ public class ContentTypeFilteringTextExtractor implements TextExtractor {
     }
 
     @Override
+    public boolean applicable(ContentType contentType) {
+        return !isBlacklisted(contentType.mimeType());
+    }
+
+    @Override
     public ParsedContent extractContent(InputStream inputStream, ContentType contentType) throws Exception {
         if (isBlacklisted(contentType.mimeType())) {
             return ParsedContent.empty();

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/ContentTypeFilteringTextExtractor.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/ContentTypeFilteringTextExtractor.java
@@ -28,6 +28,8 @@ import org.apache.james.mailbox.model.ContentType.MimeType;
 
 import com.google.common.collect.ImmutableSet;
 
+import reactor.core.publisher.Mono;
+
 public class ContentTypeFilteringTextExtractor implements TextExtractor {
 
     private final TextExtractor textExtractor;
@@ -44,6 +46,14 @@ public class ContentTypeFilteringTextExtractor implements TextExtractor {
             return ParsedContent.empty();
         }
         return textExtractor.extractContent(inputStream, contentType);
+    }
+
+    @Override
+    public Mono<ParsedContent> extractContentReactive(InputStream inputStream, ContentType contentType) {
+        if (isBlacklisted(contentType.mimeType())) {
+            return Mono.just(ParsedContent.empty());
+        }
+        return textExtractor.extractContentReactive(inputStream, contentType);
     }
 
     private boolean isBlacklisted(MimeType contentType) {

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaHttpClient.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaHttpClient.java
@@ -19,11 +19,12 @@
 package org.apache.james.mailbox.tika;
 
 import java.io.InputStream;
-import java.util.Optional;
 
 import org.apache.james.mailbox.model.ContentType;
 
+import reactor.core.publisher.Mono;
+
 public interface TikaHttpClient {
 
-    Optional<InputStream> recursiveMetaDataAsJson(InputStream inputStream, ContentType contentType);
+    Mono<InputStream> recursiveMetaDataAsJson(InputStream inputStream, ContentType contentType);
 }

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
@@ -26,7 +26,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
@@ -41,6 +40,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.TextNode;
+
+import reactor.core.publisher.Mono;
 
 class TikaTextExtractorTest {
 
@@ -170,7 +171,7 @@ class TikaTextExtractorTest {
     void deserializerShouldNotThrowWhenMoreThanOneNode() throws Exception {
         TikaTextExtractor textExtractor = new TikaTextExtractor(
             new RecordingMetricFactory(),
-            (inputStream, contentType) -> Optional.of(new ByteArrayInputStream(("[{\"X-TIKA:content\": \"This is an awesome LibreOffice document !\"}, " +
+            (inputStream, contentType) -> Mono.just(new ByteArrayInputStream(("[{\"X-TIKA:content\": \"This is an awesome LibreOffice document !\"}, " +
                                                             "{\"Chroma BlackIsZero\": \"true\"}]")
                                                         .getBytes(StandardCharsets.UTF_8))));
 
@@ -183,7 +184,7 @@ class TikaTextExtractorTest {
         String expectedExtractedContent = "content A";
         TikaTextExtractor textExtractor = new TikaTextExtractor(
             new RecordingMetricFactory(),
-            (inputStream, contentType) -> Optional.of(new ByteArrayInputStream(("[{\"X-TIKA:content\": \"" + expectedExtractedContent + "\"}, " +
+            (inputStream, contentType) -> Mono.just(new ByteArrayInputStream(("[{\"X-TIKA:content\": \"" + expectedExtractedContent + "\"}, " +
                                                             "{\"X-TIKA:content\": \"content B\"}]")
                                                         .getBytes(StandardCharsets.UTF_8))));
 
@@ -198,7 +199,7 @@ class TikaTextExtractorTest {
     void deserializerShouldThrowWhenNodeIsNotAnObject() {
         TikaTextExtractor textExtractor = new TikaTextExtractor(
             new RecordingMetricFactory(),
-            (inputStream, contentType) -> Optional.of(new ByteArrayInputStream("[\"value1\"]"
+            (inputStream, contentType) -> Mono.just(new ByteArrayInputStream("[\"value1\"]"
                                                         .getBytes(StandardCharsets.UTF_8))));
 
         InputStream inputStream = new ByteArrayInputStream("toto".getBytes(StandardCharsets.UTF_8));

--- a/pom.xml
+++ b/pom.xml
@@ -2091,6 +2091,11 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>3.0.5</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.dpaukov</groupId>
                 <artifactId>combinatoricslib3</artifactId>
                 <version>3.3.2</version>


### PR DESCRIPTION
Tika was called from reactive code and was doing blocking HTTP calls from within
the MIME parsing code.

This generate:
 - An unneeded thread consumption as we have some threads waiting for Tika
   response
 - Potentially dangerous blocking calls: for instance the InVM event bus was
  doing such calls on the parallel thread pool (where it is critical NOT to
  block)...
 - Also the connection was opened on a per-call basis, not being reused.

 We introduce the following changes:
  - Reactification of the TextExtractor API
  - We re-implement the HTTP calls done by TikaTextExtractor with reactor-netty
  which allows us to pool HTTP connections and do this in a non-blocking
  reactive fashion.
  - We provide a reactive cache using the caffeine caching library - Guava
  caches are blocking thus not an option...
  - We uncouple the text extraction from the MIME parsing phase by introducing
  an intermediate POJO. Doing so requires us to do a post-parsing copy of
  content.

 Only do the copy if necessary. We don't want to copy large attachments for whom no text is going to be extracted...

  - Finally we reactify index content generation for ElasticSearch code.