### PR TITLE
[JAMES-3721] Fixes ObjectNotFoundExceptions when browsing mails

### DIFF
--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
@@ -138,6 +138,23 @@ public interface ManageableMailQueueContract extends MailQueueContract {
     }
 
     @Test
+    default void browseShouldReturnEmptyWhenSingleDequeueMessage() throws Exception {
+        var mail = defaultMail()
+                .name("name")
+                .build();
+        enQueue(mail);
+
+        MailQueue.MailQueueItem mailQueueItem = Flux.from(getMailQueue().deQueue()).blockFirst();
+        mailQueueItem.done(true);
+
+        ManageableMailQueue.MailQueueIterator items = getManageableMailQueue().browse();
+
+        assertThat(items)
+                .toIterable()
+                .isEmpty();
+    }
+
+    @Test
     default void browseShouldReturnElementsInOrder() throws Exception {
         enQueue(defaultMail()
             .name("name1")

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
@@ -144,8 +144,9 @@ public interface ManageableMailQueueContract extends MailQueueContract {
                 .build();
         enQueue(mail);
 
-        MailQueue.MailQueueItem mailQueueItem = Flux.from(getMailQueue().deQueue()).blockFirst();
-        mailQueueItem.done(true);
+        Flux.from(getManageableMailQueue().deQueue())
+                .doOnNext(Throwing.consumer(item -> item.done(true)))
+                .blockFirst();
 
         ManageableMailQueue.MailQueueIterator items = getManageableMailQueue().browse();
 


### PR DESCRIPTION
They can have been acknowledged and thus the underlying mime message removed from the store since we started browsing. We therefore ignore messages that can no longer be found in the mime message store. 