### PR TITLE
JAMES-3433 MimeMessageStore StoragePolicy should be the same on read …

### DIFF
--- a/server/blob/mail-store/src/main/java/org/apache/james/blob/mail/MimeMessageStore.java
+++ b/server/blob/mail-store/src/main/java/org/apache/james/blob/mail/MimeMessageStore.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.blob.mail;
 
+import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
 import static org.apache.james.blob.api.BlobStore.StoragePolicy.SIZE_BASED;
 import static org.apache.james.blob.mail.MimeMessagePartsId.BODY_BLOB_TYPE;
 import static org.apache.james.blob.mail.MimeMessagePartsId.HEADER_BLOB_TYPE;
@@ -104,7 +105,7 @@ public class MimeMessageStore {
                                 throw new IOException("Failed accessing body size", e);
                             }
                         }
-                    }, SIZE_BASED))));
+                    }, LOW_COST))));
         }
     }
 


### PR DESCRIPTION
…and writes

We were using size based for bodies upon writes while we were only reading them
as low cost. Thus upon writes we were needlessly applying the caching logic that:

 - Reads eagerly 8KB into RAM (memory allocation)
 - Saves uneeded data into Cassandra (storage cost and performance impact of the
 query execution)

Turning bodies write to also use `low cost`.