### PR TITLE
JAMES-3715 Add TCP transport level tests for IMAP IDLE

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import javax.mail.Flags;
 
+import org.apache.james.events.EventListener;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.NullableMessageSequenceNumber;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -41,6 +42,10 @@ public interface SelectedMailbox {
      * Deselect the Mailbox
      */
     void deselect();
+
+    void registerIdle(EventListener idle);
+
+    void unregisterIdle();
 
     /**
      * Return the msg index of the given uid or {@link NullableMessageSequenceNumber#noMessage()} instance if no

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
@@ -83,7 +83,7 @@ public class DefaultProcessorChain {
         AppendProcessor appendProcessor = new AppendProcessor(examineProcessor, mailboxManager, statusResponseFactory, metricFactory);
         StoreProcessor storeProcessor = new StoreProcessor(appendProcessor, mailboxManager, statusResponseFactory, metricFactory);
         NoopProcessor noopProcessor = new NoopProcessor(storeProcessor, mailboxManager, statusResponseFactory, metricFactory);
-        IdleProcessor idleProcessor = new IdleProcessor(noopProcessor, mailboxManager, eventBus, statusResponseFactory, metricFactory);
+        IdleProcessor idleProcessor = new IdleProcessor(noopProcessor, mailboxManager, statusResponseFactory, metricFactory);
         StatusProcessor statusProcessor = new StatusProcessor(idleProcessor, mailboxManager, statusResponseFactory, metricFactory);
         LSubProcessor lsubProcessor = new LSubProcessor(statusProcessor, mailboxManager, subscriptionManager, statusResponseFactory, metricFactory);
         XListProcessor xlistProcessor = new XListProcessor(lsubProcessor, mailboxManager, statusResponseFactory, mailboxTyper, metricFactory);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -75,6 +75,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
 
 
     private static final Void VOID = null;
+    private static final Flag UNINTERESTING_FLAGS = Flag.RECENT;
 
     @VisibleForTesting
     static class ApplicableFlags {
@@ -126,7 +127,6 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     private final UidMsnConverter uidMsnConverter;
     private final Set<MessageUid> recentUids = new TreeSet<>();
     private final Set<MessageUid> flagUpdateUids = new TreeSet<>();
-    private final Flags.Flag uninterestingFlag = Flags.Flag.RECENT;
     private final Set<MessageUid> expungedUids = new TreeSet<>();
     private final Object applicableFlagsLock = new Object();
 
@@ -263,16 +263,12 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
         final Iterator<Flags.Flag> it = updated.modifiedSystemFlags().iterator();
         if (it.hasNext()) {
             final Flags.Flag flag = it.next();
-            if (flag.equals(uninterestingFlag)) {
-                result = false;
-            } else {
-                result = true;
-            }
+            result = !flag.equals(UNINTERESTING_FLAGS);
         } else {
             result = false;
         }
         // See if we need to check the user flags
-        if (result == false) {
+        if (!result) {
             final Iterator<String> userIt = updated.userFlagIterator();
             result = userIt.hasNext();
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
@@ -61,6 +62,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.UpdatedFlags;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -129,7 +131,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     private final Set<MessageUid> flagUpdateUids = new TreeSet<>();
     private final Set<MessageUid> expungedUids = new TreeSet<>();
     private final Object applicableFlagsLock = new Object();
-
+    private final AtomicReference<EventListener> idleEventListener = new AtomicReference<>();
     private boolean recentUidRemoved = false;
     private boolean isDeletedByOtherSession = false;
     private boolean sizeChanged = false;
@@ -161,6 +163,16 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
             .collect(ImmutableList.toImmutableList())
             .block();
         uidMsnConverter.addAll(uids);
+    }
+
+    @Override
+    public void registerIdle(EventListener idle) {
+        idleEventListener.set(idle);
+    }
+
+    @Override
+    public void unregisterIdle() {
+        idleEventListener.set(null);
     }
 
     @Override
@@ -369,11 +381,12 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     
     @Override
     public synchronized void event(Event event) {
-
         if (event instanceof MailboxEvent) {
             MailboxEvent mailboxEvent = (MailboxEvent) event;
             mailboxEvent(mailboxEvent);
         }
+        Optional.ofNullable(idleEventListener.get())
+            .ifPresent(Throwing.<EventListener>consumer(listener -> listener.event(event)).sneakyThrow());
     }
 
     private void mailboxEvent(MailboxEvent mailboxEvent) {

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -1004,8 +1004,8 @@ class IMAPServerTest {
 
         @AfterEach
         void tearDown() throws Exception {
-            imapServer.destroy();
             clientConnection.close();
+            imapServer.destroy();
         }
 
         @Test
@@ -1058,7 +1058,7 @@ class IMAPServerTest {
         }
 
         @Test
-        void idleShouldResponsesShouldBeOrdered() throws Exception {
+        void idleResponsesShouldBeOrdered() throws Exception {
             clientConnection.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
             readBytes(clientConnection);
 


### PR DESCRIPTION
In the face of Netty4 migration, pipeline modifications (which IDLE does)
deserves to be seriously tested.