### PR TITLE
JAMES-1862 Fix several issues with STARTTLS command injection detection

### DIFF
--- a/mpt/core/src/main/java/org/apache/james/mpt/session/ExternalSession.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/session/ExternalSession.java
@@ -160,14 +160,7 @@ public final class ExternalSession implements Session {
     public void writeLine(String line) throws Exception {
         monitor.note("-> " + line);
         monitor.debug("[Writing line]");
-        ByteBuffer writeBuffer = US_ASCII.encode(line);
-        while (writeBuffer.hasRemaining()) {
-            socket.write(writeBuffer);
-        }
-        lineEndBuffer.rewind();
-        while (lineEndBuffer.hasRemaining()) {
-            socket.write(lineEndBuffer);
-        }
+        socket.write(ByteBuffer.wrap((line + "\r\n").getBytes(US_ASCII)));
         monitor.debug("[Done]");
     }
 

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/AbstractProtocolTransport.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/AbstractProtocolTransport.java
@@ -53,6 +53,7 @@ public abstract class AbstractProtocolTransport implements ProtocolTransport {
             // reset state on starttls
             if (startTLS) {
                 session.resetState();
+                session.stopDetectingCommandInjection();
             }
 
             if (response.isEndSession()) {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -163,7 +163,7 @@ public class NettyImapSession implements ImapSession, NettyConstants {
 
         filter.engine().setUseClientMode(false);
         channel.pipeline().addFirst(SSL_HANDLER, filter);
-
+        stopDetectingCommandInjection();
         channel.config().setAutoRead(true);
 
         return true;

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
@@ -62,4 +62,9 @@ public class SwitchableLineBasedFrameDecoder extends AllButStartTlsLineBasedChan
         }
         return trimmedInput.substring(tagEnd + 1);
     }
+
+    @Override
+    protected boolean hasStartTLS(String trimedLowerCasedInput) {
+        return super.hasStartTLS(removeTag(trimedLowerCasedInput));
+    }
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/SwitchableLineBasedFrameDecoder.java
@@ -56,7 +56,7 @@ public class SwitchableLineBasedFrameDecoder extends AllButStartTlsLineBasedChan
 
     protected String removeTag(String input) {
         String trimmedInput = input.trim();
-        int tagEnd = input.indexOf(' ');
+        int tagEnd = trimmedInput.indexOf(' ');
         if (tagEnd < 0) {
             return input;
         }

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -447,6 +447,15 @@ class IMAPServerTest {
         }
 
         @Test
+        void tagsShouldBeWellSanitized() throws Exception {
+            IMAPSClient imapClient = new IMAPSClient();
+            imapClient.connect("127.0.0.1", port);
+            assertThatThrownBy(() -> imapClient.sendCommand("NOOP\r\n A1 STARTTLS\r\nA2 NOOP"))
+                .isInstanceOf(EOFException.class)
+                .hasMessage("Connection closed without indication.");
+        }
+
+        @Test
         void lineFollowingStartTLSShouldBeSanitized() throws Exception {
             IMAPSClient imapClient = new IMAPSClient();
             imapClient.connect("127.0.0.1", port);

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -493,6 +493,15 @@ class IMAPServerTest {
         }
 
         @Test
+        void extraLFLinesBatchedWithStartTLSShouldBeSanitized() throws Exception {
+            IMAPSClient imapClient = new IMAPSClient();
+            imapClient.connect("127.0.0.1", port);
+            assertThatThrownBy(() -> imapClient.sendCommand("STARTTLS\nA1 NOOP\r\n"))
+                .isInstanceOf(EOFException.class)
+                .hasMessage("Connection closed without indication.");
+        }
+
+        @Test
         void tagsShouldBeWellSanitized() throws Exception {
             IMAPSClient imapClient = new IMAPSClient();
             imapClient.connect("127.0.0.1", port);

--- a/server/protocols/protocols-imap4/src/test/resources/imapServerStartTLS.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapServerStartTLS.xml
@@ -1,7 +1,7 @@
 <imapserver enabled="true">
     <jmxName>imapserver</jmxName>
     <bind>0.0.0.0:0</bind>
-    <tls socketTLS="false" startTLS="false">
+    <tls socketTLS="false" startTLS="true">
         <keystore>classpath://keystore</keystore>
         <secret>james72laBalle</secret>
         <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>

--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ChannelManageSieveResponseWriter.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ChannelManageSieveResponseWriter.java
@@ -31,6 +31,7 @@ import io.netty.handler.stream.ChunkedStream;
 public class ChannelManageSieveResponseWriter implements CommandDetectionSession {
     private final Channel channel;
     private String cumulation = null;
+    private boolean needsCommandInjectionDetection = true;
 
     public ChannelManageSieveResponseWriter(Channel channel) {
         this.channel = channel;
@@ -45,17 +46,17 @@ public class ChannelManageSieveResponseWriter implements CommandDetectionSession
 
     @Override
     public boolean needsCommandInjectionDetection() {
-        return false;
+        return needsCommandInjectionDetection;
     }
 
     @Override
     public void startDetectingCommandInjection() {
-
+        needsCommandInjectionDetection = true;
     }
 
     @Override
     public void stopDetectingCommandInjection() {
-
+        needsCommandInjectionDetection = false;
     }
 
     public void resetCumulation() {

--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
@@ -48,8 +48,7 @@ public class ManageSieveChannelUpstreamHandler extends ChannelInboundHandlerAdap
     private final ManageSieveProcessor manageSieveProcessor;
     private final Encryption secure;
 
-    public ManageSieveChannelUpstreamHandler(
-            ManageSieveProcessor manageSieveProcessor, Encryption secure, Logger logger) {
+    public ManageSieveChannelUpstreamHandler(ManageSieveProcessor manageSieveProcessor, Encryption secure, Logger logger) {
         this.logger = logger;
         this.manageSieveProcessor = manageSieveProcessor;
         this.secure = secure;
@@ -76,6 +75,7 @@ public class ManageSieveChannelUpstreamHandler extends ChannelInboundHandlerAdap
                 turnSSLon(ctx.channel());
                 manageSieveSession.setSslEnabled(true);
                 manageSieveSession.setState(Session.State.UNAUTHENTICATED);
+                attachment.stopDetectingCommandInjection();
             }
         } catch (NotEnoughDataException ex) {
             // Do nothing will keep the cumulation


### PR DESCRIPTION
 - Race condition between the framing handler and the processing handler allows to leverage concurrency based man in the middle attacks allowing command injection.
 - Bad sanitizing of IMAP tags allow crafting an input that bypasses STARTTLS command detection