### PR TITLE
[PERF] Better name James' threads

### DIFF
--- a/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ClientProvider.java
+++ b/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ClientProvider.java
@@ -48,6 +48,7 @@ import org.apache.james.backends.es.v7.ElasticSearchConfiguration.HostScheme;
 import org.apache.james.backends.es.v7.ElasticSearchConfiguration.SSLConfiguration.HostNameVerifier;
 import org.apache.james.backends.es.v7.ElasticSearchConfiguration.SSLConfiguration.SSLTrustStore;
 import org.apache.james.backends.es.v7.ElasticSearchConfiguration.SSLConfiguration.SSLValidationStrategy;
+import org.apache.james.util.concurrent.NamedThreadFactory;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
@@ -74,6 +75,8 @@ public class ClientProvider implements Provider<ReactorElasticSearchClient> {
             configureAuthentication(builder);
             configureHostScheme(builder);
             configureTimeout(builder);
+
+            builder.setThreadFactory(NamedThreadFactory.withName("ElasticSearch-driver"));
 
             return builder;
         }

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
@@ -39,6 +39,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.TrustStrategy;
+import org.apache.james.util.concurrent.NamedThreadFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.rabbitmq.client.Address;
@@ -66,6 +67,7 @@ public class RabbitMQConnectionFactory {
     private ConnectionFactory from(RabbitMQConfiguration rabbitMQConfiguration) {
         try {
             ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.setThreadFactory(NamedThreadFactory.withName("rabbitmq-driver"));
             connectionFactory.setUri(rabbitMQConfiguration.getUri());
             connectionFactory.setHandshakeTimeout(rabbitMQConfiguration.getHandshakeTimeoutInMs());
             connectionFactory.setShutdownTimeout(rabbitMQConfiguration.getShutdownTimeoutInMs());


### PR DESCRIPTION
Because audit of thread counts with tools like `jstack` reports a lot of unamed threads that we can hardly audit.

```
"pool-10-thread-1" #26 prio=5 os_prio=0 cpu=509.34ms elapsed=9834.34s tid=0x00007faaabf67000 nid=0x25 runnable  [0x00007faa221b6000]
   java.lang.Thread.State: RUNNABLE
	at sun.nio.ch.EPoll.wait(java.base@11.0.14.1/Native Method)
	at sun.nio.ch.EPollSelectorImpl.doSelect(java.base@11.0.14.1/Unknown Source)
	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.14.1/Unknown Source)
	- locked <0x0000000741f969d8> (a sun.nio.ch.Util$2)
	- locked <0x0000000741f96888> (a sun.nio.ch.EPollSelectorImpl)
	at sun.nio.ch.SelectorImpl.select(java.base@11.0.14.1/Unknown Source)
	at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor.execute(AbstractMultiworkerIOReactor.java:343)
	at org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager.execute(PoolingNHttpClientConnectionManager.java:221)
	at org.apache.http.impl.nio.client.CloseableHttpAsyncClientBase$1.run(CloseableHttpAsyncClientBase.java:64)
	at java.lang.Thread.run(java.base@11.0.14.1/Unknown Source)
```

For instance...