### PR TITLE
JAMES-3594 ReadOnlyLDAPUser adapt log message

### DIFF
--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUser.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUser.java
@@ -129,11 +129,11 @@ public class ReadOnlyLDAPUser implements User {
         try {
             BindResult bindResult = connectionPool.bindAndRevertAuthentication(userDN.toString(), password);
             return bindResult.getResultCode() == ResultCode.SUCCESS;
+        } catch (LDAPBindException e) {
+            LOGGER.info("Error binding LDAP for {}: {}", userName.asString(), e.getMessage());
+            return false;
         } catch (Exception e) {
-            if (e instanceof LDAPBindException) {
-                LOGGER.info("Error binding LDAP for {}: {}", userName.asString(), e.getMessage());
-            }
-            LOGGER.error("Unexpected error upon authentication", e);
+            LOGGER.error("Unexpected error upon authenticationfor {}", userName.asString(), e);
             return false;
         }
     }

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUser.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUser.java
@@ -133,7 +133,7 @@ public class ReadOnlyLDAPUser implements User {
             LOGGER.info("Error binding LDAP for {}: {}", userName.asString(), e.getMessage());
             return false;
         } catch (Exception e) {
-            LOGGER.error("Unexpected error upon authenticationfor {}", userName.asString(), e);
+            LOGGER.error("Unexpected error upon authentication for {}", userName.asString(), e);
             return false;
         }
     }


### PR DESCRIPTION
Wrap the info and warn log into one:

 - error is too high for something that can be caused by bad user input
 - error log was missing critical information like username
 - the info log is duplicated with the error log