### PR TITLE
JAMES-3439 Email/set create should encode attachments in base64

### DIFF
--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailSet.scala
@@ -249,6 +249,7 @@ case class EmailCreationRequest(mailboxIds: MailboxIds,
     bodypartBuilder.setBody(loadedAttachment.content, attachment.`type`.value)
       .setField(contentTypeField(attachment, blob))
       .setContentDisposition(attachment.disposition.getOrElse(Disposition.ATTACHMENT).value)
+      .setContentTransferEncoding("base64")
     attachment.cid.map(_.asField).foreach(bodypartBuilder.addField)
     attachment.location.map(_.asField).foreach(bodypartBuilder.addField)
     attachment.language.map(_.asField).foreach(bodypartBuilder.addField)


### PR DESCRIPTION
Failure to do so will cause invalid characters to be present,
preventing SMTP transmition.

```
host x.x.x.x[x.x.x.x] said: 554 5.6.0
    Message contains NUL characters (in reply to end of DATA command)
```