### PR TITLE
[PERF] Allow disabling host information in protocol MDC

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/ProtocolMDCContextFactory.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/ProtocolMDCContextFactory.java
@@ -32,6 +32,8 @@ import io.netty.channel.ChannelHandlerContext;
 
 
 public interface ProtocolMDCContextFactory {
+    boolean ADD_HOST_TO_MDC = Boolean.parseBoolean(System.getProperty("james.protocols.mdc.hostname", "true"));
+
     class Standard implements ProtocolMDCContextFactory {
         @Override
         public MDCBuilder onBound(Protocol protocol, ChannelHandlerContext ctx) {
@@ -49,10 +51,14 @@ public interface ProtocolMDCContextFactory {
     MDCBuilder withContext(ProtocolSession protocolSession);
 
     static MDCBuilder mdcContext(Protocol protocol, ChannelHandlerContext ctx) {
-        return MDCBuilder.create()
+        MDCBuilder mdc = MDCBuilder.create()
             .addToContext(MDCBuilder.PROTOCOL, protocol.getName())
-            .addToContext(MDCBuilder.IP, retrieveIp(ctx))
-            .addToContext(MDCBuilder.HOST, retrieveHost(ctx));
+            .addToContext(MDCBuilder.IP, retrieveIp(ctx));
+
+        if (ADD_HOST_TO_MDC) {
+            return mdc.addToContext(MDCBuilder.HOST, retrieveHost(ctx));
+        }
+        return mdc;
     }
 
     private static String retrieveIp(ChannelHandlerContext ctx) {

--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -25,3 +25,8 @@
 #   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
 #   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
 #james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
@@ -40,3 +40,16 @@ Allowed mode values are: none, simple, advanced, testing
 
 The purpose of each mode is introduced in `config-system.xml`
 
+== Disabling host information in protocol MDC logging context
+
+Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+
+
+In `jvm.properties`
+----
+james.protocols.mdc.hostname=false
+----
+
+Optional. Boolean. Defaults to true.
+

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -25,3 +25,8 @@
 #   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
 #   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
 #james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -25,3 +25,8 @@
 #   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
 #   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
 #james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -25,3 +25,8 @@
 #   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
 #   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
 #james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -25,3 +25,8 @@
 #   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
 #   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
 #james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -25,3 +25,8 @@
 #   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
 #   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
 #james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPMDCContext.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPMDCContext.java
@@ -25,17 +25,21 @@ import java.util.Optional;
 
 import org.apache.james.core.Username;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.protocols.netty.ProtocolMDCContextFactory;
 import org.apache.james.util.MDCBuilder;
 
 import io.netty.channel.ChannelHandlerContext;
 
 public class IMAPMDCContext {
-
     public static MDCBuilder boundMDC(ChannelHandlerContext ctx) {
-        return MDCBuilder.create()
+        MDCBuilder mdc = MDCBuilder.create()
             .addToContext(MDCBuilder.PROTOCOL, "IMAP")
-            .addToContext(MDCBuilder.IP, retrieveIp(ctx))
-            .addToContext(MDCBuilder.HOST, retrieveHost(ctx));
+            .addToContext(MDCBuilder.IP, retrieveIp(ctx));
+
+        if (ProtocolMDCContextFactory.ADD_HOST_TO_MDC) {
+            return mdc.addToContext(MDCBuilder.HOST, retrieveHost(ctx));
+        }
+        return mdc;
     }
 
     private static String retrieveIp(ChannelHandlerContext ctx) {

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -190,6 +190,12 @@
                         - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources. <br/>
                         - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team. <br/>
                 </dd>
+
+                <dt><strong>james.protocols.mdc.hostname</strong></dt>
+                <dd>Optional. Boolean. Defaults to true. <br/>
+                    Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+                    is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.</dd>
+
             </dl>
 
             </subsection>


### PR DESCRIPTION
Resolving this takes up to 1% of IMAP compute time hence this information,
not necessarily useful, should be dis-activable.