### PR TITLE
JAMES-3731 Fix default configuration for rabbitmq regarding distributed images

### DIFF
--- a/server/apps/distributed-app/sample-configuration/rabbitmq.properties
+++ b/server/apps/distributed-app/sample-configuration/rabbitmq.properties
@@ -7,7 +7,7 @@ uri=amqp://rabbitmq:5672
 
 # Optional, default to the host specified as part of the URI.
 # Allow creating cluster aware connections.
-hosts=ip1:5672,ip2:5672
+# hosts=ip1:5672,ip2:5672
 
 # RabbitMQ Administration Management
 # Mandatory

--- a/server/apps/distributed-pop3-app/sample-configuration/rabbitmq.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/rabbitmq.properties
@@ -7,7 +7,7 @@ uri=amqp://rabbitmq:5672
 
 # Optional, default to the host specified as part of the URI.
 # Allow creating cluster aware connections.
-hosts=ip1:5672,ip2:5672
+# hosts=ip1:5672,ip2:5672
 
 # RabbitMQ Administration Management
 # Mandatory


### PR DESCRIPTION
The cluster hosts configuration should not be enabled by default, it creates an issue
in the dns resolution when starting James with a standalone rabbitmq.