### PR TITLE
JAMES-3737 Reactive IMAP implementation

### DIFF
--- a/event-bus/api/src/main/java/org/apache/james/events/Registration.java
+++ b/event-bus/api/src/main/java/org/apache/james/events/Registration.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.events;
 
+import org.reactivestreams.Publisher;
+
 public interface Registration {
-    void unregister();
+    Publisher<Void> unregister();
 }

--- a/event-bus/api/src/test/java/org/apache/james/events/GroupContract.java
+++ b/event-bus/api/src/test/java/org/apache/james/events/GroupContract.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 public interface GroupContract {
@@ -247,7 +248,7 @@ public interface GroupContract {
             EventListener listener = EventBusTestFixture.newListener();
             Registration registration = eventBus().register(listener, GROUP_A);
 
-            registration.unregister();
+            Mono.from(registration.unregister()).block();
 
             eventBus().dispatch(EVENT, NO_KEYS).block();
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
@@ -270,7 +271,7 @@ public interface GroupContract {
             EventListener listener = EventBusTestFixture.newListener();
             EventListener listener2 = EventBusTestFixture.newListener();
 
-            eventBus().register(listener, GROUP_A).unregister();
+            Mono.from(eventBus().register(listener, GROUP_A).unregister()).block();
 
             assertThatCode(() -> eventBus().register(listener2, GROUP_A))
                 .doesNotThrowAnyException();
@@ -281,9 +282,9 @@ public interface GroupContract {
             EventListener listener = EventBusTestFixture.newListener();
 
             Registration registration = eventBus().register(listener, GROUP_A);
-            registration.unregister();
+            Mono.from(registration.unregister()).block();
 
-            assertThatCode(registration::unregister)
+            assertThatCode(() -> Mono.from(registration.unregister()).block())
                 .doesNotThrowAnyException();
         }
 
@@ -291,7 +292,7 @@ public interface GroupContract {
         default void registerShouldAcceptAlreadyUnregisteredGroups() throws Exception {
             EventListener listener = EventBusTestFixture.newListener();
 
-            eventBus().register(listener, GROUP_A).unregister();
+            Mono.from(eventBus().register(listener, GROUP_A).unregister()).block();
             eventBus().register(listener, GROUP_A);
 
             eventBus().dispatch(EVENT, NO_KEYS).block();
@@ -384,7 +385,7 @@ public interface GroupContract {
         default void redeliverShouldThrowAfterGroupIsUnregistered() {
             EventListener listener = EventBusTestFixture.newListener();
 
-            eventBus().register(listener, GROUP_A).unregister();
+            Mono.from(eventBus().register(listener, GROUP_A).unregister()).block();
 
             assertThatThrownBy(() -> eventBus().reDeliver(GROUP_A, EVENT).block())
                 .isInstanceOf(GroupRegistrationNotFound.class);
@@ -467,7 +468,7 @@ public interface GroupContract {
         default void unregisterShouldStopNotificationForDistantGroups() throws Exception {
             EventListener listener = EventBusTestFixture.newListener();
 
-            eventBus().register(listener, GROUP_A).unregister();
+            Mono.from(eventBus().register(listener, GROUP_A).unregister()).block();
 
             eventBus2().dispatch(EVENT, NO_KEYS).block();
 

--- a/event-bus/api/src/test/java/org/apache/james/events/KeyContract.java
+++ b/event-bus/api/src/test/java/org/apache/james/events/KeyContract.java
@@ -236,7 +236,7 @@ public interface KeyContract extends EventBusContract {
         default void unregisterShouldRemoveDoubleRegisteredListener() throws Exception {
             EventListener listener = EventBusTestFixture.newListener();
             Mono.from(eventBus().register(listener, KEY_1)).block();
-            Mono.from(eventBus().register(listener, KEY_1)).block().unregister();
+            Mono.from(Mono.from(eventBus().register(listener, KEY_1)).block().unregister()).block();
 
             eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
@@ -260,8 +260,8 @@ public interface KeyContract extends EventBusContract {
         default void callingAllUnregisterMethodShouldUnregisterTheListener() throws Exception {
             EventListener listener = EventBusTestFixture.newListener();
             Registration registration = Mono.from(eventBus().register(listener, KEY_1)).block();
-            Mono.from(eventBus().register(listener, KEY_1)).block().unregister();
-            registration.unregister();
+            Mono.from(Mono.from(eventBus().register(listener, KEY_1)).block().unregister()).block();
+            Mono.from(registration.unregister()).block();
 
             eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
@@ -273,7 +273,7 @@ public interface KeyContract extends EventBusContract {
         default void unregisterShouldHaveNotNotifyWhenCalledOnDifferentKeys() throws Exception {
             EventListener listener = EventBusTestFixture.newListener();
             Mono.from(eventBus().register(listener, KEY_1)).block();
-            Mono.from(eventBus().register(listener, KEY_2)).block().unregister();
+            Mono.from(Mono.from(eventBus().register(listener, KEY_2)).block().unregister()).block();
 
             eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
@@ -285,9 +285,9 @@ public interface KeyContract extends EventBusContract {
             EventListener listener = EventBusTestFixture.newListener();
 
             Registration registration = Mono.from(eventBus().register(listener, KEY_1)).block();
-            registration.unregister();
+            Mono.from(registration.unregister()).block();
 
-            assertThatCode(registration::unregister)
+            assertThatCode(() -> Mono.from(registration.unregister()).block())
                 .doesNotThrowAnyException();
         }
 
@@ -315,7 +315,7 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldNotNotifyUnregisteredListener() throws Exception {
             EventListener listener = EventBusTestFixture.newListener();
-            Mono.from(eventBus().register(listener, KEY_1)).block().unregister();
+            Mono.from(Mono.from(eventBus().register(listener, KEY_1)).block().unregister()).block();
 
             eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
@@ -398,7 +398,7 @@ public interface KeyContract extends EventBusContract {
         default void unregisteredDistantListenersShouldNotBeNotified() throws Exception {
             EventListener eventListener = EventBusTestFixture.newListener();
 
-            Mono.from(eventBus().register(eventListener, KEY_1)).block().unregister();
+            Mono.from(Mono.from(eventBus().register(eventListener, KEY_1)).block().unregister()).block();
 
             eventBus2().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 

--- a/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistration.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistration.java
@@ -192,9 +192,11 @@ class GroupRegistration implements Registration {
     }
 
     @Override
-    public void unregister() {
-        receiverSubscriber.filter(Predicate.not(Disposable::isDisposed))
-            .ifPresent(Disposable::dispose);
-        unregisterGroup.run();
+    public Mono<Void> unregister() {
+        return Mono.fromRunnable(() -> {
+            receiverSubscriber.filter(Predicate.not(Disposable::isDisposed))
+                .ifPresent(Disposable::dispose);
+            unregisterGroup.run();
+        });
     }
 }

--- a/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
@@ -153,7 +153,7 @@ class GroupRegistrationHandler {
     }
 
     void stop() {
-        groupRegistrations.values().forEach(GroupRegistration::unregister);
+        groupRegistrations.values().forEach(groupRegistration -> Mono.from(groupRegistration.unregister()).block());
         consumer.ifPresent(Disposable::dispose);
     }
 

--- a/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistration.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistration.java
@@ -19,15 +19,19 @@
 
 package org.apache.james.events;
 
-class KeyRegistration implements Registration {
-    private final Runnable unregister;
+import java.util.function.Supplier;
 
-    KeyRegistration(Runnable unregister) {
+import reactor.core.publisher.Mono;
+
+class KeyRegistration implements Registration {
+    private final Supplier<Mono<Void>> unregister;
+
+    KeyRegistration(Supplier<Mono<Void>> unregister) {
         this.unregister = unregister;
     }
 
     @Override
-    public void unregister() {
-        unregister.run();
+    public Mono<Void> unregister() {
+        return unregister.get();
     }
 }

--- a/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistrationHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistrationHandler.java
@@ -143,12 +143,11 @@ class KeyRegistrationHandler {
         return registerIfNeeded(key, registration)
             .thenReturn(new KeyRegistration(() -> {
                 if (registration.unregister().lastListenerRemoved()) {
-                    registrationBinder.unbind(key)
+                    return registrationBinder.unbind(key)
                         .timeout(TOPOLOGY_CHANGES_TIMEOUT)
-                        .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.elastic()))
-                        .subscribeOn(Schedulers.elastic())
-                        .block();
+                        .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.elastic()));
                 }
+                return Mono.empty();
             }));
     }
 

--- a/event-bus/in-vm/src/main/java/org/apache/james/events/InVMEventBus.java
+++ b/event-bus/in-vm/src/main/java/org/apache/james/events/InVMEventBus.java
@@ -56,14 +56,14 @@ public class InVMEventBus implements EventBus {
     @Override
     public Mono<Registration> register(EventListener.ReactiveEventListener listener, RegistrationKey key) {
         registrations.put(key, listener);
-        return Mono.just(() -> registrations.remove(key, listener));
+        return Mono.just(() -> Mono.fromRunnable(() -> registrations.remove(key, listener)));
     }
 
     @Override
     public Registration register(EventListener.ReactiveEventListener listener, Group group) {
         EventListener previous = groups.putIfAbsent(group, listener);
         if (previous == null) {
-            return () -> groups.remove(group, listener);
+            return () -> Mono.fromRunnable(() -> groups.remove(group, listener));
         }
         throw new GroupAlreadyRegistered(group);
     }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -38,7 +38,10 @@ import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.reactivestreams.Publisher;
 
+import com.github.fge.lambdas.Throwing;
+
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * <p>
@@ -161,6 +164,10 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
      * Delete the mailbox with the name
      */
     void deleteMailbox(MailboxPath mailboxPath, MailboxSession session) throws MailboxException;
+
+    default Mono<Void> deleteMailboxReactive(MailboxPath mailboxPath, MailboxSession session) {
+        return Mono.fromRunnable(Throwing.runnable(() -> deleteMailbox(mailboxPath, session)));
+    }
 
     /**
      * Delete the mailbox with the given id

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -431,6 +431,10 @@ public interface MessageManager {
 
     Flags getApplicableFlags(MailboxSession session) throws MailboxException;
 
+    default Mono<Flags> getApplicableFlagsReactive(MailboxSession session) {
+        return Mono.fromCallable(() -> getApplicableFlags(session));
+    }
+
     /**
      * Gets current meta data for the mailbox.<br>
      * Consolidates common calls together to allow improved performance.<br>
@@ -446,6 +450,10 @@ public interface MessageManager {
      * @return metadata view filtered for the session's user, not null
      */
     MailboxMetaData getMetaData(boolean resetRecent, MailboxSession mailboxSession, MailboxMetaData.FetchGroup fetchGroup) throws MailboxException;
+
+    default Mono<MailboxMetaData> getMetaDataReactive(boolean resetRecent, MailboxSession mailboxSession, MailboxMetaData.FetchGroup fetchGroup) throws MailboxException {
+        return Mono.fromCallable(() -> getMetaData(resetRecent, mailboxSession, fetchGroup));
+    }
 
     /**
      * Meta data about the current state of the mailbox.

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -103,16 +103,6 @@ public interface MessageManager {
     boolean isWriteable(MailboxSession session) throws MailboxException;
 
     /**
-     * Return true if {@link MessageResult#getModSeq()} is stored in a permanent
-     * way.
-     *
-     * @deprecated use
-     *             {@link #getMetaData(boolean, MailboxSession, MailboxMetaData.FetchGroup)}
-     */
-    @Deprecated
-    boolean isModSeqPermanent(MailboxSession session);
-
-    /**
      * Searches for messages matching the given query. The result must be
      * ordered
      * 
@@ -495,7 +485,7 @@ public interface MessageManager {
          *
          * @return MailboxMetaData with default values for all fields
          */
-        public static MailboxMetaData sensibleInformationFree(MailboxACL resolvedAcl, UidValidity uidValidity, boolean writeable, boolean modSeqPermanent) {
+        public static MailboxMetaData sensibleInformationFree(MailboxACL resolvedAcl, UidValidity uidValidity, boolean writeable) {
             ImmutableList<MessageUid> recents = ImmutableList.of();
             MessageUid uidNext = MessageUid.MIN_VALUE;
             ModSeq highestModSeq = ModSeq.first();
@@ -512,7 +502,6 @@ public interface MessageManager {
                 unseenCount,
                 firstUnseen,
                 writeable,
-                modSeqPermanent,
                 resolvedAcl);
         }
 
@@ -526,10 +515,9 @@ public interface MessageManager {
         private final MessageUid firstUnseen;
         private final boolean writeable;
         private final ModSeq highestModSeq;
-        private final boolean modSeqPermanent;
         private final MailboxACL acl;
 
-        public MailboxMetaData(List<MessageUid> recent, Flags permanentFlags, UidValidity uidValidity, MessageUid uidNext, ModSeq highestModSeq, long messageCount, long unseenCount, MessageUid firstUnseen, boolean writeable, boolean modSeqPermanent, MailboxACL acl) {
+        public MailboxMetaData(List<MessageUid> recent, Flags permanentFlags, UidValidity uidValidity, MessageUid uidNext, ModSeq highestModSeq, long messageCount, long unseenCount, MessageUid firstUnseen, boolean writeable, MailboxACL acl) {
             this.recent = Optional.ofNullable(recent).map(ImmutableList::copyOf).orElseGet(ImmutableList::of);
             this.highestModSeq = highestModSeq;
             this.recentCount = this.recent.size();
@@ -541,7 +529,6 @@ public interface MessageManager {
             this.unseenCount = unseenCount;
             this.firstUnseen = firstUnseen;
             this.writeable = writeable;
-            this.modSeqPermanent = modSeqPermanent;
             this.acl = acl;
         }
 
@@ -648,16 +635,6 @@ public interface MessageManager {
          */
         public ModSeq getHighestModSeq() {
             return highestModSeq;
-        }
-
-        /**
-         * Return true if the mailbox does store the mod-sequences in a
-         * permanent way
-         *
-         * @return permanent
-         */
-        public boolean isModSeqPermanent() {
-            return modSeqPermanent;
         }
 
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -63,6 +63,7 @@ import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.message.DefaultMessageWriter;
 import org.reactivestreams.Publisher;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
@@ -130,6 +131,12 @@ public interface MessageManager {
      *             if anything went wrong
      */
     Iterator<MessageUid> expunge(MessageRange set, MailboxSession mailboxSession) throws MailboxException;
+
+    default Flux<MessageUid> expungeReactive(MessageRange set, MailboxSession mailboxSession) {
+        return Flux.fromStream(Throwing.supplier(() -> StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(expunge(set, mailboxSession), Spliterator.ORDERED),
+            false)));
+    }
 
     /**
      * Deletes a list of messages given their uids in the mailbox.

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/RightManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/RightManager.java
@@ -45,6 +45,8 @@ public interface RightManager {
      */
     boolean hasRight(MailboxPath mailboxPath, Right right, MailboxSession session) throws MailboxException;
 
+    boolean hasRight(Mailbox mailbox, Right right, MailboxSession session) throws MailboxException;
+
     /**
      * Tells whether the given {@link MailboxSession}'s user has the given
      * {@link MailboxACL.Right} for this {@link MessageManager}'s mailbox.

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/RightManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/RightManager.java
@@ -85,6 +85,8 @@ public interface RightManager {
      */
     List<MailboxACL.Rfc4314Rights> listRights(MailboxPath mailboxPath, MailboxACL.EntryKey identifier, MailboxSession session) throws MailboxException;
 
+    List<MailboxACL.Rfc4314Rights> listRights(Mailbox mailbox, MailboxACL.EntryKey identifier, MailboxSession session) throws MailboxException;
+
     MailboxACL listRights(MailboxPath mailboxPath, MailboxSession session) throws MailboxException;
 
     MailboxACL listRights(MailboxId mailboxId, MailboxSession session) throws MailboxException;

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SubscriptionManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SubscriptionManager.java
@@ -43,6 +43,8 @@ public interface SubscriptionManager extends RequestAware {
      */
     void subscribe(MailboxSession session, String mailbox) throws SubscriptionException;
 
+    Publisher<Void> subscribeReactive(String mailbox, MailboxSession session);
+
     /**
      * Finds all subscriptions for the user in the session.
      * 
@@ -68,4 +70,5 @@ public interface SubscriptionManager extends RequestAware {
      */
     void unsubscribe(MailboxSession session, String mailbox) throws SubscriptionException;
 
+    Publisher<Void> unsubscribeReactive(String mailbox, MailboxSession session);
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -385,7 +385,7 @@ public class CassandraMessageIdDAO {
         case RANGE:
             return selectRange(mailboxId, set.getUidFrom(), set.getUidTo(), limit);
         case ONE:
-            return Flux.concat(selectOneRow(mailboxId, set.getUidFrom()));
+            return Flux.from(selectOneRow(mailboxId, set.getUidFrom()));
         }
         throw new UnsupportedOperationException();
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
@@ -193,4 +193,10 @@ public class CassandraModSeqProvider implements ModSeqProvider {
             .single()
             .retryWhen(Retry.backoff(maxModSeqRetries, firstBackoff).scheduler(Schedulers.elastic()));
     }
+
+    @Override
+    public Mono<ModSeq> highestModSeqReactive(Mailbox mailbox) {
+        return findHighestModSeq((CassandraId) mailbox.getMailboxId())
+            .map(optional -> optional.orElse(ModSeq.first()));
+    }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
@@ -153,6 +153,13 @@ public class CassandraUidProvider implements UidProvider {
                 .blockOptional();
     }
 
+    @Override
+    public Mono<Optional<MessageUid>> lastUidReactive(Mailbox mailbox) {
+        return findHighestUid((CassandraId) mailbox.getMailboxId())
+            .map(Optional::of)
+            .switchIfEmpty(Mono.just(Optional.empty()));
+    }
+
     private Mono<MessageUid> findHighestUid(CassandraId mailboxId) {
         return executor.executeSingleRow(
             selectStatement.bind()

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/user/CassandraSubscriptionMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/user/CassandraSubscriptionMapper.java
@@ -42,6 +42,7 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public class CassandraSubscriptionMapper extends NonTransactionalMapper implements SubscriptionMapper {
     private final Session session;
@@ -95,6 +96,20 @@ public class CassandraSubscriptionMapper extends NonTransactionalMapper implemen
     @Override
     public synchronized void save(Subscription subscription) {
         session.execute(insertStatement.bind()
+            .setString(USER, subscription.getUser().asString())
+            .setString(MAILBOX, subscription.getMailbox()));
+    }
+
+    @Override
+    public Mono<Void> saveReactive(Subscription subscription) {
+        return executor.executeVoid(deleteStatement.bind()
+            .setString(USER, subscription.getUser().asString())
+            .setString(MAILBOX, subscription.getMailbox()));
+    }
+
+    @Override
+    public Mono<Void> deleteReactive(Subscription subscription) {
+        return executor.executeVoid(insertStatement.bind()
             .setString(USER, subscription.getUser().asString())
             .setString(MAILBOX, subscription.getMailbox()));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/user/CassandraSubscriptionMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/user/CassandraSubscriptionMapper.java
@@ -70,10 +70,8 @@ public class CassandraSubscriptionMapper extends NonTransactionalMapper implemen
     }
 
     @Override
-    public synchronized void delete(Subscription subscription) {
-        session.execute(deleteStatement.bind()
-            .setString(USER, subscription.getUser().asString())
-            .setString(MAILBOX, subscription.getMailbox()));
+    public void delete(Subscription subscription) {
+        deleteReactive(subscription).block();
     }
 
     @Override
@@ -94,22 +92,20 @@ public class CassandraSubscriptionMapper extends NonTransactionalMapper implemen
     }
 
     @Override
-    public synchronized void save(Subscription subscription) {
-        session.execute(insertStatement.bind()
-            .setString(USER, subscription.getUser().asString())
-            .setString(MAILBOX, subscription.getMailbox()));
+    public void save(Subscription subscription) {
+        saveReactive(subscription).block();
     }
 
     @Override
     public Mono<Void> saveReactive(Subscription subscription) {
-        return executor.executeVoid(deleteStatement.bind()
+        return executor.executeVoid(insertStatement.bind()
             .setString(USER, subscription.getUser().asString())
             .setString(MAILBOX, subscription.getMailbox()));
     }
 
     @Override
     public Mono<Void> deleteReactive(Subscription subscription) {
-        return executor.executeVoid(insertStatement.bind()
+        return executor.executeVoid(deleteStatement.bind()
             .setString(USER, subscription.getUser().asString())
             .setString(MAILBOX, subscription.getMailbox()));
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -836,6 +836,11 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     @Override
+    public boolean hasRight(Mailbox mailbox, Right right, MailboxSession session) throws MailboxException {
+        return storeRightManager.hasRight(mailbox, right, session);
+    }
+
+    @Override
     public boolean hasRight(MailboxId mailboxId, Right right, MailboxSession session) throws MailboxException {
         return storeRightManager.hasRight(mailboxId, right, session);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -881,6 +881,11 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     @Override
+    public List<Rfc4314Rights> listRights(Mailbox mailbox, MailboxACL.EntryKey identifier, MailboxSession session) throws MailboxException {
+        return storeRightManager.listRights(mailbox, identifier, session);
+    }
+
+    @Override
     public MailboxACL listRights(MailboxPath mailboxPath, MailboxSession session) throws MailboxException {
         return storeRightManager.listRights(mailboxPath, session);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -194,7 +194,7 @@ public class StoreMessageManager implements MessageManager {
      * Return the underlying {@link Mailbox}
      */
 
-    public Mailbox getMailboxEntity() throws MailboxException {
+    public Mailbox getMailboxEntity() {
         return mailbox;
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -250,17 +250,6 @@ public class StoreMessageManager implements MessageManager {
         return getPermanentFlags(session);
     }
 
-    /**
-     * Return true. If an subclass don't want to store mod-sequences in a
-     * permanent way just override this and return false
-     * 
-     * @return true
-     */
-    @Override
-    public boolean isModSeqPermanent(MailboxSession session) {
-        return true;
-    }
-
     @Override
     public Iterator<MessageUid> expunge(MessageRange set, MailboxSession mailboxSession) throws MailboxException {
         if (!isWriteable(mailboxSession)) {
@@ -567,7 +556,7 @@ public class StoreMessageManager implements MessageManager {
         MailboxACL resolvedAcl = getResolvedAcl(mailboxSession);
         boolean hasReadRight = storeRightManager.hasRight(mailbox, MailboxACL.Right.Read, mailboxSession);
         if (!hasReadRight) {
-            return Mono.just(MailboxMetaData.sensibleInformationFree(resolvedAcl, getMailboxEntity().getUidValidity(), isWriteable(mailboxSession), isModSeqPermanent(mailboxSession)));
+            return Mono.just(MailboxMetaData.sensibleInformationFree(resolvedAcl, getMailboxEntity().getUidValidity(), isWriteable(mailboxSession)));
         }
         Flags permanentFlags = getPermanentFlags(mailboxSession);
         UidValidity uidValidity = getMailboxEntity().getUidValidity();
@@ -608,7 +597,7 @@ public class StoreMessageManager implements MessageManager {
         long unseenCount = 0;
         long messageCount = -1;
         List<MessageUid> recent = new ArrayList<>();
-        final MailboxMetaData metaData = new MailboxMetaData(recent, permanentFlags, uidValidity, uidNext, highestModSeq, messageCount, unseenCount, firstUnseen, isWriteable(mailboxSession), isModSeqPermanent(mailboxSession), resolvedAcl);
+        final MailboxMetaData metaData = new MailboxMetaData(recent, permanentFlags, uidValidity, uidNext, highestModSeq, messageCount, unseenCount, firstUnseen, isWriteable(mailboxSession), resolvedAcl);
 
         // just reset the recent but not include them in the metadata
         if (resetRecent) {
@@ -624,7 +613,7 @@ public class StoreMessageManager implements MessageManager {
         return Mono.zip(
             messageMapper.getMailboxCountersReactive(mailbox).map(MailboxCounters::getUnseen),
             recent(resetRecent, mailboxSession))
-            .map(Throwing.function(t2 -> new MailboxMetaData(t2.getT2(), permanentFlags, uidValidity, uidNext, highestModSeq, t2.getT1(), unseenCount, firstUnseen, isWriteable(mailboxSession), isModSeqPermanent(mailboxSession), resolvedAcl)));
+            .map(Throwing.function(t2 -> new MailboxMetaData(t2.getT2(), permanentFlags, uidValidity, uidNext, highestModSeq, t2.getT1(), unseenCount, firstUnseen, isWriteable(mailboxSession), resolvedAcl)));
     }
 
     private Mono<MailboxMetaData> metadataFirstUnseen(MessageMapper messageMapper, boolean resetRecent, MailboxSession mailboxSession, MailboxACL resolvedAcl, Flags permanentFlags, UidValidity uidValidity, MessageUid uidNext, ModSeq highestModSeq) throws MailboxException {
@@ -633,7 +622,7 @@ public class StoreMessageManager implements MessageManager {
             messageMapper.getMailboxCountersReactive(mailbox).map(MailboxCounters::getCount),
             recent(resetRecent, mailboxSession),
             messageMapper.findFirstUnseenMessageUidReactive(getMailboxEntity()))
-            .map(Throwing.function(t3 -> new MailboxMetaData(t3.getT2(), permanentFlags, uidValidity, uidNext, highestModSeq, t3.getT1(), unseenCount, t3.getT3().orElse(null), isWriteable(mailboxSession), isModSeqPermanent(mailboxSession), resolvedAcl)));
+            .map(Throwing.function(t3 -> new MailboxMetaData(t3.getT2(), permanentFlags, uidValidity, uidNext, highestModSeq, t3.getT1(), unseenCount, t3.getT3().orElse(null), isWriteable(mailboxSession), resolvedAcl)));
     }
 
     private Mono<MailboxMetaData> metadataUnseenCount(MessageMapper messageMapper, boolean resetRecent, MailboxSession mailboxSession, MailboxACL resolvedAcl, Flags permanentFlags, UidValidity uidValidity, MessageUid uidNext, ModSeq highestModSeq) throws MailboxException {
@@ -641,7 +630,7 @@ public class StoreMessageManager implements MessageManager {
         return Mono.zip(
             messageMapper.getMailboxCountersReactive(mailbox),
             recent(resetRecent, mailboxSession))
-            .map(Throwing.function(t2 -> new MailboxMetaData(t2.getT2(), permanentFlags, uidValidity, uidNext, highestModSeq, t2.getT1().getCount(), t2.getT1().getUnseen(), firstUnseen, isWriteable(mailboxSession), isModSeqPermanent(mailboxSession), resolvedAcl)));
+            .map(Throwing.function(t2 -> new MailboxMetaData(t2.getT2(), permanentFlags, uidValidity, uidNext, highestModSeq, t2.getT1().getCount(), t2.getT1().getUnseen(), firstUnseen, isWriteable(mailboxSession), resolvedAcl)));
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -571,12 +571,12 @@ public class StoreMessageManager implements MessageManager {
         UidValidity uidValidity = getMailboxEntity().getUidValidity();
         MessageMapper messageMapper = mapperFactory.getMessageMapper(mailboxSession);
 
-        return Mono.zip(messageMapper.getLastUidReactive(mailbox)
+        return messageMapper.executeReactive(Mono.zip(messageMapper.getLastUidReactive(mailbox)
                 .map(optional -> optional
                     .map(MessageUid::next)
                     .orElse(MessageUid.MIN_VALUE)),
             messageMapper.getHighestModSeqReactive(mailbox))
-            .flatMap(t2 -> toMetadata(messageMapper, resetRecent, mailboxSession, fetchGroup, resolvedAcl, permanentFlags, uidValidity, t2.getT1(), t2.getT2()));
+            .flatMap(t2 -> toMetadata(messageMapper, resetRecent, mailboxSession, fetchGroup, resolvedAcl, permanentFlags, uidValidity, t2.getT1(), t2.getT2())));
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
@@ -83,6 +83,7 @@ public class StoreRightManager implements RightManager {
         return block(Mono.from(myRights(mailboxId, session))).contains(right);
     }
 
+    @Override
     public boolean hasRight(Mailbox mailbox, Right right, MailboxSession session) {
         return myRights(mailbox, session).contains(right);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
@@ -135,6 +135,12 @@ public class StoreRightManager implements RightManager {
     }
 
     @Override
+    public List<Rfc4314Rights> listRights(Mailbox mailbox, EntryKey key, MailboxSession session) throws MailboxException {
+        return aclResolver.listRights(key,
+            mailbox.getUser().asString());
+    }
+
+    @Override
     public MailboxACL listRights(MailboxPath mailboxPath, MailboxSession session) throws MailboxException {
         MailboxMapper mapper = mailboxSessionMapperFactory.getMailboxMapper(session);
         Mailbox mailbox = blockOptional(mapper.findMailboxByPath(mailboxPath))

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreSubscriptionManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreSubscriptionManager.java
@@ -35,6 +35,8 @@ import org.apache.james.mailbox.store.user.SubscriptionMapperFactory;
 import org.apache.james.mailbox.store.user.model.Subscription;
 import org.reactivestreams.Publisher;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Manages subscriptions for Users and Mailboxes.
  */
@@ -58,6 +60,28 @@ public class StoreSubscriptionManager implements SubscriptionManager {
             }));
         } catch (MailboxException e) {
             throw new SubscriptionException(e);
+        }
+    }
+
+    @Override
+    public Publisher<Void> subscribeReactive(String mailbox, MailboxSession session) {
+        try {
+            SubscriptionMapper mapper = mapperFactory.getSubscriptionMapper(session);
+            Subscription newSubscription = new Subscription(session.getUser(), mailbox);
+            return mapper.executeReactive(mapper.saveReactive(newSubscription));
+        } catch (SubscriptionException e) {
+            return Mono.error(e);
+        }
+    }
+
+    @Override
+    public Publisher<Void> unsubscribeReactive(String mailbox, MailboxSession session) {
+        try {
+            SubscriptionMapper mapper = mapperFactory.getSubscriptionMapper(session);
+            Subscription oldSubscription = new Subscription(session.getUser(), mailbox);
+            return mapper.executeReactive(mapper.deleteReactive(oldSubscription));
+        } catch (SubscriptionException e) {
+            return Mono.error(e);
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -124,11 +124,19 @@ public interface MessageMapper extends Mapper {
      */
     MessageUid findFirstUnseenMessageUid(Mailbox mailbox) throws MailboxException;
 
+    default Mono<Optional<MessageUid>> findFirstUnseenMessageUidReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> Optional.ofNullable(findFirstUnseenMessageUid(mailbox)));
+    }
+
     /**
      * Return a List of {@link MailboxMessage} which are recent.
      * The list must be ordered by the {@link MailboxMessage} uid.
      */
     List<MessageUid> findRecentMessageUidsInMailbox(Mailbox mailbox) throws MailboxException;
+
+    default Mono<List<MessageUid>> findRecentMessageUidsInMailboxReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> findRecentMessageUidsInMailbox(mailbox));
+    }
 
 
     /**
@@ -205,13 +213,24 @@ public interface MessageMapper extends Mapper {
      */
     Optional<MessageUid> getLastUid(Mailbox mailbox) throws MailboxException;
 
+    default Mono<Optional<MessageUid>> getLastUidReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> getLastUid(mailbox));
+    }
 
     /**
      * Return the higest mod-sequence which were used for storing a MailboxMessage in the {@link Mailbox}
      */
     ModSeq getHighestModSeq(Mailbox mailbox) throws MailboxException;
 
+    default Mono<ModSeq> getHighestModSeqReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> getHighestModSeq(mailbox));
+    }
+
     Flags getApplicableFlag(Mailbox mailbox) throws MailboxException;
+
+    default Mono<Flags> getApplicableFlagReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> getApplicableFlag(mailbox));
+    }
 
     /**
      * Return a list containing all MessageUid of Messages that belongs to given {@link Mailbox}

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -96,6 +96,14 @@ public interface MessageMapper extends Mapper {
      */
     List<MessageUid> retrieveMessagesMarkedForDeletion(Mailbox mailbox, MessageRange messageRange) throws MailboxException;
 
+    default Flux<MessageUid> retrieveMessagesMarkedForDeletionReactive(Mailbox mailbox, MessageRange messageRange) {
+        try {
+            return Flux.fromIterable(retrieveMessagesMarkedForDeletion(mailbox, messageRange));
+        } catch (MailboxException e) {
+            return Flux.error(e);
+        }
+    }
+
     /**
      * Return the count of messages in the mailbox
      */
@@ -118,6 +126,10 @@ public interface MessageMapper extends Mapper {
      * and return a {@link Map} which holds the uids and metadata for all deleted messages
      */
     Map<MessageUid, MessageMetaData> deleteMessages(Mailbox mailbox, List<MessageUid> uids) throws MailboxException;
+
+    default Mono<Map<MessageUid, MessageMetaData>> deleteMessagesReactive(Mailbox mailbox, List<MessageUid> uids) {
+        return Mono.fromCallable(() -> deleteMessages(mailbox, uids));
+    }
 
     /**
      * Return the uid of the first unseen message. If non can be found null will get returned

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -158,6 +158,10 @@ public interface MessageMapper extends Mapper {
     Iterator<UpdatedFlags> updateFlags(Mailbox mailbox, FlagsUpdateCalculator flagsUpdateCalculator,
             final MessageRange set) throws MailboxException;
 
+    default Mono<List<UpdatedFlags>> updateFlagsReactive(Mailbox mailbox, FlagsUpdateCalculator flagsUpdateCalculator, MessageRange set) {
+        return Mono.fromCallable(() -> ImmutableList.copyOf(updateFlags(mailbox, flagsUpdateCalculator, set)));
+    }
+
     default Optional<UpdatedFlags> updateFlags(Mailbox mailbox, MessageUid uid, FlagsUpdateCalculator flagsUpdateCalculator) throws MailboxException {
         return Iterators.toStream(updateFlags(mailbox, flagsUpdateCalculator, MessageRange.one(uid)))
             .findFirst();
@@ -174,6 +178,10 @@ public interface MessageMapper extends Mapper {
             result.addAll(updateFlags(mailbox, calculator, range));
         }
         return result.build();
+    }
+
+    default Mono<List<UpdatedFlags>> resetRecentReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> resetRecent(mailbox));
     }
 
     

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/ModSeqProvider.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/ModSeqProvider.java
@@ -54,6 +54,10 @@ public interface ModSeqProvider {
      */
     ModSeq highestModSeq(Mailbox mailbox) throws MailboxException;
 
+    default Mono<ModSeq> highestModSeqReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> highestModSeq(mailbox));
+    }
+
     /**
      * Return the highest mod-sequence which were used for the {@link Mailbox}
      */

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
@@ -49,6 +49,10 @@ public interface UidProvider {
      */
     Optional<MessageUid> lastUid(Mailbox mailbox) throws MailboxException;
 
+    default Mono<Optional<MessageUid>> lastUidReactive(Mailbox mailbox) {
+        return Mono.fromCallable(() -> lastUid(mailbox));
+    }
+
     MessageUid nextUid(MailboxId mailboxId) throws MailboxException;
 
     default Mono<MessageUid> nextUidReactive(MailboxId mailboxId) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/user/SubscriptionMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/user/SubscriptionMapper.java
@@ -25,6 +25,7 @@ import org.apache.james.mailbox.exception.SubscriptionException;
 import org.apache.james.mailbox.store.transaction.Mapper;
 import org.apache.james.mailbox.store.user.model.Subscription;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Functions;
 
 import reactor.core.publisher.Flux;
@@ -40,6 +41,10 @@ public interface SubscriptionMapper extends Mapper {
      * @param subscription not null
      */
     void save(Subscription subscription) throws SubscriptionException;
+
+    default Mono<Void> saveReactive(Subscription subscription) {
+        return Mono.fromRunnable(Throwing.runnable(() -> save(subscription)));
+    }
 
     /**
      * Finds subscriptions for the given user.
@@ -58,4 +63,8 @@ public interface SubscriptionMapper extends Mapper {
      * @param subscription not null
      */
     void delete(Subscription subscription) throws SubscriptionException;
+
+    default Mono<Void> deleteReactive(Subscription subscription) {
+        return Mono.fromRunnable(Throwing.runnable(() -> delete(subscription)));
+    }
 }

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
@@ -163,7 +163,7 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
 
         @Override
         public void stop() throws Exception {
-            session.deselect();
+            session.deselect().block();
         }
 
         @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
@@ -94,6 +94,8 @@ public class HumanReadableText {
 
     public static final HumanReadableText SEARCH_FAILED = new HumanReadableText("org.apache.james.imap.SEARCH_FAILED", "failed. Search failed.");
 
+    public static final HumanReadableText STATUS_FAILED = new HumanReadableText("org.apache.james.imap.STATUS_FAILED", "failed. Status failed.");
+
     public static final HumanReadableText COUNT_FAILED = new HumanReadableText("org.apache.james.imap.COUNT_FAILED", "failed. Count failed.");
 
     public static final HumanReadableText SAVE_FAILED = new HumanReadableText("org.apache.james.imap.SAVE_FAILED", "failed. Save failed.");

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapProcessor.java
@@ -23,6 +23,8 @@ import org.apache.james.imap.api.ImapConfiguration;
 import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.message.response.ImapResponseMessage;
 
+import reactor.core.publisher.Mono;
+
 /**
  * <p>
  * Processable IMAP command.
@@ -43,7 +45,13 @@ public interface ImapProcessor {
      * @param responder <code>not null</code>, the responder use write response for message
      * @param session the imap session
      */
-    void process(ImapMessage message, Responder responder, ImapSession session);
+    default void process(ImapMessage message, Responder responder, ImapSession session) {
+        processReactive(message, responder, session).block();
+    }
+
+    default Mono<Void> processReactive(ImapMessage message, Responder responder, ImapSession session) {
+        return Mono.fromRunnable(() -> process(message, responder, session));
+    }
 
     void configure(ImapConfiguration imapConfiguration);
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
@@ -31,6 +31,8 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.protocols.api.CommandDetectionSession;
 import org.apache.james.protocols.api.OidcSASLConfiguration;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Encapsulates all state held for an ongoing Imap session, which commences when
  * a client first establishes a connection to the Imap server, and continues
@@ -92,7 +94,7 @@ public interface ImapSession extends CommandDetectionSession {
     /**
      * Logs out the session. Marks the connection for closure;
      */
-    void logout();
+    Mono<Void> logout();
 
     /**
      * Gets the current client state.
@@ -113,14 +115,14 @@ public interface ImapSession extends CommandDetectionSession {
      * @param mailbox
      *            The selected mailbox.
      */
-    void selected(SelectedMailbox mailbox);
+    Mono<Void> selected(SelectedMailbox mailbox);
 
     /**
      * Moves the session out of {@link ImapSessionState#SELECTED} state and back
      * into {@link ImapSessionState#AUTHENTICATED} state. The selected mailbox
      * is cleared.
      */
-    void deselect();
+    Mono<Void> deselect();
 
     /**
      * Provides the selected mailbox for this session, or <code>null</code> if

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
@@ -32,6 +32,8 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Interface which represent a selected Mailbox during the selected state
  */
@@ -42,7 +44,7 @@ public interface SelectedMailbox {
     /**
      * Deselect the Mailbox
      */
-    void deselect();
+    Mono<Void> deselect();
 
     void registerIdle(EventListener idle);
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import javax.mail.Flags;
 
 import org.apache.james.events.EventListener;
+import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.NullableMessageSequenceNumber;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -98,6 +99,8 @@ public interface SelectedMailbox {
      * This is beneficial as the MailboxId is immutable.
      */
     MailboxId getMailboxId();
+
+    MessageManager getMessageManager();
 
     /**
      * Is the given uid recent ?

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
@@ -95,6 +95,8 @@ public interface SelectedMailbox {
      */
     MailboxPath getPath() throws MailboxException;
 
+    Mono<MailboxPath> getPathReactive();
+
     /**
      * Return the mailboxId of the selected Mailbox.
      *

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -88,7 +88,7 @@ public class DefaultImapDecoder implements ImapDecoder {
 
         if (count > maxInvalidCommands || session.getState() == ImapSessionState.NON_AUTHENTICATED) {
             ImapMessage message = responseFactory.bye(HumanReadableText.BYE_UNKNOWN_COMMAND);
-            session.logout();
+            session.logout().block();
             return message;
         }
         session.setAttribute(INVALID_COMMAND_COUNT, count);

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/ImapRequestStreamHandler.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/ImapRequestStreamHandler.java
@@ -113,7 +113,7 @@ public final class ImapRequestStreamHandler extends AbstractImapRequestHandler {
     private void abandon(OutputStream out, ImapSession session) {
         if (session != null) {
             try {
-                session.logout();
+                session.logout().block();
             } catch (Throwable t) {
                 LOGGER.warn("Session logout failed. Resources may not be correctly recycled.");
             }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -153,7 +153,7 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         } else {
             LOGGER.info("Too many authentication failures. Closing connection.");
             bye(responder, HumanReadableText.TOO_MANY_FAILURES);
-            session.logout();
+            session.logout().block();
         }
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -217,10 +217,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
                 if (messageManager == null) {
                     messageManager = getMailbox(session, selected);
                 }
-                if (metaData == null) {
-                    metaData = messageManager.getMetaData(false, mailboxSession, MailboxMetaData.FetchGroup.NO_COUNT);
-                }
-                boolean isModSeqPermanent = metaData.isModSeqPermanent();
+                boolean isModSeqPermanent = true;
                 while (ranges.hasNext()) {
                     addFlagsResponses(session, selected, responder, useUid, ranges.next(), messageManager, isModSeqPermanent, mailboxSession);
                 }
@@ -287,12 +284,10 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
         Set<Capability> enabled = EnableProcessor.getEnabledCapabilities(session);
         if (!enabled.contains(ImapConstants.SUPPORTS_CONDSTORE)) {
             if (sendHighestModSeq) {
-                if (metaData.isModSeqPermanent()) {
-                    ModSeq highestModSeq = metaData.getHighestModSeq();
+                ModSeq highestModSeq = metaData.getHighestModSeq();
 
-                    StatusResponse untaggedOk = getStatusResponseFactory().untaggedOk(HumanReadableText.HIGHEST_MOD_SEQ, ResponseCode.highestModSeq(highestModSeq));
-                    responder.respond(untaggedOk);        
-                }
+                StatusResponse untaggedOk = getStatusResponseFactory().untaggedOk(HumanReadableText.HIGHEST_MOD_SEQ, ResponseCode.highestModSeq(highestModSeq));
+                responder.respond(untaggedOk);
             }
             enabled.add(ImapConstants.SUPPORTS_CONDSTORE);
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -301,11 +301,6 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
             enabled.add(ImapConstants.SUPPORTS_CONDSTORE);
         }
     }
-    
-    private MessageManager getMailbox(ImapSession session, SelectedMailbox selected) throws MailboxException {
-        final MailboxManager mailboxManager = getMailboxManager();
-        return mailboxManager.getMailbox(selected.getMailboxId(), session.getMailboxSession());
-    }
 
     private void addRecentResponses(SelectedMailbox selected, ImapProcessor.Responder responder) {
         final int recentCount = selected.recentCount();
@@ -574,9 +569,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
             responder.respond(new VanishedResponse(vanishedIdRanges, true));
         }
     }
-    
-    
-    // TODO: Do we need to handle wildcards here ?
+
     protected UidRange[] uidRanges(Collection<MessageRange> mRanges) {
         UidRange[] idRanges = new UidRange[mRanges.size()];
         Iterator<MessageRange> mIt = mRanges.iterator();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -512,7 +512,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
      *            input range
      * @return normalized message range
      */
-    protected MessageRange normalizeMessageRange(SelectedMailbox selected, MessageRange range) throws MessageRangeException {
+    protected MessageRange normalizeMessageRange(SelectedMailbox selected, MessageRange range) {
         Type rangeType = range.getType();
         MessageUid start;
         MessageUid end;
@@ -543,7 +543,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
             end = selected.getLastUid().orElse(MessageUid.MAX_VALUE);
             return MessageRange.range(start, end);
         default:
-            throw new MessageRangeException("Unknown message range type: " + rangeType);
+            throw new RuntimeException("Unknown message range type: " + rangeType);
         }
     }
     
@@ -551,14 +551,14 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
     /**
      * Send VANISHED responses if needed. 
      */
-    protected void respondVanished(SelectedMailbox selectedMailbox, List<MessageRange> ranges, Responder responder) throws MailboxException {
+    protected void respondVanished(SelectedMailbox selectedMailbox, List<MessageRange> ranges, Responder responder) {
         Set<MessageUid> vanishedUids = new HashSet<>();
         for (MessageRange range : ranges) {
             MessageUid from = range.getUidFrom();
             MessageUid to = range.getUidTo();
             while (from.compareTo(to) <= 0) {
                 MessageUid copy = from;
-                selectedMailbox.msn(from).fold(
+                selectedMailbox.msn(from).foldSilent(
                     () -> vanishedUids.add(copy),
                     msn -> {
                         // ignore still there

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -175,7 +175,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
                 selected.resetRecentUidRemoved();
             }
         })
-            .then(Mono.defer(() -> addFlagsResponses(session, selected, responder, useUid)))
+            .then(addFlagsResponses(session, selected, responder, useUid))
             .doFinally(type -> selected.resetEvents());
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -75,7 +75,7 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
                 no(request, responder, HumanReadableText.FAILURE_NO_SUCH_MAILBOX, StatusResponse.ResponseCode.tryCreate());
             } else {
                 StatusResponse.ResponseCode code = handleRanges(request, session, targetMailbox, mailboxSession);
-                unsolicitedResponses(session, responder, request.isUseUids());
+                unsolicitedResponses(session, responder, request.isUseUids()).block();
                 okComplete(request, code, responder);
             }
         } catch (MessageRangeException e) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -163,7 +163,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
                 //
                 // If the mailbox does not store the mod-sequence in a permanent way its needed to not process the QRESYNC paramters
                 // The same is true if none are given ;)
-                if (metaData.isModSeqPermanent() && !lastKnownUidValidity.isUnknown()) {
+                if (!lastKnownUidValidity.isUnknown()) {
                     if (lastKnownUidValidity.correspondsTo(metaData.getUidValidity())) {
 
                         //  If the provided UIDVALIDITY matches that of the selected mailbox, the
@@ -310,13 +310,8 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
     }
 
     private void highestModSeq(Responder responder, MailboxMetaData metaData) {
-        final StatusResponse untaggedOk;
-        if (metaData.isModSeqPermanent()) {
-            final ModSeq highestModSeq = metaData.getHighestModSeq();
-            untaggedOk = statusResponseFactory.untaggedOk(HumanReadableText.HIGHEST_MOD_SEQ, ResponseCode.highestModSeq(highestModSeq));
-        } else {
-            untaggedOk = statusResponseFactory.untaggedOk(HumanReadableText.NO_MOD_SEQ, ResponseCode.noModSeq());
-        }
+        ModSeq highestModSeq = metaData.getHighestModSeq();
+        StatusResponse untaggedOk = statusResponseFactory.untaggedOk(HumanReadableText.HIGHEST_MOD_SEQ, ResponseCode.highestModSeq(highestModSeq));
         responder.respond(untaggedOk);        
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -125,7 +125,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
         }
 
         return selectMailbox(fullMailboxPath, session, responder)
-            .doOnNext(Throwing.<MailboxMetaData>consumer(metaData -> {
+            .doOnNext(metaData -> {
 
                 final SelectedMailbox selected = session.getSelected();
                 MessageUid firstUnseen = metaData.getFirstUnseen();
@@ -190,7 +190,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
                 // Reset the saved sequence-set after successful SELECT / EXAMINE
                 // See RFC 5812 2.1. Normative Description of the SEARCHRES Extension
                 SearchResUtil.resetSavedSequenceSet(session);
-            }).sneakyThrow())
+            })
             .then();
     }
 
@@ -207,7 +207,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
             });
     }
 
-    private void respondVanished(ImapSession session, Responder responder, IdRange[] knownSequences, UidRange[] knownUids, SelectedMailbox selected, UidRange[] uidSet) throws MailboxException {
+    private void respondVanished(ImapSession session, Responder responder, IdRange[] knownSequences, UidRange[] knownUids, SelectedMailbox selected, UidRange[] uidSet) {
         // RFC5162 3.1. QRESYNC Parameter to SELECT/EXAMINE
         //
         // Message sequence match data:
@@ -333,11 +333,11 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
         responder.respond(taggedOk);
     }
 
-    private boolean unseen(Responder responder, MessageUid firstUnseen, SelectedMailbox selected) throws MailboxException {
+    private boolean unseen(Responder responder, MessageUid firstUnseen, SelectedMailbox selected) {
         if (firstUnseen != null) {
             final MessageUid unseenUid = firstUnseen;
 
-            return selected.msn(unseenUid).fold(() -> {
+            return selected.msn(unseenUid).foldSilent(() -> {
                 LOGGER.debug("No message found with uid {} in mailbox {}", unseenUid, selected.getMailboxId().serialize());
                 return false;
             }, msn -> {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -392,10 +392,8 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
             }
             SelectedMailboxImpl selectedMailbox = new SelectedMailboxImpl(getMailboxManager(), eventBus, session, mailbox);
             return selectedMailbox.finishInit()
-                .then(Mono.fromCallable(() -> {
-                    session.selected(selectedMailbox);
-                    return selectedMailbox;
-                }));
+                .then(session.selected(selectedMailbox))
+                .thenReturn(selectedMailbox);
         } else {
             return Mono.just(currentMailbox);
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -168,11 +167,10 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
     }
 
     @Override
-    protected Closeable addContextToMDC(AuthenticateRequest request) {
+    protected MDCBuilder mdc(AuthenticateRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "AUTHENTICATE")
-            .addToContext("authType", request.getAuthType())
-            .build();
+            .addToContext("authType", request.getAuthType());
     }
 
     private void doOAuth(String initialResponse, ImapSession session, ImapRequest request, Responder responder) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CapabilityProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CapabilityProcessor.java
@@ -43,6 +43,8 @@ import org.apache.james.util.MDCBuilder;
 
 import com.google.common.collect.ImmutableList;
 
+import reactor.core.publisher.Mono;
+
 public class CapabilityProcessor extends AbstractMailboxProcessor<CapabilityRequest> implements CapabilityImplementingProcessor {
 
     private static final List<Capability> CAPS = ImmutableList.of(
@@ -76,11 +78,11 @@ public class CapabilityProcessor extends AbstractMailboxProcessor<CapabilityRequ
     }
 
     @Override
-    protected void processRequest(CapabilityRequest request, ImapSession session, Responder responder) {
+    protected Mono<Void> processRequestReactive(CapabilityRequest request, ImapSession session, Responder responder) {
         final CapabilityResponse result = new CapabilityResponse(getSupportedCapabilities(session));        
         responder.respond(result);
-        unsolicitedResponses(session, responder, false);
-        okComplete(request, responder);
+        return unsolicitedResponses(session, responder, false)
+            .then(Mono.fromRunnable(() -> okComplete(request, responder)));
     }
 
     /**

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CapabilityProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CapabilityProcessor.java
@@ -25,7 +25,6 @@ import static org.apache.james.imap.api.ImapConstants.SUPPORTS_I18NLEVEL_1;
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_LITERAL_PLUS;
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_RFC3348;
 
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -116,10 +115,9 @@ public class CapabilityProcessor extends AbstractMailboxProcessor<CapabilityRequ
     }
 
     @Override
-    protected Closeable addContextToMDC(CapabilityRequest request) {
+    protected MDCBuilder mdc(CapabilityRequest request) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "CAPABILITY")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "CAPABILITY");
     }
     
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CheckProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CheckProcessor.java
@@ -28,6 +28,8 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 
+import reactor.core.publisher.Mono;
+
 public class CheckProcessor extends AbstractMailboxProcessor<CheckRequest> {
 
     public CheckProcessor(MailboxManager mailboxManager, StatusResponseFactory factory,
@@ -36,9 +38,9 @@ public class CheckProcessor extends AbstractMailboxProcessor<CheckRequest> {
     }
 
     @Override
-    protected void processRequest(CheckRequest request, ImapSession session, Responder responder) {
-        unsolicitedResponses(session, responder, false);
-        okComplete(request, responder);
+    protected Mono<Void> processRequestReactive(CheckRequest request, ImapSession session, Responder responder) {
+        return unsolicitedResponses(session, responder, false)
+            .then(Mono.fromRunnable(() -> okComplete(request, responder)));
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CheckProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CheckProcessor.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
-
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.request.CheckRequest;
@@ -44,9 +42,8 @@ public class CheckProcessor extends AbstractMailboxProcessor<CheckRequest> {
     }
 
     @Override
-    protected Closeable addContextToMDC(CheckRequest request) {
+    protected MDCBuilder mdc(CheckRequest request) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "CHECK")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "CHECK");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CloseProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CloseProcessor.java
@@ -52,7 +52,7 @@ public class CloseProcessor extends AbstractMailboxProcessor<CloseRequest> {
             final MailboxSession mailboxSession = session.getMailboxSession();
             if (getMailboxManager().hasRight(mailbox.getMailboxEntity(), MailboxACL.Right.PerformExpunge, mailboxSession)) {
                 mailbox.expunge(MessageRange.all(), mailboxSession);
-                session.deselect();
+                session.deselect().block();
 
                 // Don't send HIGHESTMODSEQ when close. Like correct in the ERRATA of RFC5162
                 //

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CloseProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CloseProcessor.java
@@ -28,8 +28,8 @@ import org.apache.james.imap.message.request.CloseRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
-import org.apache.james.mailbox.MessageManager.MailboxMetaData.FetchGroup;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
@@ -50,7 +50,7 @@ public class CloseProcessor extends AbstractMailboxProcessor<CloseRequest> {
             MessageManager mailbox = getSelectedMailbox(session)
                 .orElseThrow(() -> new MailboxException("Session not in SELECTED state"));
             final MailboxSession mailboxSession = session.getMailboxSession();
-            if (mailbox.getMetaData(false, mailboxSession, FetchGroup.NO_COUNT).isWriteable()) {
+            if (getMailboxManager().hasRight(mailbox.getMailboxEntity(), MailboxACL.Right.PerformExpunge, mailboxSession)) {
                 mailbox.expunge(MessageRange.all(), mailboxSession);
                 session.deselect();
 
@@ -58,7 +58,6 @@ public class CloseProcessor extends AbstractMailboxProcessor<CloseRequest> {
                 //
                 // See http://www.rfc-editor.org/errata_search.php?rfc=5162
                 okComplete(request, responder);
-               
             }
 
         } catch (MailboxException e) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CompressProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CompressProcessor.java
@@ -18,7 +18,6 @@
  ****************************************************************/
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 
@@ -81,10 +80,9 @@ public class CompressProcessor extends AbstractProcessor<CompressRequest> implem
     }
 
     @Override
-    protected Closeable addContextToMDC(CompressRequest message) {
+    protected MDCBuilder mdc(CompressRequest message) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "COMPRESS")
-            .addToContext("algorithm", message.getAlgorithm())
-            .build();
+            .addToContext("algorithm", message.getAlgorithm());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CopyProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CopyProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.message.IdRange;
@@ -55,12 +54,11 @@ public class CopyProcessor extends AbstractMessageRangeProcessor<CopyRequest> {
     }
 
     @Override
-    protected Closeable addContextToMDC(CopyRequest request) {
+    protected MDCBuilder mdc(CopyRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "COPY")
             .addToContext("targetMailbox", request.getMailboxName())
             .addToContext("uidEnabled", Boolean.toString(request.isUseUids()))
-            .addToContext("idSet", IdRange.toString(request.getIdSet()))
-            .build();
+            .addToContext("idSet", IdRange.toString(request.getIdSet()));
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CreateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CreateProcessor.java
@@ -50,7 +50,7 @@ public class CreateProcessor extends AbstractMailboxProcessor<CreateRequest> {
         try {
             final MailboxManager mailboxManager = getMailboxManager();
             mailboxManager.createMailbox(mailboxPath, session.getMailboxSession());
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
             okComplete(request, responder);
         } catch (MailboxExistsException e) {
             LOGGER.debug("Create failed for mailbox {} as it already exists", mailboxPath, e);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CreateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CreateProcessor.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
-
 import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
@@ -65,10 +63,9 @@ public class CreateProcessor extends AbstractMailboxProcessor<CreateRequest> {
     }
 
     @Override
-    protected Closeable addContextToMDC(CreateRequest request) {
+    protected MDCBuilder mdc(CreateRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "CREATE")
-            .addToContext("mailbox", request.getMailboxName())
-            .build();
+            .addToContext("mailbox", request.getMailboxName());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessor.java
@@ -42,6 +42,8 @@ import org.apache.james.metrics.api.MetricFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import reactor.core.publisher.Mono;
+
 public class DefaultProcessor implements ImapProcessor {
 
     public static ImapProcessor createDefaultProcessor(ImapProcessor chainEndProcessor,
@@ -138,6 +140,12 @@ public class DefaultProcessor implements ImapProcessor {
     public void process(ImapMessage message, Responder responder, ImapSession session) {
         processorMap.getOrDefault(message.getClass(), chainEndProcessor)
             .process(message, responder, session);
+    }
+
+    @Override
+    public Mono<Void> processReactive(ImapMessage message, Responder responder, ImapSession session) {
+        return processorMap.getOrDefault(message.getClass(), chainEndProcessor)
+            .processReactive(message, responder, session);
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteACLProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteACLProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -138,11 +137,10 @@ public class DeleteACLProcessor extends AbstractMailboxProcessor<DeleteACLReques
     }
 
     @Override
-    protected Closeable addContextToMDC(DeleteACLRequest request) {
+    protected MDCBuilder mdc(DeleteACLRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "DELETE_ACL")
             .addToContext("mailbox", request.getMailboxName())
-            .addToContext("identifier", request.getIdentifier())
-            .build();
+            .addToContext("identifier", request.getIdentifier());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteProcessor.java
@@ -50,7 +50,7 @@ public class DeleteProcessor extends AbstractMailboxProcessor<DeleteRequest> {
         try {
             final SelectedMailbox selected = session.getSelected();
             if (selected != null && selected.getPath().equals(mailboxPath)) {
-                session.deselect();
+                session.deselect().block();
             }
             final MailboxManager mailboxManager = getMailboxManager();
             mailboxManager.deleteMailbox(mailboxPath, session.getMailboxSession());

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteProcessor.java
@@ -54,7 +54,7 @@ public class DeleteProcessor extends AbstractMailboxProcessor<DeleteRequest> {
             }
             final MailboxManager mailboxManager = getMailboxManager();
             mailboxManager.deleteMailbox(mailboxPath, session.getMailboxSession());
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
             okComplete(request, responder);
         } catch (MailboxNotFoundException e) {
             LOGGER.debug("Delete failed for mailbox {} as it doesn't exist", mailboxPath, e);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/EnableProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/EnableProcessor.java
@@ -21,7 +21,6 @@ package org.apache.james.imap.processor;
 
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_ENABLE;
 
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -130,10 +129,9 @@ public class EnableProcessor extends AbstractMailboxProcessor<EnableRequest> imp
     }
 
     @Override
-    protected Closeable addContextToMDC(EnableRequest request) {
+    protected MDCBuilder mdc(EnableRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "ENABLE")
-            .addToContext("capabilities", ImmutableList.copyOf(request.getCapabilities()).toString())
-            .build();
+            .addToContext("capabilities", ImmutableList.copyOf(request.getCapabilities()).toString());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ExamineProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ExamineProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -40,7 +39,7 @@ public class ExamineProcessor extends AbstractSelectionProcessor<ExamineRequest>
     }
 
     @Override
-    protected Closeable addContextToMDC(ExamineRequest request) {
+    protected MDCBuilder mdc(ExamineRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "EXAMINE")
             .addToContext("mailbox", request.getMailboxName())
@@ -49,7 +48,6 @@ public class ExamineProcessor extends AbstractSelectionProcessor<ExamineRequest>
             .addToContext("knownUids", UidRange.toString(request.getKnownUidSet()))
             .addToContext("knownIdRange", IdRange.toString(request.getKnownSequenceSet()))
             .addToContext("lastKnownUidValidity", request.getLastKnownUidValidity().toString())
-            .addToContext("uidSet", UidRange.toString(request.getUidSet()))
-            .build();
+            .addToContext("uidSet", UidRange.toString(request.getUidSet()));
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
@@ -88,7 +88,7 @@ public class ExpungeProcessor extends AbstractMailboxProcessor<ExpungeRequest> i
                     }
 
                 }
-                unsolicitedResponses(session, responder, false);
+                unsolicitedResponses(session, responder, false).block();
                 
                 
                 // Check if QRESYNC was enabled and at least one message was expunged. If so we need to respond with an OK response that contain the HIGHESTMODSEQ

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
@@ -91,7 +91,7 @@ public class ExpungeProcessor extends AbstractMailboxProcessor<ExpungeRequest> i
     private Mono<Integer> expunge(ExpungeRequest request, ImapSession session, MessageManager mailbox, MailboxSession mailboxSession) {
         IdRange[] ranges = request.getUidSet();
         if (ranges == null) {
-           return expunge(mailbox, MessageRange.all(), session, mailboxSession);
+            return expunge(mailbox, MessageRange.all(), session, mailboxSession);
         } else {
             // Handle UID EXPUNGE which is part of UIDPLUS
             // See http://tools.ietf.org/html/rfc4315

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetAnnotationProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetAnnotationProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -154,14 +153,13 @@ public class GetAnnotationProcessor extends AbstractMailboxProcessor<GetAnnotati
     }
 
     @Override
-    protected Closeable addContextToMDC(GetAnnotationRequest request) {
+    protected MDCBuilder mdc(GetAnnotationRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "GET_ANNOTATION")
             .addToContext("mailbox", request.getMailboxName())
             .addToContext("depth", request.getDepth().getCode())
             .addToContextIfPresent("maxSize", request.getMaxsize()
                 .map(i -> Integer.toString(i)))
-            .addToContext("keys", request.getKeys().toString())
-            .build();
+            .addToContext("keys", request.getKeys().toString());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -119,10 +118,9 @@ public class GetQuotaProcessor extends AbstractMailboxProcessor<GetQuotaRequest>
     }
 
     @Override
-    protected Closeable addContextToMDC(GetQuotaRequest request) {
+    protected MDCBuilder mdc(GetQuotaRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "GET_QUOTA")
-            .addToContext("quotaRoot", request.getQuotaRoot())
-            .build();
+            .addToContext("quotaRoot", request.getQuotaRoot());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaRootProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaRootProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.core.quota.QuotaCountLimit;
@@ -120,10 +119,9 @@ public class GetQuotaRootProcessor extends AbstractMailboxProcessor<GetQuotaRoot
     }
 
     @Override
-    protected Closeable addContextToMDC(GetQuotaRootRequest request) {
+    protected MDCBuilder mdc(GetQuotaRootRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "GET_QUOTA_ROOT")
-            .addToContext("mailbox", request.getMailboxName())
-            .build();
+            .addToContext("mailbox", request.getMailboxName());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -21,7 +21,6 @@ package org.apache.james.imap.processor;
 
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_IDLE;
 
-import java.io.Closeable;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
@@ -174,9 +173,8 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
     }
 
     @Override
-    protected Closeable addContextToMDC(IdleRequest message) {
+    protected MDCBuilder mdc(IdleRequest message) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "IDLE")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "IDLE");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LSubProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LSubProcessor.java
@@ -73,9 +73,8 @@ public class LSubProcessor extends AbstractMailboxProcessor<LsubRequest> {
 
     private Mono<Void> listSubscriptions(ImapSession session, Responder responder, String referenceName, String mailboxName) {
         MailboxSession mailboxSession = session.getMailboxSession();
-        Mono<List<String>> mailboxesMono;
         try {
-            mailboxesMono = Flux.from(subscriptionManager.subscriptionsReactive(mailboxSession))
+            Mono<List<String>> mailboxesMono = Flux.from(subscriptionManager.subscriptionsReactive(mailboxSession))
                 .collectList();
 
             String decodedMailName = ModifiedUtf7.decodeModifiedUTF7(referenceName);
@@ -84,9 +83,9 @@ public class LSubProcessor extends AbstractMailboxProcessor<LsubRequest> {
                 decodedMailName,
                 ModifiedUtf7.decodeModifiedUTF7(mailboxName),
                 mailboxSession.getPathDelimiter());
-            Collection<String> mailboxResponses = new ArrayList<>();
 
             return mailboxesMono.doOnNext(mailboxes -> {
+                Collection<String> mailboxResponses = new ArrayList<>();
                 for (String mailbox : mailboxes) {
                     respond(responder, expression, mailbox, true, mailboxes, mailboxResponses, mailboxSession.getPathDelimiter());
                 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ListRightsProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ListRightsProcessor.java
@@ -32,6 +32,7 @@ import org.apache.james.imap.message.request.ListRightsRequest;
 import org.apache.james.imap.message.response.ListRightsResponse;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.model.MailboxACL;
@@ -70,7 +71,7 @@ public class ListRightsProcessor extends AbstractMailboxProcessor<ListRightsRequ
         MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
 
         return Mono.from(mailboxManager.getMailboxReactive(mailboxPath, mailboxSession))
-            .doOnNext(Throwing.consumer(mailbox -> {
+            .doOnNext(Throwing.<MessageManager>consumer(mailbox -> {
                 /*
                  * RFC 4314 section 6.
                  * An implementation MUST make sure the ACL commands themselves do
@@ -111,7 +112,7 @@ public class ListRightsProcessor extends AbstractMailboxProcessor<ListRightsRequ
                     responder.respond(aclResponse);
                     okComplete(request, responder);
                 }
-            }))
+            }).sneakyThrow())
             .onErrorResume(MailboxNotFoundException.class, e -> {
                 no(request, responder, HumanReadableText.MAILBOX_NOT_FOUND);
                 return Mono.empty();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LoginProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LoginProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 
@@ -66,10 +65,9 @@ public class LoginProcessor extends AbstractAuthProcessor<LoginRequest> implemen
     }
 
     @Override
-    protected Closeable addContextToMDC(LoginRequest request) {
+    protected MDCBuilder mdc(LoginRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "LOGIN")
-            .addToContext(MDCBuilder.USER, request.getUserid().asString())
-            .build();
+            .addToContext("login-user", request.getUserid().asString());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
-
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.request.LogoutRequest;
@@ -49,9 +47,8 @@ public class LogoutProcessor extends AbstractMailboxProcessor<LogoutRequest> {
     }
 
     @Override
-    protected Closeable addContextToMDC(LogoutRequest request) {
+    protected MDCBuilder mdc(LogoutRequest request) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "LOGOUT")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "LOGOUT");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -70,13 +69,12 @@ public class MoveProcessor extends AbstractMessageRangeProcessor<MoveRequest> im
     }
 
     @Override
-    protected Closeable addContextToMDC(MoveRequest request) {
+    protected MDCBuilder mdc(MoveRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "MOVE")
             .addToContext("targetMailbox", request.getMailboxName())
             .addToContext("uidEnabled", Boolean.toString(request.isUseUids()))
-            .addToContext("idSet", IdRange.toString(request.getIdSet()))
-            .build();
+            .addToContext("idSet", IdRange.toString(request.getIdSet()));
     }
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/NamespaceProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/NamespaceProcessor.java
@@ -20,7 +20,6 @@ package org.apache.james.imap.processor;
 
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_NAMESPACES;
 
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -108,9 +107,8 @@ public class NamespaceProcessor extends AbstractMailboxProcessor<NamespaceReques
     }
 
     @Override
-    protected Closeable addContextToMDC(NamespaceRequest request) {
+    protected MDCBuilder mdc(NamespaceRequest request) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "NAMESPACE")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "NAMESPACE");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/NoopProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/NoopProcessor.java
@@ -28,16 +28,18 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 
+import reactor.core.publisher.Mono;
+
 public class NoopProcessor extends AbstractMailboxProcessor<NoopRequest> {
     public NoopProcessor(MailboxManager mailboxManager, StatusResponseFactory factory, MetricFactory metricFactory) {
         super(NoopRequest.class, mailboxManager, factory, metricFactory);
     }
 
     @Override
-    protected void processRequest(NoopRequest request, ImapSession session, Responder responder) {
+    protected Mono<Void> processRequestReactive(NoopRequest request, ImapSession session, Responder responder) {
         // So, unsolicated responses are returned to check for new mail
-        unsolicitedResponses(session, responder, false);
-        okComplete(request, responder);
+        return unsolicitedResponses(session, responder, false)
+            .then(Mono.fromRunnable(() -> okComplete(request, responder)));
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/NoopProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/NoopProcessor.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
-
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.request.NoopRequest;
@@ -43,9 +41,8 @@ public class NoopProcessor extends AbstractMailboxProcessor<NoopRequest> {
     }
 
     @Override
-    protected Closeable addContextToMDC(NoopRequest message) {
+    protected MDCBuilder mdc(NoopRequest message) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "NOOP")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "NOOP");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/PermitEnableCapabilityProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/PermitEnableCapabilityProcessor.java
@@ -24,6 +24,8 @@ import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.message.Capability;
 import org.apache.james.imap.api.process.ImapSession;
 
+import reactor.core.publisher.Mono;
+
 /**
  * {@link CapabilityImplementingProcessor} which allows to ENABLE one ore more Capabilities
  */
@@ -39,7 +41,7 @@ public interface PermitEnableCapabilityProcessor extends CapabilityImplementingP
     /**
      * Callback which is used when a ENABLED command was used to enable on of the CAPABILITIES which is managed by this implementation
      */
-    void enable(ImapMessage message, Responder responder, ImapSession session, Capability capability) throws EnableException;
+    Mono<Void> enable(ImapMessage message, Responder responder, ImapSession session, Capability capability);
 
     /**
      * Exception which should get thrown if for whatever reason its not possible to enable a capability

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/RenameProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/RenameProcessor.java
@@ -63,7 +63,7 @@ public class RenameProcessor extends AbstractMailboxProcessor<RenameRequest> {
                 mailboxManager.createMailbox(existingPath, mailboxsession);
             }
             okComplete(request, responder);
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
         } catch (MailboxExistsException e) {
             LOGGER.debug("Rename from {} to {} failed because the target mailbox exists", existingPath, newPath, e);
             no(request, responder, HumanReadableText.FAILURE_MAILBOX_EXISTS);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/RenameProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/RenameProcessor.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
-
 import org.apache.james.imap.api.ImapConstants;
 import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
@@ -80,11 +78,10 @@ public class RenameProcessor extends AbstractMailboxProcessor<RenameRequest> {
     }
 
     @Override
-    protected Closeable addContextToMDC(RenameRequest request) {
+    protected MDCBuilder mdc(RenameRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "RENAME")
             .addToContext("existingName", request.getExistingName())
-            .addToContext("newName", request.getNewName())
-            .build();
+            .addToContext("newName", request.getNewName());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SelectProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SelectProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -40,7 +39,7 @@ public class SelectProcessor extends AbstractSelectionProcessor<SelectRequest> {
     }
 
     @Override
-    protected Closeable addContextToMDC(SelectRequest message) {
+    protected MDCBuilder mdc(SelectRequest message) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "SELECT")
             .addToContext("mailbox", message.getMailboxName())
@@ -49,8 +48,6 @@ public class SelectProcessor extends AbstractSelectionProcessor<SelectRequest> {
             .addToContext("knownUids", UidRange.toString(message.getKnownUidSet()))
             .addToContext("knownIdRange", IdRange.toString(message.getKnownSequenceSet()))
             .addToContext("lastKnownUidValidity", message.getLastKnownUidValidity().toString())
-            .addToContext("uidSet", UidRange.toString(message.getUidSet()))
-            .build();
+            .addToContext("uidSet", UidRange.toString(message.getUidSet()));
     }
-
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SetACLProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SetACLProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -157,12 +156,11 @@ public class SetACLProcessor extends AbstractMailboxProcessor<SetACLRequest> imp
     }
 
     @Override
-    protected Closeable addContextToMDC(SetACLRequest request) {
+    protected MDCBuilder mdc(SetACLRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "SET_ACL")
             .addToContext("mailbox", request.getMailboxName())
             .addToContext("identifier", request.getIdentifier())
-            .addToContext("rights", request.getRights())
-            .build();
+            .addToContext("rights", request.getRights());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SetAnnotationProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SetAnnotationProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -80,11 +79,10 @@ public class SetAnnotationProcessor extends AbstractMailboxProcessor<SetAnnotati
     }
 
     @Override
-    protected Closeable addContextToMDC(SetAnnotationRequest request) {
+    protected MDCBuilder mdc(SetAnnotationRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "SET_ANNOTATION")
             .addToContext("mailbox", request.getMailboxName())
-            .addToContext("annotations", request.getMailboxAnnotations().toString())
-            .build();
+            .addToContext("annotations", request.getMailboxAnnotations().toString());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SetQuotaProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SetQuotaProcessor.java
@@ -34,6 +34,8 @@ import org.apache.james.util.MDCBuilder;
 
 import com.google.common.collect.ImmutableList;
 
+import reactor.core.publisher.Mono;
+
 /**
  * SETQUOTA processor
  */
@@ -51,14 +53,16 @@ public class SetQuotaProcessor extends AbstractMailboxProcessor<SetQuotaRequest>
     }
 
     @Override
-    protected void processRequest(SetQuotaRequest request, ImapSession session, Responder responder) {
-        Object[] params = new Object[]{
-            "Full admin rights",
-            request.getCommand().getName(),
-            "Can not perform SETQUOTA commands"
-        };
-        HumanReadableText humanReadableText = new HumanReadableText(HumanReadableText.UNSUFFICIENT_RIGHTS_KEY, HumanReadableText.UNSUFFICIENT_RIGHTS_DEFAULT_VALUE, params);
-        no(request, responder, humanReadableText);
+    protected Mono<Void> processRequestReactive(SetQuotaRequest request, ImapSession session, Responder responder) {
+        return Mono.fromRunnable(() -> {
+            Object[] params = new Object[]{
+                "Full admin rights",
+                request.getCommand().getName(),
+                "Can not perform SETQUOTA commands"
+            };
+            HumanReadableText humanReadableText = new HumanReadableText(HumanReadableText.UNSUFFICIENT_RIGHTS_KEY, HumanReadableText.UNSUFFICIENT_RIGHTS_DEFAULT_VALUE, params);
+            no(request, responder, humanReadableText);
+        });
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SetQuotaProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SetQuotaProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -66,11 +65,10 @@ public class SetQuotaProcessor extends AbstractMailboxProcessor<SetQuotaRequest>
     }
 
     @Override
-    protected Closeable addContextToMDC(SetQuotaRequest request) {
+    protected MDCBuilder mdc(SetQuotaRequest request) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "SET_QUOTA")
             .addToContext("quotaRoot", request.getQuotaRoot())
-            .addToContext("limits", request.getResourceLimits().toString())
-            .build();
+            .addToContext("limits", request.getResourceLimits().toString());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StartTLSProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StartTLSProcessor.java
@@ -34,6 +34,8 @@ import org.apache.james.util.MDCBuilder;
 
 import com.google.common.collect.ImmutableList;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Processing STARTLS commands
  */
@@ -47,12 +49,14 @@ public class StartTLSProcessor extends AbstractProcessor<StartTLSRequest> implem
     }
 
     @Override
-    protected void doProcess(StartTLSRequest request, Responder responder, ImapSession session) {
-        if (session.supportStartTLS()) {
-            session.startTLS((ImmutableStatusResponse) factory.taggedOk(request.getTag(), request.getCommand(), HumanReadableText.STARTTLS));
-        } else {
-            responder.respond(factory.taggedBad(request.getTag(), request.getCommand(), HumanReadableText.UNKNOWN_COMMAND));
-        }
+    protected Mono<Void> doProcess(StartTLSRequest request, Responder responder, ImapSession session) {
+        return Mono.fromRunnable(() -> {
+            if (session.supportStartTLS()) {
+                session.startTLS((ImmutableStatusResponse) factory.taggedOk(request.getTag(), request.getCommand(), HumanReadableText.STARTTLS));
+            } else {
+                responder.respond(factory.taggedBad(request.getTag(), request.getCommand(), HumanReadableText.UNKNOWN_COMMAND));
+            }
+        });
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StartTLSProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StartTLSProcessor.java
@@ -18,7 +18,6 @@
  ****************************************************************/
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 
@@ -69,9 +68,8 @@ public class StartTLSProcessor extends AbstractProcessor<StartTLSRequest> implem
     }
 
     @Override
-    protected Closeable addContextToMDC(StartTLSRequest message) {
+    protected MDCBuilder mdc(StartTLSRequest message) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "START_TLS")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "START_TLS");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
@@ -66,7 +66,7 @@ public class StatusProcessor extends AbstractMailboxProcessor<StatusRequest> {
                 condstoreEnablingCommand(session, responder, metaData, false); 
             }
             responder.respond(response);
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
 
             okComplete(request, responder);
         } catch (MailboxException e) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
@@ -166,7 +166,7 @@ public class StoreProcessor extends AbstractMailboxProcessor<StoreRequest> {
 
             }
             final boolean omitExpunged = (!useUids);
-            unsolicitedResponses(session, responder, omitExpunged, useUids);
+            unsolicitedResponses(session, responder, omitExpunged, useUids).block();
             
             // check if we had some failed uids which didn't pass the UNCHANGEDSINCE filter
             if (failed.isEmpty() && failedMsns.isEmpty()) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SubscribeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SubscribeProcessor.java
@@ -49,12 +49,12 @@ public class SubscribeProcessor extends AbstractSubscriptionProcessor<SubscribeR
         try {
             getSubscriptionManager().subscribe(mailboxSession, mailboxName);
 
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
             okComplete(request, responder);
 
         } catch (SubscriptionException e) {
             LOGGER.info("Subscribe failed for mailbox {}", mailboxName, e);
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
             no(request, responder, HumanReadableText.GENERIC_SUBSCRIPTION_FAILURE);
         }
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
@@ -30,6 +30,8 @@ import org.apache.james.util.MDCBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Processes system messages unrelated to IMAP.
  */
@@ -44,7 +46,7 @@ public class SystemMessageProcessor extends AbstractProcessor<SystemMessage> {
     }
 
     @Override
-    protected void doProcess(SystemMessage message, Responder responder, ImapSession session) {
+    protected Mono<Void> doProcess(SystemMessage message, Responder responder, ImapSession session) {
         switch (message) {
             case FORCE_LOGOUT:
                 forceLogout(session);
@@ -53,6 +55,7 @@ public class SystemMessageProcessor extends AbstractProcessor<SystemMessage> {
                 LOGGER.info("Unknown system message {}", message);
                 break;
         }
+        return Mono.empty();
     }
 
     /**

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
-
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.request.SystemMessage;
 import org.apache.james.imap.processor.base.AbstractProcessor;
@@ -75,10 +73,9 @@ public class SystemMessageProcessor extends AbstractProcessor<SystemMessage> {
     }
 
     @Override
-    protected Closeable addContextToMDC(SystemMessage message) {
+    protected MDCBuilder mdc(SystemMessage message) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "SYSTEM_MESSAGE")
-            .addToContext("message", message.toString())
-            .build();
+            .addToContext("message", message.toString());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/UnselectProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/UnselectProcessor.java
@@ -34,6 +34,8 @@ import org.apache.james.util.MDCBuilder;
 
 import com.google.common.collect.ImmutableList;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Processor which implements the UNSELECT extension.
  * 
@@ -48,14 +50,14 @@ public class UnselectProcessor extends AbstractMailboxProcessor<UnselectRequest>
     }
 
     @Override
-    protected void processRequest(UnselectRequest request, ImapSession session, Responder responder) {
+    protected Mono<Void> processRequestReactive(UnselectRequest request, ImapSession session, Responder responder) {
         if (session.getSelected() != null) {
-            session.deselect();
-            okComplete(request, responder);
+            return session.deselect()
+                .then(Mono.fromRunnable(() -> okComplete(request, responder)));
         } else {
             taggedBad(request, responder, HumanReadableText.UNSELECT);
+            return Mono.empty();
         }
-
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/UnselectProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/UnselectProcessor.java
@@ -20,7 +20,6 @@ package org.apache.james.imap.processor;
 
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_UNSELECT;
 
-import java.io.Closeable;
 import java.util.List;
 
 import org.apache.james.imap.api.display.HumanReadableText;
@@ -66,8 +65,7 @@ public class UnselectProcessor extends AbstractMailboxProcessor<UnselectRequest>
     }
 
     @Override
-    protected Closeable addContextToMDC(UnselectRequest request) {
-        return MDCBuilder.ofValue(MDCBuilder.ACTION, "UNSELECT")
-            .build();
+    protected MDCBuilder mdc(UnselectRequest request) {
+        return MDCBuilder.ofValue(MDCBuilder.ACTION, "UNSELECT");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/UnsubscribeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/UnsubscribeProcessor.java
@@ -49,12 +49,12 @@ public class UnsubscribeProcessor extends AbstractSubscriptionProcessor<Unsubscr
         try {
             getSubscriptionManager().unsubscribe(mailboxSession, mailboxName);
 
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
             okComplete(request, responder);
 
         } catch (SubscriptionException e) {
             LOGGER.info("Unsubscribe failed for mailbox {}", mailboxName, e);
-            unsolicitedResponses(session, responder, false);
+            unsolicitedResponses(session, responder, false).block();
 
             no(request, responder, HumanReadableText.GENERIC_SUBSCRIPTION_FAILURE);
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/UnsubscribeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/UnsubscribeProcessor.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.imap.processor;
 
-import java.io.Closeable;
+import static org.apache.james.util.ReactorUtils.logOnError;
 
 import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
@@ -52,18 +52,16 @@ public class UnsubscribeProcessor extends AbstractSubscriptionProcessor<Unsubscr
         return Mono.from(getSubscriptionManager().unsubscribeReactive(mailboxName, mailboxSession))
             .then(unsolicitedResponses(session, responder, false))
             .then(Mono.fromRunnable(() -> okComplete(request, responder)))
-            .onErrorResume(SubscriptionException.class, e -> {
-                LOGGER.info("Unsubscribe failed for mailbox {}", mailboxName, e);
-                return unsolicitedResponses(session, responder, false)
-                    .then(Mono.fromRunnable(() -> no(request, responder, HumanReadableText.GENERIC_SUBSCRIPTION_FAILURE)));
-            }).then();
+            .doOnEach(logOnError(SubscriptionException.class, e -> LOGGER.info("Unsubscribe failed for mailbox {}", mailboxName, e)))
+            .onErrorResume(SubscriptionException.class, e ->
+                unsolicitedResponses(session, responder, false)
+                .then(Mono.fromRunnable(() -> no(request, responder, HumanReadableText.GENERIC_SUBSCRIPTION_FAILURE)))).then();
     }
 
     @Override
-    protected Closeable addContextToMDC(UnsubscribeRequest message) {
+    protected MDCBuilder mdc(UnsubscribeRequest message) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "UNSUBSCRIBE")
-            .addToContext("mailbox", message.getMailboxName())
-            .build();
+            .addToContext("mailbox", message.getMailboxName());
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/ImapResponseMessageProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/ImapResponseMessageProcessor.java
@@ -25,6 +25,8 @@ import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.response.ImmutableStatusResponse;
 import org.apache.james.util.MDCBuilder;
 
+import reactor.core.publisher.Mono;
+
 public class ImapResponseMessageProcessor extends AbstractProcessor<ImmutableStatusResponse> {
 
     public ImapResponseMessageProcessor() {
@@ -32,8 +34,8 @@ public class ImapResponseMessageProcessor extends AbstractProcessor<ImmutableSta
     }
 
     @Override
-    protected void doProcess(ImmutableStatusResponse acceptableMessage, Responder responder, ImapSession session) {
-        responder.respond(acceptableMessage);
+    protected Mono<Void> doProcess(ImmutableStatusResponse acceptableMessage, Responder responder, ImapSession session) {
+        return Mono.fromRunnable(() -> responder.respond(acceptableMessage));
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/ImapResponseMessageProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/ImapResponseMessageProcessor.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.imap.processor.base;
 
-import java.io.Closeable;
-
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.response.ImmutableStatusResponse;
 import org.apache.james.util.MDCBuilder;
@@ -39,9 +37,8 @@ public class ImapResponseMessageProcessor extends AbstractProcessor<ImmutableSta
     }
 
     @Override
-    protected Closeable addContextToMDC(ImmutableStatusResponse message) {
+    protected MDCBuilder mdc(ImmutableStatusResponse message) {
         return MDCBuilder.create()
-            .addToContext(MDCBuilder.ACTION, "RESPOND")
-            .build();
+            .addToContext(MDCBuilder.ACTION, "RESPOND");
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -179,12 +179,12 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     }
 
     @Override
-    public synchronized Optional<MessageUid> getFirstUid() {
+    public Optional<MessageUid> getFirstUid() {
         return uidMsnConverter.getFirstUid();
     }
 
     @Override
-    public synchronized Optional<MessageUid> getLastUid() {
+    public Optional<MessageUid> getLastUid() {
         return uidMsnConverter.getLastUid();
     }
 
@@ -272,10 +272,8 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     }
 
     @Override
-    public synchronized NullableMessageSequenceNumber remove(MessageUid uid) {
-        NullableMessageSequenceNumber result = msn(uid);
-        uidMsnConverter.remove(uid);
-        return result;
+    public NullableMessageSequenceNumber remove(MessageUid uid) {
+        return uidMsnConverter.getAndRemove(uid);
     }
 
     private boolean interestingFlags(UpdatedFlags updated) {
@@ -487,12 +485,12 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     }
 
     @Override
-    public synchronized NullableMessageSequenceNumber msn(MessageUid uid) {
+    public NullableMessageSequenceNumber msn(MessageUid uid) {
         return uidMsnConverter.getMsn(uid);
     }
 
     @Override
-    public synchronized Optional<MessageUid> uid(int msn) {
+    public Optional<MessageUid> uid(int msn) {
         if (msn == NO_SUCH_MESSAGE) {
             return Optional.empty();
         }
@@ -502,7 +500,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
 
     
     @Override
-    public synchronized long existsCount() {
+    public long existsCount() {
         return uidMsnConverter.getNumMessage();
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -200,6 +200,11 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     }
 
     @Override
+    public MessageManager getMessageManager() {
+        return messageManager;
+    }
+
+    @Override
     public synchronized  boolean removeRecent(MessageUid uid) {
         final boolean result = recentUids.remove(uid);
         if (result) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -385,13 +385,17 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
 
     
     @Override
-    public synchronized void event(Event event) {
+    public void event(Event event) {
+        synchronizedEvent(event);
+        Optional.ofNullable(idleEventListener.get())
+            .ifPresent(Throwing.<EventListener>consumer(listener -> listener.event(event)).sneakyThrow());
+    }
+
+    private synchronized void synchronizedEvent(Event event) {
         if (event instanceof MailboxEvent) {
             MailboxEvent mailboxEvent = (MailboxEvent) event;
             mailboxEvent(mailboxEvent);
         }
-        Optional.ofNullable(idleEventListener.get())
-            .ifPresent(Throwing.<EventListener>consumer(listener -> listener.event(event)).sneakyThrow());
     }
 
     private void mailboxEvent(MailboxEvent mailboxEvent) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -377,7 +377,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
 
     
     @Override
-    public synchronized void resetNewApplicableFlags() {
+    public void resetNewApplicableFlags() {
         long stamp = applicableFlagsLock.writeLock();
         applicableFlags = applicableFlags.ackUpdates();
         applicableFlagsLock.unlockWrite(stamp);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -243,6 +243,12 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     }
 
     @Override
+    public Mono<MailboxPath> getPathReactive() {
+        return Mono.from(mailboxManager.getMailboxReactive(mailboxId, mailboxSession))
+            .map(Throwing.function(MessageManager::getMailboxPath));
+    }
+
+    @Override
     public MailboxId getMailboxId() {
         return mailboxId;
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -50,6 +50,10 @@ public class UidMsnConverter {
     }
 
     public synchronized NullableMessageSequenceNumber getMsn(MessageUid uid) {
+        return getMsnUnsynchronized(uid);
+    }
+
+    private NullableMessageSequenceNumber getMsnUnsynchronized(MessageUid uid) {
         int position = Collections.binarySearch(uids, uid);
         if (position < 0) {
             return NullableMessageSequenceNumber.noMessage();
@@ -81,6 +85,12 @@ public class UidMsnConverter {
 
     public synchronized void remove(MessageUid uid) {
         uids.remove(uid);
+    }
+
+    public synchronized NullableMessageSequenceNumber getAndRemove(MessageUid uid) {
+        NullableMessageSequenceNumber result = getMsnUnsynchronized(uid);
+        uids.remove(uid);
+        return result;
     }
 
     public synchronized boolean isEmpty() {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -114,7 +114,7 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
                 return processMessageRanges(session, mailbox, ranges, fetch, mailboxSession, responder)
                     // Don't send expunge responses if FETCH is used to trigger this
                     // processor. See IMAP-284
-                    .then(Mono.defer(() -> unsolicitedResponses(session, responder, omitExpunged, useUids)))
+                    .then(unsolicitedResponses(session, responder, omitExpunged, useUids))
                     .then(Mono.fromRunnable(() -> okComplete(request, responder)));
             }).sneakyThrow())
             .doOnEach(logOnError(MessageRangeException.class, e -> LOGGER.debug("Fetch failed for mailbox {} because of invalid sequence-set {}", session.getSelected().getMailboxId(), idSet, e)))

--- a/protocols/imap/src/main/java/org/apache/james/mailbox/NullableMessageSequenceNumber.java
+++ b/protocols/imap/src/main/java/org/apache/james/mailbox/NullableMessageSequenceNumber.java
@@ -22,6 +22,8 @@ package org.apache.james.mailbox;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.james.mailbox.exception.MailboxException;
 
@@ -60,6 +62,14 @@ public final class NullableMessageSequenceNumber {
             return handleMessage.handle(msn.get());
         } else {
             return handleNoMessage.handle();
+        }
+    }
+
+    public <T> T foldSilent(Supplier<T> handleNoMessage, Function<MessageSequenceNumber, T> handleMessage) {
+        if (msn.isPresent()) {
+            return handleMessage.apply(msn.get());
+        } else {
+            return handleNoMessage.get();
         }
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
@@ -93,7 +93,7 @@ class CopyProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.just(true));
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(INBOX, mailboxSession)).thenReturn(targetMessageManager);
@@ -126,7 +126,7 @@ class CopyProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.just(true));
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(INBOX, mailboxSession)).thenReturn(targetMessageManager);
@@ -158,7 +158,7 @@ class CopyProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.just(false));
 
         StatusResponse noResponse = mock(StatusResponse.class);
@@ -182,7 +182,7 @@ class CopyProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.error(new MailboxException()));
 
         StatusResponse noResponse = mock(StatusResponse.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/DeleteACLProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/DeleteACLProcessorTest.java
@@ -104,7 +104,7 @@ class DeleteACLProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Lookup, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(deleteACLRequest, responder, imapSession);
+        subject.doProcess(deleteACLRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -122,7 +122,7 @@ class DeleteACLProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Administer, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(deleteACLRequest, responder, imapSession);
+        subject.doProcess(deleteACLRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -138,7 +138,7 @@ class DeleteACLProcessorTest {
         when(mailboxManager.getMailbox(any(MailboxPath.class), any(MailboxSession.class)))
             .thenThrow(new MailboxNotFoundException(""));
 
-        subject.doProcess(deleteACLRequest, responder, imapSession);
+        subject.doProcess(deleteACLRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -159,7 +159,7 @@ class DeleteACLProcessorTest {
             .thenReturn(true);
         when(metaData.getACL()).thenReturn(acl);
 
-        subject.doProcess(deleteACLRequest, responder, imapSession);
+        subject.doProcess(deleteACLRequest, responder, imapSession).block();
 
         verify(mailboxManager).applyRightsCommand(path,
             MailboxACL.command().key(user1Key).noRights().asReplacement(),

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetACLProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetACLProcessorTest.java
@@ -99,7 +99,7 @@ class GetACLProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Lookup, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(getACLRequest, responder, imapSession);
+        subject.doProcess(getACLRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -117,7 +117,7 @@ class GetACLProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Administer, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(getACLRequest, responder, imapSession);
+        subject.doProcess(getACLRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -133,7 +133,7 @@ class GetACLProcessorTest {
         when(mailboxManager.getMailbox(any(MailboxPath.class), any(MailboxSession.class)))
             .thenThrow(new MailboxNotFoundException(""));
 
-        subject.doProcess(getACLRequest, responder, imapSession);
+        subject.doProcess(getACLRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -154,7 +154,7 @@ class GetACLProcessorTest {
         when(metaData.getACL()).thenReturn(acl);
 
         ACLResponse response = new ACLResponse(MAILBOX_NAME, acl);
-        subject.doProcess(getACLRequest, responder, imapSession);
+        subject.doProcess(getACLRequest, responder, imapSession).block();
 
         verify(responder, times(2)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaProcessorTest.java
@@ -61,8 +61,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-public class GetQuotaProcessorTest {
+class GetQuotaProcessorTest {
 
     private static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("plop", Optional.empty());
     private static final Username PLOP = Username.of("plop");
@@ -111,8 +112,8 @@ public class GetQuotaProcessorTest {
             .thenReturn(Flux.just(mailbox));
         when(mockedMailboxManager.hasRight(any(Mailbox.class), eq(MailboxACL.Right.Read), eq(mailboxSession)))
             .thenReturn(true);
-        when(mockedQuotaManager.getQuotas(any(QuotaRoot.class)))
-            .thenReturn(new QuotaManager.Quotas(MESSAGE_QUOTA, STORAGE_QUOTA));
+        when(mockedQuotaManager.getQuotasReactive(any(QuotaRoot.class)))
+            .thenReturn(Mono.just(new QuotaManager.Quotas(MESSAGE_QUOTA, STORAGE_QUOTA)));
 
         QuotaResponse storageQuotaResponse = new QuotaResponse("STORAGE", "plop", STORAGE_QUOTA);
         QuotaResponse messageQuotaResponse = new QuotaResponse("MESSAGE", "plop", MESSAGE_QUOTA);
@@ -137,8 +138,6 @@ public class GetQuotaProcessorTest {
         when(mockedQuotaRootResolver.retrieveAssociatedMailboxes(QUOTA_ROOT, mailboxSession))
             .thenReturn(Flux.just((mailbox)));
         when(mockedMailboxManager.hasRight(any(Mailbox.class), eq(MailboxACL.Right.Read), eq(mailboxSession)))
-            .thenReturn(true);
-        when(mockedQuotaManager.getQuotas(any(QuotaRoot.class)))
             .thenThrow(new MailboxException());
 
         testee.doProcess(getQuotaRequest, mockedResponder, imapSession).block();

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/LSubProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/LSubProcessorTest.java
@@ -112,7 +112,7 @@ class LSubProcessorTest {
 
         LsubRequest request = new LsubRequest("", PARENT
                 + HIERARCHY_DELIMITER + "%", TAG);
-        processor.doProcessRequest(request, session, responderImpl);
+        processor.processRequest(request, session, responderImpl);
 
         verify(responder).respond(new LSubResponse(CHILD_ONE, false, HIERARCHY_DELIMITER));
         verify(responder).respond(new LSubResponse(CHILD_TWO, false, HIERARCHY_DELIMITER));
@@ -134,7 +134,7 @@ class LSubProcessorTest {
 
         LsubRequest request = new LsubRequest("", ROOT
                 + HIERARCHY_DELIMITER + "%", TAG);
-        processor.doProcessRequest(request, session, responderImpl);
+        processor.processRequest(request, session, responderImpl);
 
         verify(responder).respond(new LSubResponse(PARENT, true, HIERARCHY_DELIMITER));
         verify(responder).respond(statusResponse);
@@ -156,7 +156,7 @@ class LSubProcessorTest {
 
         LsubRequest request = new LsubRequest("", ROOT
                 + HIERARCHY_DELIMITER + "%", TAG);
-        processor.doProcessRequest(request, session, responderImpl);
+        processor.processRequest(request, session, responderImpl);
 
         verify(responder).respond(new LSubResponse(PARENT, false, HIERARCHY_DELIMITER));
         verify(responder).respond(statusResponse);
@@ -172,7 +172,7 @@ class LSubProcessorTest {
             .thenReturn(statusResponse);
 
         LsubRequest request = new LsubRequest("", "*", TAG);
-        processor.doProcessRequest(request, session, responderImpl);
+        processor.processRequest(request, session, responderImpl);
 
         verify(responder).respond(new LSubResponse(MAILBOX_A, false, HIERARCHY_DELIMITER));
         verify(responder).respond(new LSubResponse(MAILBOX_B, false, HIERARCHY_DELIMITER));

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/LSubProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/LSubProcessorTest.java
@@ -48,6 +48,8 @@ import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import reactor.core.publisher.Flux;
+
 class LSubProcessorTest {
 
     private static final String ROOT = "ROOT";
@@ -181,6 +183,6 @@ class LSubProcessorTest {
     }
 
     private void expectSubscriptions() throws Exception {
-        when(manager.subscriptions(mailboxSession)).thenReturn(subscriptions);
+        when(manager.subscriptionsReactive(mailboxSession)).thenReturn(Flux.fromIterable(subscriptions));
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/ListRightsProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/ListRightsProcessorTest.java
@@ -110,7 +110,7 @@ class ListRightsProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Lookup, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(listRightsRequest, responder, imapSession);
+        subject.doProcess(listRightsRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -128,7 +128,7 @@ class ListRightsProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Administer, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(listRightsRequest, responder, imapSession);
+        subject.doProcess(listRightsRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -144,7 +144,7 @@ class ListRightsProcessorTest {
         when(mailboxManager.getMailbox(any(MailboxPath.class), any(MailboxSession.class)))
             .thenThrow(new MailboxNotFoundException(""));
 
-        subject.doProcess(listRightsRequest, responder, imapSession);
+        subject.doProcess(listRightsRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -169,7 +169,7 @@ class ListRightsProcessorTest {
             .thenReturn(listRights);
 
 
-        subject.doProcess(listRightsRequest, responder, imapSession);
+        subject.doProcess(listRightsRequest, responder, imapSession).block();
 
         ListRightsResponse response = new ListRightsResponse(MAILBOX_NAME, USER_1.asString(), listRights);
         verify(responder, times(2)).respond(argumentCaptor.capture());

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
@@ -109,7 +109,7 @@ public class MoveProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.just(true));
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(INBOX, mailboxSession)).thenReturn(targetMessageManager);
@@ -142,7 +142,7 @@ public class MoveProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.just(true));
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(INBOX, mailboxSession)).thenReturn(targetMessageManager);
@@ -173,7 +173,7 @@ public class MoveProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.just(false));
 
         StatusResponse noResponse = mock(StatusResponse.class);
@@ -196,7 +196,7 @@ public class MoveProcessorTest {
         when(selectedMailbox.getLastUid()).thenReturn(Optional.of(MessageUid.of(8)));
         when(selectedMailbox.existsCount()).thenReturn(8L);
         when(selectedMailbox.getPath()).thenReturn(selected);
-        imapSession.selected(selectedMailbox);
+        imapSession.selected(selectedMailbox).block();
         when(mockMailboxManager.mailboxExists(INBOX, mailboxSession)).thenReturn(Mono.error(new MailboxException()));
 
         StatusResponse noResponse = mock(StatusResponse.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/NamespaceProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/NamespaceProcessorTest.java
@@ -92,7 +92,7 @@ class NamespaceProcessorTest {
         final NamespaceResponse response = buildResponse(null);
         final Responder responderMock = mock(Responder.class);
 
-        subject.doProcess(namespaceRequest, responderMock, imapSession);
+        subject.doProcess(namespaceRequest, responderMock, imapSession).block();
 
         verify(responderMock, times(1)).respond(response);
         verify(responderMock, times(1)).respond(any(StatusResponse.class));
@@ -118,7 +118,7 @@ class NamespaceProcessorTest {
         
         final Responder responderMock = mock(Responder.class);
 
-        subject.doProcess(namespaceRequest, responderMock, imapSession);
+        subject.doProcess(namespaceRequest, responderMock, imapSession).block();
 
         verify(responderMock, times(1)).respond(response);
         verify(responderMock, times(1)).respond(any(StatusResponse.class));

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
@@ -192,7 +192,7 @@ public class SearchProcessorTest {
 
     private void expectsGetSelectedMailbox() throws Exception {
         when(mailboxManager.getMailbox(mailboxId, mailboxSession)).thenReturn(mailbox, mailbox);
-        session.selected(selectedMailbox);
+        session.selected(selectedMailbox).block();
         when(selectedMailbox.isRecentUidRemoved()).thenReturn(false);
         when(selectedMailbox.isSizeChanged()).thenReturn(false);
         when(selectedMailbox.getPath()).thenReturn(mailboxPath);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
@@ -71,6 +71,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public class SearchProcessorTest {
     private static final int DAY = 6;
@@ -191,7 +192,7 @@ public class SearchProcessorTest {
     }
 
     private void expectsGetSelectedMailbox() throws Exception {
-        when(mailboxManager.getMailbox(mailboxId, mailboxSession)).thenReturn(mailbox, mailbox);
+        when(mailboxManager.getMailboxReactive(mailboxId, mailboxSession)).thenReturn(Mono.just(mailbox));
         session.selected(selectedMailbox).block();
         when(selectedMailbox.isRecentUidRemoved()).thenReturn(false);
         when(selectedMailbox.isSizeChanged()).thenReturn(false);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SetACLProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SetACLProcessorTest.java
@@ -109,7 +109,7 @@ class SetACLProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Lookup, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(setACLRequest, responder, imapSession);
+        subject.doProcess(setACLRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -127,7 +127,7 @@ class SetACLProcessorTest {
         when(mailboxManager.hasRight(path, MailboxACL.Right.Administer, mailboxSession))
             .thenReturn(false);
 
-        subject.doProcess(replaceAclRequest, responder, imapSession);
+        subject.doProcess(replaceAclRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -143,7 +143,7 @@ class SetACLProcessorTest {
         when(mailboxManager.getMailbox(any(MailboxPath.class), any(MailboxSession.class)))
             .thenThrow(new MailboxNotFoundException(""));
 
-        subject.doProcess(replaceAclRequest, responder, imapSession);
+        subject.doProcess(replaceAclRequest, responder, imapSession).block();
 
         verify(responder, times(1)).respond(argumentCaptor.capture());
         verifyNoMoreInteractions(responder);
@@ -176,7 +176,7 @@ class SetACLProcessorTest {
             .thenReturn(true);
 
         SetACLRequest r = new SetACLRequest(TAG, MAILBOX_NAME, USER_1.asString(), prefix + SET_RIGHTS);
-        subject.doProcess(r, responder, imapSession);
+        subject.doProcess(r, responder, imapSession).block();
 
         verify(mailboxManager).applyRightsCommand(path,
             MailboxACL.command().key(user1Key).rights(setRights).mode(editMode).build(),

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SetQuotaProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SetQuotaProcessorTest.java
@@ -59,7 +59,7 @@ class SetQuotaProcessorTest {
     void processorShouldWorkOnNoRights() {
         SetQuotaRequest setQuotaRequest = new SetQuotaRequest(TAG, "quotaRoot");
 
-        testee.doProcess(setQuotaRequest, mockedResponder, imapSession);
+        testee.doProcess(setQuotaRequest, mockedResponder, imapSession).block();
 
         ArgumentCaptor<ImapResponseMessage> imapResponseMessageArgumentCaptor = ArgumentCaptor.forClass(ImapResponseMessage.class);
         verify(mockedResponder).respond(imapResponseMessageArgumentCaptor.capture());

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -234,7 +234,7 @@ class MailboxEventAnalyserTest {
 
         analyser.event(update);
         analyser.event(update);
-        analyser.deselect();
+        analyser.deselect().block();
 
         assertThat(analyser.flagUpdateUids()).isEmpty();
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -164,6 +164,7 @@ class MailboxEventAnalyserTest {
             .thenReturn(new SingleMessageResultIterator(messageResult));
 
         testee = new SelectedMailboxImpl(mailboxManager, eventBus, imapSession, messageManager);
+        testee.finishInit().block();
     }
 
     @Test

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 class MailboxEventAnalyserTest {
     private static final MessageUid UID = MessageUid.of(900);
@@ -156,12 +157,12 @@ class MailboxEventAnalyserTest {
         when(messageResult.getMailboxId()).thenReturn(MAILBOX_ID);
         when(messageResult.getUid()).thenReturn(MESSAGE_UID);
 
-        when(messageManager.getApplicableFlags(any())).thenReturn(new Flags());
+        when(messageManager.getApplicableFlagsReactive(any())).thenReturn(Mono.just(new Flags()));
         when(messageManager.getId()).thenReturn(MAILBOX_ID);
         when(messageManager.search(any(), any()))
             .thenReturn(Flux.just(MESSAGE_UID));
-        when(messageManager.getMessages(any(), any(), any()))
-            .thenReturn(new SingleMessageResultIterator(messageResult));
+        when(messageManager.getMessagesReactive(any(), any(), any()))
+            .thenReturn(Flux.just(messageResult));
 
         testee = new SelectedMailboxImpl(mailboxManager, eventBus, imapSession, messageManager);
         testee.finishInit().block();

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
@@ -212,7 +212,7 @@ class SelectedMailboxImplTest {
                     LOGGER.error("Error while processing event on a concurrent thread", e);
                 }
             });
-            return Mono.just(() -> { });
+            return Mono.just(Mono::empty);
         };
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
@@ -115,8 +115,8 @@ class SelectedMailboxImplTest {
 
         when(mailboxManager.getMailbox(eq(mailboxPath), any(MailboxSession.class)))
             .thenReturn(messageManager);
-        when(messageManager.getApplicableFlags(any(MailboxSession.class)))
-            .thenReturn(new Flags());
+        when(messageManager.getApplicableFlagsReactive(any(MailboxSession.class)))
+            .thenReturn(Mono.just(new Flags()));
         when(messageManager.search(any(SearchQuery.class), any(MailboxSession.class)))
             .thenReturn(Flux.just(MessageUid.of(1), MessageUid.of(3))
                 .delayElements(Duration.ofSeconds(1)));
@@ -144,6 +144,7 @@ class SelectedMailboxImplTest {
             eventBus,
             imapSession,
             messageManager);
+        selectedMailbox.finishInit().block();
 
         assertThat(selectedMailbox.getLastUid().get()).isEqualTo(EMITTED_EVENT_UID);
     }
@@ -155,7 +156,7 @@ class SelectedMailboxImplTest {
             .when(eventBus)
             .register(any(EventListener.class), eq(mailboxIdRegistrationKey));
 
-        new SelectedMailboxImpl(mailboxManager, eventBus, imapSession, messageManager);
+        new SelectedMailboxImpl(mailboxManager, eventBus, imapSession, messageManager).finishInit().block();
 
         assertThat(successCount.get()).isEqualTo(1);
     }
@@ -168,6 +169,7 @@ class SelectedMailboxImplTest {
             .register(any(EventListener.class), eq(mailboxIdRegistrationKey));
 
         SelectedMailboxImpl selectedMailbox = new SelectedMailboxImpl(mailboxManager, eventBus, imapSession, messageManager);
+        selectedMailbox.finishInit().block();
 
         assertThat(selectedMailbox.getApplicableFlags().getUserFlags()).containsOnly(CUSTOM_FLAG);
     }
@@ -183,7 +185,7 @@ class SelectedMailboxImplTest {
             mailboxManager,
             eventBus,
             imapSession,
-            messageManager);
+            messageManager).finishInit().block();
 
         assertThat(successCount.get())
             .as("Get the incremented value in case of successful event processing.")

--- a/server/container/feature-checks/src/main/java/org/apache/james/healthcheck/MailReceptionCheck.java
+++ b/server/container/feature-checks/src/main/java/org/apache/james/healthcheck/MailReceptionCheck.java
@@ -39,6 +39,7 @@ import org.apache.james.core.healthcheck.Result;
 import org.apache.james.events.Event;
 import org.apache.james.events.EventBus;
 import org.apache.james.events.EventListener;
+import org.apache.james.events.Registration;
 import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -217,7 +218,7 @@ public class MailReceptionCheck implements HealthCheck {
                 Mono.from(eventBus.register(listener, new MailboxIdRegistrationKey(mailbox.getId()))),
                 registration -> sendMail(username)
                     .flatMap(content -> checkReceived(session, listener, mailbox, content)),
-                registration -> Mono.fromRunnable(registration::unregister)))
+                Registration::unregister))
             .subscribeOn(Schedulers.elastic())
             .timeout(configuration.getTimeout(), Mono.error(() -> new RuntimeException("HealthCheck email was not received after " + configuration.getTimeout().toMillis() + "ms")))
             .onErrorResume(e -> {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
@@ -63,7 +63,7 @@ case class ClientContext(outbound: Sinks.Many[OutboundMessage], pushRegistration
   }
 
   def withRegistration(registration: Option[Registration]): Unit = Option(pushRegistration.getAndSet(registration.orNull))
-    .foreach(oldRegistration => SMono.fromCallable(() => oldRegistration.unregister())
+    .foreach(oldRegistration => SMono(oldRegistration.unregister())
       .subscribeOn(Schedulers.elastic())
       .subscribe())
 }

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
@@ -78,7 +78,7 @@ class MailboxChangeListenerTest {
     val eventBus = new EventBus {
       override def register(listener: EventListener.ReactiveEventListener, key: RegistrationKey): Publisher[Registration] = Mono.empty()
 
-      override def register(listener: EventListener.ReactiveEventListener, group: Group): Registration = () => {}
+      override def register(listener: EventListener.ReactiveEventListener, group: Group): Registration = () => Mono.empty()
 
       override def dispatch(event: Event, key: util.Set[RegistrationKey]): Mono[Void] = Mono.empty()
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -254,19 +254,15 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
     @Override
     protected ChannelInboundHandlerAdapter createCoreHandler() {
         Encryption secure = getEncryption();
-        ImapChannelUpstreamHandler.ImapChannelUpstreamHandlerBuilder coreHandlerBuilder = ImapChannelUpstreamHandler.builder()
+        return ImapChannelUpstreamHandler.builder()
             .hello(hello)
             .processor(processor)
             .encoder(encoder)
             .compress(compress)
             .authenticationConfiguration(authenticationConfiguration)
             .secure(secure)
-            .imapMetrics(imapMetrics);
-
-        if (secure != null && secure.isStartTLS()) {
-            coreHandlerBuilder.secure(secure);
-        }
-        return coreHandlerBuilder.build();
+            .imapMetrics(imapMetrics)
+            .build();
     }
 
     @Override

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -195,7 +195,9 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                 .orElse(Mono.empty())
                 .doFinally(signal -> imapConnectionsMetric.decrement())
                 .doFinally(Throwing.consumer(signal -> super.channelInactive(ctx)))
-                .subscribe();
+                .subscribe(any -> {
+
+                }, ctx::fireExceptionCaught);
         }
     }
 
@@ -239,7 +241,15 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                         }
                     })
                     .doFinally(Throwing.consumer(signal -> super.channelInactive(ctx)))
-                    .subscribe();
+                    .subscribe(any -> {
+                        
+                    }, e -> {
+                        LOGGER.error("Exception while handling errors for channel {}", ctx.channel(), e);
+                        Channel channel = ctx.channel();
+                        if (channel.isActive()) {
+                            channel.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+                        }
+                    });
             }
         }
     }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapIdleStateHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapIdleStateHandler.java
@@ -66,7 +66,9 @@ public class ImapIdleStateHandler extends IdleStateHandler implements NettyConst
                 // close the channel
                 .then(Mono.fromRunnable(() -> ctx.channel().close()))
                 .then(Mono.fromRunnable(Throwing.runnable(() -> super.channelIdle(ctx, e))))
-                .subscribe();
+                .subscribe(any -> {
+
+                }, ctx::fireExceptionCaught);
         } else {
             super.channelIdle(ctx, e);
         }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -213,20 +213,15 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
     }
 
     public void disableFraming(ChannelHandlerContext ctx) {
-        ctx.channel().config().setAutoRead(false);
-        ctx.channel().eventLoop().execute(() -> ctx.channel().pipeline().remove(FRAMER));
-        ctx.channel().config().setAutoRead(true);
+        ctx.channel().pipeline().remove(FRAMER);
         framingEnabled.set(false);
     }
 
     public void enableFraming(ChannelHandlerContext ctx) {
         if (!framingEnabled.get()) {
             framingEnabled.set(true);
-            ctx.channel().config().setAutoRead(false);
-            ctx.channel().eventLoop().execute(() ->
-                ctx.channel().pipeline().addBefore(REQUEST_DECODER, FRAMER,
-                        new SwitchableLineBasedFrameDecoder(ctx.channel().pipeline(), maxFrameLength, false)));
-            ctx.channel().config().setAutoRead(true);
+            ctx.channel().pipeline().addBefore(REQUEST_DECODER, FRAMER,
+                new SwitchableLineBasedFrameDecoder(ctx.channel().pipeline(), maxFrameLength, false));
         }
     }
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -101,7 +101,7 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     @Override
     public Mono<Void> logout() {
         return closeMailbox()
-            .then(Mono.fromRunnable(() ->state = ImapSessionState.LOGOUT));
+            .then(Mono.fromRunnable(() -> state = ImapSessionState.LOGOUT));
     }
 
     @Override

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -1479,6 +1479,7 @@ class IMAPServerTest {
             readStringUntil(clientConnection, s -> s.contains("a2 OK [READ-WRITE] SELECT completed."));
 
             clientConnection.write(ByteBuffer.wrap(("a3 IDLE\r\n").getBytes(StandardCharsets.UTF_8)));
+            System.out.println("toto");
             readStringUntil(clientConnection, s -> s.contains("+ Idling"));
 
             inbox.appendMessage(MessageManager.AppendCommand.builder().build("h: value\r\n\r\nbody".getBytes()), mailboxSession);
@@ -1748,6 +1749,7 @@ class IMAPServerTest {
         ImmutableList.Builder<String> result = ImmutableList.builder();
         while (true) {
             String line = new String(readBytes(channel), StandardCharsets.US_ASCII);
+            System.out.println(line);
             result.add(line);
             if (condition.test(line)) {
                 return result.build();

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -63,7 +63,6 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.tree.ImmutableNode;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.net.imap.AuthenticatingIMAPClient;
 import org.apache.commons.net.imap.IMAPReply;
 import org.apache.commons.net.imap.IMAPSClient;
@@ -473,7 +472,6 @@ class IMAPServerTest {
                 .connectNow();
             responses = new ConcurrentLinkedDeque<>();
             connection.inbound().receive().asString()
-                .doOnNext(s -> System.out.println("A: " + s))
                 .doOnNext(responses::addLast)
                 .subscribeOn(Schedulers.elastic())
                 .subscribe();
@@ -1479,7 +1477,6 @@ class IMAPServerTest {
             readStringUntil(clientConnection, s -> s.contains("a2 OK [READ-WRITE] SELECT completed."));
 
             clientConnection.write(ByteBuffer.wrap(("a3 IDLE\r\n").getBytes(StandardCharsets.UTF_8)));
-            System.out.println("toto");
             readStringUntil(clientConnection, s -> s.contains("+ Idling"));
 
             inbox.appendMessage(MessageManager.AppendCommand.builder().build("h: value\r\n\r\nbody".getBytes()), mailboxSession);
@@ -1741,7 +1738,6 @@ class IMAPServerTest {
         line.rewind();
         byte[] bline = new byte[line.remaining()];
         line.get(bline);
-        System.out.println("O: " + IOUtils.toString(bline));
         return bline;
     }
 
@@ -1749,7 +1745,6 @@ class IMAPServerTest {
         ImmutableList.Builder<String> result = ImmutableList.builder();
         while (true) {
             String line = new String(readBytes(channel), StandardCharsets.US_ASCII);
-            System.out.println(line);
             result.add(line);
             if (condition.test(line)) {
                 return result.build();


### PR DESCRIPTION
Large throughtput gains

### Before

![Screenshot from 2022-03-29 13-08-53](https://user-images.githubusercontent.com/6928740/160544720-40aaae93-3bae-4f4f-8a61-4de045adcf98.png)

### After

![Screenshot from 2022-03-29 13-09-42](https://user-images.githubusercontent.com/6928740/160546270-a2cb4098-f9a4-45bd-8903-d08dd9176abc.png)

### TODO

**MUST**

 - [ ] Better evalute latencies on low throughtput
 - [x] I would really like to reactify IMAP STORE command
 - [x] The following bench can further be improved by reactifying `SelectedMailboxImpl.deselect`. `jstack` thread analysis shows worker threads blocked on that operation.
 - [X] Preserve structured logging for IMAP

**COULD**

 - [ ] IMAP MOVE + IMAP COPY spaghetti code get's in the way too and would need a massive refactoring

