### PR TITLE
JAMES-3740 Compact primitive collections for UID <-> MSN mapping

### DIFF
--- a/protocols/imap/pom.xml
+++ b/protocols/imap/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>vavr</artifactId>
         </dependency>
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil-core</artifactId>
+            <version>8.5.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -55,25 +55,71 @@ public class UidMsnConverter {
 
     private void addAllUnSynchronized(List<MessageUid> addedUids) {
         if (usesInts) {
-            IntAVLTreeSet tmp = new IntAVLTreeSet(uidsAsInts);
-            for (MessageUid uid : addedUids) {
-                if (uid.asLong() > INTERGER_MAX_VALUE) {
-                    switchToLongs();
-                    addAllUnSynchronized(addedUids);
-                    return;
-                }
-                tmp.add((int) uid.asLong());
+            if (uidsAsInts.isEmpty()) {
+                // Avoids intermediary tree structure
+                addAllToEmptyIntStructure(addedUids);
+            } else {
+                addAllToNonEmptyIntStructure(addedUids);
             }
-            uidsAsInts.clear();
-            uidsAsInts.addAll(tmp);
         } else {
-            LongAVLTreeSet tmp = new LongAVLTreeSet(uids);
-            for (MessageUid uid : addedUids) {
-                tmp.add(uid.asLong());
+            if (uids.isEmpty()) {
+                // Avoids intermediary tree structure
+                addAllToEmptyLongStructure(addedUids);
+            } else {
+                addAllToNonEmptyLongStructure(addedUids);
             }
-            uids.clear();
-            uids.addAll(tmp);
         }
+    }
+
+    private void addAllToNonEmptyLongStructure(List<MessageUid> addedUids) {
+        LongAVLTreeSet tmp = new LongAVLTreeSet(uids);
+        for (MessageUid uid : addedUids) {
+            tmp.add(uid.asLong());
+        }
+        uids.clear();
+        uids.addAll(tmp);
+    }
+
+    private void addAllToEmptyLongStructure(List<MessageUid> addedUids) {
+        uids.ensureCapacity(addedUids.size());
+        for (MessageUid uid : addedUids) {
+            if (uid.asLong() > INTERGER_MAX_VALUE) {
+                uids.clear();
+                switchToLongs();
+                addAllUnSynchronized(addedUids);
+                return;
+            }
+            uids.add((int) uid.asLong());
+        }
+        uids.sort(LongComparators.NATURAL_COMPARATOR);
+    }
+
+    private void addAllToNonEmptyIntStructure(List<MessageUid> addedUids) {
+        IntAVLTreeSet tmp = new IntAVLTreeSet(uidsAsInts);
+        for (MessageUid uid : addedUids) {
+            if (uid.asLong() > INTERGER_MAX_VALUE) {
+                switchToLongs();
+                addAllUnSynchronized(addedUids);
+                return;
+            }
+            tmp.add((int) uid.asLong());
+        }
+        uidsAsInts.clear();
+        uidsAsInts.addAll(tmp);
+    }
+
+    private void addAllToEmptyIntStructure(List<MessageUid> addedUids) {
+        uidsAsInts.ensureCapacity(addedUids.size());
+        for (MessageUid uid : addedUids) {
+            if (uid.asLong() > INTERGER_MAX_VALUE) {
+                uidsAsInts.clear();
+                switchToLongs();
+                addAllUnSynchronized(addedUids);
+                return;
+            }
+            uidsAsInts.add((int) uid.asLong());
+        }
+        uidsAsInts.sort(IntComparators.NATURAL_COMPARATOR);
     }
 
     private void switchToLongs() {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -38,7 +38,7 @@ import it.unimi.dsi.fastutil.longs.LongComparators;
 
 public class UidMsnConverter {
     private static final int FIRST_MSN = 1;
-    private static final long INTERGER_MAX_VALUE = Integer.MAX_VALUE;
+    private static final long INTEGER_MAX_VALUE = Integer.MAX_VALUE;
 
     @VisibleForTesting final LongArrayList uids;
     @VisibleForTesting final IntArrayList uidsAsInts;
@@ -83,7 +83,7 @@ public class UidMsnConverter {
     private void addAllToEmptyLongStructure(List<MessageUid> addedUids) {
         uids.ensureCapacity(addedUids.size());
         for (MessageUid uid : addedUids) {
-            if (uid.asLong() > INTERGER_MAX_VALUE) {
+            if (uid.asLong() > INTEGER_MAX_VALUE) {
                 uids.clear();
                 switchToLongs();
                 addAllUnSynchronized(addedUids);
@@ -97,7 +97,7 @@ public class UidMsnConverter {
     private void addAllToNonEmptyIntStructure(List<MessageUid> addedUids) {
         IntAVLTreeSet tmp = new IntAVLTreeSet(uidsAsInts);
         for (MessageUid uid : addedUids) {
-            if (uid.asLong() > INTERGER_MAX_VALUE) {
+            if (uid.asLong() > INTEGER_MAX_VALUE) {
                 switchToLongs();
                 addAllUnSynchronized(addedUids);
                 return;
@@ -111,7 +111,7 @@ public class UidMsnConverter {
     private void addAllToEmptyIntStructure(List<MessageUid> addedUids) {
         uidsAsInts.ensureCapacity(addedUids.size());
         for (MessageUid uid : addedUids) {
-            if (uid.asLong() > INTERGER_MAX_VALUE) {
+            if (uid.asLong() > INTEGER_MAX_VALUE) {
                 uidsAsInts.clear();
                 switchToLongs();
                 addAllUnSynchronized(addedUids);
@@ -136,7 +136,7 @@ public class UidMsnConverter {
 
     private NullableMessageSequenceNumber getMsnUnsynchronized(MessageUid uid) {
         if (usesInts) {
-            if (uid.asLong() > INTERGER_MAX_VALUE) {
+            if (uid.asLong() > INTEGER_MAX_VALUE) {
                 return NullableMessageSequenceNumber.noMessage();
             }
             int position = Arrays.binarySearch(uidsAsInts.elements(), 0, uidsAsInts.size(), (int) uid.asLong());
@@ -191,7 +191,7 @@ public class UidMsnConverter {
 
     private void removeUnsynchronized(MessageUid uid) {
         if (usesInts) {
-            if (uid.asLong() > INTERGER_MAX_VALUE) {
+            if (uid.asLong() > INTEGER_MAX_VALUE) {
                 return;
             }
             int index = Arrays.binarySearch(uidsAsInts.elements(), 0, uidsAsInts.size(), (int) uid.asLong());
@@ -227,7 +227,7 @@ public class UidMsnConverter {
 
     private void addUidUnSynchronized(MessageUid uid) {
         if (usesInts) {
-            if (uid.asLong() > INTERGER_MAX_VALUE) {
+            if (uid.asLong() > INTEGER_MAX_VALUE) {
                 switchToLongs();
                 addUidUnSynchronized(uid);
                 return;

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -286,9 +286,9 @@ class UidMsnConverterTest {
 
     @Test
     void addAllShouldRemoveDuplicates() {
+        testee.addUid(messageUid2);
         testee.addAll(ImmutableList.of(
             messageUid1,
-            messageUid2,
             messageUid2,
             messageUid3,
             messageUid4));

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -461,8 +461,14 @@ class UidMsnConverterTest {
 
     private Map<Integer, MessageUid> mapTesteeInternalDataToMsnByUid() {
         ImmutableMap.Builder<Integer, MessageUid> result = ImmutableMap.builder();
+        if (testee.usesInts) {
+            for (int i = 0; i < testee.uidsAsInts.size(); i++) {
+                result.put(i + 1, MessageUid.of(testee.uidsAsInts.get(i)));
+            }
+            return result.build();
+        }
         for (int i = 0; i < testee.uids.size(); i++) {
-            result.put(i + 1, testee.uids.get(i));
+            result.put(i + 1, MessageUid.of(testee.uids.get(i)));
         }
         return result.build();
     }


### PR DESCRIPTION
This reduces HEAP memory consumption of this use case by a factor 6.

## What is UID <-> MSN mapping ?

In IMAP RFC-3501 there is two ways one addresses a message:
 - By its UID (Unique ID) that is unique (until UID_VALIDITY changes...)
 - By its MSN (Message Sequence  Number) which is the (mutable) position of a message in the mailbox.

We then need:
 - Given a UID return its MSN which is for instance compulsory upon EXPUNGED notifications when QRESYNCH is not enabled.
 - Given a MSN based request we need to convert it back to a UID (rare).

We do store the list of UIDs, sorted, in RAM and perform binarysearches to resolve those.

## What is the impact on heap?

Each uid is wrapped in a MessageUID object. This object wrapping comes with an overhead of at least 12 bytes in addition to the 8 bytes payload (long). Quick benchmarks shows it's actually worse: 10 million uids did take up to 275 MB.

```
    @Test
    void measureHeapUsage() throws InterruptedException {
        int count =10000000;
        testee.addAll(IntStream.range(0, count)
            .mapToObj(i -> MessageUid.of(i + 1))
            .collect(Collectors.toList()));
        Thread.sleep(1000);
        System.out.println("GCing");
        System.gc();
        Thread.sleep(1000);

        System.out.println(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed());
    }
```

Now, from let's take a classical production deployment I get:
 - Some users have up to 2.5 million messages in their INBOX
 - I can get an average of 100.000 messages for each user

So for a small scale deployment, we are already "consuming" ~300 MB of memory just for the UID <-> mapping.

Scaling to 1.000 users on a single James instance we clearly see that HEAP consumption will start being a problem (~3GB) without even speaking of target of 10.000 users per James I do have in mind.

It's worth mentioning that IMAP being statefull, and UID <-> MSN mapping attached to a selected mailbox, such a mapping is long lived:
 - Multiple small objects would need to be copied individually by the GC, putting pressure during long gen
 - Those long lived object will eventually be promoted to old gen, thus the more there is the longer the resulting stop-the-world GC pauses will be.

## Temporary fix ?

We can get rid of the object boxing in UidMsnConverter by using primitive type collections for instance provided by fastutils project.

The same bench was down to 84MB.

Also, we could get things more compact by using an INT representation of UIDs. (Those are most of the case below 2 billions, to be above this there need to be more than 2 billion emails transiting through one's mailbox which is highly unlikely). A fallback to "long" storage can be setted up if a UID above 2 billion is observed.

This such a compact int storage we are down to 46MB.

So taking the prior mentioned numbers we could expect a 1.000 people deployment to require ~400 MB and a larger scale 10.000 people deployment on a single James to consume up to 4GB. Not that enjoyable but definitly more manageable.

Please note that primitive collections are more GC friendly as their elements are manages together, as a single object (backing array).

## What other mail servers do

I found references to Dovecote, which does a similar algorithm compared to us: binary search on a list of uids. The noticeable difference is that this list of UIDs is held on disk and not in memory as we do.

References: https://doc.dovecot.org/developer_manual/design/indexes/mail_index_api/?highlight=time

Of course, such a solution would be attractive... We could imagine keeping the last 1.000 uids in memory, which would most of the time be the ones used for MSN resolution and locate the rest on-disk, use them only when needed and thus dramatically reduce heap pressure.

Making UidMsnConverter an interface with a backing factory would enable different implementation to co-exist and allow some experimentation ;-)