### PR TITLE
JAMES-3715 Schedule IMAP IDLE heartbits on the Netty Event loop

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.imap.api.process;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -246,4 +247,6 @@ public interface ImapSession extends CommandDetectionSession {
     default boolean isAuthenticatingNonEncryptedWhenRequiredSSL() {
         return isSSLRequired() && !isTLSActive();
     }
+
+    void schedule(Runnable runnable, Duration waitDelay);
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/FakeImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/FakeImapSession.java
@@ -18,9 +18,14 @@
  ****************************************************************/
 package org.apache.james.imap.encode;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.james.imap.api.ImapSessionState;
 import org.apache.james.imap.api.process.ImapLineHandler;
@@ -28,8 +33,12 @@ import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.SelectedMailbox;
 import org.apache.james.imap.message.response.ImmutableStatusResponse;
 import org.apache.james.protocols.api.OidcSASLConfiguration;
+import org.apache.james.util.concurrent.NamedThreadFactory;
 
 public class FakeImapSession implements ImapSession {
+    private static final int DEFAULT_SCHEDULED_POOL_CORE_SIZE = 5;
+    private static final ThreadFactory THREAD_FACTORY = NamedThreadFactory.withClassName(FakeImapSession.class);
+    private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(DEFAULT_SCHEDULED_POOL_CORE_SIZE, THREAD_FACTORY);
 
     private ImapSessionState state = ImapSessionState.NON_AUTHENTICATED;
 
@@ -182,4 +191,8 @@ public class FakeImapSession implements ImapSession {
         return false;
     }
 
+    @Override
+    public void schedule(Runnable runnable, Duration waitDelay) {
+       EXECUTOR_SERVICE.schedule(runnable, waitDelay.toMillis(), TimeUnit.MILLISECONDS);
+    }
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -19,9 +19,11 @@
 package org.apache.james.imapserver.netty;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.imap.api.ImapSessionState;
@@ -284,4 +286,8 @@ public class NettyImapSession implements ImapSession, NettyConstants {
         return channel.pipeline().get(ZLIB_DECODER) != null;
     }
 
+    @Override
+    public void schedule(Runnable runnable, Duration waitDelay) {
+        channel.eventLoop().schedule(runnable, waitDelay.toMillis(), TimeUnit.MILLISECONDS);
+    }
 }


### PR DESCRIPTION
IDLE event implementation in Netty uses a similar
pattern and this allows to get rid of a useless thread
pool... The less threads, the better!