### PR TITLE
JAMES-3745 Use FastByteArrayOutputStream as a short lived object

### DIFF
--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -156,7 +156,6 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
             imapConnectionsMetric.increment();
 
             ImapResponseComposer response = new ImapResponseComposerImpl(new ChannelImapResponseWriter(ctx.channel()));
-            ctx.channel().attr(CONTEXT_ATTACHMENT_ATTRIBUTE_KEY).set(response);
 
             // write hello to client
             response.untagged().message("OK").message(hello).end();
@@ -217,8 +216,8 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                 // command length."
                 //
                 // See also JAMES-1190
-                ImapResponseComposer composer = (ImapResponseComposer) ctx.channel().attr(CONTEXT_ATTACHMENT_ATTRIBUTE_KEY).get();
-                composer.untaggedResponse(ImapConstants.BAD + " failed. Maximum command line length exceeded");
+                ImapResponseComposer response = new ImapResponseComposerImpl(new ChannelImapResponseWriter(ctx.channel()));
+                response.untaggedResponse(ImapConstants.BAD + " failed. Maximum command line length exceeded");
 
             } else {
 
@@ -243,7 +242,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
         try (Closeable closeable = mdc(ctx).build()) {
             imapCommandsMetric.increment();
             ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
-            ImapResponseComposer response = (ImapResponseComposer) ctx.channel().attr(CONTEXT_ATTACHMENT_ATTRIBUTE_KEY).get();
+            ImapResponseComposer response = new ImapResponseComposerImpl(new ChannelImapResponseWriter(ctx.channel()));
             ImapMessage message = (ImapMessage) msg;
             ChannelPipeline cp = ctx.pipeline();
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyConstants.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyConstants.java
@@ -40,7 +40,6 @@ public interface NettyConstants {
     String HEARTBEAT_HANDLER = "heartbeatHandler";
 
     AttributeKey<ImapSession> IMAP_SESSION_ATTRIBUTE_KEY = AttributeKey.valueOf("ImapSession");
-    AttributeKey<Object> CONTEXT_ATTACHMENT_ATTRIBUTE_KEY = AttributeKey.valueOf("ContextAttachment");
     AttributeKey<Map<String, Object>> FRAME_DECODE_ATTACHMENT_ATTRIBUTE_KEY  = AttributeKey.valueOf("FrameDecoderMap");
 
 }


### PR DESCRIPTION
From connection scoped to request scoped.

I started studying production heap dump in an effort to reduce the per user memory footprint. In conjunction with issues discussed in JAMES-3740 I found that in FastByteArrayOutputStream, upon writing a long line this buffer is sized up and never sized down.

We can end up with 60KB+ memory allocated per user... Forever.

While the impact is not as huge as the one described in JAMES-3740 yet for James deployment with a high connection density this could be non neglictible (100s MB of RAM).

Furthermore given the long lived lifecycle of this buffer (connection) it is very likely to be promoted to the old gen, which could build up to eventually get long GC pauses.

Suggestion: create a new IMAP composer for each request, 2 -> 64KB allocation is anyway neglictibe, likely cheaper than the lookups to get them back! We will thus allocate more memory, yes, but only for short lived durations, wich JVM GC is really good at.

IMO it is so easy to avoid this unwanted behaviour that it would be sad not to do it.