### PR TITLE
JAMES-3746 Backport behaviour changes for IMAP IDLE [3.7.x]

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/SelectedMailbox.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import javax.mail.Flags;
 
+import org.apache.james.events.EventListener;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.NullableMessageSequenceNumber;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -41,6 +42,10 @@ public interface SelectedMailbox {
      * Deselect the Mailbox
      */
     void deselect();
+
+    void registerIdle(EventListener idle);
+
+    void unregisterIdle();
 
     /**
      * Return the msg index of the given uid or {@link NullableMessageSequenceNumber#noMessage()} instance if no

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
@@ -83,7 +83,7 @@ public class DefaultProcessorChain {
         AppendProcessor appendProcessor = new AppendProcessor(examineProcessor, mailboxManager, statusResponseFactory, metricFactory);
         StoreProcessor storeProcessor = new StoreProcessor(appendProcessor, mailboxManager, statusResponseFactory, metricFactory);
         NoopProcessor noopProcessor = new NoopProcessor(storeProcessor, mailboxManager, statusResponseFactory, metricFactory);
-        IdleProcessor idleProcessor = new IdleProcessor(noopProcessor, mailboxManager, eventBus, statusResponseFactory, metricFactory);
+        IdleProcessor idleProcessor = new IdleProcessor(noopProcessor, mailboxManager, statusResponseFactory, metricFactory);
         StatusProcessor statusProcessor = new StatusProcessor(idleProcessor, mailboxManager, statusResponseFactory, metricFactory);
         LSubProcessor lsubProcessor = new LSubProcessor(statusProcessor, mailboxManager, subscriptionManager, statusResponseFactory, metricFactory);
         XListProcessor xlistProcessor = new XListProcessor(lsubProcessor, mailboxManager, statusResponseFactory, mailboxTyper, metricFactory);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
@@ -61,6 +62,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.UpdatedFlags;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -129,7 +131,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     private final Flags.Flag uninterestingFlag = Flags.Flag.RECENT;
     private final Set<MessageUid> expungedUids = new TreeSet<>();
     private final Object applicableFlagsLock = new Object();
-
+    private final AtomicReference<EventListener> idleEventListener = new AtomicReference<>();
     private boolean recentUidRemoved = false;
     private boolean isDeletedByOtherSession = false;
     private boolean sizeChanged = false;
@@ -161,6 +163,16 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
             .collect(ImmutableList.toImmutableList())
             .block();
         uidMsnConverter.addAll(uids);
+    }
+
+    @Override
+    public void registerIdle(EventListener idle) {
+        idleEventListener.set(idle);
+    }
+
+    @Override
+    public void unregisterIdle() {
+        idleEventListener.set(null);
     }
 
     @Override
@@ -372,8 +384,13 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
 
     
     @Override
-    public synchronized void event(Event event) {
+    public void event(Event event) {
+        eventSynchronized(event);
+        Optional.ofNullable(idleEventListener.get())
+            .ifPresent(Throwing.<EventListener>consumer(listener -> listener.event(event)).sneakyThrow());
+    }
 
+    private synchronized void eventSynchronized(Event event) {
         if (event instanceof MailboxEvent) {
             MailboxEvent mailboxEvent = (MailboxEvent) event;
             mailboxEvent(mailboxEvent);


### PR DESCRIPTION
 - Avoid a data race resulting in some updates not to be sent
 - Avoid the IDLE listener to never be unregistered and leak
 - Finally prevent duplicated RabbitMQ registrations for IDLE and SELECT

All this is fixed by piggy backing IDLE notifications on SELECTED mailbox listener.

Please note that special care was put to avoid deadlocks.