### PR TITLE
JAMES-3737 Ability to execute IMAP workload directly on the event loop

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -71,6 +71,7 @@ import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends AbstractProcessor<R> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMailboxProcessor.class);
@@ -375,7 +376,8 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        }));
+        })).subscribeOn(Schedulers.elastic())
+            .then();
     }
 
     /**

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -237,10 +237,10 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
 
                 pipeline.addLast(CHUNK_WRITE_HANDLER, new ChunkedWriteHandler());
 
-                pipeline.addLast(getExecutorGroup(), REQUEST_DECODER, new ImapRequestFrameDecoder(decoder, inMemorySizeLimit,
+                pipeline.addLast(REQUEST_DECODER, new ImapRequestFrameDecoder(decoder, inMemorySizeLimit,
                     literalSizeLimit, maxLineLength));
 
-                pipeline.addLast(getExecutorGroup(), CORE_HANDLER, createCoreHandler());
+                pipeline.addLast(CORE_HANDLER, createCoreHandler());
             }
 
         };

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -57,6 +57,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements NettyConstants, LineHandlerAware {
     @VisibleForTesting
     static final String NEEDED_DATA = "NEEDED_DATA";
+    private static final boolean RETRY = true;
     private static final String STORED_DATA = "STORED_DATA";
     private static final String WRITTEN_DATA = "WRITTEN_DATA";
     private static final String OUTPUT_STREAM = "OUTPUT_STREAM";
@@ -156,9 +157,10 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         // check if we failed before and if we already know how much data we
         // need to sucess next run
         int size = -1;
-        if (attachment.containsKey(NEEDED_DATA)) {
+        final Object rawSize = attachment.get(NEEDED_DATA);
+        if (rawSize != null) {
             retry = true;
-            size = (Integer) attachment.get(NEEDED_DATA);
+            size = (Integer) rawSize;
             // now see if the buffer hold enough data to process.
             if (size != NettyImapRequestLineReader.NotEnoughDataException.UNKNOWN_SIZE && size > in.readableBytes()) {
 
@@ -168,7 +170,7 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
 
                     // ok seems like it will not fit in the memory limit so we
                     // need to store it in a temporary file
-                    reader = uploadToAFile(ctx, in, retry, attachment, size);
+                    reader = uploadToAFile(ctx, in, attachment, size);
                     if (reader == null) return null;
 
                 } else {
@@ -186,7 +188,7 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         return Pair.of(reader, size);
     }
 
-    private ImapRequestLineReader uploadToAFile(ChannelHandlerContext ctx, ByteBuf in, boolean retry, Map<String, Object> attachment, int size) throws IOException {
+    private ImapRequestLineReader uploadToAFile(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int size) throws IOException {
         ImapRequestLineReader reader;
         final File f;
         int written;
@@ -229,7 +231,7 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
                 //ignore exception during close
             }
 
-            reader = new NettyStreamImapRequestLineReader(ctx.channel(), f, retry);
+            reader = new NettyStreamImapRequestLineReader(ctx.channel(), f, RETRY);
         } else {
             attachment.put(WRITTEN_DATA, written);
             return null;

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.imapserver.netty;
 
+import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.imap.api.ImapMessage;
@@ -49,6 +52,9 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import reactor.core.Disposable;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
 
 
 /**
@@ -61,6 +67,9 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
     private static final String STORED_DATA = "STORED_DATA";
     private static final String WRITTEN_DATA = "WRITTEN_DATA";
     private static final String OUTPUT_STREAM = "OUTPUT_STREAM";
+    private static final String SINK = "SINK";
+    private static final String SUBSCRIPTION = "SUBSCRIPTION";
+
 
     private final ImapDecoder decoder;
     private final int inMemorySizeLimit;
@@ -170,8 +179,8 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
 
                     // ok seems like it will not fit in the memory limit so we
                     // need to store it in a temporary file
-                    reader = uploadToAFile(ctx, in, attachment, size);
-                    if (reader == null) return null;
+                    uploadToAFile(ctx, in, attachment, size);
+                    return null;
 
                 } else {
                     in.resetReaderIndex();
@@ -188,55 +197,70 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         return Pair.of(reader, size);
     }
 
-    private ImapRequestLineReader uploadToAFile(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int size) throws IOException {
-        ImapRequestLineReader reader;
+    private void uploadToAFile(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int size) throws IOException {
         final File f;
-        int written;
+        Sinks.Many<byte[]> sink;
 
         OutputStream outputStream;
         // check if we have created a temporary file already or if
         // we need to create a new one
         if (attachment.containsKey(STORED_DATA)) {
-            f = (File) attachment.get(STORED_DATA);
-            written = (Integer) attachment.get(WRITTEN_DATA);
-            outputStream = (OutputStream) attachment.get(OUTPUT_STREAM);
+            sink = (Sinks.Many<byte[]>) attachment.get(SINK);
         } else {
             f = File.createTempFile("imap-literal", ".tmp");
             attachment.put(STORED_DATA, f);
-            written = 0;
+            final AtomicInteger written = new AtomicInteger(0);
             attachment.put(WRITTEN_DATA, written);
             outputStream = new FileOutputStream(f, true);
             attachment.put(OUTPUT_STREAM, outputStream);
+            sink = Sinks.many().unicast().onBackpressureBuffer();
+            attachment.put(SINK, sink);
 
+            Disposable subscribe = sink.asFlux()
+                .publishOn(Schedulers.elastic())
+                .doOnNext(next -> {
+                    try {
+                        int amount = Math.min(next.length, size - written.get());
+                        outputStream.write(next, 0, amount);
+                        written.addAndGet(amount);
+                    } catch (Exception e) {
+                        try {
+                            outputStream.close();
+                        } catch (IOException ignored) {
+                            //ignore exception during close
+                        }
+                        throw new RuntimeException(e);
+                    }
+
+                    // Check if all needed data was streamed to the file.
+                    if (written.get() == size) {
+                        try {
+                            outputStream.close();
+                        } catch (IOException ignored) {
+                            //ignore exception during close
+                        }
+
+                        ImapRequestLineReader reader = new NettyStreamImapRequestLineReader(ctx.channel(), f, RETRY);
+
+                        try {
+                            parseImapMessage(ctx, null, attachment, Pair.of(reader, written.get()))
+                                .ifPresent(ctx::fireChannelRead);
+                        } catch (DecodingException e) {
+                            ctx.fireExceptionCaught(e);
+                        }
+                    }
+                })
+                .subscribe(o -> {},
+                    ctx::fireExceptionCaught,
+                    () -> {
+
+                    });
+            attachment.put(SUBSCRIPTION, subscribe);
         }
-
-
-        try {
-            int amount = Math.min(in.readableBytes(), size - written);
-            in.readBytes(outputStream, amount);
-            written += amount;
-        } catch (Exception e) {
-            try {
-                outputStream.close();
-            } catch (IOException ignored) {
-                //ignore exception during close
-            }
-            throw e;
-        }
-        // Check if all needed data was streamed to the file.
-        if (written == size) {
-            try {
-                outputStream.close();
-            } catch (IOException ignored) {
-                //ignore exception during close
-            }
-
-            reader = new NettyStreamImapRequestLineReader(ctx.channel(), f, RETRY);
-        } else {
-            attachment.put(WRITTEN_DATA, written);
-            return null;
-        }
-        return reader;
+        final int readableBytes = in.readableBytes();
+        final byte[] bytes = new byte[readableBytes];
+        in.readBytes(bytes);
+        sink.emitNext(bytes, FAIL_FAST);
     }
 
     public void disableFraming(ChannelHandlerContext ctx) {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -27,12 +27,15 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.ImapSessionState;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.decode.DecodingException;
 import org.apache.james.imap.decode.ImapDecoder;
 import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.apache.james.protocols.netty.LineHandlerAware;
@@ -88,12 +91,70 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         }
 
         in.markReaderIndex();
-        boolean retry = false;
 
+        Map<String, Object> attachment = ctx.channel().attr(FRAME_DECODE_ATTACHMENT_ATTRIBUTE_KEY).get();
+
+        Pair<ImapRequestLineReader, Integer> readerAndSize = obtainReader(ctx, in, attachment);
+        if (readerAndSize == null) return;
+
+        parseImapMessage(ctx, in, attachment, readerAndSize)
+            .ifPresent(out::add);
+    }
+
+    private Optional<ImapMessage> parseImapMessage(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, Pair<ImapRequestLineReader, Integer> readerAndSize) throws DecodingException {
+        ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
+
+        // check if the session was removed before to prevent a harmless NPE. See JAMES-1312
+        // Also check if the session was logged out if so there is not need to try to decode it. See JAMES-1341
+        if (session != null && session.getState() != ImapSessionState.LOGOUT) {
+            try {
+
+                ImapMessage message = decoder.decode(readerAndSize.getLeft(), session);
+
+                // if size is != -1 the case was a literal. if thats the case we
+                // should not consume the line
+                // See JAMES-1199
+                if (readerAndSize.getRight() == -1) {
+                    readerAndSize.getLeft().consumeLine();
+                }
+
+                enableFraming(ctx);
+
+                attachment.clear();
+                return Optional.of(message);
+            } catch (NettyImapRequestLineReader.NotEnoughDataException e) {
+                // this exception was thrown because we don't have enough data yet
+                requestMoreData(ctx, in, attachment, e.getNeededSize());
+            }
+        } else {
+            // The session was null so may be the case because the channel was already closed but there were still bytes in the buffer.
+            // We now try to disconnect the client if still connected
+            if (ctx.channel().isActive()) {
+                ctx.channel().writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private void requestMoreData(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int neededData) {
+        // store the needed data size for later usage
+        attachment.put(NEEDED_DATA, neededData);
+
+        // SwitchableDelimiterBasedFrameDecoder added further to JAMES-1436.
+        disableFraming(ctx);
+        if (in.readableBytes() > 0) {
+            ByteBuf spareBytes = in.retainedDuplicate();
+            internalBuffer().clear();
+            ctx.fireChannelRead(spareBytes);
+        }
+        in.resetReaderIndex();
+    }
+
+    private Pair<ImapRequestLineReader, Integer> obtainReader(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment) throws IOException {
+        boolean retry = false;
         ImapRequestLineReader reader;
         // check if we failed before and if we already know how much data we
         // need to sucess next run
-        Map<String, Object> attachment = ctx.channel().attr(FRAME_DECODE_ATTACHMENT_ATTRIBUTE_KEY).get();
         int size = -1;
         if (attachment.containsKey(NEEDED_DATA)) {
             retry = true;
@@ -107,56 +168,12 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
 
                     // ok seems like it will not fit in the memory limit so we
                     // need to store it in a temporary file
-                    final File f;
-                    int written;
-
-                    OutputStream outputStream;
-                    // check if we have created a temporary file already or if
-                    // we need to create a new one
-                    if (attachment.containsKey(STORED_DATA)) {
-                        f = (File) attachment.get(STORED_DATA);
-                        written = (Integer) attachment.get(WRITTEN_DATA);
-                        outputStream = (OutputStream) attachment.get(OUTPUT_STREAM);
-                    } else {
-                        f = File.createTempFile("imap-literal", ".tmp");
-                        attachment.put(STORED_DATA, f);
-                        written = 0;
-                        attachment.put(WRITTEN_DATA, written);
-                        outputStream = new FileOutputStream(f, true);
-                        attachment.put(OUTPUT_STREAM, outputStream);
-
-                    }
-
-
-                    try {
-                        int amount = Math.min(in.readableBytes(), size - written);
-                        in.readBytes(outputStream, amount);
-                        written += amount;
-                    } catch (Exception e) {
-                        try {
-                            outputStream.close();
-                        } catch (IOException ignored) {
-                            //ignore exception during close
-                        }
-                        throw e;
-                    }
-                    // Check if all needed data was streamed to the file.
-                    if (written == size) {
-                        try {
-                            outputStream.close();
-                        } catch (IOException ignored) {
-                            //ignore exception during close
-                        }
-
-                        reader = new NettyStreamImapRequestLineReader(ctx.channel(), f, retry);
-                    } else {
-                        attachment.put(WRITTEN_DATA, written);
-                        return;
-                    }
+                    reader = uploadToAFile(ctx, in, retry, attachment, size);
+                    if (reader == null) return null;
 
                 } else {
                     in.resetReaderIndex();
-                    return;
+                    return null;
                 }
 
             } else {
@@ -166,50 +183,58 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         } else {
             reader = new NettyImapRequestLineReader(ctx.channel(), in, retry, literalSizeLimit);
         }
+        return Pair.of(reader, size);
+    }
 
-        ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
+    private ImapRequestLineReader uploadToAFile(ChannelHandlerContext ctx, ByteBuf in, boolean retry, Map<String, Object> attachment, int size) throws IOException {
+        ImapRequestLineReader reader;
+        final File f;
+        int written;
 
-        // check if the session was removed before to prevent a harmless NPE. See JAMES-1312
-        // Also check if the session was logged out if so there is not need to try to decode it. See JAMES-1341
-        if (session != null && session.getState() != ImapSessionState.LOGOUT) {
-            try {
-
-                ImapMessage message = decoder.decode(reader, session);
-
-                // if size is != -1 the case was a literal. if thats the case we
-                // should not consume the line
-                // See JAMES-1199
-                if (size == -1) {
-                    reader.consumeLine();
-                }
-                
-                enableFraming(ctx);
-                
-                attachment.clear();
-                out.add(message);
-            } catch (NettyImapRequestLineReader.NotEnoughDataException e) {
-                // this exception was thrown because we don't have enough data
-                // yet
-                int neededData = e.getNeededSize();
-                // store the needed data size for later usage
-                attachment.put(NEEDED_DATA, neededData);
-
-                // SwitchableDelimiterBasedFrameDecoder added further to JAMES-1436.
-                disableFraming(ctx);
-                if (in.readableBytes() > 0) {
-                    ByteBuf spareBytes = in.retainedDuplicate();
-                    internalBuffer().clear();
-                    ctx.fireChannelRead(spareBytes);
-                }
-                in.resetReaderIndex();
-            }
+        OutputStream outputStream;
+        // check if we have created a temporary file already or if
+        // we need to create a new one
+        if (attachment.containsKey(STORED_DATA)) {
+            f = (File) attachment.get(STORED_DATA);
+            written = (Integer) attachment.get(WRITTEN_DATA);
+            outputStream = (OutputStream) attachment.get(OUTPUT_STREAM);
         } else {
-            // The session was null so may be the case because the channel was already closed but there were still bytes in the buffer.
-            // We now try to disconnect the client if still connected
-            if (ctx.channel().isActive()) {
-                ctx.channel().writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
-            }
+            f = File.createTempFile("imap-literal", ".tmp");
+            attachment.put(STORED_DATA, f);
+            written = 0;
+            attachment.put(WRITTEN_DATA, written);
+            outputStream = new FileOutputStream(f, true);
+            attachment.put(OUTPUT_STREAM, outputStream);
+
         }
+
+
+        try {
+            int amount = Math.min(in.readableBytes(), size - written);
+            in.readBytes(outputStream, amount);
+            written += amount;
+        } catch (Exception e) {
+            try {
+                outputStream.close();
+            } catch (IOException ignored) {
+                //ignore exception during close
+            }
+            throw e;
+        }
+        // Check if all needed data was streamed to the file.
+        if (written == size) {
+            try {
+                outputStream.close();
+            } catch (IOException ignored) {
+                //ignore exception during close
+            }
+
+            reader = new NettyStreamImapRequestLineReader(ctx.channel(), f, retry);
+        } else {
+            attachment.put(WRITTEN_DATA, written);
+            return null;
+        }
+        return reader;
     }
 
     public void disableFraming(ChannelHandlerContext ctx) {


### PR DESCRIPTION
Given that we now have reactive IMAP command execution (non blocking)

If we succeed to do large appends command parsing (buffered to a file thus blocking) asynchronously

Then we could handle the all IMAP workload without context switches.

Experimentally we were able to sensibly