### PR TITLE
JAMES-3714 Fix CRLF line separator on test code

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailGetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailGetMethodContract.scala
@@ -4472,7 +4472,7 @@ trait EmailGetMethodContract {
          |                        ],
          |                        "bodyValues": {
          |                            "2": {
-         |                                "value": "Main test message...\\n",
+         |                                "value": "Main test message...\\r\\n",
          |                                "isEncodingProblem": false,
          |                                "isTruncated": false
          |                            }


### PR DESCRIPTION
Fix 
```
Different value found in node "methodResponses[0][1].list[0].bodyValues.2.value", 
Expected :"Main test message...\n"
Actual   :"Main test message...\r\n"
```

`.eml` file has format CRLF => `\\n` -> `\\r\\n`
