### PR TITLE
JAMES-1489 Fix decoding for complex UTF-8 searches

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/SearchCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/SearchCommandParser.java
@@ -24,6 +24,7 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.imap.api.ImapConstants;
 import org.apache.james.imap.api.ImapMessage;
@@ -49,6 +50,18 @@ import org.slf4j.LoggerFactory;
  * Parse SEARCH commands
  */
 public class SearchCommandParser extends AbstractUidCommandParser {
+    private static class Context {
+        private Optional<Charset> previousCharset = Optional.empty();
+
+        public void setCharset(Charset charset) {
+            previousCharset = Optional.of(charset);
+        }
+
+        public Charset getCharset() {
+            return previousCharset.orElse(null);
+        }
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchCommandParser.class);
 
     public SearchCommandParser(StatusResponseFactory statusResponseFactory) {
@@ -60,18 +73,18 @@ public class SearchCommandParser extends AbstractUidCommandParser {
      * 
      * @param request
      *            <code>ImapRequestLineReader</code>, not null
-     * @param charset
-     *            <code>Charset</code> or null if there is no charset
+     * @param context
+     *            Holder for <code>Charset</code> or null if there is no charset
      * @param isFirstToken
      *            true when this is the first token read, false otherwise
      */
-    protected SearchKey searchKey(ImapSession session, ImapRequestLineReader request, Charset charset, boolean isFirstToken) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
+    protected SearchKey searchKey(ImapSession session, ImapRequestLineReader request, Context context, boolean isFirstToken) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
         final char next = request.nextChar();
         
         if (next >= '0' && next <= '9' || next == '*' || next == '$') {
             return sequenceSet(session, request);
         } else if (next == '(') {
-            return paren(session, request, charset);
+            return paren(session, request, context);
         } else {
             final int cap = consumeAndCap(request);
             switch (cap) {
@@ -79,19 +92,19 @@ public class SearchCommandParser extends AbstractUidCommandParser {
             case 'A':
                 return a(request);
             case 'B':
-                return b(request, charset);
+                return b(request, context.getCharset());
             case 'C':
-                return c(session, request, isFirstToken, charset);
+                return c(session, request, isFirstToken, context);
             case 'D':
                 return d(request);
             case 'E':
                 throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
             case 'F':
-                return f(request, charset);
+                return f(request, context.getCharset());
             case 'G':
                 throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
             case 'H':
-                return header(request, charset);
+                return header(request, context.getCharset());
             case 'I':
                 throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
             case 'J':
@@ -103,9 +116,9 @@ public class SearchCommandParser extends AbstractUidCommandParser {
             case 'M':
                 return modseq(request);
             case 'N':
-                return n(session, request, charset);
+                return n(session, request, context);
             case 'O':
-                return o(session, request, charset);
+                return o(session, request, context);
             case 'P':
                 throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
             case 'Q':
@@ -115,9 +128,9 @@ public class SearchCommandParser extends AbstractUidCommandParser {
                 nextIsC(request);
                 return recent(request);
             case 'S':
-                return s(request, charset);
+                return s(request, context.getCharset());
             case 'T':
-                return t(request, charset);
+                return t(request, context.getCharset());
             case 'U':
                 return u(request);
             case 'Y':
@@ -146,21 +159,21 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         }
     }
 
-    private SearchKey paren(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
+    private SearchKey paren(ImapSession session, ImapRequestLineReader request, Context context) throws DecodingException {
         request.consume();
         List<SearchKey> keys = new ArrayList<>();
-        addUntilParen(session, request, keys, charset);
+        addUntilParen(session, request, keys, context);
         return SearchKey.buildAnd(keys);
     }
 
-    private void addUntilParen(ImapSession session, ImapRequestLineReader request, List<SearchKey> keys, Charset charset) throws DecodingException {
+    private void addUntilParen(ImapSession session, ImapRequestLineReader request, List<SearchKey> keys, Context context) throws DecodingException {
         final char next = request.nextWordChar();
         if (next == ')') {
             request.consume();
         } else {
-            final SearchKey key = searchKey(session, request, null, false);
+            final SearchKey key = searchKey(session, request, context, false);
             keys.add(key);
-            addUntilParen(session, request, keys, charset);
+            addUntilParen(session, request, keys, context);
         }
     }
 
@@ -177,19 +190,19 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         return result;
     }
 
-    private SearchKey c(ImapSession session, ImapRequestLineReader request, boolean isFirstToken, Charset charset) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
+    private SearchKey c(ImapSession session, ImapRequestLineReader request, boolean isFirstToken, Context context) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
         final int next = consumeAndCap(request);
         switch (next) {
         case 'C':
-            return cc(request, charset);
+            return cc(request, context.getCharset());
         case 'H':
-            return charset(session, request, isFirstToken);
+            return charset(session, request, isFirstToken, context);
         default:
             throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
         }
     }
 
-    private SearchKey charset(ImapSession session, ImapRequestLineReader request, boolean isFirstToken) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
+    private SearchKey charset(ImapSession session, ImapRequestLineReader request, boolean isFirstToken, Context context) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
         final SearchKey result;
         nextIsA(request);
         nextIsR(request);
@@ -203,7 +216,8 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         final String value = request.astring();
         final Charset charset = Charset.forName(value);
         request.nextWordChar();
-        result = searchKey(session, request, charset, false);
+        context.setCharset(charset);
+        result = searchKey(session, request, context, false);
         return result;
     }
 
@@ -313,7 +327,7 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         }
     }
 
-    private SearchKey o(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
+    private SearchKey o(ImapSession session, ImapRequestLineReader request, Context context) throws DecodingException {
         final int next = consumeAndCap(request);
         switch (next) {
         case 'L':
@@ -321,7 +335,7 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         case 'N':
             return on(request);
         case 'R':
-            return or(session, request, charset);
+            return or(session, request, context);
         default:
             throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
         }
@@ -338,13 +352,13 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         }
     }
     
-    private SearchKey n(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
+    private SearchKey n(ImapSession session, ImapRequestLineReader request, Context context) throws DecodingException {
         final int next = consumeAndCap(request);
         switch (next) {
         case 'E':
             return newOperator(request);
         case 'O':
-            return not(session, request, charset);
+            return not(session, request, context);
         default:
             throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
         }
@@ -540,21 +554,21 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         return result;
     }
 
-    private SearchKey or(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
+    private SearchKey or(ImapSession session, ImapRequestLineReader request, Context context) throws DecodingException {
         final SearchKey result;
         nextIsSpace(request);
-        final SearchKey firstKey = searchKey(session, request, charset, false);
+        final SearchKey firstKey = searchKey(session, request, context, false);
         nextIsSpace(request);
-        final SearchKey secondKey = searchKey(session, request, charset, false);
+        final SearchKey secondKey = searchKey(session, request, context, false);
         result = SearchKey.buildOr(firstKey, secondKey);
         return result;
     }
 
-    private SearchKey not(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
+    private SearchKey not(ImapSession session, ImapRequestLineReader request, Context context) throws DecodingException {
         final SearchKey result;
         nextIsT(request);
         nextIsSpace(request);
-        final SearchKey nextKey = searchKey(session, request, charset, false);
+        final SearchKey nextKey = searchKey(session, request, context, false);
         result = SearchKey.buildNot(nextKey);
         return result;
     }
@@ -883,14 +897,15 @@ public class SearchCommandParser extends AbstractUidCommandParser {
 
     public SearchKey decode(ImapSession session, ImapRequestLineReader request) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
         request.nextWordChar();
-        final SearchKey firstKey = searchKey(session, request, null, true);
+        final Context context = new Context();
+        final SearchKey firstKey = searchKey(session, request, context, true);
         final SearchKey result;
         if (request.nextChar() == ' ') {
             List<SearchKey> keys = new ArrayList<>();
             keys.add(firstKey);
             while (request.nextChar() == ' ') {
                 request.nextWordChar();
-                final SearchKey key = searchKey(session, request, null, false);
+                final SearchKey key = searchKey(session, request, context, false);
                 keys.add(key);
             }
             result = SearchKey.buildAnd(keys);

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/SearchCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/SearchCommandParser.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * Parse SEARCH commands
  */
 public class SearchCommandParser extends AbstractUidCommandParser {
-    private static class Context {
+    public static class Context {
         private Optional<Charset> previousCharset = Optional.empty();
 
         public void setCharset(Charset charset) {

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserCharsetTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserCharsetTest.java
@@ -41,6 +41,7 @@ import org.apache.james.imap.api.message.response.StatusResponse;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.decode.parser.SearchCommandParser.Context;
 import org.apache.james.imap.encode.FakeImapSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,7 +157,7 @@ class SearchCommandParserCharsetTest {
                 new ByteArrayInputStream(NioUtils.add(NioUtils.add(CHARSET,
                         term), BYTES_UTF8_NON_ASCII_SEARCH_TERM)),
                 new ByteArrayOutputStream());
-        final SearchKey searchKey = parser.searchKey(null, reader, null, true);
+        final SearchKey searchKey = parser.searchKey(null, reader, new Context(), true);
         assertThat(searchKey).isEqualTo(key);
     }
 
@@ -166,7 +167,7 @@ class SearchCommandParserCharsetTest {
                 new ByteArrayInputStream(input.getBytes(charset)),
                 new ByteArrayOutputStream());
 
-        final SearchKey searchKey = parser.searchKey(null, reader, null, isFirst);
+        final SearchKey searchKey = parser.searchKey(null, reader, new Context(), isFirst);
         assertThat(searchKey).isEqualTo(key);
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserNotTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserNotTest.java
@@ -36,6 +36,7 @@ import org.apache.james.imap.api.message.request.SearchKey;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.decode.parser.SearchCommandParser.Context;
 import org.apache.james.mailbox.MessageUid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,7 +119,7 @@ class SearchCommandParserNotTest {
         ImapRequestLineReader reader = new ImapRequestStreamLineReader(
                 new ByteArrayInputStream("NOT (KEYWORD bar KEYWORD foo)".getBytes(StandardCharsets.US_ASCII)),
                 new ByteArrayOutputStream()); 
-        SearchKey key = parser.searchKey(null, reader, null, false); 
+        SearchKey key = parser.searchKey(null, reader, new Context(), false);
         List<SearchKey> keys = key.getKeys().get(0).getKeys(); 
         assertThat(keys.size()).isEqualTo(2);
         assertThat(keys.get(0).getValue()).isEqualTo("bar");
@@ -130,6 +131,6 @@ class SearchCommandParserNotTest {
                 new ByteArrayInputStream(input.getBytes(StandardCharsets.US_ASCII)),
                 new ByteArrayOutputStream());
 
-        assertThat(parser.searchKey(null, reader, null, false)).isEqualTo(key);
+        assertThat(parser.searchKey(null, reader, new Context(), false)).isEqualTo(key);
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserOrTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserOrTest.java
@@ -35,6 +35,7 @@ import org.apache.james.imap.api.message.request.SearchKey;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.decode.parser.SearchCommandParser.Context;
 import org.apache.james.mailbox.MessageUid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -178,7 +179,7 @@ class SearchCommandParserOrTest {
                 new ByteArrayInputStream(input.getBytes(StandardCharsets.US_ASCII)),
                 new ByteArrayOutputStream());
 
-        assertThat(parser.searchKey(null, reader, null, false)).isEqualTo(key);
+        assertThat(parser.searchKey(null, reader, new Context(), false)).isEqualTo(key);
     }
 
     public class Input {

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserQuotedCharsetTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserQuotedCharsetTest.java
@@ -44,6 +44,7 @@ import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.decode.DecodingException;
 import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.decode.parser.SearchCommandParser.Context;
 import org.apache.james.imap.encode.FakeImapSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -148,7 +149,7 @@ class SearchCommandParserQuotedCharsetTest {
                         .getBytes(StandardCharsets.US_ASCII)),
                         BYTES_QUOTED_UTF8_LENGTHY_NON_ASCII_SEARCH_TERM)),
                 new ByteArrayOutputStream());
-        final SearchKey searchKey = parser.searchKey(null, reader, null, true);
+        final SearchKey searchKey = parser.searchKey(null, reader, new Context(), true);
         assertThat(searchKey).isEqualTo(key);
     }
 
@@ -160,7 +161,7 @@ class SearchCommandParserQuotedCharsetTest {
                         .getBytes(StandardCharsets.US_ASCII)),
                         BYTES_QUOTED_UTF8_NON_ASCII_SEARCH_TERM)),
                 new ByteArrayOutputStream());
-        final SearchKey searchKey = parser.searchKey(null, reader, null, true);
+        final SearchKey searchKey = parser.searchKey(null, reader, new Context(), true);
         assertThat(searchKey).isEqualTo(key);
     }
 
@@ -262,7 +263,7 @@ class SearchCommandParserQuotedCharsetTest {
                 new ByteArrayInputStream(add(add(CHARSET, term),
                         BYTES_UTF8_NON_ASCII_SEARCH_TERM)),
                 new ByteArrayOutputStream());
-        final SearchKey searchKey = parser.searchKey(null, reader, null, true);
+        final SearchKey searchKey = parser.searchKey(null, reader, new Context(), true);
         assertThat(searchKey).isEqualTo(key);
     }
 
@@ -271,7 +272,7 @@ class SearchCommandParserQuotedCharsetTest {
                 new ByteArrayInputStream(input.getBytes(charset)),
                 new ByteArrayOutputStream());
 
-        final SearchKey searchKey = parser.searchKey(null, reader, null, isFirst);
+        final SearchKey searchKey = parser.searchKey(null, reader, new Context(), isFirst);
         assertThat(searchKey).isEqualTo(key);
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserSearchKeySequenceSetTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserSearchKeySequenceSetTest.java
@@ -33,6 +33,7 @@ import org.apache.james.imap.api.message.request.SearchKey;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.decode.parser.SearchCommandParser.Context;
 import org.apache.james.mailbox.MessageUid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -132,7 +133,7 @@ class SearchCommandParserSearchKeySequenceSetTest {
                 new ByteArrayInputStream(input.getBytes(StandardCharsets.US_ASCII)),
                 new ByteArrayOutputStream());
 
-        final SearchKey searchKey = parser.searchKey(null, reader, null, false);
+        final SearchKey searchKey = parser.searchKey(null, reader, new Context(), false);
         assertThat(searchKey).isEqualTo(key);
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserSearchKeyTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/SearchCommandParserSearchKeyTest.java
@@ -36,6 +36,7 @@ import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.decode.DecodingException;
 import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.decode.parser.SearchCommandParser.Context;
 import org.apache.james.mailbox.MessageUid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -378,7 +379,7 @@ class SearchCommandParserSearchKeyTest {
                 new ByteArrayInputStream(input.getBytes(StandardCharsets.US_ASCII)),
                 new ByteArrayOutputStream());
 
-        assertThat(parser.searchKey(null, reader, null, false)).isEqualTo(key);
+        assertThat(parser.searchKey(null, reader, new Context(), false)).isEqualTo(key);
     }
 
     @Test
@@ -732,7 +733,7 @@ class SearchCommandParserSearchKeyTest {
                 new ByteArrayOutputStream());
 
         try {
-            parser.searchKey(null, reader, null, false);
+            parser.searchKey(null, reader, new Context(), false);
             fail("Expected protocol exception to be throw since input is invalid");
         } catch (DecodingException e) {
             // expected

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -86,7 +86,7 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
             return;
         }
 
-        in.markReaderIndex();
+        int readerIndex = in.readerIndex();
         boolean retry = false;
 
         ImapRequestLineReader reader;
@@ -200,7 +200,7 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
                     internalBuffer().clear();
                     ctx.fireChannelRead(spareBytes);
                 }
-                in.resetReaderIndex();
+                in.readerIndex(readerIndex);
             }
         } else {
             // The session was null so may be the case because the channel was already closed but there were still bytes in the buffer.
@@ -212,8 +212,10 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
     }
 
     public void disableFraming(ChannelHandlerContext ctx) {
-        ctx.channel().pipeline().remove(FRAMER);
-        framingEnabled.set(false);
+        if (framingEnabled.get()) {
+            ctx.channel().pipeline().remove(FRAMER);
+            framingEnabled.set(false);
+        }
     }
 
     public void enableFraming(ChannelHandlerContext ctx) {

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -98,7 +98,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -1066,7 +1065,6 @@ class IMAPServerTest {
             imapServer.destroy();
         }
 
-        @Disabled("JAMES-1489 IMAP Search do not support continuation")
         @Test
         void searchingShouldSupportMultipleUTF8Criteria() throws Exception {
             String host = "127.0.0.1";


### PR DESCRIPTION
 - Reader index was  not properly reset for
multiple subsequent continuations.
 - Charset was not carried over for all the
 terms of the search.