### PR TITLE
[UPGRADE] jackson 2.13.1 -> 2.13.2.2 fixes CVE-2020-36518 [3.7.x]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
 
         <pax-logging-api.version>1.6.4</pax-logging-api.version>
         <jackson.version>2.13.2</jackson.version>
-        <jackson.databing.version>2.13.2.2</jackson.databing.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
         <feign.version>11.8</feign.version>
         <feign-form.version>3.8.0</feign-form.version>
         <jjwt.version>0.11.2</jjwt.version>
@@ -2074,7 +2074,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.databing.version}</version>
+                <version>${jackson.databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
         <cucumber.version>2.4.0</cucumber.version>
 
         <pax-logging-api.version>1.6.4</pax-logging-api.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.2.2</jackson.version>
         <feign.version>11.8</feign.version>
         <feign-form.version>3.8.0</feign-form.version>
         <jjwt.version>0.11.2</jjwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,8 @@
         <cucumber.version>2.4.0</cucumber.version>
 
         <pax-logging-api.version>1.6.4</pax-logging-api.version>
-        <jackson.version>2.13.2.2</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jackson.databing.version>2.13.2.2</jackson.databing.version>
         <feign.version>11.8</feign.version>
         <feign-form.version>3.8.0</feign-form.version>
         <jjwt.version>0.11.2</jjwt.version>
@@ -2073,7 +2074,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.databing.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244

com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.

Affected versions of this package are vulnerable to Denial of Service (DoS) via a large depth of nested objects.