### PR TITLE
JAMES-3769 Allow defining search overrides

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
@@ -752,6 +752,18 @@ public class SearchQuery {
             return this;
         }
 
+        public Builder andCriterion(Criterion criterion) {
+            if (criterion instanceof ConjunctionCriterion) {
+                ConjunctionCriterion conjunctionCriterion = (ConjunctionCriterion) criterion;
+                if (conjunctionCriterion.getType() == Conjunction.AND) {
+                    this.criterias.addAll(conjunctionCriterion.getCriteria());
+                    return this;
+                }
+            }
+            this.criterias.add(criterion);
+            return this;
+        }
+
         public Builder sorts(Sort... sorts) {
             return this.sorts(Arrays.asList(sorts));
         }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
@@ -50,6 +50,8 @@ import com.google.common.collect.ImmutableSet;
  */
 public class SearchQuery {
     private static final String DATE_HEADER_NAME = "Date";
+    public static final ImmutableList<Sort> DEFAULT_SORTS = ImmutableList.of(new Sort(Sort.SortClause.Uid, Sort.Order.NATURAL));
+
 
     /**
      * The Resolution which should get used for {@link Date} searches
@@ -769,7 +771,7 @@ public class SearchQuery {
 
         public SearchQuery build() {
             return new SearchQuery(criterias.build(),
-                sorts.orElse(ImmutableList.of(new Sort(Sort.SortClause.Uid, Sort.Order.NATURAL))),
+                sorts.orElse(DEFAULT_SORTS),
                 recentMessageUids.build());
         }
     }
@@ -1896,6 +1898,13 @@ public class SearchQuery {
          */
         public UidRange[] getRange() {
             return ranges;
+        }
+
+        public boolean isAll() {
+            return ranges.length == 0
+                || (ranges.length == 1
+                && ranges[0].getLowValue() == MessageUid.MIN_VALUE
+                && ranges[0].getHighValue() == MessageUid.MAX_VALUE);
         }
 
         

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraFirstUnseenDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraFirstUnseenDAO.java
@@ -56,7 +56,7 @@ public class CassandraFirstUnseenDAO {
         this.deleteStatement = prepareDeleteStatement(session);
         this.deleteAllStatement = prepareDeleteAllStatement(session);
         this.readStatement = prepareReadStatement(session);
-        this.listStatement = prepareReadStatement(session);
+        this.listStatement = prepareListStatement(session);
     }
 
     private PreparedStatement prepareReadStatement(Session session) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -248,6 +248,7 @@ public class CassandraMessageIdDAO {
             select(
                 IMAP_UID,
                 MESSAGE_ID,
+                THREAD_ID_LOWERCASE,
                 ANSWERED.toLowerCase(Locale.US),
                 DELETED.toLowerCase(Locale.US),
                 DRAFT.toLowerCase(Locale.US),
@@ -421,7 +422,7 @@ public class CassandraMessageIdDAO {
             });
     }
 
-    public Flux<MessageUid> doListUids(CassandraId mailboxId, MessageRange range) {
+    private Flux<MessageUid> doListUids(CassandraId mailboxId, MessageRange range) {
         return cassandraAsyncExecutor.executeRows(selectUidOnlyRange.bind()
                 .setUUID(MAILBOX_ID, mailboxId.asUuid())
                 .setLong(IMAP_UID_GTE, range.getUidFrom().asLong())

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -243,8 +243,7 @@ public class CassandraMessageMapper implements MessageMapper {
     @Override
     public Flux<ComposedMessageIdWithMetaData> listMessagesMetadata(Mailbox mailbox, MessageRange set) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
-        return messageIdDAO.retrieveMessages(mailboxId, set, Limit.unlimited())
-            .map(CassandraMessageMetadata::getComposedMessageId);
+        return messageIdDAO.listMessagesMetadata(mailboxId, set);
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/AllSearchOverride.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/AllSearchOverride.java
@@ -1,0 +1,70 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class AllSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final CassandraMessageIdDAO dao;
+
+    @Inject
+    public AllSearchOverride(CassandraMessageIdDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return isAll(searchQuery)
+            || isFromOne(searchQuery)
+            || isEmpty(searchQuery);
+    }
+
+    private boolean isAll(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0).equals(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isFromOne(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0).equals(SearchQuery.all())
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isEmpty(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().isEmpty()
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        return dao.listUids((CassandraId) mailbox.getMailboxId());
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/DeletedSearchOverride.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/DeletedSearchOverride.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class DeletedSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final CassandraDeletedMessageDAO dao;
+
+    @Inject
+    public DeletedSearchOverride(CassandraDeletedMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0).equals(SearchQuery.flagIsSet(Flags.Flag.DELETED))
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        return dao.retrieveDeletedMessage((CassandraId) mailbox.getMailboxId(), MessageRange.all());
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/DeletedWithRangeSearchOverride.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/DeletedWithRangeSearchOverride.java
@@ -1,0 +1,69 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+
+public class DeletedWithRangeSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final CassandraDeletedMessageDAO dao;
+
+    @Inject
+    public DeletedWithRangeSearchOverride(CassandraDeletedMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return searchQuery.getCriteria().size() == 2
+            && searchQuery.getCriteria().contains(SearchQuery.flagIsSet(Flags.Flag.DELETED))
+            && searchQuery.getCriteria().stream()
+                .anyMatch(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        SearchQuery.UidCriterion uidArgument = searchQuery.getCriteria().stream()
+            .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            .map(SearchQuery.UidCriterion.class::cast)
+            .findAny()
+            .orElseThrow(() -> new RuntimeException("Missing Uid argument"));
+
+        SearchQuery.UidRange[] uidRanges = uidArgument.getOperator().getRange();
+
+        return Flux.fromIterable(ImmutableList.copyOf(uidRanges))
+            .concatMap(range -> dao.retrieveDeletedMessage((CassandraId) mailbox.getMailboxId(),
+                MessageRange.range(range.getLowValue(), range.getHighValue())));
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverride.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverride.java
@@ -1,0 +1,83 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+
+public class NotDeletedWithRangeSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final CassandraMessageIdDAO dao;
+
+    @Inject
+    public NotDeletedWithRangeSearchOverride(CassandraMessageIdDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return isDeletedUnset(searchQuery) || isDeletedNotSet(searchQuery);
+    }
+
+    private boolean isDeletedUnset(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 2
+            && searchQuery.getCriteria().contains(SearchQuery.flagIsUnSet(Flags.Flag.DELETED))
+            && searchQuery.getCriteria().stream()
+                .anyMatch(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isDeletedNotSet(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 2
+            && searchQuery.getCriteria().contains(SearchQuery.not(SearchQuery.flagIsSet(Flags.Flag.DELETED)))
+            && searchQuery.getCriteria().stream()
+                .anyMatch(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        SearchQuery.UidCriterion uidArgument = searchQuery.getCriteria().stream()
+            .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            .map(SearchQuery.UidCriterion.class::cast)
+            .findAny()
+            .orElseThrow(() -> new RuntimeException("Missing Uid argument"));
+
+        SearchQuery.UidRange[] uidRanges = uidArgument.getOperator().getRange();
+
+        return Flux.fromIterable(ImmutableList.copyOf(uidRanges))
+            .concatMap(range -> dao.listMessagesMetadata((CassandraId) mailbox.getMailboxId(),
+                MessageRange.range(range.getLowValue(), range.getHighValue())))
+            .filter(message -> !message.getFlags().contains(Flags.Flag.DELETED))
+            .map(message -> message.getComposedMessageId().getUid());
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/UidSearchOverride.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/UidSearchOverride.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+
+public class UidSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final CassandraMessageIdDAO dao;
+
+    @Inject
+    public UidSearchOverride(CassandraMessageIdDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0) instanceof SearchQuery.UidCriterion
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        SearchQuery.UidCriterion uidArgument = searchQuery.getCriteria().stream()
+            .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            .map(SearchQuery.UidCriterion.class::cast)
+            .findAny()
+            .orElseThrow(() -> new RuntimeException("Missing Uid argument"));
+
+        SearchQuery.UidRange[] uidRanges = uidArgument.getOperator().getRange();
+
+        return Flux.fromIterable(ImmutableList.copyOf(uidRanges))
+            .concatMap(range -> dao.listUids((CassandraId) mailbox.getMailboxId(),
+                MessageRange.range(range.getLowValue(), range.getHighValue())));
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/UnseenSearchOverride.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/search/UnseenSearchOverride.java
@@ -1,0 +1,81 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class UnseenSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final CassandraFirstUnseenDAO dao;
+
+    @Inject
+    public UnseenSearchOverride(CassandraFirstUnseenDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return isUnseenWithAll(searchQuery)
+            || isNotSeenWithAll(searchQuery);
+    }
+
+    private boolean isUnseenWithAll(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().contains(SearchQuery.flagIsUnSet(Flags.Flag.SEEN))
+            && allMessages(searchQuery)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isNotSeenWithAll(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().contains(SearchQuery.not(SearchQuery.flagIsSet(Flags.Flag.SEEN)))
+            && allMessages(searchQuery)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean allMessages(SearchQuery searchQuery) {
+        if (searchQuery.getCriteria().size() == 1) {
+            // Only the unseen critrion
+            return true;
+        }
+        if (searchQuery.getCriteria().size() == 2) {
+            return searchQuery.getCriteria().stream()
+                .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+                .map(SearchQuery.UidCriterion.class::cast)
+                .anyMatch(uidCriterion -> uidCriterion.getOperator().isAll()) ||
+                searchQuery.getCriteria().stream()
+                    .anyMatch(criterion -> criterion instanceof SearchQuery.AllCriterion);
+        }
+        return false;
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        return dao.listUnseen((CassandraId) mailbox.getMailboxId());
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraFirstUnseenDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraFirstUnseenDAOTest.java
@@ -97,6 +97,22 @@ class CassandraFirstUnseenDAOTest {
     }
 
     @Test
+    void listUnseenShouldReturnAllValues() {
+        testee.addUnread(MAILBOX_ID, UID_1).block();
+        testee.addUnread(MAILBOX_ID, UID_2).block();
+        testee.addUnread(CassandraId.timeBased(), MessageUid.of(3)).block();
+
+        assertThat(testee.listUnseen(MAILBOX_ID).collectList().block())
+            .containsOnly(UID_1, UID_2);
+    }
+
+    @Test
+    void listUnseenShouldReturnEmptyByDefault() {
+        assertThat(testee.listUnseen(MAILBOX_ID).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
     void retrieveFirstUnreadShouldBeOrderIndependent() {
         testee.addUnread(MAILBOX_ID, UID_2).block();
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/AllSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/AllSearchOverrideTest.java
@@ -1,0 +1,177 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.Optional;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageMetadata;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class AllSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final CassandraModule MODULE = CassandraModule.aggregateModules(
+        CassandraMessageModule.MODULE,
+        CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULE);
+
+    private CassandraMessageIdDAO dao;
+    private AllSearchOverride testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+        testee = new AllSearchOverride(dao);
+    }
+
+    @Test
+    void emptyQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void allQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.all())
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void fromOneQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.all())
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        CassandraMessageId messageId = new CassandraMessageId.Factory().generate();
+        dao.insert(CassandraMessageMetadata.builder()
+            .ids(ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(MAILBOX.getMailboxId(), messageId, messageUid))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .threadId(ThreadId.fromBaseMessageId(messageId))
+                .build())
+            .internalDate(new Date())
+            .bodyStartOctet(18L)
+            .size(36L)
+            .headerContent(Optional.of(HEADER_BLOB_ID_1))
+            .build())
+            .block();
+        MessageUid messageUid2 = MessageUid.of(2);
+        CassandraMessageId messageId2 = new CassandraMessageId.Factory().generate();
+        dao.insert(CassandraMessageMetadata.builder()
+            .ids(ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(MAILBOX.getMailboxId(), messageId2, messageUid2))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .threadId(ThreadId.fromBaseMessageId(messageId2))
+                .build())
+            .internalDate(new Date())
+            .bodyStartOctet(18L)
+            .size(36L)
+            .headerContent(Optional.of(HEADER_BLOB_ID_1))
+            .build())
+            .block();
+        MessageUid messageUid3 = MessageUid.of(3);
+        CassandraMessageId messageId3 = new CassandraMessageId.Factory().generate();
+        dao.insert(CassandraMessageMetadata.builder()
+            .ids(ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(CassandraId.timeBased(), messageId3, messageUid3))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .threadId(ThreadId.fromBaseMessageId(messageId3))
+                .build())
+            .internalDate(new Date())
+            .bodyStartOctet(18L)
+            .size(36L)
+            .headerContent(Optional.of(HEADER_BLOB_ID_1))
+            .build())
+            .block();
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.all())
+                .build()).collectList().block())
+            .containsOnly(messageUid, messageUid2);
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/DeletedSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/DeletedSearchOverrideTest.java
@@ -1,0 +1,109 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import static javax.mail.Flags.Flag.DELETED;
+import static javax.mail.Flags.Flag.SEEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
+import org.apache.james.mailbox.cassandra.modules.CassandraDeletedMessageModule;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.UidValidity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DeletedSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
+    private static final CassandraModule MODULE = CassandraModule.aggregateModules(
+        CassandraDeletedMessageModule.MODULE,
+        CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULE);
+
+    private CassandraDeletedMessageDAO dao;
+    private DeletedSearchOverride testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraDeletedMessageDAO(cassandra.getConf());
+        testee = new DeletedSearchOverride(dao);
+    }
+
+    @Test
+    void deletedQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        MessageUid messageUid2 = MessageUid.of(2);
+        MessageUid messageUid3 = MessageUid.of(3);
+
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid).block();
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid2).block();
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid3).block();
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(DELETED))
+                .build()).collectList().block())
+            .containsOnly(messageUid, messageUid2, messageUid3);
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/DeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/DeletedWithRangeSearchOverrideTest.java
@@ -1,0 +1,126 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import static javax.mail.Flags.Flag.DELETED;
+import static javax.mail.Flags.Flag.SEEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
+import org.apache.james.mailbox.cassandra.modules.CassandraDeletedMessageModule;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.UidValidity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DeletedWithRangeSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
+    private static final CassandraModule MODULE = CassandraModule.aggregateModules(
+        CassandraDeletedMessageModule.MODULE,
+        CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULE);
+
+    private CassandraDeletedMessageDAO dao;
+    private DeletedWithRangeSearchOverride testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraDeletedMessageDAO(cassandra.getConf());
+        testee = new DeletedWithRangeSearchOverride(dao);
+    }
+
+    @Test
+    void deletedWithRangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void deletedQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.of(45))))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        MessageUid messageUid2 = MessageUid.of(2);
+        MessageUid messageUid3 = MessageUid.of(3);
+        MessageUid messageUid4 = MessageUid.of(4);
+        MessageUid messageUid5 = MessageUid.of(5);
+
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid).block();
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid2).block();
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid3).block();
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid4).block();
+        dao.addDeleted((CassandraId) MAILBOX.getMailboxId(), messageUid5).block();
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(DELETED))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(messageUid2, messageUid4)))
+                .build()).collectList().block())
+            .containsOnly(messageUid2, messageUid3, messageUid4);
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverrideTest.java
@@ -1,0 +1,158 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import static javax.mail.Flags.Flag.DELETED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.Optional;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageMetadata;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class NotDeletedWithRangeSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final CassandraModule MODULE = CassandraModule.aggregateModules(
+        CassandraMessageModule.MODULE,
+        CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULE);
+
+    private CassandraMessageIdDAO dao;
+    private NotDeletedWithRangeSearchOverride testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+        testee = new NotDeletedWithRangeSearchOverride(dao);
+    }
+
+    @Test
+    void undeletedRangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(DELETED))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notDeletedRangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(DELETED)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(DELETED)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(34), MessageUid.of(345))))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        insert(messageUid, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid2 = MessageUid.of(2);
+        insert(messageUid2, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid3 = MessageUid.of(3);
+        insert(messageUid3, MAILBOX.getMailboxId(), new Flags(DELETED));
+        MessageUid messageUid4 = MessageUid.of(5);
+        insert(messageUid4, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid5 = MessageUid.of(5);
+        insert(messageUid5, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid6 = MessageUid.of(4);
+        insert(messageUid6, CassandraId.timeBased(), new Flags(DELETED));
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(DELETED)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(messageUid2, messageUid4)))
+                .build()).collectList().block())
+            .containsOnly(messageUid2, messageUid4);
+    }
+
+    private void insert(MessageUid messageUid5, MailboxId cassandraId, Flags flags) {
+        CassandraMessageId messageId5 = new CassandraMessageId.Factory().generate();
+        dao.insert(CassandraMessageMetadata.builder()
+            .ids(ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(cassandraId, messageId5, messageUid5))
+                .flags(flags)
+                .modSeq(ModSeq.of(1))
+                .threadId(ThreadId.fromBaseMessageId(messageId5))
+                .build())
+            .internalDate(new Date())
+            .bodyStartOctet(18L)
+            .size(36L)
+            .headerContent(Optional.of(HEADER_BLOB_ID_1))
+            .build())
+            .block();
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UidSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UidSearchOverrideTest.java
@@ -1,0 +1,143 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.Optional;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageMetadata;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class UidSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final CassandraModule MODULE = CassandraModule.aggregateModules(
+        CassandraMessageModule.MODULE,
+        CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULE);
+
+    private CassandraMessageIdDAO dao;
+    private UidSearchOverride testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+        testee = new UidSearchOverride(dao);
+    }
+
+    @Test
+    void rangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(34), MessageUid.of(345))))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        insert(messageUid, MAILBOX.getMailboxId());
+        MessageUid messageUid2 = MessageUid.of(2);
+        insert(messageUid2, MAILBOX.getMailboxId());
+        MessageUid messageUid3 = MessageUid.of(3);
+        insert(messageUid3, MAILBOX.getMailboxId());
+        MessageUid messageUid4 = MessageUid.of(5);
+        insert(messageUid4, MAILBOX.getMailboxId());
+        MessageUid messageUid5 = MessageUid.of(5);
+        insert(messageUid5, MAILBOX.getMailboxId());
+        MessageUid messageUid6 = MessageUid.of(6);
+        insert(messageUid6, CassandraId.timeBased());
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(messageUid2, messageUid4)))
+                .build()).collectList().block())
+            .containsOnly(messageUid2, messageUid3, messageUid4);
+    }
+
+    private void insert(MessageUid messageUid5, MailboxId cassandraId) {
+        CassandraMessageId messageId5 = new CassandraMessageId.Factory().generate();
+        dao.insert(CassandraMessageMetadata.builder()
+            .ids(ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(cassandraId, messageId5, messageUid5))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .threadId(ThreadId.fromBaseMessageId(messageId5))
+                .build())
+            .internalDate(new Date())
+            .bodyStartOctet(18L)
+            .size(36L)
+            .headerContent(Optional.of(HEADER_BLOB_ID_1))
+            .build())
+            .block();
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UnseenSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UnseenSearchOverrideTest.java
@@ -1,0 +1,162 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.search;
+
+import static javax.mail.Flags.Flag.SEEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
+import org.apache.james.mailbox.cassandra.modules.CassandraFirstUnseenModule;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.UidValidity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class UnseenSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
+    private static final CassandraModule MODULE = CassandraModule.aggregateModules(
+        CassandraFirstUnseenModule.MODULE,
+        CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULE);
+
+    private CassandraFirstUnseenDAO dao;
+    private UnseenSearchOverride testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraFirstUnseenDAO(cassandra.getConf());
+        testee = new UnseenSearchOverride(dao);
+    }
+
+    @Test
+    void unseenQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notSeenQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(SEEN)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void unseenAndAllQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .andCriteria(SearchQuery.all())
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notSeenAndAllQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(SEEN)))
+                .andCriteria(SearchQuery.all())
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void unseenAndFromOneQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notSeenFromOneQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(SEEN)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        MessageUid messageUid2 = MessageUid.of(2);
+        MessageUid messageUid3 = MessageUid.of(3);
+
+        dao.addUnread((CassandraId) MAILBOX.getMailboxId(), messageUid).block();
+        dao.addUnread((CassandraId) MAILBOX.getMailboxId(), messageUid2).block();
+        dao.addUnread((CassandraId) MAILBOX.getMailboxId(), messageUid3).block();
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build()).collectList().block())
+            .containsOnly(messageUid, messageUid2, messageUid3);
+    }
+}

--- a/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndex.java
+++ b/mailbox/elasticsearch-v7/src/main/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndex.java
@@ -35,6 +35,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -100,10 +101,11 @@ public class ElasticSearchListeningMessageSearchIndex extends ListeningMessageSe
 
     @Inject
     public ElasticSearchListeningMessageSearchIndex(MailboxSessionMapperFactory factory,
+                                                    Set<SearchOverride> searchOverrides,
                                                     @Named(MailboxElasticSearchConstants.InjectionNames.MAILBOX) ElasticSearchIndexer indexer,
                                                     ElasticSearchSearcher searcher, MessageToElasticSearchJson messageToElasticSearchJson,
                                                     SessionProvider sessionProvider, RoutingKey.Factory<MailboxId> routingKeyFactory, MessageId.Factory messageIdFactory) {
-        super(factory, sessionProvider);
+        super(factory, searchOverrides, sessionProvider);
         this.elasticSearchIndexer = indexer;
         this.messageToElasticSearchJson = messageToElasticSearchJson;
         this.searcher = searcher;
@@ -128,12 +130,11 @@ public class ElasticSearchListeningMessageSearchIndex extends ListeningMessageSe
     }
     
     @Override
-    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+    protected Flux<MessageUid> doSearch(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
         Preconditions.checkArgument(session != null, "'session' is mandatory");
         Optional<Integer> noLimit = Optional.empty();
 
-        return searcher
-            .search(ImmutableList.of(mailbox.getMailboxId()), searchQuery, noLimit, UID_FIELD)
+        return searcher.search(ImmutableList.of(mailbox.getMailboxId()), searchQuery, noLimit, UID_FIELD)
             .handle(this::extractUidFromHit);
     }
     

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/ElasticSearchIntegrationTest.java
@@ -69,6 +69,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 
@@ -124,6 +125,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
             .defaultMessageParser()
             .listeningSearchIndex(preInstanciationStage -> new ElasticSearchListeningMessageSearchIndex(
                 preInstanciationStage.getMapperFactory(),
+                ImmutableSet.of(),
                 new ElasticSearchIndexer(client,
                     MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new ElasticSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -51,7 +51,6 @@ import org.apache.james.mailbox.elasticsearch.v7.query.QueryConverter;
 import org.apache.james.mailbox.elasticsearch.v7.search.ElasticSearchSearcher;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
-import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMailboxSessionMapperFactory;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.manager.ManagerTestProvisionner;
@@ -92,6 +91,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
 class ElasticSearchListeningMessageSearchIndexTest {
@@ -198,7 +198,8 @@ class ElasticSearchListeningMessageSearchIndexTest {
 
         elasticSearchIndexer = new ElasticSearchIndexer(client, MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS);
         
-        testee = new ElasticSearchListeningMessageSearchIndex(mapperFactory, elasticSearchIndexer, elasticSearchSearcher,
+        testee = new ElasticSearchListeningMessageSearchIndex(mapperFactory,
+            ImmutableSet.of(), elasticSearchIndexer, elasticSearchSearcher,
             messageToElasticSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory(), messageIdFactory);
         session = sessionProvider.createSystemSession(USERNAME);
 
@@ -212,7 +213,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
     
     @Test
-    void addShouldIndexMessageWithoutAttachment() {
+    void addShouldIndexMessageWithoutAttachment() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 1L);
 
@@ -222,7 +223,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void addShouldIndexMessageWithAttachment() {
+    void addShouldIndexMessageWithAttachment() throws Exception {
         testee.add(session, mailbox, MESSAGE_WITH_ATTACHMENT).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 1L);
 
@@ -232,7 +233,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void addShouldBeIndempotent() {
+    void addShouldBeIndempotent() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         testee.add(session, mailbox, MESSAGE_1).block();
 
@@ -244,7 +245,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void addShouldIndexMultipleMessages() {
+    void addShouldIndexMultipleMessages() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         testee.add(session, mailbox, MESSAGE_2).block();
 
@@ -256,13 +257,14 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void addShouldIndexEmailBodyWhenNotIndexableAttachment() {
+    void addShouldIndexEmailBodyWhenNotIndexableAttachment() throws Exception {
         MessageToElasticSearchJson messageToElasticSearchJson = new MessageToElasticSearchJson(
             new FailingTextExtractor(),
             ZoneId.of("Europe/Paris"),
             IndexAttachments.YES);
 
-        testee = new ElasticSearchListeningMessageSearchIndex(mapperFactory, elasticSearchIndexer, elasticSearchSearcher,
+        testee = new ElasticSearchListeningMessageSearchIndex(mapperFactory,
+            ImmutableSet.of(), elasticSearchIndexer, elasticSearchSearcher,
             messageToElasticSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory(), new InMemoryMessageId.Factory());
 
         testee.add(session, mailbox, MESSAGE_WITH_ATTACHMENT).block();
@@ -285,7 +287,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void deleteShouldRemoveIndex() {
+    void deleteShouldRemoveIndex() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 1L);
 
@@ -298,7 +300,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void deleteShouldOnlyRemoveIndexesPassedAsArguments() {
+    void deleteShouldOnlyRemoveIndexesPassedAsArguments() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         testee.add(session, mailbox, MESSAGE_2).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 2L);
@@ -312,7 +314,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void deleteShouldRemoveMultipleIndexes() {
+    void deleteShouldRemoveMultipleIndexes() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         testee.add(session, mailbox, MESSAGE_2).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 2L);
@@ -326,7 +328,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void deleteShouldBeIdempotent() {
+    void deleteShouldBeIdempotent() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 1L);
 
@@ -357,7 +359,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void updateShouldUpdateIndex() {
+    void updateShouldUpdateIndex() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 1L);
 
@@ -378,7 +380,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void updateShouldNotUpdateNorThrowOnUnknownMessageUid() {
+    void updateShouldNotUpdateNorThrowOnUnknownMessageUid() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 1L);
 
@@ -398,7 +400,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void updateShouldBeIdempotent() {
+    void updateShouldBeIdempotent() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 1L);
 
@@ -439,7 +441,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
     }
 
     @Test
-    void deleteAllShouldRemoveAllIndexes() {
+    void deleteAllShouldRemoveAllIndexes() throws Exception {
         testee.add(session, mailbox, MESSAGE_1).block();
         testee.add(session, mailbox, MESSAGE_2).block();
         awaitForElasticSearch(QueryBuilders.matchAllQuery(), 2L);

--- a/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/search/ElasticSearchSearcherTest.java
+++ b/mailbox/elasticsearch-v7/src/test/java/org/apache/james/mailbox/elasticsearch/v7/search/ElasticSearchSearcherTest.java
@@ -44,7 +44,6 @@ import org.apache.james.mailbox.elasticsearch.v7.events.ElasticSearchListeningMe
 import org.apache.james.mailbox.elasticsearch.v7.json.MessageToElasticSearchJson;
 import org.apache.james.mailbox.elasticsearch.v7.query.CriterionConverter;
 import org.apache.james.mailbox.elasticsearch.v7.query.QueryConverter;
-import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
@@ -75,6 +74,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 class ElasticSearchSearcherTest {
 
@@ -119,6 +119,7 @@ class ElasticSearchSearcherTest {
             .defaultMessageParser()
             .listeningSearchIndex(preInstanciationStage -> new ElasticSearchListeningMessageSearchIndex(
                 preInstanciationStage.getMapperFactory(),
+                ImmutableSet.of(),
                 new ElasticSearchIndexer(client,
                     MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new ElasticSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,

--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
@@ -122,6 +122,7 @@ import org.slf4j.LoggerFactory;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -389,7 +390,7 @@ public class LuceneMessageSearchIndex extends ListeningMessageSearchIndex {
             boolean lenient,
             MessageId.Factory messageIdFactory,
             SessionProvider sessionProvider) throws IOException {
-        super(factory, sessionProvider);
+        super(factory, ImmutableSet.of(), sessionProvider);
         this.mailboxIdFactory = mailboxIdFactory;
         this.messageIdFactory = messageIdFactory;
         this.directory = directory;
@@ -460,7 +461,7 @@ public class LuceneMessageSearchIndex extends ListeningMessageSearchIndex {
     
     
     @Override
-    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
+    public Flux<MessageUid> doSearch(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
         Preconditions.checkArgument(session != null, "'session' is mandatory");
 
         return Flux.fromIterable(searchMultimap(ImmutableList.of(mailbox.getMailboxId()), searchQuery))

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/LazyMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/LazyMessageSearchIndex.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -73,7 +74,7 @@ public class LazyMessageSearchIndex extends ListeningMessageSearchIndex {
     private final MailboxSessionMapperFactory factory;
 
     public LazyMessageSearchIndex(ListeningMessageSearchIndex index, MailboxSessionMapperFactory factory, SessionProvider sessionProvider) {
-        super(factory, sessionProvider);
+        super(factory, ImmutableSet.of(), sessionProvider);
         this.index = index;
         this.factory = factory;
     }
@@ -110,7 +111,7 @@ public class LazyMessageSearchIndex extends ListeningMessageSearchIndex {
      * 
      */
     @Override
-    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
+    public Flux<MessageUid> doSearch(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
         Preconditions.checkArgument(session != null, "'session' is mandatory");
         MailboxId id = mailbox.getMailboxId();
         

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
@@ -44,7 +44,6 @@ import org.apache.james.mailbox.elasticsearch.v7.json.MessageToElasticSearchJson
 import org.apache.james.mailbox.elasticsearch.v7.query.CriterionConverter;
 import org.apache.james.mailbox.elasticsearch.v7.query.QueryConverter;
 import org.apache.james.mailbox.elasticsearch.v7.search.ElasticSearchSearcher;
-import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 import org.apache.james.mailbox.store.StoreMailboxManager;
@@ -55,6 +54,8 @@ import org.apache.james.metrics.logger.DefaultMetricFactory;
 import org.apache.james.mpt.api.ImapFeatures;
 import org.apache.james.mpt.api.ImapFeatures.Feature;
 import org.apache.james.mpt.host.JamesImapHostSystem;
+
+import com.google.common.collect.ImmutableSet;
 
 public class ElasticSearchHostSystem extends JamesImapHostSystem {
 
@@ -97,6 +98,7 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
             .defaultMessageParser()
             .listeningSearchIndex(preInstanciationStage -> new ElasticSearchListeningMessageSearchIndex(
                 preInstanciationStage.getMapperFactory(),
+                ImmutableSet.of(),
                 new ElasticSearchIndexer(client,
                     MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new ElasticSearchSearcher(client, new QueryConverter(new CriterionConverter()), ElasticSearchSearcher.DEFAULT_SEARCH_SIZE,

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
@@ -270,7 +270,7 @@ public class SearchProcessor extends AbstractMailboxProcessor<SearchRequest> imp
         if (selected != null) {
             builder.addRecentMessageUids(selected.getRecent());
         }
-        return builder.andCriteria(criterion)
+        return builder.andCriterion(criterion)
             .build();
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
@@ -20,8 +20,12 @@
 package org.apache.james.imap.processor;
 
 import static org.apache.james.imap.ImapFixture.TAG;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -296,8 +300,10 @@ public class SearchProcessorTest {
     @Test
     void testNEW() throws Exception {
         expectsGetSelectedMailbox();
-        check(SearchKey.buildNew(), SearchQuery.and(SearchQuery
-                .flagIsSet(Flag.RECENT), SearchQuery.flagIsUnSet(Flag.SEEN)));
+        check(SearchKey.buildNew(), SearchQuery.builder()
+            .andCriteria(SearchQuery.flagIsSet(Flag.RECENT),
+                SearchQuery.flagIsUnSet(Flag.SEEN))
+            .build());
     }
 
     @Test
@@ -332,7 +338,9 @@ public class SearchProcessorTest {
         criteria.add(SearchQuery.internalDateOn(getDate(DAY, MONTH, YEAR), DateResolution.Day));
         criteria.add(SearchQuery.flagIsUnSet(Flag.RECENT));
         criteria.add(SearchQuery.sizeGreaterThan(SIZE));
-        check(SearchKey.buildAnd(keys), SearchQuery.and(criteria));
+        check(SearchKey.buildAnd(keys), SearchQuery.builder()
+            .andCriteria(criteria)
+            .build());
     }
 
     @Test

--- a/server/apps/cassandra-app/sample-configuration/elasticsearch.properties
+++ b/server/apps/cassandra-app/sample-configuration/elasticsearch.properties
@@ -89,7 +89,7 @@ elasticsearch.metrics.reports.index=james-metrics
 #
 # Possible values are:
 #  - `org.apache.james.mailbox.cassandra.search.AllSearchOverride` Some IMAP clients uses SEARCH ALL to fully list messages in
-# a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from am IMAP perspective
+# a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from an IMAP perspective
 # is considered an optimisation as less data is transmitted compared to a FETCH command. Resolving such requests against
 # Cassandra is enabled by this search override and likely desirable.
 #  - `org.apache.james.mailbox.cassandra.search.UidSearchOverride`. Same as above but restricted by ranges.

--- a/server/apps/cassandra-app/sample-configuration/elasticsearch.properties
+++ b/server/apps/cassandra-app/sample-configuration/elasticsearch.properties
@@ -82,3 +82,24 @@ elasticsearch.http.port=9200
 elasticsearch.metrics.reports.enabled=true
 elasticsearch.metrics.reports.period=30
 elasticsearch.metrics.reports.index=james-metrics
+
+# Search overrides allow resolution of predefined search queries against alternative sources of data
+# and allow bypassing ElasticSearch. This is useful to handle most resynchronisation queries that
+# are simple enough to be resolved against Cassandra.
+#
+# Possible values are:
+#  - `org.apache.james.mailbox.cassandra.search.AllSearchOverride` Some IMAP clients uses SEARCH ALL to fully list messages in
+# a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from am IMAP perspective
+# is considered an optimisation as less data is transmitted compared to a FETCH command. Resolving such requests against
+# Cassandra is enabled by this search override and likely desirable.
+#  - `org.apache.james.mailbox.cassandra.search.UidSearchOverride`. Same as above but restricted by ranges.
+#  - `org.apache.james.mailbox.cassandra.search.DeletedSearchOverride`. Find deleted messages by looking up in the relevant Cassandra
+# table.
+#  - `org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride`. Same as above but limited by ranges.
+#  - `org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride`. List non deleted messages in a given range.
+# Lists all messages and filters out deleted message thus this is based on the following heuristic: most messages are not marked as deleted.
+#  - `org.apache.james.mailbox.cassandra.search.UnseenSearchOverride`. List unseen messages in the corresponding cassandra projection.
+#
+# Please note that custom overrides can be defined here.
+#
+# elasticsearch.search.overrides=org.apache.james.mailbox.cassandra.search.AllSearchOverride,org.apache.james.mailbox.cassandra.search.DeletedSearchOverride, org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.UidSearchOverride,org.apache.james.mailbox.cassandra.search.UnseenSearchOverride

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/elasticsearch.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/elasticsearch.adoc
@@ -208,3 +208,31 @@ You can configure to use which HostNameVerifier in the client.
 accept_any_hostname: accept any host (not recommended).
 
 |===
+
+== Search overrides
+
+*Search overrides* allow resolution of predefined search queries against alternative sources of data
+and allow bypassing ElasticSearch. This is useful to handle most resynchronisation queries that
+are simple enough to be resolved against Cassandra.
+
+Possible values are:
+  - `org.apache.james.mailbox.cassandra.search.AllSearchOverride` Some IMAP clients uses SEARCH ALL to fully list messages in
+ a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from an IMAP perspective
+ is considered an optimisation as less data is transmitted compared to a FETCH command. Resolving such requests against
+ Cassandra is enabled by this search override and likely desirable.
+  - `org.apache.james.mailbox.cassandra.search.UidSearchOverride`. Same as above but restricted by ranges.
+  - `org.apache.james.mailbox.cassandra.search.DeletedSearchOverride`. Find deleted messages by looking up in the relevant Cassandra
+ table.
+  - `org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride`. Same as above but limited by ranges.
+  - `org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride`. List non deleted messages in a given range.
+ Lists all messages and filters out deleted message thus this is based on the following heuristic: most messages are not marked as deleted.
+  - `org.apache.james.mailbox.cassandra.search.UnseenSearchOverride`. List unseen messages in the corresponding cassandra projection.
+
+Please note that custom overrides can be defined here. `elasticsearch.search.overrides` allow specifying search overrides and is a
+coma separated list of search override FQDNs. Default to none.
+
+EG:
+
+----
+elasticsearch.search.overrides=org.apache.james.mailbox.cassandra.search.AllSearchOverride,org.apache.james.mailbox.cassandra.search.DeletedSearchOverride, org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.UidSearchOverride,org.apache.james.mailbox.cassandra.search.UnseenSearchOverride
+----

--- a/server/apps/distributed-app/sample-configuration/elasticsearch.properties
+++ b/server/apps/distributed-app/sample-configuration/elasticsearch.properties
@@ -81,3 +81,24 @@ elasticsearch.http.port=9200
 elasticsearch.metrics.reports.enabled=true
 elasticsearch.metrics.reports.period=30
 elasticsearch.metrics.reports.index=james-metrics
+
+# Search overrides allow resolution of predefined search queries against alternative sources of data
+# and allow bypassing ElasticSearch. This is useful to handle most resynchronisation queries that
+# are simple enough to be resolved against Cassandra.
+#
+# Possible values are:
+#  - `org.apache.james.mailbox.cassandra.search.AllSearchOverride` Some IMAP clients uses SEARCH ALL to fully list messages in
+# a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from am IMAP perspective
+# is considered an optimisation as less data is transmitted compared to a FETCH command. Resolving such requests against
+# Cassandra is enabled by this search override and likely desirable.
+#  - `org.apache.james.mailbox.cassandra.search.UidSearchOverride`. Same as above but restricted by ranges.
+#  - `org.apache.james.mailbox.cassandra.search.DeletedSearchOverride`. Find deleted messages by looking up in the relevant Cassandra
+# table.
+#  - `org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride`. Same as above but limited by ranges.
+#  - `org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride`. List non deleted messages in a given range.
+# Lists all messages and filters out deleted message thus this is based on the following heuristic: most messages are not marked as deleted.
+#  - `org.apache.james.mailbox.cassandra.search.UnseenSearchOverride`. List unseen messages in the corresponding cassandra projection.
+#
+# Please note that custom overrides can be defined here.
+#
+# elasticsearch.search.overrides=org.apache.james.mailbox.cassandra.search.AllSearchOverride,org.apache.james.mailbox.cassandra.search.DeletedSearchOverride, org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.UidSearchOverride,org.apache.james.mailbox.cassandra.search.UnseenSearchOverride

--- a/server/apps/distributed-app/sample-configuration/elasticsearch.properties
+++ b/server/apps/distributed-app/sample-configuration/elasticsearch.properties
@@ -88,7 +88,7 @@ elasticsearch.metrics.reports.index=james-metrics
 #
 # Possible values are:
 #  - `org.apache.james.mailbox.cassandra.search.AllSearchOverride` Some IMAP clients uses SEARCH ALL to fully list messages in
-# a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from am IMAP perspective
+# a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from an IMAP perspective
 # is considered an optimisation as less data is transmitted compared to a FETCH command. Resolving such requests against
 # Cassandra is enabled by this search override and likely desirable.
 #  - `org.apache.james.mailbox.cassandra.search.UidSearchOverride`. Same as above but restricted by ranges.

--- a/server/container/guice/elasticsearch/pom.xml
+++ b/server/container/guice/elasticsearch/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-filesystem-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-common</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/elasticsearch/src/main/java/org/apache/james/SearchModuleChooser.java
+++ b/server/container/guice/elasticsearch/src/main/java/org/apache/james/SearchModuleChooser.java
@@ -47,6 +47,7 @@ import org.apache.james.quota.search.QuotaSearcher;
 import org.apache.james.quota.search.scanning.ScanningQuotaSearcher;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -67,7 +68,7 @@ public class SearchModuleChooser {
     private static class FakeMessageSearchIndex extends ListeningMessageSearchIndex {
 
         public FakeMessageSearchIndex() {
-            super(null, null);
+            super(null, ImmutableSet.of(), null);
         }
 
         @Override
@@ -101,7 +102,7 @@ public class SearchModuleChooser {
         }
 
         @Override
-        public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
+        public Flux<MessageUid> doSearch(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
             throw new NotImplementedException("not implemented");
         }
 

--- a/server/container/guice/elasticsearch/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
+++ b/server/container/guice/elasticsearch/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
@@ -46,7 +46,6 @@ import org.apache.james.mailbox.elasticsearch.v7.events.ElasticSearchListeningMe
 import org.apache.james.mailbox.elasticsearch.v7.query.QueryConverter;
 import org.apache.james.mailbox.elasticsearch.v7.search.ElasticSearchSearcher;
 import org.apache.james.mailbox.model.MailboxId;
-import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
 import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex.SearchOverride;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
@@ -141,8 +140,6 @@ public class ElasticSearchMailboxModule extends AbstractModule {
     @Singleton
     private ElasticSearchSearcher createMailboxElasticSearchSearcher(ReactorElasticSearchClient client,
                                                                      QueryConverter queryConverter,
-                                                                     MailboxId.Factory mailboxIdFactory,
-                                                                     MessageId.Factory messageIdFactory,
                                                                      ElasticSearchMailboxConfiguration configuration,
                                                                      RoutingKey.Factory<MailboxId> routingKeyFactory) {
         return new ElasticSearchSearcher(

--- a/server/container/guice/elasticsearch/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
+++ b/server/container/guice/elasticsearch/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
@@ -22,7 +22,6 @@ package org.apache.james.modules.mailbox;
 import static org.apache.james.mailbox.elasticsearch.v7.search.ElasticSearchSearcher.DEFAULT_SEARCH_SIZE;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -86,7 +85,7 @@ public class ElasticSearchMailboxModule extends AbstractModule {
             this.client = client;
         }
 
-        void createIndex() throws IOException {
+        void createIndex() {
             MailboxIndexCreationUtil.prepareClient(client,
                 mailboxConfiguration.getReadAliasMailboxName(),
                 mailboxConfiguration.getWriteAliasMailboxName(),

--- a/server/container/guice/elasticsearch/src/test/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModuleTest.java
+++ b/server/container/guice/elasticsearch/src/test/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModuleTest.java
@@ -1,0 +1,60 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import static org.apache.james.filesystem.api.FileSystemFixture.RECURSIVE_CLASSPATH_FILE_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.apache.james.backends.es.v7.ElasticSearchConfiguration;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+import org.apache.james.util.Host;
+import org.apache.james.utils.ExtendedClassLoader;
+import org.apache.james.utils.ExtensionConfiguration;
+import org.apache.james.utils.GuiceGenericLoader;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+
+class ElasticSearchMailboxModuleTest {
+    @Test
+    void test() {
+        GuiceGenericLoader genericLoader = new GuiceGenericLoader(
+            Guice.createInjector(),
+            new ExtendedClassLoader(RECURSIVE_CLASSPATH_FILE_SYSTEM),
+            new ExtensionConfiguration(ImmutableList.of()));
+
+        Set<ListeningMessageSearchIndex.SearchOverride> searchOverrides = new ElasticSearchMailboxModule()
+            .provideSearchOverrides(genericLoader,
+            ElasticSearchConfiguration.builder()
+                .addHost(Host.parseConfString("127.0.0.1", 9200))
+                .withSearchOverrides(ImmutableList.of(
+                    "org.apache.james.modules.mailbox.SearchOverrideA",
+                    "org.apache.james.modules.mailbox.SearchOverrideB"))
+                .build());
+
+        assertThat(searchOverrides)
+            .hasSize(2)
+            .<Class>extracting(ListeningMessageSearchIndex.SearchOverride::getClass)
+            .containsOnly(SearchOverrideA.class, SearchOverrideB.class);
+    }
+}

--- a/server/container/guice/elasticsearch/src/test/java/org/apache/james/modules/mailbox/SearchOverrideA.java
+++ b/server/container/guice/elasticsearch/src/test/java/org/apache/james/modules/mailbox/SearchOverrideA.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class SearchOverrideA implements ListeningMessageSearchIndex.SearchOverride {
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return false;
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        return Flux.empty();
+    }
+}

--- a/server/container/guice/elasticsearch/src/test/java/org/apache/james/modules/mailbox/SearchOverrideB.java
+++ b/server/container/guice/elasticsearch/src/test/java/org/apache/james/modules/mailbox/SearchOverrideB.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class SearchOverrideB implements ListeningMessageSearchIndex.SearchOverride {
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return false;
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        return Flux.empty();
+    }
+}

--- a/server/container/guice/memory/src/main/java/org/apache/james/FakeMessageSearchIndex.java
+++ b/server/container/guice/memory/src/main/java/org/apache/james/FakeMessageSearchIndex.java
@@ -39,6 +39,8 @@ import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
 
+import com.google.common.collect.ImmutableSet;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -50,7 +52,7 @@ public class FakeMessageSearchIndex extends ListeningMessageSearchIndex {
     private static final FakeMessageSearchIndexGroup GROUP = new FakeMessageSearchIndexGroup();
 
     public FakeMessageSearchIndex() {
-        super(null, null);
+        super(null, ImmutableSet.of(), null);
     }
 
     @Override
@@ -79,7 +81,7 @@ public class FakeMessageSearchIndex extends ListeningMessageSearchIndex {
     }
 
     @Override
-    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
+    public Flux<MessageUid> doSearch(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
         throw new NotImplementedException("not implemented");
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -143,6 +143,7 @@ class MailboxesRoutesTest {
             .defaultMessageParser()
             .listeningSearchIndex(preInstanciationStage -> new ElasticSearchListeningMessageSearchIndex(
                 preInstanciationStage.getMapperFactory(),
+                ImmutableSet.of(),
                 new ElasticSearchIndexer(client,
                     MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new ElasticSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -1471,6 +1471,7 @@ class UserMailboxesRoutesTest {
                 .defaultMessageParser()
                 .listeningSearchIndex(preInstanciationStage -> new ElasticSearchListeningMessageSearchIndex(
                     preInstanciationStage.getMapperFactory(),
+                    ImmutableSet.of(),
                     new ElasticSearchIndexer(client,
                         MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                     new ElasticSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,

--- a/src/adr/0054-elasticsearch-search-overrides.md
+++ b/src/adr/0054-elasticsearch-search-overrides.md
@@ -1,0 +1,76 @@
+# 54. ElasticSearch search overrides
+
+Date: 2022-05-16
+
+## Status
+
+Accepted (lazy consensus).
+
+Implemented.
+
+## Context
+
+IMAP SEARCH requests can of course be used for user searches. But many applications (eg Samsung email client) also uses
+IMAP SEARCH for resynchronization.
+
+The use of ElasticSearch in the context of resynchronization is a problem as:
+
+ - Resynchronization incurs many requests that ElasticSearch is not made to cope with.
+ - This has a performance impact, and some 60+ seconds can be spotted.
+ - ElasticSearch indexing is asynchronous which is not ideal for resynchronization
+ - An ElasticSearch downtime would imply a full downtime for these clients.
+ 
+Those resynchronization queries would better be served by the metadata database
+
+## Decision
+
+Define an API, `SearchOverride` that can be called on matching search queries and thus offload ElasticSearch.
+
+Provide an extension mechanism for search overrides, where potentially custom implementations can be loaded from the
+configuration.
+
+Provide well targeted `SearchOverride`, implemented on top of `Cassandra` database.
+
+## Consequences
+
+We expect to :
+
+ - Observe less IMAP SEARCH slow requests
+ - ElasticSearch downtime should not impact IMAP clients using IMAP SEARCH like IMAP Samsung application
+ - Thus also be able to support a higher IMAP workload as Cassandra is more suited to resynchronisation requests
+
+## Sample IMAP requests
+
+
+```
+SearchOperation{key=SearchKey{type=TYPE_UID, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=[IdRange : TYPE: FROM UID: MessageUid{uid=1}:MessageUid{uid=9223372036854775807}], sequences=null, keys=Optional.empty}, options=[]}
+```
+
+```
+SearchOperation{key=SearchKey{type=TYPE_AND, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional[[
+    SearchKey{type=TYPE_SEQUENCE_SET, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=[IdRange ( 1->9223372036854775807 )], keys=Optional.empty}, 
+    SearchKey{type=TYPE_DELETED, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional.empty}]]},
+    options=[COUNT]}
+```
+
+```
+SearchOperation{key=SearchKey{type=TYPE_AND, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional[[
+    SearchKey{type=TYPE_UID, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=[IdRange : TYPE: FROM UID: MessageUid{uid=1}:MessageUid{uid=9223372036854775807}], sequences=null, keys=Optional.empty}, 
+    SearchKey{type=TYPE_UNSEEN, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional.empty}]]}, options=[COUNT]}
+```
+
+```
+SearchOperation{key=SearchKey{type=TYPE_AND, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional[[
+    SearchKey{type=TYPE_SEQUENCE_SET, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=[IdRange ( 1->9223372036854775807 )], keys=Optional.empty}, 
+     SearchKey{type=TYPE_NOT, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional[[
+        SearchKey{type=TYPE_DELETED, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional.empty}]]}]]}, options=[ALL]}
+```
+
+```
+SearchOperation{key=SearchKey{type=TYPE_ALL, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=null, sequences=null, keys=Optional.empty}, options=[]}
+```
+
+
+## References
+
+- [JIRA](https://issues.apache.org/jira/browse/JAMES-3769)

--- a/src/site/xdoc/server/config-elasticsearch.xml
+++ b/src/site/xdoc/server/config-elasticsearch.xml
@@ -289,6 +289,35 @@
             </dd>
         </dl>
     </section>
+    <section name="Search overrides">
+
+        <p><b>Search overrides</b> allow resolution of predefined search queries against alternative sources of data
+            and allow bypassing ElasticSearch. This is useful to handle most resynchronisation queries that
+            are simple enough to be resolved against Cassandra.</p>
+
+        <ul>Possible values are:<br/>
+            <li><pre>org.apache.james.mailbox.cassandra.search.AllSearchOverride</pre> Some IMAP clients uses SEARCH ALL to fully list messages in
+                a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from an IMAP perspective
+                is considered an optimisation as less data is transmitted compared to a FETCH command. Resolving such requests against
+                Cassandra is enabled by this search override and likely desirable.</li>
+            <li><pre>org.apache.james.mailbox.cassandra.search.UidSearchOverride</pre>. Same as above but restricted by ranges.</li>
+            <li><pre>org.apache.james.mailbox.cassandra.search.DeletedSearchOverride</pre>. Find deleted messages by looking up in the relevant Cassandra
+                table.</li>
+            <li><pre>org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride</pre>. Same as above but limited by ranges.
+                <li><pre>org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride</pre>. List non deleted messages in a given range.</li>
+                Lists all messages and filters out deleted message thus this is based on the following heuristic: most messages are not marked as deleted.</li>
+            <li><pre>org.apache.james.mailbox.cassandra.search.UnseenSearchOverride</pre>. List unseen messages in the corresponding cassandra projection.</li>
+        </ul>
+
+        <p>
+            Please note that custom overrides can be defined here. <pre>elasticsearch.search.overrides</pre> allow specifying search overrides and is a
+            coma separated list of search override FQDNs. Default to none.
+        </p>
+
+        <p>EG:</p>
+
+        <pre><code>elasticsearch.search.overrides=org.apache.james.mailbox.cassandra.search.AllSearchOverride,org.apache.james.mailbox.cassandra.search.DeletedSearchOverride, org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.UidSearchOverride,org.apache.james.mailbox.cassandra.search.UnseenSearchOverride</code></pre>
+    </section>
 </body>
 
 </document>


### PR DESCRIPTION
 ## Motivation
 
 IMAP SEARCH command is used by some clients to resynchronize data and are often performed queries.
 
 The use of ElasticSearch pose several issues:
 
  - Long lasting queries: it's not uncommon to see some search hanged for 60+ seconds
  - Many results returned kicking in ES driver paging
  - ElasticSearch is not the primary data store and can get out of date, reindexed. Indexing is a background process. Acceptable for user search, not really for resynchronisation.
  
The scope of this ticket is to allow execution of well chosen search requests against existing Cassandra datastructures. Optional and extensible.
 
 ## TODO
 
 - [x] Unit tests for search overrides
 - [x] Documentation
 - [x] Unit test for search override loading
 - [x] JIRA ticket and ADR