### PR TITLE
[BUILD] Increase ConcurrentTestRunnerTest await time

### DIFF
--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -41,7 +41,7 @@ import reactor.core.publisher.Mono;
 
 class ConcurrentTestRunnerTest {
     private static final ConcurrentTestRunner.ConcurrentOperation NOOP = (threadNumber, step) -> { };
-    private static final Duration DEFAULT_AWAIT_TIME = Duration.ofMillis(100);
+    private static final Duration DEFAULT_AWAIT_TIME = Duration.ofSeconds(2);
 
     @Test
     void constructorShouldThrowOnNegativeThreadCount() {


### PR DESCRIPTION
Locally 50ms was borderline with random failures, so
I expect the default value of 100 ms to be too low for
being reliable on a busy CI server where context switch
might be made expensive with expensive concurrent builds.

I hereby propose a safer, higher value of 2 seconds.