### PR TITLE
JAMES-3431 Stricter validation for DSN ENVID

### DIFF
--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/DSNDelayRequestedTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/DSNDelayRequestedTest.java
@@ -27,13 +27,11 @@ import static org.apache.mailet.base.MailAddressFixture.RECIPIENT1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.EnumSet;
 
 import org.apache.james.server.core.MailImpl;
 import org.apache.mailet.DsnParameters;
-import org.apache.mailet.base.MailAddressFixture;
 import org.apache.mailet.base.test.FakeMatcherConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;


### PR DESCRIPTION
Setting an invalid EndId leads to emails not being
transmissible to third party systems. Stricter validation
fixes this.