### PR TITLE
JAMES-3737 RabbitMQ unbinding is potentially blocking

### DIFF
--- a/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistrationHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistrationHandler.java
@@ -147,7 +147,9 @@ class KeyRegistrationHandler {
                 if (registration.unregister().lastListenerRemoved()) {
                     return Mono.from(metricFactory.decoratePublisherWithTimerMetric("rabbit-unregister", registrationBinder.unbind(key)
                         .timeout(TOPOLOGY_CHANGES_TIMEOUT)
-                        .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.elastic()))));
+                        .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.elastic()))))
+                        // Unbind is potentially blocking
+                        .subscribeOn(Schedulers.elastic());
                 }
                 return Mono.empty();
             }));


### PR DESCRIPTION
AMQP channel uses a lock to execute one RPC

Shitty driver design, iterating the channel pool to get a channel without RPC looks like a dead end.

At the very least we should not block the Netty event loop....

CF flame graph in the event loop:

![Screenshot from 2022-05-17 18-07-46](https://user-images.githubusercontent.com/6928740/168799036-dd56bcdc-bc03-4029-8a83-1a8d0263f300.png)

CF AMQPChannel code:

```
    private void doEnqueueRpc(Supplier<RpcWrapper> rpcWrapperSupplier) {
        synchronized(this._channelMutex) {
            boolean waitClearedInterruptStatus = false;

            while(this._activeRpc != null) {
                try {
                    this._channelMutex.wait();
                } catch (InterruptedException var6) {
                    waitClearedInterruptStatus = true;
                }
            }

            if (waitClearedInterruptStatus) {
                Thread.currentThread().interrupt();
            }

            this._activeRpc = (RpcWrapper)rpcWrapperSupplier.get();
        }
    }
```

Getting tired of RabbitMQ driver and its fake reactive implementation.
