### PR TITLE
James 3758 Endpoint to delete old emails from INBOXes

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -293,7 +293,7 @@ public class StoreMailboxManager implements MailboxManager {
                 return createMessageManager(mailboxRow, session);
             }).sneakyThrow())
             .switchIfEmpty(Mono.fromCallable(() -> {
-                LOGGER.info("Mailbox '{}' not found.", mailboxPath);
+                LOGGER.debug("Mailbox '{}' not found.", mailboxPath);
                 throw new MailboxNotFoundException(mailboxPath);
             }));
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
@@ -533,9 +533,10 @@ public class MessageSearches implements Iterable<SimpleMessageSearchIndex.Search
     private Date toISODate(String value) throws ParseException {
         StringReader reader = new StringReader(value);
         DateTime dateTime = new DateTimeParser(reader).parseAll();
-        Calendar cal = getGMT();
+        Calendar cal = getGMT(dateTime.getTimeZone());
         cal.set(dateTime.getYear(), dateTime.getMonth() - 1, dateTime.getDay(), dateTime.getHour(),
                 dateTime.getMinute(), dateTime.getSecond());
+        cal.set(Calendar.MILLISECOND, 0);
         return cal.getTime();
     }
 
@@ -653,6 +654,10 @@ public class MessageSearches implements Iterable<SimpleMessageSearchIndex.Search
 
     private Calendar getGMT() {
         return Calendar.getInstance(TimeZone.getTimeZone("GMT"), Locale.ENGLISH);
+    }
+
+    private Calendar getGMT(int timeZone) {
+        return Calendar.getInstance(TimeZone.getTimeZone(String.format("GMT%+04d", timeZone)), Locale.ENGLISH);
     }
 
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/SearchUtilsTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/SearchUtilsTest.java
@@ -761,7 +761,7 @@ class SearchUtilsTest {
     
     @Test
     void testMatchHeaderDateOnWithOffset() throws Exception {
-        builder.header(DATE_FIELD, "Mon, 26 Mar 2007 00:00:00 +0300");
+        builder.header(DATE_FIELD, "Mon, 26 Mar 2007 03:00:00 +0300");
         MailboxMessage row = builder.build();
         assertThat(messageSearches.isMatch(SearchQuery.headerDateOn(DATE_FIELD, getDate(26, 3,
                 2007), DateResolution.Day),row, recent)).isTrue();
@@ -775,7 +775,7 @@ class SearchUtilsTest {
 
     @Test
     void testShouldMatchHeaderDateBeforeWithOffset() throws Exception {
-        builder.header(DATE_FIELD, "Mon, 26 Mar 2007 00:00:00 +0300");
+        builder.header(DATE_FIELD, "Mon, 26 Mar 2007 03:00:00 +0300");
         MailboxMessage row = builder.build();
         assertThat(messageSearches.isMatch(SearchQuery.headerDateBefore(DATE_FIELD, getDate(26, 3,
                 2007), DateResolution.Day),row, recent)).isFalse();
@@ -788,7 +788,7 @@ class SearchUtilsTest {
 
     @Test
     void testShouldMatchHeaderDateAfterWithOffset() throws Exception {
-        builder.header(DATE_FIELD, "Mon, 26 Mar 2007 00:00:00 +0300");
+        builder.header(DATE_FIELD, "Mon, 26 Mar 2007 03:00:00 +0300");
         MailboxMessage row = builder.build();
         assertThat(messageSearches.isMatch(SearchQuery.headerDateAfter(DATE_FIELD, getDate(26, 3,
                 2007), DateResolution.Day),row, recent)).isFalse();

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/Expires.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/Expires.java
@@ -1,0 +1,150 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import java.io.StringReader;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.james.mime4j.dom.datetime.DateTime;
+import org.apache.james.mime4j.field.datetime.parser.DateTimeParser;
+import org.apache.james.mime4j.field.datetime.parser.ParseException;
+import org.apache.james.util.DurationParser;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.DateFormats;
+import org.apache.mailet.base.GenericMailet;
+
+
+/**
+ * <p>Adds an Expires header to the message, or enforces the period of an existing one.</p>
+ *
+ * <p>Sample configuration:</p>
+ *
+ * <pre><code>
+ * &lt;mailet match="All" class="Expires"&gt;
+ *   &lt;minAge&gt;1d&lt;/minAge&gt;
+ *   &lt;maxAge&gt;1w&lt;/maxAge&gt;
+ *   &lt;defaultAge&gt;4w&lt;/defaultAge&gt;
+ * &lt;/mailet&gt;
+ * </code></pre>
+ *
+ * Note that the Expires header is informational only. But some variants of James
+ * will let you delete expired messages through the WebAdmin interface:
+ * <code>
+ * curl -XDELETE http://ip:port/messages?byExpiresHeader
+ * </code>
+ */
+public class Expires extends GenericMailet {
+    
+    public static final String EXPIRES = "Expires";
+    
+    private final Clock clock;
+
+    private Optional<Duration> minAge = Optional.empty();
+    private Optional<Duration> maxAge = Optional.empty();
+    private Optional<Duration> defaultAge = Optional.empty();
+    
+    @Inject
+    public Expires(Clock clock) {
+        this.clock = clock;
+    }
+    
+    @Override
+    public void init() throws MessagingException {
+        minAge = parseDuration("minAge");
+        maxAge = parseDuration("maxAge");
+        defaultAge = parseDuration("defaultAge");
+
+        if (minAge.isEmpty() && maxAge.isEmpty() && defaultAge.isEmpty()) {
+            throw new MessagingException("Please configure at least one of minAge, maxAge, defaultAge");
+        }
+
+        if (isAfter(minAge, maxAge)) {
+            throw new MessagingException("minAge must be before maxAge");
+        }
+        if (isAfter(defaultAge, maxAge)) {
+            throw new MessagingException("defaultAge must be before maxAge");
+        }
+        if (isAfter(minAge, defaultAge)) {
+            throw new MessagingException("minAge must be before defaultAge");
+        }
+    }
+
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        ZonedDateTime now = ZonedDateTime.now(clock);
+        MimeMessage message = mail.getMessage();
+        Optional<ZonedDateTime> expires = parseExpiresHeader(message);
+        if (expires.isPresent()) {
+            if (minAge.isPresent() && expires.get().isBefore(now.plus(minAge.get()))) {
+                setExpiresAfter(message, now, minAge.get());
+            } else
+            if (maxAge.isPresent() && expires.get().isAfter(now.plus(maxAge.get()))) {
+                setExpiresAfter(message, now, maxAge.get());
+            }
+        } else if (defaultAge.isPresent()) {
+            setExpiresAfter(message, now, defaultAge.get());
+        }
+    }
+
+    @Override
+    public String getMailetInfo() {
+        return "Expire Mailet";
+    }
+
+    private Optional<Duration> parseDuration(String param) {
+        return Optional.ofNullable(getInitParameter(param))
+            .map(duration -> DurationParser.parse(duration, ChronoUnit.DAYS));
+    }
+    
+    private boolean isAfter(Optional<Duration> a, Optional<Duration> b) {
+        return a.isPresent() && b.isPresent() && a.get().compareTo(b.get()) > 0;
+    }
+    
+    private Optional<ZonedDateTime> parseExpiresHeader(MimeMessage message) {
+        try {
+            String[] expires = message.getHeader(EXPIRES);
+            if (expires == null || expires.length == 0) {
+                return Optional.empty();
+            } else {
+                DateTime dt = new DateTimeParser(new StringReader(expires[0])).parseAll();
+                return Optional.of(ZonedDateTime.of(
+                    dt.getYear(), dt.getMonth(), dt.getDay(),
+                    dt.getHour(), dt.getMinute(), dt.getSecond(), 0,
+                    ZoneOffset.ofHoursMinutes(dt.getTimeZone() / 100, dt.getTimeZone() % 100)));
+            }
+        } catch (MessagingException | ParseException e) {
+            return Optional.empty();
+        }
+    }
+    
+    private void setExpiresAfter(MimeMessage message, ZonedDateTime now, Duration age) throws MessagingException {
+        message.setHeader(EXPIRES, DateFormats.RFC822_DATE_FORMAT.format(now.plus(age)));
+        message.saveChanges();
+    }
+}

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/ExpiresTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/ExpiresTest.java
@@ -1,0 +1,298 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.Mailet;
+import org.apache.mailet.base.DateFormats;
+import org.apache.mailet.base.test.FakeMailetConfig;
+import org.apache.mailet.base.test.MailUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.time.Clock;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExpiresTest {
+
+    private final ZonedDateTime NOW = ZonedDateTime.parse("2021-12-14T16:36:47Z");
+    
+    private Mailet mailet;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(NOW.toInstant(), NOW.getZone());
+        mailet = new Expires(clock);
+    }
+
+    @Test
+    void shouldThrowWhenNoConfiguration() {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .build();
+        assertThatThrownBy(() -> mailet.init(mailetConfig))
+            .isInstanceOf(MessagingException.class)
+            .hasMessage("Please configure at least one of minAge, maxAge, defaultAge");
+    }
+
+    @Test
+    void shouldThrowWhenMinAgeAfterMaxAge() {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("minAge", "3d")
+            .setProperty("maxAge", "1h")
+            .build();
+        assertThatThrownBy(() -> mailet.init(mailetConfig))
+            .isInstanceOf(MessagingException.class)
+            .hasMessage("minAge must be before maxAge");
+    }
+
+    @Test
+    void shouldThrowWhenDefaultAgeAfterMaxAge() {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("defaultAge", "3d")
+            .setProperty("maxAge", "1h")
+            .build();
+        assertThatThrownBy(() -> mailet.init(mailetConfig))
+            .isInstanceOf(MessagingException.class)
+            .hasMessage("defaultAge must be before maxAge");
+    }
+
+    @Test
+    void shouldThrowWhenDefaultAgeBeforeMinAge() {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("defaultAge", "1h")
+            .setProperty("minAge", "3d")
+            .build();
+        assertThatThrownBy(() -> mailet.init(mailetConfig))
+            .isInstanceOf(MessagingException.class)
+            .hasMessage("minAge must be before defaultAge");
+    }
+
+    @Test
+    void shouldThrowOnMessagingException() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("defaultAge", "1d")
+            .build();
+        mailet.init(mailetConfig);
+
+        Mail mail = mock(Mail.class);
+        when(mail.getMessage()).thenThrow(new MessagingException());
+
+        assertThatThrownBy(() -> mailet.service(mail))
+            .isInstanceOf(MessagingException.class);
+    }
+
+    @Test
+    void shouldSetHeaderOnMessage() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("defaultAge", "1h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+        
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(1)));
+    }
+
+    @Test
+    void shouldKeepHeaderWhenAlreadyPresent() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("defaultAge", "1h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        mimeMessage.addHeader("Expires", asDateTime(NOW.plusHours(2)));
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(2)));
+    }
+
+    @Test
+    void shouldReplaceHeaderWhenBelowMinimum() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("minAge", "3h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        mimeMessage.addHeader("Expires", asDateTime(NOW.plusHours(1)));
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(3)));
+    }
+
+    @Test
+    void shouldKeepHeaderWhenAboveMinimum() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("minAge", "1h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        mimeMessage.addHeader("Expires", asDateTime(NOW.plusHours(2)));
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(2)));
+    }
+    
+    @Test
+    void shouldReplaceHeaderWhenAboveMaximum() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("maxAge", "3h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        mimeMessage.addHeader("Expires", asDateTime(NOW.plusHours(5)));
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(3)));
+    }
+
+    @Test
+    void shouldKeepHeaderWhenBelowMaximum() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("maxAge", "5h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        mimeMessage.addHeader("Expires", asDateTime(NOW.plusHours(3)));
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(3)));
+    }
+
+    @Test
+    void shouldKeepHeaderWhenInRange() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("minAge", "1h")
+            .setProperty("maxAge", "5h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        mimeMessage.addHeader("Expires", asDateTime(NOW.plusHours(3)));
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(3)));
+    }
+
+    @Test
+    void shouldIgnoreRangeWhenNoHeaderPresent() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("minAge", "1h")
+            .setProperty("maxAge", "5h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires")).isNullOrEmpty();
+    }
+
+    @Test
+    void shouldSetHeaderForFixedRange() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("minAge", "3h")
+            .setProperty("defaultAge", "3h")
+            .setProperty("maxAge", "3h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(3)));
+    }
+
+    @Test
+    void shouldReplaceHeaderForFixedRange() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .mailetName("Test")
+            .setProperty("minAge", "3h")
+            .setProperty("defaultAge", "3h")
+            .setProperty("maxAge", "3h")
+            .build();
+        mailet.init(mailetConfig);
+
+        MimeMessage mimeMessage = MailUtil.createMimeMessage();
+        mimeMessage.addHeader("Expires", asDateTime(NOW.plusHours(5)));
+        Mail mail = MailUtil.createMockMail2Recipients(mimeMessage);
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader("Expires"))
+            .containsExactly(asDateTime(NOW.plusHours(3)));
+    }
+
+    private static String asDateTime(ZonedDateTime when) {
+        return DateFormats.RFC822_DATE_FORMAT.format(when);
+    }
+}

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/mailets.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/mailets.adoc
@@ -26,6 +26,8 @@ include::partial$DKIMVerify.adoc[]
 
 include::partial$DSNBounce.adoc[]
 
+include::partial$Expires.adoc[]
+
 include::partial$ExtractMDNOriginalJMAPMessageId.adoc[]
 
 include::partial$Forward.adoc[]

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/operate/webadmin.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/operate/webadmin.adoc
@@ -1206,6 +1206,63 @@ This task could be run safely online and can be scheduled on a recurring
 basis outside of peak traffic by an admin to ensure Cassandra message
 consistency.
 
+=== Deleting old messages of all users
+
+*Note:*
+Consider enabling the xref:configure/vault.adoc[Deleted Messages Vault]
+if you use this feature.
+
+Old messages tend to pile up in user INBOXes. An admin might want to delete
+these on behalf of the users, e.g. all messages older than 30 days:
+....
+curl -XDELETE http://ip:port/messages?olderThan=30d
+....
+
+link:#_endpoints_returning_a_task[More details about endpoints returning a task].
+
+The `olderThan` parameter should be expressed in the following format: `Nunit`.
+`N` should be strictly positive. `unit` could be either in the short form
+(`d`, `w`, `y` etc.), or in the long form (`days`, `weeks`, `months`, `years`).
+The default unit is `days`.
+
+Response codes:
+
+* 201: Success. Corresponding task id is returned.
+* 400: Error in the request. Details can be found in the reported error.
+
+The scheduled task will have the type `ExpireMailboxTask` and the following `additionalInformation`:
+
+....
+{
+  "type": "ExpireMailboxTask"
+  "mailboxesExpired": 5,
+  "mailboxesFailed": 2,
+  "mailboxesProcessed": 10,
+  "messagesDeleted": 23,
+}
+....
+
+To delete old mails from a different mailbox than INBOX, e.g. a mailbox
+named "Archived" :
+....
+curl -XDELETE http://ip:port/messages?mailbox=Archived&olderThan=30d
+....
+
+Since this is a somewhat expensive operation, the task is throttled to one user
+per second. You may speed it up via `usersPerSecond=10` for example. But keep
+in mind that a high rate might overwhelm your database or blob store.
+
+*Scanning search only:* (unsupported for Lucene and ElasticSearch search implementations) +
+Some mail clients can add an `Expires` header (RFC 4021) to their messages.
+Instead of specifying an absolute age, you may choose to delete only such
+messages where the expiration date from this header lies in the past:
+....
+curl -XDELETE http://ip:port/messages?byExpiresHeader
+....
+In this case you should also add the xref:configure/mailets.adoc[mailet]
+`Expires` to your mailet container, which can sanitize expiration date headers.
+
+
 == Administrating user mailboxes
 
 === Creating a mailbox

--- a/server/apps/distributed-app/docs/modules/ROOT/partials/Expires.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/partials/Expires.adoc
@@ -1,0 +1,34 @@
+=== Expires
+
+Sanitizes or adds an expiration date to a message, in the form of an `Expires`
+header (RFC 4021).
+
+The mailet can force an existing expiration date to be within the bounds
+given by `minAge`, `maxAge`, or both. `minAge` specifies the minimum time
+the date must lie in the future, while `maxAge` specifies a maximum.
+
+If a message has no expiration date, the mailet can add one according to
+the optional `defaultAge` parameter.
+
+All parameter values should be expressed in the following format: `Nunit`.
+`N` should be positive. `unit` could be either in the short form
+(`h`, `d`, `w`, `y` etc.), or in the long form (`hours`, days`, `weeks`,
+`months`, `years`). The default unit is `days`.
+
+Sample configuration:
+
+....
+<mailet match="All" class="Expires">
+    <minAge>12h</minAge>
+    <defaultAge>7d</defaultAge>
+    <maxAge>8w</maxAge>
+</mailet>
+....
+
+By itself the `Expires` header is informational only. But some variants of James
+will let you delete expired messages through the 
+xref:operate/webadmin.adoc#_administrating_messages[WebAdmin] interface:
+
+....
+curl -XDELETE http://ip:port/messages?byExpiresHeader
+....

--- a/server/container/guice/protocols/webadmin-mailbox/src/main/java/org/apache/james/modules/server/WebadminMailboxTaskSerializationModule.java
+++ b/server/container/guice/protocols/webadmin-mailbox/src/main/java/org/apache/james/modules/server/WebadminMailboxTaskSerializationModule.java
@@ -39,6 +39,9 @@ import org.apache.james.webadmin.service.EventDeadLettersRedeliverGroupTaskDTO;
 import org.apache.james.webadmin.service.EventDeadLettersRedeliverOneTaskDTO;
 import org.apache.james.webadmin.service.EventDeadLettersRedeliverService;
 import org.apache.james.webadmin.service.EventDeadLettersRedeliveryTaskAdditionalInformationDTO;
+import org.apache.james.webadmin.service.ExpireMailboxAdditionalInformationDTO;
+import org.apache.james.webadmin.service.ExpireMailboxDTO;
+import org.apache.james.webadmin.service.ExpireMailboxService;
 import org.apache.james.webadmin.service.SubscribeAllTaskAdditionalInformationDTO;
 import org.apache.james.webadmin.service.SubscribeAllTaskDTO;
 import org.apache.james.webadmin.service.UserMailboxesService;
@@ -81,6 +84,11 @@ public class WebadminMailboxTaskSerializationModule extends AbstractModule {
     @ProvidesIntoSet
     public TaskDTOModule<? extends Task, ? extends TaskDTO> clearMailboxContentTask(UserMailboxesService userMailboxesService) {
         return ClearMailboxContentTaskDTO.module(userMailboxesService);
+    }
+
+    @ProvidesIntoSet
+    public TaskDTOModule<? extends Task, ? extends TaskDTO> expireMailboxTask(ExpireMailboxService service) {
+        return ExpireMailboxDTO.module(service);
     }
 
     @ProvidesIntoSet
@@ -158,6 +166,17 @@ public class WebadminMailboxTaskSerializationModule extends AbstractModule {
     @ProvidesIntoSet
     public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends  AdditionalInformationDTO> webAdminClearMailboxContentAdditionalInformation() {
         return ClearMailboxContentTaskAdditionalInformationDTO.SERIALIZATION_MODULE;
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> expireMailboxAdditionalInformationDTO() {
+        return ExpireMailboxAdditionalInformationDTO.module();
+    }
+
+    @Named(DTOModuleInjections.WEBADMIN_DTO)
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> webAdminExpireMailboxAdditionalInformationDTO() {
+        return ExpireMailboxAdditionalInformationDTO.module();
     }
 
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxAdditionalInformationDTO.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxAdditionalInformationDTO.java
@@ -1,0 +1,118 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.service;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+import org.apache.james.webadmin.service.ExpireMailboxService.RunningOptions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ExpireMailboxAdditionalInformationDTO implements AdditionalInformationDTO {
+
+    public static AdditionalInformationDTOModule<ExpireMailboxTask.AdditionalInformation, ExpireMailboxAdditionalInformationDTO> module() {
+        return DTOModule.forDomainObject(ExpireMailboxTask.AdditionalInformation.class)
+            .convertToDTO(ExpireMailboxAdditionalInformationDTO.class)
+            .toDomainObjectConverter(ExpireMailboxAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(ExpireMailboxAdditionalInformationDTO::toDto)
+            .typeName(ExpireMailboxTask.TASK_TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+    }
+
+    private static ExpireMailboxTask.AdditionalInformation toDomainObject(ExpireMailboxAdditionalInformationDTO dto) {
+        return new ExpireMailboxTask.AdditionalInformation(
+            dto.getTimestamp(),
+            dto.getRunningOptions(),
+            dto.getMailboxesExpired(),
+            dto.getMailboxesFailed(),
+            dto.getMailboxesProcessed(),
+            dto.getMessagesDeleted());
+    }
+
+    private static ExpireMailboxAdditionalInformationDTO toDto(ExpireMailboxTask.AdditionalInformation details, String type) {
+        return new ExpireMailboxAdditionalInformationDTO(
+            details.timestamp(),
+            type,
+            details.getRunningOptions(),
+            details.getMailboxesExpired(),
+            details.getMailboxesFailed(),
+            details.getMailboxesProcessed(),
+            details.getMessagesDeleted());
+    }
+
+    private final Instant timestamp;
+    private final String type;
+    private final RunningOptions runningOptions;
+    private final long mailboxesExpired;
+    private final long mailboxesFailed;
+    private final long mailboxesProcessed;
+    private final long messagesDeleted;
+
+    @JsonCreator
+    public ExpireMailboxAdditionalInformationDTO(@JsonProperty("timestamp") Instant timestamp,
+                                                 @JsonProperty("type") String type,
+                                                 @JsonProperty("runningOptions") RunningOptions runningOptions,
+                                                 @JsonProperty("mailboxesExpired") long mailboxesExpired,
+                                                 @JsonProperty("mailboxesFailed") long mailboxesFailed,
+                                                 @JsonProperty("mailboxesProcessed") long mailboxesProcessed,
+                                                 @JsonProperty("messagesDeleted") long messagesDeleted) {
+        this.timestamp = timestamp;
+        this.type = type;
+        this.runningOptions = runningOptions;
+        this.mailboxesExpired = mailboxesExpired;
+        this.mailboxesFailed = mailboxesFailed;
+        this.mailboxesProcessed = mailboxesProcessed;
+        this.messagesDeleted = messagesDeleted;
+    }
+
+    public RunningOptions getRunningOptions() {
+        return runningOptions;
+    }
+
+    public long getMailboxesExpired() {
+        return mailboxesExpired;
+    }
+
+    public long getMailboxesFailed() {
+        return mailboxesFailed;
+    }
+
+    public long getMailboxesProcessed() {
+        return mailboxesProcessed;
+    }
+
+    public long getMessagesDeleted() {
+        return messagesDeleted;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxDTO.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxDTO.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.service;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+import org.apache.james.webadmin.service.ExpireMailboxService.RunningOptions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ExpireMailboxDTO implements TaskDTO {
+    public static TaskDTOModule<ExpireMailboxTask, ExpireMailboxDTO> module(ExpireMailboxService service) {
+        return DTOModule.forDomainObject(ExpireMailboxTask.class)
+            .convertToDTO(ExpireMailboxDTO.class)
+            .toDomainObjectConverter(dto -> toDomainObject(dto, service))
+            .toDTOConverter(ExpireMailboxDTO::toDto)
+            .typeName(ExpireMailboxTask.TASK_TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    private static ExpireMailboxTask toDomainObject(ExpireMailboxDTO dto, ExpireMailboxService service) {
+        return new ExpireMailboxTask(service, dto.getRunningOptions());
+    }
+
+    private static ExpireMailboxDTO toDto(ExpireMailboxTask details, String type) {
+        return new ExpireMailboxDTO(details.getRunningOptions(), type);
+    }
+
+    private final RunningOptions runningOptions;
+    private final String type;
+
+    @JsonCreator
+    public ExpireMailboxDTO(@JsonProperty("runningOptions") RunningOptions runningOptions,
+                            @JsonProperty("type") String type) {
+        this.runningOptions = runningOptions;
+        this.type = type;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public RunningOptions getRunningOptions() {
+        return runningOptions;
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxService.java
@@ -1,0 +1,248 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.service;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.exception.MailboxNotFoundException;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.SearchQuery.DateResolution;
+import org.apache.james.task.Task;
+import org.apache.james.task.Task.Result;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.util.DurationParser;
+import org.apache.james.util.ReactorUtils;
+import org.apache.james.util.streams.Iterators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+
+public class ExpireMailboxService {
+
+    public static class RunningOptions {
+        public static final RunningOptions DEFAULT = new RunningOptions(1, MailboxConstants.INBOX, true, Optional.empty());
+
+        public static RunningOptions fromParams(
+                Optional<String> byExpiresHeader, Optional<String> olderThan,
+                Optional<String> usersPerSecond, Optional<String> mailbox) {
+            try {
+                if (byExpiresHeader.isPresent() == olderThan.isPresent()) {
+                    throw new IllegalArgumentException("Must specify either 'olderThan' or 'byExpiresHeader' parameter");
+                }
+                return new RunningOptions(
+                    usersPerSecond.map(Integer::parseInt).orElse(DEFAULT.getUsersPerSecond()),
+                    mailbox.orElse(DEFAULT.getMailbox()), byExpiresHeader.isPresent(), olderThan);
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("'usersPerSecond' must be numeric");
+            }
+        }
+        
+        private final int usersPerSecond;
+        
+        private final String mailbox;
+        
+        private final boolean byExpiresHeader;
+
+        private final Optional<String> olderThan;
+
+        @JsonIgnore
+        private final Optional<Duration> maxAgeDuration;
+
+        @JsonCreator
+        public RunningOptions(@JsonProperty("usersPerSecond") int usersPerSecond,
+                              @JsonProperty("mailbox") String mailbox,
+                              @JsonProperty("byExpiresHeader") boolean byExpiresHeader,
+                              @JsonProperty("olderThan") Optional<String> olderThan) {
+            Preconditions.checkArgument(usersPerSecond > 0, "'usersPerSecond' must be strictly positive");
+            this.usersPerSecond = usersPerSecond;
+            this.mailbox = mailbox;
+            this.byExpiresHeader = byExpiresHeader;
+            this.olderThan = olderThan;
+            this.maxAgeDuration = olderThan.map(v -> DurationParser.parse(olderThan.get(), ChronoUnit.DAYS));
+        }
+
+        public int getUsersPerSecond() {
+            return usersPerSecond;
+        }
+        
+        public String getMailbox() { 
+            return mailbox;
+        }
+
+        public boolean getByExpiresHeader() {
+            return byExpiresHeader;
+        }
+
+        public Optional<String> getOlderThan() {
+            return olderThan;
+        }
+    }
+
+    public static class Context {
+        private final AtomicLong inboxesExpired;
+        private final AtomicLong inboxesFailed;
+        private final AtomicLong inboxesProcessed;
+        private final AtomicLong messagesDeleted;
+
+        public Context() {
+            this.inboxesExpired = new AtomicLong(0L);
+            this.inboxesFailed = new AtomicLong(0L);
+            this.inboxesProcessed = new AtomicLong(0L);
+            this.messagesDeleted = new AtomicLong(0L);
+        }
+
+        public long getInboxesExpired() {
+            return inboxesExpired.get();
+        }
+
+        public long getInboxesFailed() {
+            return inboxesFailed.get();
+        }
+
+        public long getInboxesProcessed() {
+            return inboxesProcessed.get();
+        }
+
+        public long getMessagesDeleted() {
+            return messagesDeleted.get();
+        }
+
+        public void incrementExpiredCount() {
+            inboxesExpired.incrementAndGet();
+        }
+
+        public void incrementFailedCount() {
+            inboxesFailed.incrementAndGet();
+        }
+
+        public void incrementProcessedCount() {
+            inboxesProcessed.incrementAndGet();
+        }
+        
+        public void incrementMessagesDeleted(long count) { 
+            messagesDeleted.addAndGet(count);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExpireMailboxService.class);
+
+    private final UsersRepository usersRepository;
+    private final MailboxManager mailboxManager;
+
+    @Inject
+    public ExpireMailboxService(UsersRepository usersRepository, MailboxManager mailboxManager) {
+        this.usersRepository = usersRepository;
+        this.mailboxManager = mailboxManager;
+    }
+
+    public Mono<Result> expireMailboxes(Context context, RunningOptions runningOptions, Date now) {
+        try {
+            SearchQuery expiration = SearchQuery.of(
+                runningOptions.maxAgeDuration.map(maxAge -> {
+                        Date limit = Date.from(now.toInstant().minus(maxAge));
+                        return SearchQuery.internalDateBefore(limit, DateResolution.Second);
+                    })
+                    .orElse(
+                        SearchQuery.headerDateBefore("Expires", now, DateResolution.Second)
+                    )
+            );
+            return Iterators.toFlux(usersRepository.list())
+                .transform(ReactorUtils.<Username, Task.Result>throttle()
+                    .elements(runningOptions.getUsersPerSecond())
+                    .per(Duration.ofSeconds(1))
+                    .forOperation(username -> 
+                        expireUserMailbox(context, username, runningOptions.getMailbox(), expiration)))
+                .reduce(Task.Result.COMPLETED, Task::combine);
+        } catch (UsersRepositoryException e) {
+            LOGGER.error("Error while accessing users from repository", e);
+            return Mono.just(Task.Result.PARTIAL);
+        }
+    }
+
+    private Mono<Result> expireUserMailbox(Context context, Username username, String mailbox, SearchQuery expiration) {
+        MailboxSession session = mailboxManager.createSystemSession(username);
+        MailboxPath mailboxPath = MailboxPath.forUser(username, mailbox);
+        return Mono.from(mailboxManager.getMailboxReactive(mailboxPath, session))
+            // newly created users do not have mailboxes yet, just skip them
+            .onErrorResume(MailboxNotFoundException.class, ignore -> Mono.empty())
+            .flatMap(mgr -> searchMessagesReactive(mgr, session, expiration)
+                .flatMap(list -> deleteMessagesReactive(mgr, session, list)))
+            .doOnNext(expired -> {
+                if (expired > 0) {
+                    context.incrementExpiredCount();
+                    context.incrementMessagesDeleted(expired);
+                }
+                context.incrementProcessedCount();
+            })
+            .then(Mono.just(Task.Result.COMPLETED))
+            .onErrorResume(e -> {
+                LOGGER.warn("Failed to expire user mailbox {}", username, e);
+                context.incrementFailedCount();
+                context.incrementProcessedCount();
+                return Mono.just(Task.Result.PARTIAL);
+            });
+    }
+
+    private Mono<List<MessageUid>> searchMessagesReactive(MessageManager mgr, MailboxSession session, SearchQuery expiration) {
+        try {
+            return Flux.from(mgr.search(expiration, session)).collectList();
+        } catch (MailboxException e) {
+            return Mono.error(e);
+        }
+    }
+
+    private Mono<Integer> deleteMessagesReactive(MessageManager mgr, MailboxSession session, List<MessageUid> uids) {
+        if (uids.isEmpty()) {
+            return Mono.just(0);
+        } else {
+            return Mono.fromCallable(
+                    () -> {
+                        mgr.delete(uids, session);
+                        return uids.size();
+                    })
+                .subscribeOn(Schedulers.elastic());
+        }
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxTask.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxTask.java
@@ -1,0 +1,129 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+import org.apache.james.webadmin.service.ExpireMailboxService.Context;
+import org.apache.james.webadmin.service.ExpireMailboxService.RunningOptions;
+
+public class ExpireMailboxTask implements Task {
+    public static final TaskType TASK_TYPE = TaskType.of("ExpireMailboxTask");
+
+    public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
+
+        public static ExpireMailboxTask.AdditionalInformation from(Context context,
+                                                                   RunningOptions runningOptions) {
+            return new ExpireMailboxTask.AdditionalInformation(
+                Clock.systemUTC().instant(),
+                runningOptions,
+                context.getInboxesExpired(),
+                context.getInboxesFailed(),
+                context.getInboxesProcessed(),
+                context.getMessagesDeleted());
+        }
+
+        private final Instant timestamp;
+        private final RunningOptions runningOptions;
+        private final long mailboxesExpired;
+        private final long mailboxesFailed;
+        private final long mailboxesProcessed;
+        private final long messagesDeleted;
+
+        public AdditionalInformation(Instant timestamp,
+                                     RunningOptions runningOptions,
+                                     long mailboxesExpired,
+                                     long mailboxesFailed,
+                                     long mailboxesProcessed,
+                                     long messagesDeleted) {
+            this.timestamp = timestamp;
+            this.runningOptions = runningOptions;
+            this.mailboxesExpired = mailboxesExpired;
+            this.mailboxesFailed = mailboxesFailed;
+            this.mailboxesProcessed = mailboxesProcessed;
+            this.messagesDeleted = messagesDeleted;
+        }
+
+        public RunningOptions getRunningOptions() {
+            return runningOptions;
+        }
+
+        public long getMailboxesExpired() {
+            return mailboxesExpired;
+        }
+
+        public long getMailboxesFailed() {
+            return mailboxesFailed;
+        }
+
+        public long getMailboxesProcessed() {
+            return mailboxesProcessed;
+        }
+
+        public long getMessagesDeleted() {
+            return messagesDeleted;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return timestamp;
+        }
+    }
+
+    private final ExpireMailboxService expireMailboxService;
+    private final Context context;
+    private final RunningOptions runningOptions;
+
+    @Inject
+    public ExpireMailboxTask(ExpireMailboxService expireMailboxService,
+                             RunningOptions runningOptions) {
+        this.expireMailboxService = expireMailboxService;
+        this.context = new Context();
+        this.runningOptions = runningOptions;
+    }
+
+    @Override
+    public Result run() {
+        return expireMailboxService.expireMailboxes(context, runningOptions, new Date())
+            .block();
+    }
+
+    @Override
+    public TaskType type() {
+        return TASK_TYPE;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        return Optional.of(ExpireMailboxTask.AdditionalInformation.from(context, runningOptions));
+    }
+
+    public RunningOptions getRunningOptions() {
+        return runningOptions;
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MessageRoutesExpireTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MessageRoutesExpireTest.java
@@ -1,0 +1,300 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.routes;
+
+import com.google.common.collect.ImmutableSet;
+import io.restassured.RestAssured;
+import org.apache.james.core.Username;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.json.DTOConverter;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
+import org.apache.james.mailbox.inmemory.InMemoryMessageId;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.user.memory.MemoryUsersRepository;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.service.ExpireMailboxAdditionalInformationDTO;
+import org.apache.james.webadmin.service.ExpireMailboxService;
+import org.apache.james.webadmin.service.ExpireMailboxService.RunningOptions;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class MessageRoutesExpireTest {
+    private static final DomainList NO_DOMAIN_LIST = null;
+    private static final Username USERNAME = Username.of("benwa");
+    private static final MailboxPath INBOX = MailboxPath.inbox(USERNAME);
+
+    private WebAdminServer webAdminServer;
+    private InMemoryMailboxManager mailboxManager;
+    private MemoryTaskManager taskManager;
+    private MemoryUsersRepository usersRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        taskManager = new MemoryTaskManager(new Hostname("foo"));
+        mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
+        usersRepository = MemoryUsersRepository.withoutVirtualHosting(NO_DOMAIN_LIST);
+        JsonTransformer jsonTransformer = new JsonTransformer();
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+                new TasksRoutes(taskManager, jsonTransformer,
+                    DTOConverter.of(
+                        ExpireMailboxAdditionalInformationDTO.module())),
+                new MessagesRoutes(taskManager,
+                    new InMemoryMessageId.Factory(),
+                    null,
+                    new ExpireMailboxService(usersRepository, mailboxManager),
+                    jsonTransformer,
+                    ImmutableSet.of()))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+        taskManager.stop();
+    }
+
+    @Nested
+    class ExpireMailbox {
+        @Nested
+        class Validation {
+            @Test
+            void expireMailboxShouldFailWithNoOption() {
+                when()
+                    .delete("/messages")
+                .then()
+                    .statusCode(HttpStatus.BAD_REQUEST_400)
+                    .body("statusCode", is(400))
+                    .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                    .body("message", is("Invalid arguments supplied in the user request"))
+                    .body("details", is("Must specify either 'olderThan' or 'byExpiresHeader' parameter"));
+            }
+
+            @Test
+            void expireMailboxShouldFailWithBothOptions() {
+                when()
+                    .delete("/messages?byExpiresHeader&olderThan=30d")
+                .then()
+                    .statusCode(HttpStatus.BAD_REQUEST_400)
+                    .body("statusCode", is(400))
+                    .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                    .body("message", is("Invalid arguments supplied in the user request"))
+                    .body("details", is("Must specify either 'olderThan' or 'byExpiresHeader' parameter"));
+            }
+
+            @Test
+            void expireMailboxShouldFailWithBadOlderThan() {
+                when()
+                    .delete("/messages?olderThan=bad")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST_400)
+                    .body("statusCode", is(400))
+                    .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                    .body("message", is("Invalid arguments supplied in the user request"))
+                    .body("details", is("'usersPerSecond' must be numeric"));
+            }
+
+            @Test
+            void expireMailboxShouldFailWithNegativeOlderThan() {
+                when()
+                    .delete("/messages?olderThan=-30d")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST_400)
+                    .body("statusCode", is(400))
+                    .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                    .body("message", is("Invalid arguments supplied in the user request"))
+                    .body("details", is("Duration amount should be positive"));
+            }
+
+            @Test
+            void expireMailboxShouldFailWithBadUsersPerSeconds() {
+                when()
+                    .delete("/messages?byExpiresHeader&usersPerSecond=bad")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST_400)
+                    .body("statusCode", is(400))
+                    .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                    .body("message", is("Invalid arguments supplied in the user request"))
+                    .body("details", is("'usersPerSecond' must be numeric"));
+            }
+
+            @Test
+            void expireMailboxShouldFailWithNegativeUsersPerSeconds() {
+                when()
+                    .delete("/messages?byExpiresHeader&usersPerSecond=-10")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST_400)
+                    .body("statusCode", is(400))
+                    .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                    .body("message", is("Invalid arguments supplied in the user request"))
+                    .body("details", is("'usersPerSecond' must be strictly positive"));
+            }
+
+        }
+
+        @Nested
+        class TaskDetails {
+            @Test
+            void expireMailboxShouldNotFailWhenNoMailsFound() {
+                String taskId = when()
+                    .delete("/messages?byExpiresHeader")
+                    .jsonPath()
+                    .get("taskId");
+
+                given()
+                    .basePath(TasksRoutes.BASE)
+                .when()
+                    .get(taskId + "/await")
+                .then()
+                    .body("type", Matchers.is("ExpireMailboxTask"))
+                    .body("status", is("completed"))
+                    .body("taskId", is(notNullValue()))
+                    .body("additionalInformation.type", is("ExpireMailboxTask"))
+                    .body("additionalInformation.runningOptions.usersPerSecond", is(RunningOptions.DEFAULT.getUsersPerSecond()))
+                    .body("additionalInformation.runningOptions.byExpiresHeader", is(true))
+                    .body("additionalInformation.runningOptions.olderThan", is(nullValue()))
+                    .body("additionalInformation.mailboxesExpired", is(0))
+                    .body("additionalInformation.mailboxesFailed", is(0))
+                    .body("additionalInformation.mailboxesProcessed", is(0))
+                    .body("additionalInformation.messagesDeleted", is(0));
+            }
+
+            @Test
+            void expireMailboxShouldReturnTaskDetailsWhenMail() throws Exception {
+                usersRepository.addUser(USERNAME, "secret");
+                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                mailboxManager.createMailbox(INBOX, systemSession).get();
+                mailboxManager.getMailbox(INBOX, systemSession).appendMessage(
+                    MessageManager.AppendCommand.builder()
+                        .withInternalDate(new Date(System.currentTimeMillis() - 5000))
+                        .build("header: value\r\n\r\nbody"),
+                    systemSession).getId();
+
+                String taskId = when()
+                    .delete("/messages?olderThan=1s")
+                    .jsonPath()
+                    .get("taskId");
+
+                given()
+                    .basePath(TasksRoutes.BASE)
+                .when()
+                    .get(taskId + "/await")
+                .then()
+                    .body("type", Matchers.is("ExpireMailboxTask"))
+                    .body("status", is("completed"))
+                    .body("taskId", is(notNullValue()))
+                    .body("additionalInformation.type", is("ExpireMailboxTask"))
+                    .body("additionalInformation.runningOptions.usersPerSecond", is(RunningOptions.DEFAULT.getUsersPerSecond()))
+                    .body("additionalInformation.runningOptions.byExpiresHeader", is(false))
+                    .body("additionalInformation.runningOptions.olderThan", is("1s"))
+                    .body("additionalInformation.mailboxesExpired", is(1))
+                    .body("additionalInformation.mailboxesFailed", is(0))
+                    .body("additionalInformation.mailboxesProcessed", is(1))
+                    .body("additionalInformation.messagesDeleted", is(1));
+            }
+        }
+
+        @Nested
+        class SideEffects {
+            @Test
+            void expireMailboxShouldExpireOldMail() throws Exception {
+                usersRepository.addUser(USERNAME, "secret");
+                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                mailboxManager.createMailbox(INBOX, systemSession).get();
+                mailboxManager.getMailbox(INBOX, systemSession).appendMessage(
+                    MessageManager.AppendCommand.builder()
+                        .withInternalDate(new Date(System.currentTimeMillis() - 5000))
+                        .build("header: value\r\n\r\nbody"),
+                    systemSession).getId();
+
+                String taskId = when()
+                    .delete("/messages?olderThan=1s")
+                    .jsonPath()
+                    .get("taskId");
+
+                given()
+                    .basePath(TasksRoutes.BASE)
+                    .when()
+                    .get(taskId + "/await")
+                    .then()
+                    .body("status", is("completed"))
+                    .body("additionalInformation.messagesDeleted", is(1));
+
+                MessageManager mailbox = mailboxManager.getMailbox(INBOX, systemSession);
+                assertThat(mailbox.getMessageCount(systemSession)).isEqualTo(0);
+            }
+
+            @Test
+            void expireMailboxShouldNotExpireNewMail() throws Exception {
+                usersRepository.addUser(USERNAME, "secret");
+                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                mailboxManager.createMailbox(INBOX, systemSession).get();
+                mailboxManager.getMailbox(INBOX, systemSession).appendMessage(
+                    MessageManager.AppendCommand.builder()
+                        .withInternalDate(new Date(System.currentTimeMillis()))
+                        .build("header: value\r\n\r\nbody"),
+                    systemSession).getId();
+
+                String taskId = when()
+                    .delete("/messages?olderThan=7d")
+                    .jsonPath()
+                    .get("taskId");
+
+                given()
+                    .basePath(TasksRoutes.BASE)
+                    .when()
+                    .get(taskId + "/await")
+                    .then()
+                    .body("status", is("completed"))
+                    .body("additionalInformation.messagesDeleted", is(0));
+
+                MessageManager mailbox = mailboxManager.getMailbox(INBOX, systemSession);
+                assertThat(mailbox.getMessageCount(systemSession)).isEqualTo(1);
+            }
+        }
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MessageRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MessageRoutesTest.java
@@ -77,7 +77,7 @@ class MessageRoutesTest {
     void beforeEach() {
         taskManager = new MemoryTaskManager(new Hostname("foo"));
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
-        searchIndex = mock(ListeningMessageSearchIndex.class);;
+        searchIndex = mock(ListeningMessageSearchIndex.class);
         Mockito.when(searchIndex.add(any(), any(), any())).thenReturn(Mono.empty());
         Mockito.when(searchIndex.deleteAll(any(), any())).thenReturn(Mono.empty());
         ReIndexerPerformer reIndexerPerformer = new ReIndexerPerformer(
@@ -93,6 +93,7 @@ class MessageRoutesTest {
                 new MessagesRoutes(taskManager,
                     new InMemoryMessageId.Factory(),
                     new MessageIdReIndexerImpl(reIndexerPerformer),
+                    null,
                     jsonTransformer,
                     ImmutableSet.of()))
             .start();

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxServiceTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxServiceTest.java
@@ -1,0 +1,354 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.service;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
+import org.apache.james.mailbox.store.search.MessageSearchIndex;
+import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.field.Fields;
+import org.apache.james.task.Task;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExpireMailboxServiceTest {
+
+    private static class FailingSearchIndex implements MessageSearchIndex {
+
+        private MessageSearchIndex delegate;
+
+        private int failuresRemaining = 0;
+
+        public MessageSearchIndex setDelegate(MessageSearchIndex delegate) {
+            this.delegate = delegate;
+            return this;
+        }
+
+        public void generateFailures(int count) {
+            this.failuresRemaining = count;
+        }
+
+        private synchronized void handleFailure() throws MailboxException {
+            if (failuresRemaining > 0) {
+                --failuresRemaining;
+                throw new MailboxException("search failed");
+            }
+        }
+
+        @Override
+        public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
+            handleFailure();
+            return delegate.search(session, mailbox, searchQuery);
+        }
+
+        @Override
+        public Flux<MessageId> search(MailboxSession session, Collection<MailboxId> mailboxIds, SearchQuery searchQuery, long limit) throws MailboxException {
+            handleFailure();
+            return delegate.search(session, mailboxIds, searchQuery, limit);
+        }
+
+        @Override
+        public EnumSet<MailboxManager.SearchCapabilities> getSupportedCapabilities(EnumSet<MailboxManager.MessageCapabilities> messageCapabilities) {
+            return delegate.getSupportedCapabilities(messageCapabilities);
+        }
+    }
+    
+    private static final ExpireMailboxService.RunningOptions OLDER_THAN_1S = new ExpireMailboxService.RunningOptions(1, MailboxConstants.INBOX, false, Optional.of("1s"));
+
+    private final Username alice = Username.of("alice@example.org");
+    private final MailboxPath aliceInbox = MailboxPath.inbox(alice);
+
+    private UsersRepository usersRepository;
+
+    private MailboxSession aliceSession;
+    private MailboxManager mailboxManager;
+    private FailingSearchIndex searchIndex;
+    
+    private ExpireMailboxService testee;
+    
+    @BeforeEach
+    public void setUp() {
+        searchIndex = new FailingSearchIndex();
+        
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.builder()
+            .preProvisionnedFakeAuthenticator()
+            .fakeAuthorizator()
+            .inVmEventBus()
+            .defaultAnnotationLimits()
+            .defaultMessageParser()
+            .searchIndex(stage -> searchIndex.setDelegate(new SimpleMessageSearchIndex(stage.getMapperFactory(), stage.getMapperFactory(), new DefaultTextExtractor(), stage.getAttachmentContentLoader())))
+            .noPreDeletionHooks()
+            .storeQuotaManager()
+            .build();
+
+        usersRepository = mock(UsersRepository.class);
+
+        mailboxManager = resources.getMailboxManager();
+        aliceSession = mailboxManager.createSystemSession(alice);
+        
+        testee = new ExpireMailboxService(usersRepository, mailboxManager);
+    }
+    
+    private static Date asDate(ZonedDateTime dateTime) {
+        return Date.from(dateTime.toInstant());
+    }
+ 
+    private ComposedMessageId appendMessage(MessageManager messageManager, MailboxSession session, ZonedDateTime internalDate) throws Exception {
+        return appendMessage(messageManager, session, Message.Builder.of()
+            .setSubject("test")
+            .setBody("whatever", StandardCharsets.UTF_8)
+            .setDate(asDate(internalDate))
+            .build());
+    }
+
+    private ComposedMessageId appendMessage(MessageManager messageManager, MailboxSession session, Message mailContent) throws Exception {
+        return messageManager.appendMessage(MessageManager.AppendCommand.builder()
+                .withInternalDate(mailContent.getDate())
+                .build(mailContent), session)
+            .getId();
+    }
+
+
+    @Test
+    public void testIgnoresUserListFailure() throws Exception {
+        when(usersRepository.list()).thenThrow(new UsersRepositoryException("it is broken"));
+
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, OLDER_THAN_1S, now).block();
+
+        assertThat(result).isEqualTo(Task.Result.PARTIAL);
+        assertThat(context.getInboxesExpired()).isEqualTo(0);
+        assertThat(context.getInboxesFailed()).isEqualTo(0);
+        assertThat(context.getInboxesProcessed()).isEqualTo(0);
+        assertThat(context.getMessagesDeleted()).isEqualTo(0);
+    }
+
+    @Test
+    public void testIgnoresMissingMailbox() throws Exception {
+        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+        
+        // intentionally no mailbox creation
+        
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, OLDER_THAN_1S, now).block();
+
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(context.getInboxesExpired()).isEqualTo(0);
+        assertThat(context.getInboxesFailed()).isEqualTo(0);
+        assertThat(context.getInboxesProcessed()).isEqualTo(0); // skipped
+        assertThat(context.getMessagesDeleted()).isEqualTo(0);
+    }
+    
+    @Test
+    public void testIgnoresEmptyMailbox() throws Exception {
+        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+       
+        mailboxManager.createMailbox(aliceInbox, aliceSession);
+
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, OLDER_THAN_1S, now).block();
+        
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(context.getInboxesExpired()).isEqualTo(0);
+        assertThat(context.getInboxesFailed()).isEqualTo(0);
+        assertThat(context.getInboxesProcessed()).isEqualTo(1);
+        assertThat(context.getMessagesDeleted()).isEqualTo(0);
+        assertThat(context.getMessagesDeleted()).isEqualTo(0);
+    }
+
+    @Test
+    public void testHandlesMailboxErrors() throws Exception {
+        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+
+        mailboxManager.createMailbox(aliceInbox, aliceSession);
+        MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);
+        appendMessage(aliceManager, aliceSession, ZonedDateTime.now());
+
+        searchIndex.generateFailures(1);
+        
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, OLDER_THAN_1S, now).block();
+
+        assertThat(result).isEqualTo(Task.Result.PARTIAL);
+        assertThat(context.getInboxesExpired()).isEqualTo(0);
+        assertThat(context.getInboxesFailed()).isEqualTo(1);
+        assertThat(context.getInboxesProcessed()).isEqualTo(1);
+        assertThat(context.getMessagesDeleted()).isEqualTo(0);
+    }
+
+    @Test
+    public void testExpiresMailboxByAge() throws Exception {
+        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+
+        mailboxManager.createMailbox(aliceInbox, aliceSession);
+        MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);
+        appendMessage(aliceManager, aliceSession, ZonedDateTime.now().minusSeconds(5));
+
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, OLDER_THAN_1S, now).block();
+
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(context.getInboxesExpired()).isEqualTo(1);
+        assertThat(context.getInboxesFailed()).isEqualTo(0);
+        assertThat(context.getInboxesProcessed()).isEqualTo(1);
+        assertThat(context.getMessagesDeleted()).isEqualTo(1);
+
+        assertThat(aliceManager.getMessageCount(aliceSession)).isEqualTo(0);
+    }
+
+    @Test
+    public void testExpiresMailboxByHeader() throws Exception {
+        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+
+        mailboxManager.createMailbox(aliceInbox, aliceSession);
+        MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);
+
+        ZonedDateTime created = ZonedDateTime.now();
+        ZonedDateTime expires = created.plusSeconds(5); 
+        ZonedDateTime now = expires.plusSeconds(10);
+
+        appendMessage(aliceManager, aliceSession, Message.Builder.of()
+            .setSubject("test")
+            .setBody("whatever", StandardCharsets.UTF_8)
+            .setDate(asDate(created))
+            .setField(Fields.date("Expires", asDate(expires), TimeZone.getTimeZone(expires.getZone())))
+            .build()
+        );
+
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        ExpireMailboxService.RunningOptions options = new ExpireMailboxService.RunningOptions(1, MailboxConstants.INBOX, true, Optional.empty());
+        Task.Result result = testee.expireMailboxes(context, options, asDate(now)).block();
+
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(context.getInboxesExpired()).isEqualTo(1);
+        assertThat(context.getInboxesFailed()).isEqualTo(0);
+        assertThat(context.getInboxesProcessed()).isEqualTo(1);
+        assertThat(context.getMessagesDeleted()).isEqualTo(1);
+
+        assertThat(aliceManager.getMessageCount(aliceSession)).isEqualTo(0);
+    }
+
+    @Test
+    public void testExpiresNamedMailbox() throws Exception {
+        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+
+        String mailboxName = "Archived";
+        MailboxPath mailboxPath = MailboxPath.forUser(alice, mailboxName);
+        mailboxManager.createMailbox(mailboxPath, aliceSession);
+        MessageManager aliceManager = mailboxManager.getMailbox(mailboxPath, aliceSession);
+        appendMessage(aliceManager, aliceSession, ZonedDateTime.now().minusSeconds(5));
+
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        ExpireMailboxService.RunningOptions options = new ExpireMailboxService.RunningOptions(1, mailboxName, false, Optional.of("1s"));
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, options, now).block();
+
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(context.getInboxesExpired()).isEqualTo(1);
+        assertThat(context.getInboxesFailed()).isEqualTo(0);
+        assertThat(context.getInboxesProcessed()).isEqualTo(1);
+        assertThat(context.getMessagesDeleted()).isEqualTo(1);
+
+        assertThat(aliceManager.getMessageCount(aliceSession)).isEqualTo(0);
+    }
+
+    @Test
+    public void testExpiresNamedMailbox2() throws Exception {
+        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        ExpireMailboxService.RunningOptions options = new ExpireMailboxService.RunningOptions(1, "NoSuchMailbox", false, Optional.of("1s"));
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, options, now).block();
+
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(context.getInboxesExpired()).isEqualTo(0);
+        assertThat(context.getInboxesFailed()).isEqualTo(0);
+        assertThat(context.getInboxesProcessed()).isEqualTo(0);
+        assertThat(context.getMessagesDeleted()).isEqualTo(0);
+    }
+
+    @Test
+    public void testContinuesAfterFailure() throws Exception {
+        Username bob = Username.of("bob@example.org");
+        MailboxPath bobInbox = MailboxPath.inbox(bob);
+        MailboxSession bobSession = mailboxManager.createSystemSession(bob);
+        
+        when(usersRepository.list()).thenReturn(List.of(alice, bob).iterator());
+
+        mailboxManager.createMailbox(aliceInbox, aliceSession);
+        MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);
+        appendMessage(aliceManager, aliceSession, ZonedDateTime.now().minusSeconds(5));
+
+        mailboxManager.createMailbox(bobInbox, bobSession);
+        MessageManager bobManager = mailboxManager.getMailbox(bobInbox, bobSession);
+        appendMessage(bobManager, bobSession, ZonedDateTime.now().minusSeconds(5));
+
+        searchIndex.generateFailures(1);
+        
+        ExpireMailboxService.Context context = new ExpireMailboxService.Context();
+        Date now = new Date();
+        Task.Result result = testee.expireMailboxes(context, OLDER_THAN_1S, now).block();
+
+        assertThat(result).isEqualTo(Task.Result.PARTIAL);
+        assertThat(context.getInboxesExpired()).isEqualTo(1);
+        assertThat(context.getInboxesFailed()).isEqualTo(1);
+        assertThat(context.getInboxesProcessed()).isEqualTo(2);
+        assertThat(context.getMessagesDeleted()).isEqualTo(1);
+
+        assertThat(aliceManager.getMessageCount(aliceSession)).isEqualTo(1);
+        assertThat(bobManager.getMessageCount(bobSession)).isEqualTo(0);
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxTaskAdditionalInformationDTOTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxTaskAdditionalInformationDTOTest.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.service;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.util.ClassLoaderUtils;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public class ExpireMailboxTaskAdditionalInformationDTOTest {
+    private static final Instant INSTANT = Instant.parse("2007-12-03T10:15:30.00Z");
+    
+    private static final ExpireMailboxTask.AdditionalInformation DOMAIN_OBJECT = new ExpireMailboxTask.AdditionalInformation(
+        INSTANT, new ExpireMailboxService.RunningOptions(1, MailboxConstants.INBOX, false, Optional.of("90d")), 5, 2, 10, 234);
+
+    @Test
+    void shouldMatchJsonSerializationContract() throws Exception {
+        JsonSerializationVerifier.dtoModule(ExpireMailboxAdditionalInformationDTO.module())
+            .bean(DOMAIN_OBJECT)
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/expireMailbox.additionalInformation.json"))
+            .verify();
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxTaskSerializationTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxTaskSerializationTest.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.service;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.util.ClassLoaderUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+
+public class ExpireMailboxTaskSerializationTest {
+    private ExpireMailboxService expireMailboxService;
+
+    @BeforeEach
+    void setUp() {
+        expireMailboxService = mock(ExpireMailboxService.class);
+    }
+
+    @Test
+    void shouldMatchJsonSerializationContractWithOlderThan() throws Exception {
+        JsonSerializationVerifier.dtoModule(ExpireMailboxDTO.module(expireMailboxService))
+            .bean(new ExpireMailboxTask(expireMailboxService, new ExpireMailboxService.RunningOptions(1, MailboxConstants.INBOX, false, Optional.of("90d"))))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/expireMailbox.age.task.json"))
+            .verify();
+    }
+
+    @Test
+    void shouldMatchJsonSerializationContractWithExpiresHeader() throws Exception {
+        JsonSerializationVerifier.dtoModule(ExpireMailboxDTO.module(expireMailboxService))
+            .bean(new ExpireMailboxTask(expireMailboxService, new ExpireMailboxService.RunningOptions(1, MailboxConstants.INBOX, true, Optional.empty())))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/expireMailbox.header.task.json"))
+            .verify();
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/resources/json/expireMailbox.additionalInformation.json
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/resources/json/expireMailbox.additionalInformation.json
@@ -1,0 +1,14 @@
+{
+  "mailboxesExpired": 5,
+  "mailboxesFailed": 2,
+  "mailboxesProcessed": 10,
+  "messagesDeleted": 234,
+  "runningOptions": {
+    "usersPerSecond": 1,
+    "mailbox": "INBOX",
+    "byExpiresHeader": false,
+    "olderThan": "90d"
+  },
+  "timestamp": "2007-12-03T10:15:30Z",
+  "type": "ExpireMailboxTask"
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/resources/json/expireMailbox.age.task.json
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/resources/json/expireMailbox.age.task.json
@@ -1,0 +1,9 @@
+{
+  "runningOptions": {
+    "usersPerSecond": 1,
+    "mailbox": "INBOX",
+    "byExpiresHeader": false,
+    "olderThan": "90d"
+  },
+  "type": "ExpireMailboxTask"
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/resources/json/expireMailbox.header.task.json
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/resources/json/expireMailbox.header.task.json
@@ -1,0 +1,8 @@
+{
+  "runningOptions": {
+    "usersPerSecond": 1,
+    "mailbox": "INBOX",
+    "byExpiresHeader": true
+  },
+  "type": "ExpireMailboxTask"
+}


### PR DESCRIPTION
As discussed in the Jira ticket, this is my solution for deleting old emails form users INBOX. It can work in two ways:

1. Use Expires header in the stored mails:
    POST http://ip:port/mailboxes?task=expireInboxes
2. Use age relative to time of invocation, e.g. all mails older than 30 days:
    POST http://ip:port/mailboxes?task=expireInboxes&maxAge=30d

Optionally include &usersPerSecond=10 to control execution throttling.

To use variant 1, there is also a new "Expires" Mailet, which can add a default expires header, or enforce a min/max time bracket on an existing Expires header.

(Also includes a small fix to MessageSearches to respect the zone offset in a date-time value.)