### PR TITLE
JAMES-3770 SendMailHandler should log MIME MessageID

### DIFF
--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
@@ -71,7 +71,11 @@ public class SendMailHandler implements JamesMessageHook {
 
         try {
             queue.enQueue(mail);
-            LOGGER.info("Successfully spooled mail {} from {} on {} for {}", mail.getName(), mail.getMaybeSender(), session.getRemoteAddress().getAddress(), mail.getRecipients());
+            LOGGER.info("Successfully spooled mail {} with messageId {} from {} on {} for {}", mail.getName(),
+                mail.getMessage().getMessageID(),
+                mail.getMaybeSender(),
+                session.getRemoteAddress().getAddress(),
+                mail.getRecipients());
         } catch (Exception me) {
             LOGGER.error("Unknown error occurred while processing DATA.", me);
             return HookResult.builder()


### PR DESCRIPTION
Systems like postfix logs this information.

Today James logs only the transport envelope, which do not allow connecting James logs with external systems.

Such a log would also allows better identify messages concerned by an issue.

Proposal: add the messageId to SendMailHandler log.