### PR TITLE
JAMES-3715 Prevent possible NPE upon inactive SMTP channel

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
@@ -134,7 +134,7 @@ public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter imp
                     connectHandler.onDisconnect(session);
                 }
             }
-            LOGGER.info("Connection closed for {}", session.getRemoteAddress().getAddress().getHostAddress());
+            LOGGER.info("Connection closed for {}", ctx.channel().remoteAddress());
             cleanup(ctx);
             super.channelInactive(ctx);
         }
@@ -187,7 +187,7 @@ public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter imp
      * Cleanup the channel
      */
     protected void cleanup(ChannelHandlerContext ctx) {
-        ProtocolSession session = (ProtocolSession) ctx.channel().attr(SESSION_ATTRIBUTE_KEY).getAndRemove();
+        ProtocolSession session = (ProtocolSession) ctx.channel().attr(SESSION_ATTRIBUTE_KEY).getAndSet(null);
         if (session != null) {
             session.resetState();
         }


### PR DESCRIPTION
```
java.lang.NullPointerException: null
         at org.apache.james.protocols.netty.BasicChannelInboundHandler.channelInactive(BasicChannelInboundHandler.java:137)
         at org.apache.james.smtpserver.netty.SMTPChannelInboundHandler.channelInactive(SMTPChannelInboundHandler.java:64)
         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:262)
         at io.netty.channel.AbstractChannelHandlerContext.access$300(AbstractChannelHandlerContext.java:61)
         at io.netty.channel.AbstractChannelHandlerContext$4.run(AbstractChannelHandlerContext.java:253)
         at io.netty.util.concurrent.DefaultEventExecutor.run(DefaultEventExecutor.java:66)
         at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
         at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
         at java.base/java.lang.Thread.run(Unknown Source) 
```