### PR TITLE
JAMES-3737 Defer unsolicited flags notifications

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -200,18 +200,18 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
 
         Collection<MessageUid> flagUpdateUids = selected.flagUpdateUids();
         if (!flagUpdateUids.isEmpty()) {
-            addApplicableFlagResponse(session, selected, responder, useUid);
-            return Flux.fromIterable(MessageRange.toRanges(flagUpdateUids))
-                .concatMap(range ->
-                    addFlagsResponses(session, selected, responder, useUid, range, messageManager, mailboxSession))
-                .then()
-                .onErrorResume(MailboxException.class, e -> {
-                    handleResponseException(responder, e, HumanReadableText.FAILURE_TO_LOAD_FLAGS, session);
-                    return Mono.empty();
-                });
+
+            return Mono.fromRunnable(() -> addApplicableFlagResponse(session, selected, responder, useUid))
+                .then(Flux.fromIterable(MessageRange.toRanges(flagUpdateUids))
+                    .concatMap(range ->
+                        addFlagsResponses(session, selected, responder, useUid, range, messageManager, mailboxSession))
+                    .then()
+                    .onErrorResume(MailboxException.class, e -> {
+                        handleResponseException(responder, e, HumanReadableText.FAILURE_TO_LOAD_FLAGS, session);
+                        return Mono.empty();
+                    }));
         } else {
-            addApplicableFlagResponse(session, selected, responder, useUid);
-            return Mono.empty();
+            return Mono.fromRunnable(() -> addApplicableFlagResponse(session, selected, responder, useUid));
         }
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -403,8 +403,9 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
                     .untaggedOk(HumanReadableText.QRESYNC_CLOSED, ResponseCode.closed()));
             }
             SelectedMailboxImpl selectedMailbox = new SelectedMailboxImpl(getMailboxManager(), eventBus, session, mailbox);
-            return selectedMailbox.finishInit()
-                .then(session.selected(selectedMailbox))
+
+            return session.selected(selectedMailbox)
+                .then(selectedMailbox.finishInit())
                 .thenReturn(selectedMailbox);
         } else {
             return Mono.just(currentMailbox);


### PR DESCRIPTION
Not defered, it gets evaluated when building pipeline and this
may lead to either incorrect or buggy results.

 - Some random tests fails upon select
 - NPE spotted:

```
java.lang.NullPointerException: null
  at org.apache.james.imap.processor.AbstractMailboxProcessor.flags(AbstractMailboxProcessor.java:117)
  at org.apache.james.imap.processor.AbstractSelectionProcessor.lambda$respond$5(AbstractSelectionProcessor.java:138)
```

This should fix the issue.