### PR TITLE
JAMES-3773 get rid of Reactor Elastic scheduler

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
@@ -65,7 +65,7 @@ public class CassandraTableManager {
     public void clearAllTables() {
         CassandraAsyncExecutor executor = new CassandraAsyncExecutor(session);
         Flux.fromIterable(module.moduleTables())
-                .publishOn(Schedulers.elastic())
+                .publishOn(Schedulers.boundedElastic())
                 .map(CassandraTable::getName)
                 .flatMap(name -> truncate(executor, name), DEFAULT_CONCURRENCY)
                 .then()

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/ResilientClusterProvider.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/ResilientClusterProvider.java
@@ -55,8 +55,7 @@ public class ResilientClusterProvider implements Provider<Cluster> {
         Duration waitDelay = Duration.ofMillis(configuration.getMinDelay());
         cluster = Mono.fromCallable(getClusterRetryCallable(configuration, consistenciesConfiguration))
             .doOnError(e -> LOGGER.warn("Error establishing Cassandra connection. Next retry scheduled in {} ms", waitDelay, e))
-            .retryWhen(Retry.backoff(configuration.getMaxRetry(), waitDelay).scheduler(Schedulers.elastic()))
-            .publishOn(Schedulers.elastic())
+            .retryWhen(Retry.backoff(configuration.getMaxRetry(), waitDelay).scheduler(Schedulers.boundedElastic()))
             .block();
     }
 

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/utils/CassandraAsyncExecutor.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/utils/CassandraAsyncExecutor.java
@@ -48,7 +48,7 @@ public class CassandraAsyncExecutor {
     public Mono<ResultSet> execute(Statement statement) {
         return Mono.fromFuture(() -> FutureConverter
                 .toCompletableFuture(session.executeAsync(statement)))
-                .publishOn(Schedulers.elastic());
+                .publishOn(Schedulers.boundedElastic());
     }
 
     public Mono<Boolean> executeReturnApplied(Statement statement) {

--- a/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ClientProvider.java
+++ b/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ClientProvider.java
@@ -204,8 +204,7 @@ public class ClientProvider implements Provider<ReactorElasticSearchClient> {
         return Mono.fromCallable(() -> connectToCluster(configuration))
             .doOnError(e -> LOGGER.warn("Error establishing ElasticSearch connection. Next retry scheduled in {}",
                 DurationFormatUtils.formatDurationWords(waitDelay.toMillis(), suppressLeadingZeroElements, suppressTrailingZeroElements), e))
-            .retryWhen(Retry.backoff(configuration.getMaxRetries(), waitDelay).scheduler(Schedulers.elastic()))
-            .publishOn(Schedulers.elastic())
+            .retryWhen(Retry.backoff(configuration.getMaxRetries(), waitDelay).scheduler(Schedulers.boundedElastic()))
             .block();
     }
 

--- a/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ReactorElasticSearchClient.java
+++ b/backends-common/elasticsearch-v7/src/main/java/org/apache/james/backends/es/v7/ReactorElasticSearchClient.java
@@ -161,7 +161,7 @@ public class ReactorElasticSearchClient implements AutoCloseable {
 
     private static <T> Mono<T> toReactor(Consumer<ActionListener<T>> async) {
         return Mono.<T>create(sink -> async.accept(getListener(sink)))
-            .publishOn(Schedulers.elastic());
+            .publishOn(Schedulers.boundedElastic());
     }
 
     private static <T> ActionListener<T> getListener(MonoSink<T> sink) {

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
@@ -180,7 +180,7 @@ public class RabbitMQConnectionFactory {
         return Mono.fromCallable(this::createConnection)
             .retryWhen(Retry.backoff(configuration.getMaxRetries(),
                 Duration.ofMillis(configuration.getMinDelayInMs()))
-                .scheduler(Schedulers.elastic()));
+                .scheduler(Schedulers.boundedElastic()));
     }
 
     private Connection createConnection() throws IOException, TimeoutException {

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -694,7 +694,7 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
             .map(maybeChannel ->
                 maybeChannel.orElseThrow(() -> new RuntimeException("RabbitMQ reached to maximum opened channels, cannot get more channels")))
             .map(SelectOnceChannel::new)
-            .retryWhen(configuration.backoffSpec().scheduler(Schedulers.elastic()))
+            .retryWhen(configuration.backoffSpec().scheduler(Schedulers.boundedElastic()))
             .doOnError(throwable -> LOGGER.error("error when creating new channel", throwable));
     }
 

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
@@ -120,7 +120,7 @@ public class SimpleConnectionPool implements AutoCloseable, Startable {
 
     public Mono<Connection> getResilientConnection() {
         return Mono.defer(this::getOpenConnection)
-            .retryWhen(Retry.backoff(configuration.getNumRetries(), configuration.getInitialDelay()).scheduler(Schedulers.elastic()));
+            .retryWhen(Retry.backoff(configuration.getNumRetries(), configuration.getInitialDelay()).scheduler(Schedulers.boundedElastic()));
     }
 
     private Mono<Connection> getOpenConnection() {

--- a/event-bus/api/pom.xml
+++ b/event-bus/api/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-util</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/event-bus/api/src/main/java/org/apache/james/events/EventListener.java
+++ b/event-bus/api/src/main/java/org/apache/james/events/EventListener.java
@@ -21,12 +21,12 @@ package org.apache.james.events;
 
 import java.util.Objects;
 
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * Listens to events.<br>
@@ -64,7 +64,7 @@ public interface EventListener {
         @Override
         public Publisher<Void> reactiveEvent(Event event) {
             return Mono.fromRunnable(Throwing.runnable(() -> delegate.event(event)))
-                .subscribeOn(Schedulers.elastic())
+                .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
                 .then();
         }
 

--- a/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
@@ -186,7 +186,7 @@ public class EventDispatcher {
     private Mono<Void> remoteDispatchWithAcks(byte[] serializedEvent) {
         if (configuration.isEventBusPublishConfirmEnabled()) {
             return Mono.from(sender.sendWithPublishConfirms(Mono.just(toMessage(serializedEvent, RoutingKey.empty())))
-                .subscribeOn(Schedulers.elastic())) // channel.confirmSelect is synchronous
+                .subscribeOn(Schedulers.boundedElastic())) // channel.confirmSelect is synchronous
                 .filter(outboundMessageResult -> !outboundMessageResult.isAck())
                 .handle((result, sink) -> sink.error(new Exception("Publish was not acked")))
                 .retryWhen(Retry.backoff(2, Duration.ofMillis(100)))

--- a/event-bus/distributed/src/main/java/org/apache/james/events/WaitDelayGenerator.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/WaitDelayGenerator.java
@@ -60,7 +60,7 @@ class WaitDelayGenerator {
         }
 
         return countRetryMono
-            .delayElement(generateDelay(retryCount), Schedulers.elastic());
+            .delayElement(generateDelay(retryCount), Schedulers.parallel());
     }
 
     @VisibleForTesting

--- a/event-bus/in-vm/src/main/java/org/apache/james/events/delivery/EventDelivery.java
+++ b/event-bus/in-vm/src/main/java/org/apache/james/events/delivery/EventDelivery.java
@@ -86,7 +86,7 @@ public interface EventDelivery {
             @Override
             public Mono<Void> doRetry(Mono<Void> executionResult, Event event) {
                 return executionResult
-                    .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.elastic()))
+                    .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()).scheduler(Schedulers.parallel()))
                     .doOnError(throwable -> LOGGER.error("listener {} exceeded maximum retry({}) to handle event {}",
                         listener.getClass().getCanonicalName(),
                         retryBackoff.getMaxRetries(),

--- a/event-sourcing/event-sourcing-core/pom.xml
+++ b/event-sourcing/event-sourcing-core/pom.xml
@@ -48,6 +48,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
         </dependency>

--- a/event-sourcing/event-sourcing-core/src/main/scala/org/apache/james/eventsourcing/Subscriber.scala
+++ b/event-sourcing/event-sourcing-core/src/main/scala/org/apache/james/eventsourcing/Subscriber.scala
@@ -18,9 +18,9 @@
  * ***************************************************************/
 package org.apache.james.eventsourcing
 
+import org.apache.james.util.ReactorUtils
 import org.reactivestreams.Publisher
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 
 trait Subscriber {
   def handle(event: Event) : Unit
@@ -43,6 +43,6 @@ class ReactiveSubscriberWrapper(delegate: Subscriber) extends ReactiveSubscriber
   override def handle(event: Event) : Unit = delegate.handle(event)
 
   def handleReactive(event: Event): Publisher[Void] = SMono.fromCallable(() => handle(event))
-    .subscribeOn(Schedulers.elastic())
+    .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
     .`then`()
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageIdManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageIdManager.java
@@ -39,7 +39,6 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public interface MessageIdManager {
     default Publisher<ComposedMessageIdWithMetaData> messageMetadata(MessageId id, MailboxSession session) {
@@ -82,7 +81,6 @@ public interface MessageIdManager {
 
     default DeleteResult delete(MessageId messageId, MailboxSession mailboxSession) {
         return Mono.from(delete(ImmutableList.of(messageId), mailboxSession))
-            .subscribeOn(Schedulers.elastic())
             .block();
     }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
@@ -35,7 +35,7 @@ public interface TextExtractor {
 
     default Mono<ParsedContent> extractContentReactive(InputStream inputStream, ContentType contentType) {
         return Mono.fromCallable(() -> extractContent(inputStream, contentType))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
@@ -32,12 +32,12 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.Quota.Scope;
 import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * This interface describe how to set the max quotas for users
@@ -156,14 +156,14 @@ public interface MaxQuotaManager {
 
     default Publisher<Map<Scope, QuotaCountLimit>> listMaxMessagesDetailsReactive(QuotaRoot quotaRoot) {
         return Mono.fromCallable(() -> listMaxMessagesDetails(quotaRoot))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     Map<Quota.Scope, QuotaSizeLimit> listMaxStorageDetails(QuotaRoot quotaRoot);
 
     default Publisher<Map<Quota.Scope, QuotaSizeLimit>> listMaxStorageDetailsReactive(QuotaRoot quotaRoot) {
         return Mono.fromCallable(() -> listMaxStorageDetails(quotaRoot))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
 

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
@@ -42,6 +42,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.search.MailboxQuery;
+import org.apache.james.util.ReactorUtils;
 import org.apache.james.util.streams.Iterators;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -52,7 +53,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class DefaultMailboxBackup implements MailboxBackup {
 
@@ -120,7 +120,7 @@ public class DefaultMailboxBackup implements MailboxBackup {
         }
 
         return Mono.fromRunnable(Throwing.runnable(() -> archiveRestorer.restore(username, source)).sneakyThrow())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .doOnError(e -> LOGGER.error("Error during account restoration for user : " + username.asString(), e))
             .doOnTerminate(Throwing.runnable(source::close).sneakyThrow())
             .thenReturn(BackupStatus.DONE)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -497,7 +497,7 @@ public class CassandraMessageIdDAO {
             // We filter out such records, and cleanup them.
             delete(CassandraId.of(row.getUUID(MAILBOX_ID)),
                 MessageUid.of(row.getLong(IMAP_UID)))
-                .subscribeOn(Schedulers.elastic())
+                .subscribeOn(Schedulers.parallel())
                 .subscribe();
             return Optional.empty();
         }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -67,7 +67,6 @@ import com.google.common.collect.Multimap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.GroupedFlux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 
 public class CassandraMessageIdMapper implements MessageIdMapper {
@@ -243,7 +242,6 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
     public Mono<Void> deleteReactive(Multimap<MessageId, MailboxId> ids) {
         return Flux.fromIterable(ids.asMap()
             .entrySet())
-            .publishOn(Schedulers.elastic())
             .flatMap(entry -> deleteReactive(entry.getKey(), entry.getValue()), cassandraConfiguration.getExpungeChunkSize(),
                 DEFAULT_CONCURRENCY)
             .then();

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -175,7 +175,7 @@ public class CassandraMessageMapper implements MessageMapper {
     private void readRepair(Mailbox mailbox, MailboxCounters counters) {
         if (shouldReadRepair(counters)) {
             fixCounters(mailbox)
-                .subscribeOn(Schedulers.elastic())
+                .subscribeOn(Schedulers.parallel())
                 .subscribe();
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
@@ -101,7 +101,7 @@ public class CassandraModSeqProvider implements ModSeqProvider {
         this.select = prepareSelect(session);
         Duration firstBackoff = Duration.ofMillis(10);
         this.retrySpec = Retry.backoff(cassandraConfiguration.getModSeqMaxRetry(), firstBackoff)
-            .scheduler(Schedulers.elastic());
+            .scheduler(Schedulers.parallel());
     }
 
     private PreparedStatement prepareInsert(Session session) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProvider.java
@@ -77,7 +77,7 @@ public class CassandraUidProvider implements UidProvider {
         this.insertStatement = prepareInsert(session);
         Duration firstBackoff = Duration.ofMillis(10);
         this.retrySpec = Retry.backoff(cassandraConfiguration.getUidMaxRetry(), firstBackoff)
-            .scheduler(Schedulers.elastic());
+            .scheduler(Schedulers.parallel());
     }
 
     private PreparedStatement prepareSelect(Session session) {

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
@@ -138,15 +138,15 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
                                                             Flags newState, FlagsUpdateMode updateMode) {
         return findReactive(ImmutableList.of(messageId), MessageMapper.FetchType.METADATA)
             .filter(message -> mailboxIds.contains(message.getMailboxId()))
-            .map(updateMessage(newState, updateMode))
+            .concatMap(updateMessage(newState, updateMode))
             .distinct()
             .collect(ImmutableListMultimap.toImmutableListMultimap(
                 Pair::getKey,
                 Pair::getValue));
     }
 
-    private Function<MailboxMessage, Pair<MailboxId, UpdatedFlags>> updateMessage(Flags newState, FlagsUpdateMode updateMode) {
-        return Throwing.function((MailboxMessage message) -> {
+    private Function<MailboxMessage, Mono<Pair<MailboxId, UpdatedFlags>>> updateMessage(Flags newState, FlagsUpdateMode updateMode) {
+        return (MailboxMessage message) -> {
             FlagsUpdateCalculator flagsUpdateCalculator = new FlagsUpdateCalculator(newState, updateMode);
             if (flagsUpdateCalculator.buildNewFlags(message.createFlags()).equals(message.createFlags())) {
                 UpdatedFlags updatedFlags = UpdatedFlags.builder()
@@ -156,14 +156,16 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
                     .oldFlags(message.createFlags())
                     .newFlags(newState)
                     .build();
-                return Pair.of(message.getMailboxId(), updatedFlags);
+                return Mono.just(Pair.of(message.getMailboxId(), updatedFlags));
             }
-            return Pair.of(message.getMailboxId(),
-                messageMapper.updateFlags(
-                    MailboxReactorUtils.block(mailboxMapper.findMailboxById(message.getMailboxId())),
+            return mailboxMapper.findMailboxById(message.getMailboxId())
+                .flatMap(mailboxId -> Mono.from(messageMapper.updateFlagsReactive(
+                    mailboxId,
                     flagsUpdateCalculator,
-                    message.getUid().toRange())
-                    .next());
-        });
+                    message.getUid().toRange()))
+                    .flatMapIterable(Function.identity())
+                    .next()
+                    .map(updatedFlags -> Pair.of(message.getMailboxId(), updatedFlags)));
+        };
     }
 }

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/quota/InMemoryCurrentQuotaManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/quota/InMemoryCurrentQuotaManager.java
@@ -87,7 +87,7 @@ public class InMemoryCurrentQuotaManager implements CurrentQuotaManager {
     @Override
     public Mono<CurrentQuotas> getCurrentQuotas(QuotaRoot quotaRoot) {
         return Mono.fromCallable(() -> quotaCache.get(quotaRoot).get())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .onErrorMap(this::wrapAsMailboxException);
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/PreDeletionHooks.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/PreDeletionHooks.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class PreDeletionHooks {
     private static final int CONCURRENCY = 1;
@@ -54,7 +53,6 @@ public class PreDeletionHooks {
 
     public Mono<Void> runHooks(PreDeletionHook.DeleteOperation deleteOperation) {
         return Flux.fromIterable(hooks)
-            .publishOn(Schedulers.elastic())
             .flatMap(hook -> metricFactory.map(factory -> publishMetric(deleteOperation, hook, factory))
                     .orElse(Mono.empty()),
                 CONCURRENCY)

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -408,7 +408,7 @@ public class StoreMessageManager implements MessageManager {
                 throw new MailboxException("Unable to parse message", e);
             }
         }).flatMap(Function.identity())
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     private Pair<PropertyBuilder, HeaderImpl> parseProperties(BodyOffsetInputStream bIn) throws IOException, MimeException {
@@ -700,7 +700,6 @@ public class StoreMessageManager implements MessageManager {
                 .updatedFlags(updatedFlags)
                 .build(),
                 new MailboxIdRegistrationKey(mailbox.getMailboxId()))
-            .subscribeOn(Schedulers.elastic())
             .block();
 
         return updatedFlags.stream().collect(ImmutableMap.toImmutableMap(

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
@@ -59,7 +59,7 @@ public class DefaultTextExtractor implements TextExtractor {
         if (applicable(contentType)) {
             Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
             return Mono.fromCallable(() -> new ParsedContent(Optional.ofNullable(IOUtils.toString(inputStream, charset)), new HashMap<>()))
-                .subscribeOn(Schedulers.elastic());
+                .subscribeOn(Schedulers.boundedElastic());
         } else {
             return Mono.just(new ParsedContent(Optional.empty(), new HashMap<>()));
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/JsoupTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/JsoupTextExtractor.java
@@ -78,11 +78,11 @@ public class JsoupTextExtractor implements TextExtractor {
         Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
         if (contentType.mimeType().equals(TEXT_HTML)) {
             return Mono.fromCallable(() -> parseHtmlContent(inputStream, charset))
-                .subscribeOn(Schedulers.elastic());
+                .subscribeOn(Schedulers.boundedElastic());
         }
         if (contentType.mimeType().equals(TEXT_PLAIN)) {
             return Mono.fromCallable(() -> parsePlainTextContent(inputStream, charset))
-                .subscribeOn(Schedulers.elastic());
+                .subscribeOn(Schedulers.boundedElastic());
         }
         return Mono.just(ParsedContent.empty());
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
@@ -31,9 +31,9 @@ import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.ParsedAttachment;
 import org.apache.james.mailbox.store.transaction.Mapper;
+import org.apache.james.util.ReactorUtils;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public interface AttachmentMapper extends Mapper {
 
@@ -47,7 +47,7 @@ public interface AttachmentMapper extends Mapper {
 
     default Mono<List<MessageAttachmentMetadata>> storeAttachmentsReactive(Collection<ParsedAttachment> attachments, MessageId ownerMessageId) {
         return Mono.fromCallable(() -> storeAttachments(attachments, ownerMessageId))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) throws MailboxException;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageIdMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageIdMapper.java
@@ -33,6 +33,7 @@ import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
@@ -40,7 +41,6 @@ import com.google.common.collect.Multimap;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public interface MessageIdMapper {
 
@@ -60,7 +60,7 @@ public interface MessageIdMapper {
 
     default Mono<Void> copyInMailboxReactive(MailboxMessage mailboxMessage, Mailbox mailbox) {
         return Mono.<Void>fromRunnable(Throwing.runnable(() -> copyInMailbox(mailboxMessage, mailbox)).sneakyThrow())
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     void delete(MessageId messageId);
@@ -69,7 +69,7 @@ public interface MessageIdMapper {
 
     default Mono<Void> deleteReactive(MessageId messageId, Collection<MailboxId> mailboxIds) {
         return Mono.fromRunnable(() -> delete(messageId, mailboxIds))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .then();
     }
 
@@ -80,7 +80,7 @@ public interface MessageIdMapper {
 
     default Mono<Void> deleteReactive(Multimap<MessageId, MailboxId> ids) {
         return Mono.fromRunnable(() -> delete(ids))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .then();
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -51,7 +51,6 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * Maps {@link MailboxMessage} in a {@link org.apache.james.mailbox.MessageManager}. A {@link MessageMapper} has a lifecycle from the start of a request
@@ -160,7 +159,7 @@ public interface MessageMapper extends Mapper {
 
     default Publisher<MessageMetaData> addReactive(Mailbox mailbox, MailboxMessage message) {
         return Mono.fromCallable(() -> add(mailbox, message))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     /**

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaHttpClientImpl.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaHttpClientImpl.java
@@ -74,7 +74,7 @@ public class TikaHttpClientImpl implements TikaHttpClient {
             .uri(recursiveMetaData)
             .send(ReactorUtils.toChunks(inputStream, 16 * 1024)
                 .map(Unpooled::wrappedBuffer)
-                .subscribeOn(Schedulers.elastic()))
+                .subscribeOn(Schedulers.boundedElastic()))
             .responseSingle((resp, content) -> {
                 if (resp.status().code() == 200) {
                     return content.asInputStream();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -71,7 +71,6 @@ import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends AbstractProcessor<R> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMailboxProcessor.class);
@@ -356,7 +355,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        })).subscribeOn(Schedulers.elastic())
+        })).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .then();
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -195,7 +195,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener {
     public Mono<Void> deselect() {
         return Mono.from(registration.get().unregister())
             .then(Mono.fromRunnable(this::clearInternalStructures)
-                .subscribeOn(Schedulers.elastic()))
+                .subscribeOn(Schedulers.boundedElastic()))
             .then();
     }
 

--- a/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
+++ b/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
@@ -83,6 +83,12 @@ public class AESBlobStoreDAO implements BlobStoreDAO {
     }
 
     @Override
+    public Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId) {
+        return Mono.from(underlying.readReactive(bucketName, blobId))
+            .map(Throwing.function(this::decrypt));
+    }
+
+    @Override
     public Publisher<byte[]> readBytes(BucketName bucketName, BlobId blobId) {
         return Mono.from(underlying.readBytes(bucketName, blobId))
             .map(ByteArrayInputStream::new)

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
@@ -48,12 +48,18 @@ public interface BlobStore {
 
     InputStream read(BucketName bucketName, BlobId blobId);
 
+    Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId);
+
     default Publisher<byte[]> readBytes(BucketName bucketName, BlobId blobId, StoragePolicy storagePolicy) {
        return readBytes(bucketName, blobId);
     }
 
     default InputStream read(BucketName bucketName, BlobId blobId, StoragePolicy storagePolicy) {
         return read(bucketName, blobId);
+    }
+
+    default Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId, StoragePolicy storagePolicy) {
+        return readReactive(bucketName, blobId);
     }
 
     BucketName getDefaultBucketName();

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStoreDAO.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStoreDAO.java
@@ -37,6 +37,7 @@ public interface BlobStoreDAO {
      */
     InputStream read(BucketName bucketName, BlobId blobId) throws ObjectStoreIOException, ObjectNotFoundException;
 
+    Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId);
 
     /**
      * Reads a Blob based on its BucketName and its BlobId

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
@@ -77,6 +77,11 @@ public class MetricableBlobStore implements BlobStore {
     }
 
     @Override
+    public Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId) {
+        return metricFactory.decoratePublisherWithTimerMetric(READ_TIMER_NAME, blobStoreImpl.readReactive(bucketName, blobId));
+    }
+
+    @Override
     public Publisher<byte[]> readBytes(BucketName bucketName, BlobId blobId, StoragePolicy storagePolicy) {
         return metricFactory.decoratePublisherWithTimerMetric(READ_BYTES_TIMER_NAME, blobStoreImpl.readBytes(bucketName, blobId, storagePolicy));
     }

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreDAO.java
@@ -101,6 +101,11 @@ public class CassandraBlobStoreDAO implements BlobStoreDAO {
     }
 
     @Override
+    public Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId) {
+        return Mono.just(read(bucketName, blobId));
+    }
+
+    @Override
     public Mono<byte[]> readBytes(BucketName bucketName, BlobId blobId) {
         return readBlobParts(bucketName, blobId)
             .collectList()

--- a/server/blob/blob-common/pom.xml
+++ b/server/blob/blob-common/pom.xml
@@ -44,6 +44,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>

--- a/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
+++ b/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.blob.api.BlobStore.StoragePolicy;
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
 import com.google.common.base.Optional;
@@ -103,7 +104,7 @@ public interface Store<T, I> {
         @Override
         public Mono<T> read(I blobIds) {
             return Flux.fromIterable(blobIds.asMap().entrySet())
-                .publishOn(Schedulers.elastic())
+                .publishOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
                 .collectMap(Map.Entry::getKey, entry -> readByteSource(bucketName, entry.getValue(), entry.getKey().getStoragePolicy()))
                 .map(decoder::decode);
         }

--- a/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStoreDAO.java
+++ b/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStoreDAO.java
@@ -57,6 +57,12 @@ public class MemoryBlobStoreDAO implements BlobStoreDAO {
     }
 
     @Override
+    public Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId) {
+        return readBytes(bucketName, blobId)
+            .map(ByteArrayInputStream::new);
+    }
+
+    @Override
     public Mono<byte[]> readBytes(BucketName bucketName, BlobId blobId) {
         return Mono.fromCallable(() -> blobs.get(bucketName, blobId))
             .switchIfEmpty(Mono.error(() -> new ObjectNotFoundException(String.format("blob '%s' not found in bucket '%s'", blobId.asString(), bucketName.asString()))));

--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -167,6 +167,11 @@ public class S3BlobStoreDAO implements BlobStoreDAO, Startable, Closeable {
             .flux);
     }
 
+    @Override
+    public Publisher<InputStream> readReactive(BucketName bucketName, BlobId blobId) {
+        return Mono.just(read(bucketName, blobId));
+    }
+
     private static class FluxResponse {
         final CompletableFuture<FluxResponse> supportingCompletableFuture = new CompletableFuture<>();
         GetObjectResponse sdkResponse;

--- a/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
+++ b/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
@@ -100,6 +100,12 @@ class DeDuplicationBlobStore @Inject()(blobStoreDAO: BlobStoreDAO,
     blobStoreDAO.read(bucketName, blobId)
   }
 
+  override def readReactive(bucketName: BucketName, blobId: BlobId): Publisher[InputStream] = {
+    Preconditions.checkNotNull(bucketName)
+
+    blobStoreDAO.readReactive(bucketName, blobId)
+  }
+
   override def getDefaultBucketName: BucketName = defaultBucketName
 
   override def deleteBucket(bucketName: BucketName): Publisher[Void] = {

--- a/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/PassThroughBlobStore.scala
+++ b/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/PassThroughBlobStore.scala
@@ -74,6 +74,12 @@ class PassThroughBlobStore @Inject()(blobStoreDAO: BlobStoreDAO,
     blobStoreDAO.read(bucketName, blobId)
   }
 
+  override def readReactive(bucketName: BucketName, blobId: BlobId): Publisher[InputStream] = {
+    Preconditions.checkNotNull(bucketName)
+
+    blobStoreDAO.readReactive(bucketName, blobId)
+  }
+
   override def getDefaultBucketName: BucketName = defaultBucketName
 
   override def deleteBucket(bucketName: BucketName): Publisher[Void] = {

--- a/server/container/feature-checks/src/main/java/org/apache/james/healthcheck/MailReceptionCheck.java
+++ b/server/container/feature-checks/src/main/java/org/apache/james/healthcheck/MailReceptionCheck.java
@@ -169,7 +169,7 @@ public class MailReceptionCheck implements HealthCheck {
         public Publisher<Void> reactiveEvent(Event event) {
             if (event instanceof Added) {
                 return Mono.fromRunnable(() -> sink.emitNext((Added) event, FAIL_FAST))
-                    .subscribeOn(Schedulers.elastic())
+                    .subscribeOn(Schedulers.boundedElastic())
                     .then();
             }
             return Mono.empty();
@@ -219,7 +219,7 @@ public class MailReceptionCheck implements HealthCheck {
                 registration -> sendMail(username)
                     .flatMap(content -> checkReceived(session, listener, mailbox, content)),
                 Registration::unregister))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .timeout(configuration.getTimeout(), Mono.error(() -> new RuntimeException("HealthCheck email was not received after " + configuration.getTimeout().toMillis() + "ms")))
             .onErrorResume(e -> {
                 LOGGER.error("Mail reception check failed", e);

--- a/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
@@ -40,6 +40,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Signal;
 import reactor.core.publisher.SynchronousSink;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 import reactor.util.context.ContextView;
@@ -48,6 +50,17 @@ public class ReactorUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReactorUtils.class);
     public static final String MDC_KEY_PREFIX = "MDC-";
     public static final int DEFAULT_CONCURRENCY = 16;
+    private static final int DEFAULT_BOUNDED_ELASTIC_SIZE = Optional.ofNullable(System.getProperty("james.schedulers.defaultBoundedElasticSize"))
+        .map(Integer::parseInt)
+        .orElseGet(() -> 10 * Runtime.getRuntime().availableProcessors());
+    public static final int DEFAULT_BOUNDED_ELASTIC_QUEUESIZE = Optional.ofNullable(System.getProperty("james.schedulers.defaultBoundedElasticQueueSize"))
+        .map(Integer::parseInt)
+        .orElse(100000);
+    private static final int TTL_SECONDS = 60;
+    private static final boolean DAEMON = true;
+    public static final Scheduler BLOCKING_CALL_WRAPPER = Schedulers.newBoundedElastic(DEFAULT_BOUNDED_ELASTIC_SIZE, DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
+        "blocking-call-wrapper", TTL_SECONDS, DAEMON);
+
 
     public static <T, U> RequiresQuantity<T, U> throttle() {
         return elements -> duration -> operation -> {

--- a/server/container/util/src/main/java/org/apache/james/util/Runnables.java
+++ b/server/container/util/src/main/java/org/apache/james/util/Runnables.java
@@ -31,9 +31,9 @@ public class Runnables {
 
     public static void runParallel(Flux<Runnable> runnables) {
         runnables
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .parallel()
-            .runOn(Schedulers.elastic())
+            .runOn(Schedulers.boundedElastic())
             .flatMap(runnable -> {
                 runnable.run();
                 return Mono.empty();

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersDAO.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersDAO.java
@@ -25,10 +25,10 @@ import java.util.Optional;
 import org.apache.james.core.Username;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.user.api.model.User;
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public interface UsersDAO {
     default boolean getDefaultVirtualHostingValue() {
@@ -45,7 +45,7 @@ public interface UsersDAO {
 
     default Publisher<Boolean> containsReactive(Username name) {
         return Mono.fromCallable(() -> contains(name))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     int countUsers() throws UsersRepositoryException;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailDispatcher.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailDispatcher.java
@@ -174,7 +174,7 @@ public class MailDispatcher {
     private Mono<Void> storeMailWithRetry(Mail mail, MailAddress recipient) {
        return Mono.from(mailStore.storeMail(recipient, mail))
            .doOnError(error -> LOGGER.warn("Error While storing mail. This error will be retried.", error))
-           .retryWhen(Retry.backoff(RETRIES, FIRST_BACKOFF).maxBackoff(MAX_BACKOFF).scheduler(Schedulers.elastic()))
+           .retryWhen(Retry.backoff(RETRIES, FIRST_BACKOFF).maxBackoff(MAX_BACKOFF).scheduler(Schedulers.parallel()))
            .then();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MessageAppender.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MessageAppender.java
@@ -49,6 +49,7 @@ import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mime4j.dom.Message;
+import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,6 @@ import com.google.common.collect.Sets;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class MessageAppender {
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageAppender.class);
@@ -106,7 +106,7 @@ public class MessageAppender {
                 Date internalDate = Date.from(createdEntry.getValue().getDate().toInstant());
 
                 return new NewMessage(messageContent, message, internalDate);
-            }).subscribeOn(Schedulers.elastic())
+            }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .flatMap(newMessage -> Mono.from(mailboxManager.getMailboxReactive(targetMailboxes.get(0), session))
                 .flatMap(mailbox -> Mono.from(mailbox.appendMessageReactive(
                     MessageManager.AppendCommand.builder()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MessageSender.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MessageSender.java
@@ -76,7 +76,7 @@ public class MessageSender {
     public Mono<Void> sendMessage(MetaDataWithContent message, Envelope envelope, MailboxSession session) {
         return Mono.usingWhen(Mono.fromCallable(() -> buildMail(message, envelope)),
             mail -> sendMessage(message.getMessageId(), mail, session),
-            mail -> Mono.fromRunnable(() -> LifecycleUtil.dispose(mail)).subscribeOn(Schedulers.elastic()));
+            mail -> Mono.fromRunnable(() -> LifecycleUtil.dispose(mail)).subscribeOn(Schedulers.boundedElastic()));
     }
 
     @VisibleForTesting

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMailboxesProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMailboxesProcessor.java
@@ -22,9 +22,9 @@ package org.apache.james.jmap.draft.methods;
 import org.apache.james.jmap.draft.model.SetMailboxesRequest;
 import org.apache.james.jmap.draft.model.SetMailboxesResponse;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.util.ReactorUtils;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public interface SetMailboxesProcessor {
 
@@ -33,6 +33,6 @@ public interface SetMailboxesProcessor {
 
     default Mono<SetMailboxesResponse> processReactive(SetMailboxesRequest request, MailboxSession mailboxSession) {
         return Mono.fromCallable(() -> process(request, mailboxSession))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
@@ -62,6 +62,7 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.server.core.Envelope;
+import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,6 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 
 public class SetMessagesCreationProcessor implements SetMessagesProcessor {
@@ -299,7 +299,7 @@ public class SetMessagesCreationProcessor implements SetMessagesProcessor {
             } else {
                 LOG.debug("{} is allowed to send a mail using {} identity", connectedUser.asString(), from);
             }
-        }).sneakyThrow()).subscribeOn(Schedulers.elastic())
+        }).sneakyThrow()).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .then();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesProcessor.java
@@ -22,9 +22,9 @@ package org.apache.james.jmap.draft.methods;
 import org.apache.james.jmap.draft.model.SetMessagesRequest;
 import org.apache.james.jmap.draft.model.SetMessagesResponse;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.util.ReactorUtils;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public interface SetMessagesProcessor {
     default SetMessagesResponse process(SetMessagesRequest request, MailboxSession mailboxSession) {
@@ -33,6 +33,6 @@ public interface SetMessagesProcessor {
 
     default Mono<SetMessagesResponse> processReactive(SetMessagesRequest request, MailboxSession mailboxSession) {
         return Mono.fromCallable(() -> process(request, mailboxSession))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactory.java
@@ -154,7 +154,7 @@ public class MessageFullViewFactory implements MessageViewFactory<MessageFullVie
         return computeProjection(messageContent, hasAttachments)
             .doOnNext(projection -> Mono.from(fastViewProjection.store(messageId, projection))
                 .doOnError(throwable -> LOGGER.error("Cannot store the projection to MessageFastViewProjection", throwable))
-                .subscribeOn(Schedulers.elastic())
+                .subscribeOn(Schedulers.parallel())
                 .subscribe());
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AuthenticationRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AuthenticationRoutes.java
@@ -64,6 +64,7 @@ import org.apache.james.jmap.exceptions.UnauthorizedException;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,7 +144,7 @@ public class AuthenticationRoutes implements JMAPRoutes {
             .onErrorResume(e -> handleInternalError(response, LOGGER, e))
             .contextWrite(jmapContext(request))
             .contextWrite(jmapAction("auth-post"))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     private Mono<Void> returnEndPointsResponse(HttpServerRequest req, HttpServerResponse resp) {
@@ -157,7 +158,7 @@ public class AuthenticationRoutes implements JMAPRoutes {
                 .onErrorResume(UnauthorizedException.class, e -> handleAuthenticationFailure(resp, LOGGER, e))
                 .contextWrite(jmapContext(req))
                 .contextWrite(jmapAction("returnEndPoints"))
-                .subscribeOn(Schedulers.elastic());
+                .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     private Mono<Void> returnEndPointsResponse(HttpServerResponse resp) {
@@ -190,7 +191,7 @@ public class AuthenticationRoutes implements JMAPRoutes {
             .onErrorResume(UnauthorizedException.class, e -> handleAuthenticationFailure(resp, LOGGER, e))
             .contextWrite(jmapContext(req))
             .contextWrite(jmapAction("auth-delete"))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     private HttpServerRequest assertJsonContentType(HttpServerRequest req) {
@@ -283,7 +284,7 @@ public class AuthenticationRoutes implements JMAPRoutes {
                 LOGGER.error("Error while trying to validate authentication for user '{}'", username, e);
                 return false;
             }
-        }).subscribeOn(Schedulers.elastic());
+        }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     private Mono<Void> returnAccessTokenResponse(HttpServerResponse resp, Username username) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DownloadRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DownloadRoutes.java
@@ -148,7 +148,7 @@ public class DownloadRoutes implements JMAPRoutes {
             .onErrorResume(e -> handleInternalError(response, LOGGER, e))
             .contextWrite(jmapContext(request))
             .contextWrite(jmapAction("download-post"))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     private Mono<Void> getFromId(HttpServerRequest request, HttpServerResponse response) {
@@ -179,7 +179,7 @@ public class DownloadRoutes implements JMAPRoutes {
             .onErrorResume(e -> handleInternalError(response, LOGGER, e))
             .contextWrite(jmapContext(request))
             .contextWrite(jmapAction("download-get"))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     private Mono<Void> respondAttachmentAccessToken(MailboxSession mailboxSession, DownloadPath downloadPath, HttpServerResponse resp) {
@@ -235,7 +235,7 @@ public class DownloadRoutes implements JMAPRoutes {
             .status(OK)
             .send(ReactorUtils.toChunks(stream, BUFFER_SIZE)
                 .map(Unpooled::wrappedBuffer)
-                .subscribeOn(Schedulers.elastic()))
+                .subscribeOn(Schedulers.boundedElastic()))
             .then();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UploadRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UploadRoutes.java
@@ -112,7 +112,7 @@ public class UploadRoutes implements JMAPRoutes {
                 .onErrorResume(e -> handleInternalError(response, LOGGER, e))
                 .contextWrite(jmapContext(request))
                 .contextWrite(jmapAction("upload-get"))
-                .subscribeOn(Schedulers.elastic());
+                .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
         }
     }
 
@@ -121,7 +121,7 @@ public class UploadRoutes implements JMAPRoutes {
             // Unwrapping to byte array needed to solve data races and buffer reordering when using .asByteBuffer()
             .asByteArray()
             .map(ByteBuffer::wrap)
-            .subscribeOn(Schedulers.elastic()));
+            .subscribeOn(Schedulers.boundedElastic()));
         return Mono.from(metricFactory.decoratePublisherWithTimerMetric("JMAP-upload-post",
             handle(contentType, content, session, response)));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UserProvisioner.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UserProvisioner.java
@@ -29,12 +29,12 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.user.api.AlreadyExistInUsersRepositoryException;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.util.FunctionalUtils;
+import org.apache.james.util.ReactorUtils;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class UserProvisioner {
     private final JMAPConfiguration jmapConfiguration;
@@ -67,7 +67,7 @@ public class UserProvisioner {
 
     private Mono<Void> createAccount(Username username) {
         return Mono.fromRunnable(Throwing.runnable(() -> usersRepository.addUser(username, generatePassword())))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .then();
     }
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EventSourceContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EventSourceContract.scala
@@ -188,7 +188,7 @@ trait EventSourceContract {
         new String(bytes, StandardCharsets.UTF_8)
       })
       .doOnNext(seq.addOne)
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     Thread.sleep(500)
@@ -215,7 +215,7 @@ trait EventSourceContract {
         new String(bytes, StandardCharsets.UTF_8)
       })
       .doOnNext(seq.addOne)
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     Thread.sleep(500)
@@ -244,7 +244,7 @@ trait EventSourceContract {
         new String(bytes, StandardCharsets.UTF_8)
       })
       .doOnNext(seq.addOne)
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     Thread.sleep(500)
@@ -278,7 +278,7 @@ trait EventSourceContract {
         new String(bytes, StandardCharsets.UTF_8)
       })
       .doOnNext(seq.addOne)
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     Thread.sleep(2000)
@@ -306,7 +306,7 @@ trait EventSourceContract {
         new String(bytes, StandardCharsets.UTF_8)
       })
       .doOnNext(seq.addOne)
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     Thread.sleep(500)
@@ -339,7 +339,7 @@ trait EventSourceContract {
         new String(bytes, StandardCharsets.UTF_8)
       })
       .doOnNext(seq.addOne)
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     Thread.sleep(500)
@@ -373,7 +373,7 @@ trait EventSourceContract {
         new String(bytes, StandardCharsets.UTF_8)
       })
       .doOnNext(seq.addOne)
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     Thread.sleep(500)

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -48,7 +48,6 @@ import org.assertj.core.api.{Assertions, SoftAssertions}
 import org.hamcrest.Matchers.{equalTo, hasSize, not}
 import org.junit.jupiter.api.{BeforeEach, Disabled, RepeatedTest, Tag, Test}
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 trait MailboxSetMethodContract {
 
@@ -3062,7 +3061,6 @@ trait MailboxSetMethodContract {
     SFlux.range(0, 100)
       .concatMap(i =>  SMono.fromCallable(() => server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.forUser(BOB, s"mailbox1.$i"))))
       .asJava()
-      .subscribeOn(Schedulers.elastic())
       .blockLast()
 
     val request =

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
@@ -38,7 +38,6 @@ import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.{BeforeEach, Test, Timeout}
 import play.api.libs.json.{JsString, Json}
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 import sttp.capabilities.WebSockets
 import sttp.client3.monad.IdMonad
 import sttp.client3.okhttp.OkHttpSyncBackend
@@ -1021,7 +1020,6 @@ trait WebSocketContract {
                 t.payload
               })
               .timeout(scala.concurrent.duration.Duration.fromNanos(100000000), Some(SMono.just("No notification received")))
-              .subscribeOn(Schedulers.elastic())
               .block()
 
           List(response, maybeNotification)

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
@@ -38,6 +38,7 @@ import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.{BeforeEach, Test, Timeout}
 import play.api.libs.json.{JsString, Json}
 import reactor.core.scala.publisher.SMono
+import reactor.core.scheduler.Schedulers
 import sttp.capabilities.WebSockets
 import sttp.client3.monad.IdMonad
 import sttp.client3.okhttp.OkHttpSyncBackend
@@ -1020,6 +1021,7 @@ trait WebSocketContract {
                 t.payload
               })
               .timeout(scala.concurrent.duration.Duration.fromNanos(100000000), Some(SMono.just("No notification received")))
+              .subscribeOn(Schedulers.boundedElastic())
               .block()
 
           List(response, maybeNotification)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/BasicAuthenticationStrategy.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/BasicAuthenticationStrategy.scala
@@ -31,10 +31,10 @@ import org.apache.james.jmap.exceptions.UnauthorizedException
 import org.apache.james.jmap.http.UserCredential._
 import org.apache.james.mailbox.{MailboxManager, MailboxSession}
 import org.apache.james.user.api.UsersRepository
+import org.apache.james.util.ReactorUtils
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 import reactor.netty.http.server.HttpServerRequest
 
 import scala.jdk.CollectionConverters._
@@ -130,5 +130,5 @@ class BasicAuthenticationStrategy @Inject()(val usersRepository: UsersRepository
 
   private def isValid(userCredential: UserCredential): SMono[Boolean] =
     SMono.fromCallable(() => usersRepository.test(userCredential.username, userCredential.password))
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/UserProvisioning.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/UserProvisioning.scala
@@ -27,8 +27,8 @@ import org.apache.james.jmap.JMAPConfiguration
 import org.apache.james.mailbox.MailboxSession
 import org.apache.james.metrics.api.MetricFactory
 import org.apache.james.user.api.{AlreadyExistInUsersRepositoryException, UsersRepository}
+import org.apache.james.util.ReactorUtils
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 
 class UserProvisioning @Inject() (usersRepository: UsersRepository, metricFactory: MetricFactory, jmapConfiguration: JMAPConfiguration = JMAPConfiguration.DEFAULT) {
   def provisionUser(session: MailboxSession): SMono[Unit] =
@@ -50,7 +50,7 @@ class UserProvisioning @Inject() (usersRepository: UsersRepository, metricFactor
 
   private def createAccount(username: Username): SMono[Unit] =
     SMono.fromCallable(() => usersRepository.addUser(username, generatePassword))
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
 
   private def needsAccountCreation(username: Username): SMono[Boolean] =
     SMono(usersRepository.containsReactive(username)).map(b => !b)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Email.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Email.scala
@@ -616,7 +616,7 @@ private class EmailFastViewReader @Inject()(messageIdManager: MessageIdManager,
         .hasAttachment(fullView.bodyMetadata.hasAttachment.value)
         .build()))
       .doOnError(e => EmailFastViewReader.logger.error(s"Cannot store the projection to MessageFastViewProjection for ${fullView.metadata.id}", e))
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.parallel())
       .subscribe()
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailSet.scala
@@ -42,7 +42,6 @@ import org.apache.james.mime4j.message.{BodyPartBuilder, MultipartBuilder}
 import org.apache.james.mime4j.stream.{Field, NameValuePair, RawField}
 import org.apache.james.util.html.HtmlTextExtractor
 import play.api.libs.json.JsObject
-import reactor.core.scheduler.Schedulers
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
@@ -190,7 +189,7 @@ case class EmailCreationRequest(mailboxIds: MailboxIds,
   }
 
   private def loadWithMetadata(blobResolvers: BlobResolvers, mailboxSession: MailboxSession)(attachment: Attachment): Either[Throwable, LoadedAttachment] =
-    Try(blobResolvers.resolve(attachment.blobId, mailboxSession).subscribeOn(Schedulers.elastic()).block())
+    Try(blobResolvers.resolve(attachment.blobId, mailboxSession).block())
       .toEither.flatMap(blob => load(blob).map(content => LoadedAttachment(attachment, blob, content)))
 
   private def load(blob: Blob): Either[Throwable, Array[Byte]] =

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailImportMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailImportMethod.scala
@@ -42,10 +42,10 @@ import org.apache.james.mime4j.codec.DecodeMonitor
 import org.apache.james.mime4j.dom.Message
 import org.apache.james.mime4j.message.DefaultMessageBuilder
 import org.apache.james.mime4j.stream.MimeConfig
+import org.apache.james.util.ReactorUtils
 import org.reactivestreams.Publisher
 import play.api.libs.json.JsError
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 import scala.util.{Try, Using}
 
@@ -98,7 +98,7 @@ class EmailImportMethod @Inject() (val metricFactory: MetricFactory,
     for {
       oldState <- retrieveState(capabilities, mailboxSession)
       importResults <- importEmails(request, mailboxSession)
-        .subscribeOn(Schedulers.elastic())
+        .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
       newState <- retrieveState(capabilities, mailboxSession)
     } yield {
       val updatedContext = updateProcessingContext(importResults, invocation.processingContext)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailSetCreatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailSetCreatePerformer.scala
@@ -38,9 +38,9 @@ import org.apache.james.mailbox.exception.{MailboxNotFoundException, OverQuotaEx
 import org.apache.james.mailbox.model.MailboxId
 import org.apache.james.mailbox.{MailboxManager, MailboxSession}
 import org.apache.james.mime4j.dom.Message
+import org.apache.james.util.ReactorUtils
 import org.apache.james.util.html.HtmlTextExtractor
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 import scala.jdk.OptionConverters._
 
@@ -105,7 +105,7 @@ class EmailSetCreatePerformer @Inject()(serializer: EmailSetSerializer,
               .fold(e => SMono.error(e),
               appendCommand => append(clientId, appendCommand, mailboxSession, mailboxIds))))
         .onErrorResume(e => SMono.just[CreationResult](CreationFailure(clientId, e)))
-        .subscribeOn(Schedulers.elastic())
+        .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
     }
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/IdentityGetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/IdentityGetMethod.scala
@@ -31,9 +31,9 @@ import org.apache.james.jmap.mail.{IdentityGet, IdentityGetRequest, IdentityGetR
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.mailbox.MailboxSession
 import org.apache.james.metrics.api.MetricFactory
+import org.apache.james.util.ReactorUtils
 import play.api.libs.json.{JsError, JsObject, JsSuccess}
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 class IdentityGetMethod @Inject() (identityRepository: IdentityRepository,
                                    val metricFactory: MetricFactory,
@@ -45,7 +45,7 @@ class IdentityGetMethod @Inject() (identityRepository: IdentityRepository,
     val requestedProperties: Properties = request.properties.getOrElse(IdentityGet.allProperties)
     (requestedProperties -- IdentityGet.allProperties match {
       case invalidProperties if invalidProperties.isEmpty() => getIdentities(request, mailboxSession)
-        .subscribeOn(Schedulers.elastic())
+        .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
         .map(identityGetResponse => Invocation(
           methodName = methodName,
           arguments = Arguments(IdentitySerializer.serialize(identityGetResponse, requestedProperties ++ IdentityGet.idProperty).as[JsObject]),

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MDNSendMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MDNSendMethod.scala
@@ -47,9 +47,9 @@ import org.apache.james.mime4j.stream.MimeConfig
 import org.apache.james.queue.api.MailQueueFactory.SPOOL
 import org.apache.james.queue.api.{MailQueue, MailQueueFactory}
 import org.apache.james.server.core.MailImpl
+import org.apache.james.util.ReactorUtils
 import play.api.libs.json.{JsError, JsObject, JsSuccess, Json}
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
@@ -121,7 +121,7 @@ class MDNSendMethod @Inject()(serializer: MDNSerializer,
           (MDNSendResults.merge(acc._1, creationResult) -> updatedProcessingContext)
         }
       }
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
 
   private def createMDNSend(session: MailboxSession,
                             identity: Identity,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxQueryMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxQueryMethod.scala
@@ -28,9 +28,9 @@ import org.apache.james.jmap.mail.{MailboxQueryRequest, MailboxQueryResponse}
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.mailbox.{MailboxSession, SystemMailboxesProvider}
 import org.apache.james.metrics.api.MetricFactory
+import org.apache.james.util.ReactorUtils
 import play.api.libs.json.{JsError, JsSuccess}
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 class MailboxQueryMethod @Inject()(systemMailboxesProvider: SystemMailboxesProvider,
                                    val metricFactory: MetricFactory,
@@ -68,5 +68,5 @@ class MailboxQueryMethod @Inject()(systemMailboxesProvider: SystemMailboxesProvi
         position = Position.zero,
         limit = Some(Limit.default)))
       .map(response => Invocation(methodName = methodName, arguments = Arguments(MailboxQuerySerializer.serialize(response)), methodCallId = invocation.methodCallId))
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetCreatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetCreatePerformer.scala
@@ -32,9 +32,9 @@ import org.apache.james.mailbox.exception.{InsufficientRightsException, MailboxE
 import org.apache.james.mailbox.model.{MailboxId, MailboxPath}
 import org.apache.james.mailbox.{MailboxManager, MailboxSession, SubscriptionManager}
 import org.apache.james.metrics.api.MetricFactory
+import org.apache.james.util.ReactorUtils
 import play.api.libs.json.{JsError, JsObject, JsPath, JsSuccess, Json, JsonValidationError}
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 import scala.util.Try
 
@@ -94,7 +94,7 @@ class MailboxSetCreatePerformer @Inject()(serializer: MailboxSerializer,
           (MailboxCreationResults(acc._1.created :+ creationResult), updatedProcessingContext)
         }
       }
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
   }
 
   private def createMailbox(mailboxSession: MailboxSession,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetDeletePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetDeletePerformer.scala
@@ -27,8 +27,8 @@ import org.apache.james.jmap.method.MailboxSetDeletePerformer.{MailboxDeletionFa
 import org.apache.james.mailbox.exception.MailboxNotFoundException
 import org.apache.james.mailbox.model.{FetchGroup, MailboxId, MessageRange}
 import org.apache.james.mailbox.{MailboxManager, MailboxSession, MessageManager, Role, SubscriptionManager}
+import org.apache.james.util.ReactorUtils
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 object MailboxSetDeletePerformer {
   sealed trait MailboxDeletionResult
@@ -76,7 +76,7 @@ class MailboxSetDeletePerformer @Inject()(mailboxManager: MailboxManager,
     MailboxGet.parse(mailboxIdFactory)(id)
       .fold(e => SMono.error(e),
         id => SMono.fromCallable(() => doDelete(mailboxSession, id, onDestroy))
-          .subscribeOn(Schedulers.elastic())
+          .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
           .`then`(SMono.just[MailboxDeletionResult](MailboxDeletionSuccess(id))))
 
   }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
@@ -32,8 +32,8 @@ import org.apache.james.mailbox.exception.{InsufficientRightsException, MailboxE
 import org.apache.james.mailbox.model.search.{MailboxQuery, PrefixedWildcard}
 import org.apache.james.mailbox.model.{MailboxId, MailboxPath}
 import org.apache.james.mailbox.{MailboxManager, MailboxSession, MessageManager, Role, SubscriptionManager}
+import org.apache.james.util.ReactorUtils
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 import scala.jdk.CollectionConverters._
 
@@ -121,7 +121,7 @@ class MailboxSetUpdatePerformer @Inject()(serializer: MailboxSerializer,
           subscriptionManager.unsubscribe(mailboxSession, mailbox.getMailboxPath.getName)
         }
       }).`then`(SMono.just[MailboxUpdateResult](MailboxUpdateSuccess(mailboxId)))
-        .subscribeOn(Schedulers.elastic())
+        .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
     })
       .getOrElse(SMono.just[MailboxUpdateResult](MailboxUpdateSuccess(mailboxId)))
   }
@@ -155,7 +155,7 @@ class MailboxSetUpdatePerformer @Inject()(serializer: MailboxSerializer,
           case e: Exception => MailboxUpdateFailure(unparsedMailboxId, e, Some(validatedPatch))
         }
       })
-        .subscribeOn(Schedulers.elastic())
+        .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
     } else {
       SMono.just[MailboxUpdateResult](MailboxUpdateSuccess(mailboxId))
     }
@@ -222,7 +222,7 @@ class MailboxSetUpdatePerformer @Inject()(serializer: MailboxSerializer,
     SFlux.merge(Seq(resetOperation, partialUpdatesOperation))
       .`then`()
       .`then`(SMono.just[MailboxUpdateResult](MailboxUpdateSuccess(mailboxId)))
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
 
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionSetCreatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionSetCreatePerformer.scala
@@ -12,9 +12,9 @@ import org.apache.james.jmap.json.{PushSerializer, PushSubscriptionSerializer}
 import org.apache.james.jmap.method.PushSubscriptionSetCreatePerformer.{CreationFailure, CreationResult, CreationResults, CreationSuccess}
 import org.apache.james.jmap.pushsubscription.{PushRequest, PushTTL, WebPushClient}
 import org.apache.james.mailbox.MailboxSession
+import org.apache.james.util.ReactorUtils
 import play.api.libs.json.{JsObject, JsPath, Json, JsonValidationError}
 import reactor.core.scala.publisher.{SFlux, SMono}
-import reactor.core.scheduler.Schedulers
 
 object PushSubscriptionSetCreatePerformer {
   trait CreationResult
@@ -82,7 +82,7 @@ class PushSubscriptionSetCreatePerformer @Inject()(pushSubscriptionRepository: P
         .`then`(SMono.just(subscription)))
       .map(subscription => CreationSuccess(clientId, PushSubscriptionCreationResponse(subscription.id, showExpires(subscription.expires, request))))
       .onErrorResume(e => SMono.just[CreationResult](CreationFailure(clientId, e)))
-      .subscribeOn(Schedulers.elastic)
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
 
   private def showExpires(expires: PushSubscriptionExpiredTime, request: PushSubscriptionCreationRequest): Option[PushSubscriptionExpiredTime] = request.expires match {
     case Some(requestExpires) if expires.eq(requestExpires) => None

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/pushsubscription/WebPushClient.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/pushsubscription/WebPushClient.scala
@@ -111,7 +111,7 @@ class DefaultWebPushClient @Inject()(configuration: PushClientConfiguration) ext
   private def validate(pushServerUrl: PushSubscriptionServerURL): SMono[PushSubscriptionServerURL] =
     if (configuration.preventServerSideRequestForgery) {
       SMono.just(pushServerUrl.value.getHost)
-        .flatMap(host => SMono.fromCallable(() => InetAddress.getByName(host)).subscribeOn(Schedulers.elastic()))
+        .flatMap(host => SMono.fromCallable(() => InetAddress.getByName(host)).subscribeOn(Schedulers.boundedElastic()))
         .handle[InetAddress]((inetAddress, sink) => validate(pushServerUrl, inetAddress).fold(sink.error, sink.next))
         .`then`(SMono.just(pushServerUrl))
     } else {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/DownloadRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/DownloadRoutes.scala
@@ -276,7 +276,7 @@ class DownloadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator:
             ProblemDetails(status = INTERNAL_SERVER_ERROR, detail = e.getMessage),
             INTERNAL_SERVER_ERROR)
       }
-      .subscribeOn(Schedulers.elastic)
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
       .asJava()
       .`then`
 
@@ -321,7 +321,7 @@ class DownloadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator:
         .status(OK)
         .send(ReactorUtils.toChunks(stream, BUFFER_SIZE)
           .map(Unpooled.wrappedBuffer(_))
-          .subscribeOn(Schedulers.elastic))
+          .subscribeOn(Schedulers.boundedElastic()))
         .`then`,
       asJavaConsumer[InputStream]((stream: InputStream) => stream.close())))
       .`then`

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/EventSourceRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/EventSourceRoutes.scala
@@ -44,6 +44,7 @@ import org.apache.james.jmap.json.{PushSerializer, ResponseSerializer}
 import org.apache.james.jmap.routes.PingPolicy.Interval
 import org.apache.james.jmap.{Endpoint, JMAPRoute, JMAPRoutes, InjectionKeys => JMAPInjectionKeys}
 import org.apache.james.mailbox.MailboxSession
+import org.apache.james.util.ReactorUtils
 import play.api.libs.json.Json
 import reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST
 import reactor.core.publisher.{Mono, Sinks}
@@ -129,7 +130,7 @@ case object NoPingPolicy extends PingPolicy {
   override def asFlux(): SFlux[PingMessage] = SFlux.never[PingMessage]()
 }
 case class PingEnabled(interval: Interval) extends PingPolicy {
-  override def asFlux(): SFlux[PingMessage] = SFlux.interval(interval.value seconds, Schedulers.elastic())
+  override def asFlux(): SFlux[PingMessage] = SFlux.interval(interval.value seconds, Schedulers.parallel())
     .map(_ => PingMessage(interval))
 }
 
@@ -177,7 +178,7 @@ class EventSourceRoutes@Inject() (@Named(InjectionKeys.RFC_8621) val authenticat
             .`then`
             .`then`(registerSSE(response, mailboxSession, options))))
       .onErrorResume(throwable => handleConnectionEstablishmentError(throwable, response))
-      .subscribeOn(Schedulers.elastic)
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
       .asJava()
       .`then`()
 
@@ -194,7 +195,7 @@ class EventSourceRoutes@Inject() (@Named(InjectionKeys.RFC_8621) val authenticat
         StateChangeListener(options.types, context.outbound),
         AccountIdRegistrationKey.of(session.getUser)))
       .doOnNext(newRegistration => context.withRegistration(newRegistration))
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(Schedulers.boundedElastic())
       .subscribe()
 
     SMono(response

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/JMAPApiRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/JMAPApiRoutes.scala
@@ -37,11 +37,11 @@ import org.apache.james.jmap.http.{Authenticator, UserProvisioning}
 import org.apache.james.jmap.json.ResponseSerializer
 import org.apache.james.jmap.{Endpoint, JMAPRoute, JMAPRoutes}
 import org.apache.james.mailbox.MailboxSession
+import org.apache.james.util.ReactorUtils
 import org.slf4j.{Logger, LoggerFactory}
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import reactor.core.publisher.Mono
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 import reactor.netty.http.server.{HttpServerRequest, HttpServerResponse}
 
 object JMAPApiRoutes {
@@ -69,7 +69,7 @@ class JMAPApiRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticator:
         .`then`(this.requestAsJsonStream(httpServerRequest)
           .flatMap(requestObject => this.process(requestObject, httpServerResponse, mailboxSession))))
       .onErrorResume(throwable => handleError(throwable, httpServerResponse))
-      .subscribeOn(Schedulers.elastic)
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
       .asJava()
       .`then`()
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/SessionRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/SessionRoutes.scala
@@ -35,11 +35,11 @@ import org.apache.james.jmap.http.rfc8621.InjectionKeys
 import org.apache.james.jmap.json.ResponseSerializer
 import org.apache.james.jmap.routes.SessionRoutes.{JMAP_SESSION, LOGGER, WELL_KNOWN_JMAP}
 import org.apache.james.jmap.{Endpoint, JMAPRoute, JMAPRoutes}
+import org.apache.james.util.ReactorUtils
 import org.slf4j.{Logger, LoggerFactory}
 import play.api.libs.json.Json
 import reactor.core.publisher.Mono
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 import reactor.netty.http.server.HttpServerResponse
 
 object SessionRoutes {
@@ -61,7 +61,7 @@ class SessionRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticator:
       }
       .flatMap(session => sendRespond(session, response))
       .onErrorResume(throwable => SMono.fromPublisher(errorHandling(throwable, response)))
-      .subscribeOn(Schedulers.elastic())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
       .asJava()
 
   private val redirectToSession: JMAPRoute.Action = JMAPRoutes.redirectTo(JMAP_SESSION)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
@@ -50,7 +50,6 @@ import org.slf4j.{Logger, LoggerFactory}
 import play.api.libs.json.Json
 import reactor.core.publisher.Mono
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 import reactor.netty.http.server.{HttpServerRequest, HttpServerResponse}
 
 case class TooBigUploadException() extends RuntimeException
@@ -111,7 +110,7 @@ class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: A
               INTERNAL_SERVER_ERROR)
         }
         .asJava()
-        .subscribeOn(Schedulers.elastic())
+        .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
         .`then`()
       case _ => response.status(BAD_REQUEST).send
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/JWTAuthenticationStrategy.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/JWTAuthenticationStrategy.java
@@ -28,12 +28,12 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.util.ReactorUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import reactor.netty.http.server.HttpServerRequest;
 
 public class JWTAuthenticationStrategy implements AuthenticationStrategy {
@@ -70,7 +70,7 @@ public class JWTAuthenticationStrategy implements AuthenticationStrategy {
                 }
 
                 return username;
-            }).subscribeOn(Schedulers.elastic()))
+            }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER))
             .map(mailboxManager::createSystemSession);
     }
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -213,7 +213,7 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
             attachment.put(SINK, sink);
 
             Disposable subscribe = sink.asFlux()
-                .publishOn(Schedulers.elastic())
+                .publishOn(Schedulers.boundedElastic())
                 .doOnNext(next -> {
                     try {
                         int amount = Math.min(next.length, size - written.get());

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
@@ -46,7 +46,6 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class DistributedMailboxAdapter implements Mailbox {
     public static class Factory implements MailboxAdapterFactory {
@@ -119,7 +118,6 @@ public class DistributedMailboxAdapter implements Mailbox {
         return Flux.from(metadataStore.stat(mailbox.getId()))
             .map(message -> new MessageMetaData(message.getMessageId().serialize(), message.getSize()))
             .collect(ImmutableList.toImmutableList())
-            .subscribeOn(Schedulers.elastic())
             .block();
     }
 

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/EmailQueryViewPopulator.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/EmailQueryViewPopulator.java
@@ -60,7 +60,6 @@ import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class EmailQueryViewPopulator {
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailQueryViewPopulator.class);
@@ -196,12 +195,7 @@ public class EmailQueryViewPopulator {
     }
 
     private Flux<MessageResult> listAllMessages(MessageManager messageManager, MailboxSession session) {
-        try {
-            return Iterators.toFlux(messageManager.getMessages(MessageRange.all(), FetchGroup.HEADERS, session))
-                .subscribeOn(Schedulers.elastic());
-        } catch (MailboxException e) {
-            return Flux.error(e);
-        }
+        return Flux.from(messageManager.getMessagesReactive(MessageRange.all(), FetchGroup.HEADERS, session));
     }
 
     private Message parseMessage(MessageResult messageResult) throws IOException, MailboxException {

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/MessageFastViewProjectionCorrector.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/MessageFastViewProjectionCorrector.java
@@ -56,7 +56,6 @@ import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class MessageFastViewProjectionCorrector {
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageFastViewProjectionCorrector.class);
@@ -219,13 +218,8 @@ public class MessageFastViewProjectionCorrector {
     }
 
     private Mono<MessageResult> retrieveContent(MessageManager messageManager, MailboxSession session, MessageUid uid) {
-        try {
-            return Iterators.toFlux(messageManager.getMessages(MessageRange.one(uid), FetchGroup.FULL_CONTENT, session))
-                .subscribeOn(Schedulers.elastic())
-                .next();
-        } catch (MailboxException e) {
-            return Mono.error(e);
-        }
+        return Flux.from(messageManager.getMessagesReactive(MessageRange.one(uid), FetchGroup.FULL_CONTENT, session))
+            .next();
     }
 
     private Pair<MessageId, MessageFastViewPrecomputedProperties> computeProjectionEntry(MessageResult messageResult) {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExportService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExportService.java
@@ -103,7 +103,7 @@ public class ExportService {
         PipedInputStream in = new PipedInputStream(out);
 
         writeUserMailboxesContent(username, out)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .subscribe();
 
         return in;
@@ -132,7 +132,7 @@ public class ExportService {
                 .fileExtension(FileExtension.ZIP)
                 .export())
             .sneakyThrow())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .then();
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
@@ -42,6 +42,7 @@ import org.apache.james.task.Task;
 import org.apache.james.task.Task.Result;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.util.ReactorUtils;
 import org.apache.james.webadmin.dto.MailboxResponse;
 import org.apache.james.webadmin.utils.MailboxHaveChildrenException;
 import org.apache.james.webadmin.validation.MailboxName;
@@ -54,7 +55,6 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class UserMailboxesService {
     private static final Logger LOGGER = LoggerFactory.getLogger(UserMailboxesService.class);
@@ -133,7 +133,7 @@ public class UserMailboxesService {
                     return Result.PARTIAL;
                 }
             })
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     public void deleteMailbox(Username username, MailboxName mailboxName) throws MailboxException, UsersRepositoryException, MailboxHaveChildrenException {

--- a/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
+++ b/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
@@ -102,7 +102,7 @@ public class MemoryMailQueueFactory implements MailQueueFactory<MemoryMailQueueF
             this.name = name;
             this.flux = Mono.fromCallable(mailItems::take)
                 .repeat()
-                .subscribeOn(Schedulers.elastic())
+                .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(item ->
                     Mono.fromRunnable(() -> inProcessingMailItems.add(item)).thenReturn(item), DEFAULT_CONCURRENCY)
                 .map(item -> mailQueueItemDecoratorFactory.decorate(item, name));

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
@@ -118,7 +118,7 @@ class Enqueuer {
 
         if (configuration.isMailQueuePublishConfirmEnabled()) {
             return sender.sendWithPublishConfirms(Mono.just(data))
-                .subscribeOn(Schedulers.elastic()) // channel.confirmSelect is synchronous
+                .subscribeOn(Schedulers.boundedElastic()) // channel.confirmSelect is synchronous
                 .next()
                 .handle((result, sink) -> {
                     if (!result.isAck()) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
@@ -139,7 +139,7 @@ public class RabbitMQMailQueue implements ManageableMailQueue {
     public Flux<String> republishNotProcessedMails(Instant olderThan) {
         Function<CassandraMailQueueBrowser.CassandraMailQueueItemView, Mono<String>> requeue = item ->
             enqueuer.reQueue(item)
-                .then(Mono.fromRunnable(item::dispose).subscribeOn(Schedulers.elastic()))
+                .then(Mono.fromRunnable(item::dispose).subscribeOn(Schedulers.boundedElastic()))
                 .thenReturn(item.getMail().getName());
 
         return mailQueueView.browseOlderThanReactive(olderThan)

--- a/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriber.java
+++ b/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriber.java
@@ -86,7 +86,7 @@ public class RabbitMQTerminationSubscriber implements TerminationSubscriber, Sta
         sendQueue = Sinks.many().unicast().onBackpressureBuffer();
         sendQueueHandle = sender
             .send(sendQueue.asFlux())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .subscribe();
 
         listener = Sinks.many().multicast().directBestEffort();
@@ -104,7 +104,7 @@ public class RabbitMQTerminationSubscriber implements TerminationSubscriber, Sta
                 receiverProvider::createReceiver,
                 receiver -> receiver.consumeAutoAck(queueName.asString()),
                 Receiver::close)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .map(this::toEvent)
             .handle(publishIfPresent())
             .subscribe(e -> listener.emitNext(e, FAIL_FAST));

--- a/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
+++ b/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
@@ -146,7 +146,7 @@ public class RabbitMQWorkQueue implements WorkQueue {
                 receiverProvider::createReceiver,
                 receiver -> receiver.consumeManualAck(QUEUE_NAME, new ConsumeOptions()),
                 Receiver::close)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .concatMap(this::executeTask)
             .subscribe();
     }
@@ -195,7 +195,7 @@ public class RabbitMQWorkQueue implements WorkQueue {
         sendCancelRequestsQueue = Sinks.many().unicast().onBackpressureBuffer();
         sendCancelRequestsQueueHandle = sender
             .send(sendCancelRequestsQueue.asFlux().map(this::makeCancelRequestMessage))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .subscribe();
     }
 
@@ -204,7 +204,7 @@ public class RabbitMQWorkQueue implements WorkQueue {
                 receiverProvider::createReceiver,
                 receiver -> receiver.consumeAutoAck(queueName),
                 Receiver::close)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .map(this::readCancelRequestMessage)
             .doOnNext(worker::cancelTask)
             .subscribe();

--- a/server/task/task-memory/src/main/java/org/apache/james/task/MemoryTaskManager.java
+++ b/server/task/task-memory/src/main/java/org/apache/james/task/MemoryTaskManager.java
@@ -157,7 +157,7 @@ public class MemoryTaskManager implements TaskManager {
     @Override
     public TaskExecutionDetails await(TaskId id, Duration timeout) throws TaskNotFoundException, ReachedTimeoutException {
         try {
-            return Flux.interval(NOW, AWAIT_POLLING_DURATION, Schedulers.elastic())
+            return Flux.interval(NOW, AWAIT_POLLING_DURATION, Schedulers.parallel())
                 .map(ignored -> getExecutionDetails(id))
                 .filter(details -> details.getStatus().isFinished())
                 .blockFirst(timeout);

--- a/server/task/task-memory/src/main/java/org/apache/james/task/MemoryWorkQueue.java
+++ b/server/task/task-memory/src/main/java/org/apache/james/task/MemoryWorkQueue.java
@@ -37,7 +37,7 @@ public class MemoryWorkQueue implements WorkQueue {
         this.worker = worker;
         this.tasks = Sinks.many().unicast().onBackpressureBuffer();
         this.subscription = tasks.asFlux()
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .limitRate(1)
             .concatMap(this::dispatchTaskToWorker)
             .subscribe();

--- a/server/task/task-memory/src/main/java/org/apache/james/task/SerialTaskManagerWorker.java
+++ b/server/task/task-memory/src/main/java/org/apache/james/task/SerialTaskManagerWorker.java
@@ -94,7 +94,7 @@ public class SerialTaskManagerWorker implements TaskManagerWorker {
 
     private Flux<TaskExecutionDetails.AdditionalInformation> pollAdditionalInformation(TaskWithId taskWithId) {
         return Mono.fromCallable(() -> taskWithId.getTask().details())
-            .delayElement(pollingInterval, Schedulers.elastic())
+            .delayElement(pollingInterval, Schedulers.parallel())
             .repeat()
             .handle(publishIfPresent())
             .flatMap(information -> Mono.from(listener.updated(taskWithId.getId(), information)).thenReturn(information), DEFAULT_CONCURRENCY);

--- a/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
+++ b/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
@@ -33,7 +33,6 @@ import org.apache.james.task._
 import org.apache.james.task.eventsourcing.TaskCommand._
 import reactor.core.publisher.{Flux, Mono}
 import reactor.core.scala.publisher.SMono
-import reactor.core.scheduler.Schedulers
 
 class EventSourcingTaskManager @Inject @VisibleForTesting private[eventsourcing](
                                                                                   workQueueSupplier: WorkQueueSupplier,
@@ -115,7 +114,6 @@ class EventSourcingTaskManager @Inject @VisibleForTesting private[eventsourcing]
         .`then`(details)
 
       Flux.merge(findEvent, details)
-        .subscribeOn(Schedulers.elastic)
         .blockFirst(timeout)
     } catch {
       case _: IllegalStateException => throw new ReachedTimeoutException


### PR DESCRIPTION
 -> Convert blocking non-reactor calls to boundedElastic
 -> Convert calls that wraps reactor.block call in a dedicated scheduler to avoid starvation
 -> Remove unneeded subscribeOn calls
 -> Reactify things slightly better where possible.

## TODO

 - [x] Performance tests, IMAP, JMAP
 - [x] jstack : we expect more control on the count of threads
 - [x] Run distributed integration tests
 - [x] Open a JIRA & reword this.
 
 ## Conclusion
 
 Equivalent performance for IMAP, JMAP draft, JMAP RFC-8621 and SMTP.
 
 Uncarefull .block calls leads to dead locks, we need to be carefull on this.
 
 