### PR TITLE
[PERF] More IMAP performance enhancement

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/ResultUtils.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/ResultUtils.java
@@ -38,6 +38,8 @@ import org.apache.james.mailbox.store.streaming.PartContentBuilder;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.parser.AbstractContentHandler;
 import org.apache.james.mime4j.parser.MimeStreamParser;
+import org.apache.james.mime4j.stream.BodyDescriptor;
+import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
 import org.apache.james.mime4j.stream.RawField;
@@ -53,9 +55,69 @@ public class ResultUtils {
         FetchGroup.Profile.FULL_CONTENT,
         FetchGroup.Profile.MIME_DESCRIPTOR);
 
+    private static class NoopBodyDescriptor implements BodyDescriptorBuilder {
+        static final NoopBodyDescriptor INSTANCE = new NoopBodyDescriptor();
+
+        @Override
+        public void reset() {
+
+        }
+
+        @Override
+        public Field addField(RawField rawField) {
+            return rawField;
+        }
+
+        @Override
+        public BodyDescriptor build() {
+            return new BodyDescriptor() {
+                @Override
+                public String getBoundary() {
+                    return null;
+                }
+
+                @Override
+                public String getMimeType() {
+                    return null;
+                }
+
+                @Override
+                public String getMediaType() {
+                    return null;
+                }
+
+                @Override
+                public String getSubType() {
+                    return null;
+                }
+
+                @Override
+                public String getCharset() {
+                    return null;
+                }
+
+                @Override
+                public String getTransferEncoding() {
+                    return null;
+                }
+
+                @Override
+                public long getContentLength() {
+                    return 0;
+                }
+            };
+        }
+
+        @Override
+        public BodyDescriptorBuilder newChild() {
+            return this;
+        }
+    }
+
     public static List<Header> createHeaders(MailboxMessage document) throws IOException {
         List<Header> results = new ArrayList<>();
-        MimeStreamParser parser = new MimeStreamParser(MimeConfig.PERMISSIVE);
+        MimeStreamParser parser = new MimeStreamParser(MimeConfig.PERMISSIVE, null, NoopBodyDescriptor.INSTANCE);
+
         parser.setContentHandler(new AbstractContentHandler() {
             @Override
             public void endHeader() {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/HeaderBodyElement.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/HeaderBodyElement.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
 import org.apache.james.imap.message.response.FetchResponse.BodyElement;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Header;
 
 /**
@@ -34,7 +33,7 @@ import org.apache.james.mailbox.model.Header;
  */
 public class HeaderBodyElement extends MimeBodyElement {
 
-    public HeaderBodyElement(String name, List<Header> headers) throws MailboxException {
+    public HeaderBodyElement(String name, List<Header> headers) {
         super(name, headers);
     }
     
@@ -49,7 +48,7 @@ public class HeaderBodyElement extends MimeBodyElement {
     }
 
     @Override
-    protected long calculateSize(List<Header> headers) throws MailboxException {
+    protected long calculateSize(List<Header> headers) {
         if (headers.isEmpty()) {
             // even if the headers are empty we need to include the headers body
             // seperator

--- a/server/container/util/src/test/java/org/apache/james/util/BodyOffsetInputStreamTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/BodyOffsetInputStreamTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.james.util.io.BodyOffsetInputStream;
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +54,14 @@ class BodyOffsetInputStreamTest {
         }
         assertThat(in.getBodyStartOffset()).isEqualTo(expectedOffset);
         assertThat(in.getReadBytes()).isEqualTo(bytes);
+        in.close();
+    }
+
+    @Test
+    void testReadWithArrayShouldPreserveContent() throws IOException {
+        BodyOffsetInputStream in = new BodyOffsetInputStream(new ByteArrayInputStream(mail.getBytes()));
+
+        assertThat(IOUtils.toByteArray(in)).isEqualTo(mail.getBytes());
         in.close();
     }
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
@@ -77,7 +77,7 @@ public class ChannelImapResponseWriter implements ImapResponseWriter {
                     channel.writeAndFlush(new ChunkedNioFile(fc, 8192));
                 }
             } else {
-                channel.writeAndFlush(new ChunkedStream(literal.getInputStream()));
+                channel.writeAndFlush(new ChunkedStream(in));
             }
         }
     }


### PR DESCRIPTION
## BodyOffsetInputStream

#### Before

![Screenshot from 2022-05-27 15-41-10](https://user-images.githubusercontent.com/6928740/170664257-2bd96b12-6145-4948-b0bb-4faeb88902ae.png)

#### After

![Screenshot from 2022-05-27 15-41-58](https://user-images.githubusercontent.com/6928740/170664277-67288714-0491-4980-abeb-54ea60c800eb.png)

Less time is spent reading data on input stream as we better leverage buffering.

Benefits storing messages (so also JMAP, SMTP)

## MimeBodyElement

#### Before

![Screenshot from 2022-05-27 15-43-46](https://user-images.githubusercontent.com/6928740/170664590-cab0be67-d834-4223-9b22-753162f92607.png)

#### After

![Screenshot from 2022-05-27 15-44-39](https://user-images.githubusercontent.com/6928740/170664731-b691c1ee-0805-454e-801e-0b16fb66a256.png)

(while still computing the input stream twice!)

