### PR TITLE
JAMES-3772 Close ReactorRabbitMQChannelPool synchronously

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -731,12 +731,10 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
 
                 if (!channel.isOpen() || !executeWithoutError(signalType)) {
                     pooledRef.invalidate()
-                        .subscribeOn(Schedulers.elastic())
                         .subscribe();
                     return;
                 }
                 pooledRef.release()
-                    .subscribeOn(Schedulers.elastic())
                     .subscribe();
             });
     }


### PR DESCRIPTION
Fixes:

```
org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPoolTest.notUsedChannelShouldBeClosedWhenPoolIsClosed
Error Message

Expecting value to be false but was true

Stacktrace

org.opentest4j.AssertionFailedError: 

Expecting value to be false but was true
	at org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPoolTest.notUsedChannelShouldBeClosedWhenPoolIsClosed(ReactorRabbitMQChannelPoolTest.java:117)
```