### PR TITLE
JAMES-343 Mail: Fix resetting DSN parameters

### DIFF
--- a/mailet/api/src/main/java/org/apache/mailet/DsnParameters.java
+++ b/mailet/api/src/main/java/org/apache/mailet/DsnParameters.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javax.mail.internet.AddressException;
 
@@ -385,6 +386,13 @@ public class DsnParameters {
                     .flatMap(attribute -> attribute.getValue().asMapAttributeValueOf(String.class));
 
             return new DsnAttributeValues(notify, orcpt, envId, ret);
+        }
+
+        public static void forEachDsnAttributeName(Consumer<AttributeName> action) {
+            action.accept(ENVID_ATTRIBUTE_NAME);
+            action.accept(RET_ATTRIBUTE_NAME);
+            action.accept(NOTIFY_ATTRIBUTE_NAME);
+            action.accept(ORCPT_ATTRIBUTE_NAME);
         }
 
         private final Optional<AttributeValue<Map<String, AttributeValue<String>>>> notifyAttributeValue;

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -444,6 +444,7 @@ public interface Mail extends Serializable, Cloneable {
     }
 
     default void setDsnParameters(DsnParameters dsnParameters) {
+        DsnParameters.DsnAttributeValues.forEachDsnAttributeName(this::removeAttribute);
         dsnParameters.toAttributes()
             .asAttributes()
             .forEach(this::setAttribute);

--- a/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
+++ b/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
@@ -405,6 +405,31 @@ public class MailImplTest extends ContractMailTest {
     }
 
     @Test
+    void setDsnParametersShouldUpdateStoredValue() throws Exception {
+        DsnParameters dsnParameters1 = DsnParameters.builder()
+            .envId(DsnParameters.EnvId.of("434554-55445-33443"))
+            .ret(DsnParameters.Ret.FULL)
+            .addRcptParameter(new MailAddress("bob@apache.org"), DsnParameters.RecipientDsnParameters.of(new MailAddress("andy@apache.org")))
+            .addRcptParameter(new MailAddress("cedric@apache.org"), DsnParameters.RecipientDsnParameters.of(EnumSet.of(DsnParameters.Notify.SUCCESS)))
+            .addRcptParameter(new MailAddress("domi@apache.org"), DsnParameters.RecipientDsnParameters.of(EnumSet.of(DsnParameters.Notify.FAILURE), new MailAddress("eric@apache.org")))
+            .build().get();
+        DsnParameters dsnParameters2 = DsnParameters.builder()
+            .envId(DsnParameters.EnvId.of("434554-55445-33434ee4"))
+            .addRcptParameter(new MailAddress("domi@apache.org"), DsnParameters.RecipientDsnParameters.of(EnumSet.of(DsnParameters.Notify.FAILURE), new MailAddress("eric@apache.org")))
+            .build().get();
+
+        MailImpl mail = MailImpl.builder()
+            .name("mail-id")
+            .build();
+
+        mail.setDsnParameters(dsnParameters1);
+        mail.setDsnParameters(dsnParameters2);
+
+        assertThat(mail.dsnParameters())
+            .contains(dsnParameters2);
+    }
+
+    @Test
     void dsnParametersShouldBeEmptyByDefault() {
         MailImpl mail = MailImpl.builder()
             .name("mail-id")


### PR DESCRIPTION
Updating from DSN_PARAMETERS_1 to DSN_PARAMETERS_2 where
DSN_PARAMETERS_2 misses some parameters present in
DSN_PARAMETERS_1 causes those parameters to still be present
in DSN_PARAMETERS_2.