### PR TITLE
[REACTOR] Revert subscribeOn call on get mailbox by id pipeline in Ma…

### DIFF
--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxGetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxGetMethod.scala
@@ -36,6 +36,7 @@ import org.apache.james.mailbox.model.search.MailboxQuery
 import org.apache.james.mailbox.model.{MailboxId, MailboxMetaData}
 import org.apache.james.mailbox.{MailboxManager, MailboxSession, SubscriptionManager}
 import org.apache.james.metrics.api.MetricFactory
+import org.apache.james.util.ReactorUtils
 import play.api.libs.json.{JsError, JsObject, JsSuccess}
 import reactor.core.scala.publisher.{SFlux, SMono}
 
@@ -145,6 +146,7 @@ class MailboxGetMethod @Inject() (serializer: MailboxSerializer,
         case _: MailboxNotFoundException => SMono.just(MailboxGetResults.notFound(mailboxId))
         case error => SMono.error(error)
       }
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
 
   private def filterShared(capabilities: Set[CapabilityIdentifier], mailbox: Mailbox): MailboxGetResults = {
     if (capabilities.contains(CapabilityIdentifier.JAMES_SHARES)) {


### PR DESCRIPTION
…ilboxGetMethod

This removal was making the test concurrencyChecksUponParentIdUpdate in MemoryMailboxSetMethodTest