### PR TITLE
JAMES-3773: Acquiring the Mailbox path lock on another dedicated Scheduler

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/JVMMailboxPathLocker.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/JVMMailboxPathLocker.java
@@ -19,6 +19,9 @@
 
 package org.apache.james.mailbox.store;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE;
+import static reactor.core.scheduler.Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -31,6 +34,8 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.reactivestreams.Publisher;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * {@link MailboxPathLocker} implementation which helps to synchronize the access the
@@ -39,6 +44,11 @@ import reactor.core.publisher.Mono;
  */
 public final class JVMMailboxPathLocker implements MailboxPathLocker {
     private final ConcurrentHashMap<MailboxPath, StampedLock> paths = new ConcurrentHashMap<>();
+
+    private static final int TTL_SECONDS = 60;
+    private static final boolean DAEMON = true;
+    public static final Scheduler LOCKER_WRAPPER = Schedulers.newBoundedElastic(DEFAULT_BOUNDED_ELASTIC_SIZE, DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
+        "jvm-path-locker", TTL_SECONDS, DAEMON);
 
     @Override
     public <T> T executeWithLock(MailboxPath path, LockAwareExecution<T> execution, LockType writeLock) throws MailboxException {
@@ -56,12 +66,14 @@ public final class JVMMailboxPathLocker implements MailboxPathLocker {
         switch (lockType) {
             case Read:
                 return Mono.using(stampedLock::readLock,
-                    stamp -> Mono.from(execution),
-                    stampedLock::unlockRead);
+                        stamp -> Mono.from(execution),
+                        stampedLock::unlockRead)
+                    .subscribeOn(LOCKER_WRAPPER);
             case Write:
                 return Mono.using(stampedLock::writeLock,
-                    stamp -> Mono.from(execution),
-                    stampedLock::unlockWrite);
+                        stamp -> Mono.from(execution),
+                        stampedLock::unlockWrite)
+                    .subscribeOn(LOCKER_WRAPPER);
             default:
                 throw new RuntimeException("Lock type not supported");
         }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/JVMMailboxPathLockerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/JVMMailboxPathLockerTest.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store;
+
+import java.time.Duration;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxPathLocker;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.junit.jupiter.api.RepeatedTest;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+class JVMMailboxPathLockerTest {
+    JVMMailboxPathLocker testee = new JVMMailboxPathLocker();
+
+    @RepeatedTest(20)
+    void concurrentExecutionShouldNotBeDeadlockedByTheWriteLock() throws Exception {
+        ConcurrentTestRunner.builder()
+            .operation((a, b) -> Mono.from(testee.executeReactiveWithLockReactive(MailboxPath.inbox(Username.of("bob")),
+                Mono.fromCallable(() -> {
+                    Thread.sleep(5);
+                    return null;
+                }).subscribeOn(Schedulers.boundedElastic()), MailboxPathLocker.LockType.Write))
+                .subscribeOn(Schedulers.boundedElastic()).block())
+            .threadCount(100)
+            .operationCount(10)
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
+    }
+
+    @RepeatedTest(20)
+    void concurrentExecutionShouldNotBeDeadlockedByTheReadLock() throws Exception {
+        ConcurrentTestRunner.builder()
+            .operation((a, b) -> Mono.from(testee.executeReactiveWithLockReactive(MailboxPath.inbox(Username.of("bob")),
+                    Mono.fromCallable(() -> {
+                        Thread.sleep(5);
+                        return null;
+                    }).subscribeOn(Schedulers.boundedElastic()), MailboxPathLocker.LockType.Read))
+                .subscribeOn(Schedulers.boundedElastic()).block())
+            .threadCount(100)
+            .operationCount(10)
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
+    }
+
+}


### PR DESCRIPTION
### Before
Nowadays when working with lock, we use the same Bounded Elastic scheduler for two stuff:
- Acquiring the lock (a thread)
- Execution task and releasing the lock (another thread - when we subscribe the execution on Bounded elastic again).

This could cause the deadlock situation when the bounded elastic pool is exhausted then the execution and lock releasing never happened.

Deadlock illustrate: Let's say we have a thread pool size = 2
Thread 1: need the lock, have thread pool resource (itself) but won't release the thread pool until finished
Thread 2: holding the lock, need a new thread from the thread pool for execution and releasing the lock and won't release the lock until finished
=> Deadlock

Our thread log: https://pastebin.com/9iVxLYra
`boundedElastic-8 Acquired the lock successfully. Trying to execute task...` There was no thread left in the bounded elastic pool for execution and releasing the lock.

### After
Schedule lock acquiring on a dedicated scheduler would solve this deadlock.
Log: https://pastebin.com/gSBqhtu0
