### PR TITLE
[REACTOR] Reactify CanSendFrom::userCanSendFrom

### DIFF
--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
@@ -24,8 +24,6 @@ import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.reactivestreams.Publisher;
 
-import reactor.core.publisher.Mono;
-
 public interface CanSendFrom {
 
     /**
@@ -33,9 +31,7 @@ public interface CanSendFrom {
      */
     boolean userCanSendFrom(Username connectedUser, Username fromUser);
 
-    default Publisher<Boolean> userCanSendFromReactive(Username connectedUser, Username fromUser) {
-        return Mono.just(userCanSendFrom(connectedUser, fromUser));
-    }
+    Publisher<Boolean> userCanSendFromReactive(Username connectedUser, Username fromUser);
 
     /**
      * For a given user, return all the addresses he can use in the from clause of an email.

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
@@ -22,6 +22,9 @@ import java.util.stream.Stream;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
 
 public interface CanSendFrom {
 
@@ -29,6 +32,10 @@ public interface CanSendFrom {
      * Indicate if the connectedUser can send a mail using the fromUser in the from clause.
      */
     boolean userCanSendFrom(Username connectedUser, Username fromUser);
+
+    default Publisher<Boolean> userCanSendFromReactive(Username connectedUser, Username fromUser) {
+        return Mono.just(userCanSendFrom(connectedUser, fromUser));
+    }
 
     /**
      * For a given user, return all the addresses he can use in the from clause of an email.

--- a/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/identity/IdentityRepositoryTest.scala
+++ b/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/identity/IdentityRepositoryTest.scala
@@ -84,14 +84,14 @@ class IdentityRepositoryTest {
 
   @Test
   def saveShouldSuccess(): Unit = {
-    when(identityFactory.userCanSendFrom(any(), any())).thenReturn(true)
+    when(identityFactory.userCanSendFrom(any(), any())).thenReturn(SMono.just(true))
     assertThatCode(() => SMono.fromPublisher(testee.save(BOB, CREATION_REQUEST)).block())
       .doesNotThrowAnyException()
   }
 
   @Test
   def saveShouldFailWhenUserCanNotSendFrom(): Unit = {
-    when(identityFactory.userCanSendFrom(any(), any())).thenReturn(false)
+    when(identityFactory.userCanSendFrom(any(), any())).thenReturn(SMono.just(false))
     assertThatThrownBy(() => SMono.fromPublisher(testee.save(BOB, CREATION_REQUEST)).block())
       .isInstanceOf(classOf[ForbiddenSendFromException])
   }
@@ -153,7 +153,7 @@ class IdentityRepositoryTest {
   @Test
   def updateShouldSuccessWhenCustomExistsAndAliasExists(): Unit = {
     when(identityFactory.listIdentities(BOB)).thenReturn(List(IDENTITY1))
-    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(true)
+    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(SMono.just(true))
     val customIdentity: Identity = SMono(customIdentityDAO.save(BOB, CREATION_REQUEST)).block()
 
     assertThatCode(() => SMono(testee.update(BOB, customIdentity.id, UPDATE_REQUEST)).block())
@@ -163,7 +163,7 @@ class IdentityRepositoryTest {
   @Test
   def updateShouldModifiedEntry(): Unit = {
     when(identityFactory.listIdentities(BOB)).thenReturn(List(IDENTITY1))
-    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(true)
+    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(SMono.just(true))
 
     val customIdentity: Identity = SMono(customIdentityDAO.save(BOB, CREATION_REQUEST)).block()
 
@@ -177,7 +177,7 @@ class IdentityRepositoryTest {
   @Test
   def updateShouldSuccessWhenMultiUpdateServerSetId(): Unit = {
     when(identityFactory.listIdentities(BOB)).thenReturn(List(IDENTITY1))
-    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(true)
+    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(SMono.just(true))
     SMono(testee.update(BOB, IDENTITY1.id, UPDATE_REQUEST)).block()
 
     assertThatCode(() => SMono.fromPublisher(testee.update(BOB, IDENTITY1.id, UPDATE_REQUEST.copy(name = Some(IdentityNameUpdate(IdentityName("Bob (3)")))))).block())
@@ -197,7 +197,7 @@ class IdentityRepositoryTest {
   @Test
   def updateShouldSuccessWhenSecondPartialUpdateServerSetId(): Unit = {
     when(identityFactory.listIdentities(BOB)).thenReturn(List(IDENTITY1))
-    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(true)
+    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(SMono.just(true))
 
     SMono(testee.update(BOB, IDENTITY1.id, UPDATE_REQUEST)).block()
     val secondUpdateWithName: IdentityUpdateRequest = IdentityUpdateRequest(name = Some(IdentityNameUpdate(name = IdentityName("Bob (3)"))))
@@ -218,11 +218,11 @@ class IdentityRepositoryTest {
 
   @Test
   def updateShouldFailWhenAliasNotExists(): Unit = {
-    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(true)
+    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(SMono.just(true))
 
     val identity: Identity = SMono.fromPublisher(testee.save(BOB, CREATION_REQUEST)).block()
 
-    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(false)
+    when(identityFactory.userCanSendFrom(BOB, BOB.asMailAddress())).thenReturn(SMono.just(false))
     when(identityFactory.listIdentities(BOB)).thenReturn(List())
 
     assertThatThrownBy(() => SMono.fromPublisher(testee.update(BOB, identity.id, UPDATE_REQUEST)).block())

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
@@ -35,8 +35,12 @@ import org.apache.james.rrt.api.AliasReverseResolver;
 import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.apache.james.util.ReactorUtils;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
 
 public class CanSendFromImpl implements CanSendFrom {
 
@@ -67,6 +71,12 @@ public class CanSendFromImpl implements CanSendFrom {
                 connectedUser.asString());
             return false;
         }
+    }
+
+    @Override
+    public Publisher<Boolean> userCanSendFromReactive(Username connectedUser, Username fromUser) {
+        return Mono.just(userCanSendFrom(connectedUser, fromUser))
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 
     @Override

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessorTest.java
@@ -272,7 +272,7 @@ public class SetMessagesUpdateProcessorTest {
 
         recipientRewriteTable.addAliasMapping(MappingSource.fromUser("alias", "example.com"), USER.asString());
 
-        assertThatCode(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
+        assertThatCode(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)).block())
             .doesNotThrowAnyException();
     }
 
@@ -282,8 +282,8 @@ public class SetMessagesUpdateProcessorTest {
 
         recipientRewriteTable.addAliasMapping(MappingSource.fromUser("alias", "example.com"), OTHER_USER.asString());
 
-        assertThatThrownBy(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
-            .isInstanceOf(MailboxSendingNotAllowedException.class);
+        assertThatThrownBy(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)).block())
+            .hasCause(new MailboxSendingNotAllowedException(USER, Optional.of(sender)));
     }
 
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailSubmissionSetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailSubmissionSetMethod.scala
@@ -52,6 +52,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import play.api.libs.json._
 import reactor.core.scala.publisher.{SFlux, SMono}
 import reactor.core.scheduler.Schedulers
+import reactor.util.concurrent.Queues
 
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
@@ -254,7 +255,7 @@ class EmailSubmissionSetMethod @Inject()(serializer: EmailSubmissionSetSerialize
       submissionId = EmailSubmissionId.generate
       message <- SMono.fromTry(toMimeMessage(submissionId.value, message))
       envelope <- SMono.fromTry(resolveEnvelope(message, request.envelope))
-      _ <- SMono.fromTry(validate(mailboxSession)(message, envelope))
+      _ <- validate(mailboxSession)(message, envelope)
       mail = {
         val mailImpl = MailImpl.builder()
           .name(submissionId.value)
@@ -283,21 +284,30 @@ class EmailSubmissionSetMethod @Inject()(serializer: EmailSubmissionSetSerialize
       })
   }
 
-  private def validate(session: MailboxSession)(mimeMessage: MimeMessage, envelope: Envelope): Try[MimeMessage] = {
-    val forbiddenMailFrom: List[String] = (Option(mimeMessage.getSender).toList ++ Option(mimeMessage.getFrom).toList.flatten)
+  private def validate(session: MailboxSession)(mimeMessage: MimeMessage, envelope: Envelope): SMono[MimeMessage] =
+    SFlux.fromIterable(Option(mimeMessage.getSender).toList ++ Option(mimeMessage.getFrom).toList.flatten)
       .map(_.asInstanceOf[InternetAddress].getAddress)
-      .filter(addressAsString => !canSendFrom.userCanSendFrom(session.getUser, Username.fromMailAddress(new MailAddress(addressAsString))))
-
-    if (forbiddenMailFrom.nonEmpty) {
-      Failure(ForbiddenMailFromException(forbiddenMailFrom))
-    } else if (envelope.rcptTo.isEmpty) {
-      Failure(NoRecipientException())
-    } else if (!canSendFrom.userCanSendFrom(session.getUser, Username.fromMailAddress(envelope.mailFrom.email))) {
-      Failure(ForbiddenFromException(envelope.mailFrom.email.asString))
-    } else {
-      Success(mimeMessage)
-    }
-  }
+      .filterWhen(addressAsString => SMono.fromPublisher(canSendFrom.userCanSendFromReactive(session.getUser, Username.fromMailAddress(new MailAddress(addressAsString))))
+        .map(Boolean.unbox(_)).map(!_), Queues.SMALL_BUFFER_SIZE)
+      .collectSeq()
+      .flatMap(forbiddenMailFrom => {
+        if (forbiddenMailFrom.nonEmpty) {
+          SMono.just(Failure(ForbiddenMailFromException(forbiddenMailFrom.toList)))
+        } else if (envelope.rcptTo.isEmpty) {
+          SMono.just(Failure(NoRecipientException()))
+        } else {
+          SMono.fromPublisher(canSendFrom.userCanSendFromReactive(session.getUser, Username.fromMailAddress(envelope.mailFrom.email)))
+            .filter(bool => bool.equals(false))
+            .map(_ => Failure(ForbiddenFromException(envelope.mailFrom.email.asString)))
+            .switchIfEmpty(SMono.just(Success(mimeMessage)))
+        }
+      })
+      .handle[MimeMessage]((aTry, sink) => {
+        aTry match {
+          case Success(mimeMessage) => sink.next(mimeMessage)
+          case Failure(ex) => sink.error(ex)
+        }
+      })
 
   private def resolveEnvelope(mimeMessage: MimeMessage, maybeEnvelope: Option[Envelope]): Try[Envelope] =
     maybeEnvelope.map(Success(_)).getOrElse(extractEnvelope(mimeMessage))


### PR DESCRIPTION
This change should improve the reactive chain where using CanSendFrom::userCanSendFrom (reactive).
One place left using this is `SenderAuthIdentifyVerificationRcptHook` (SMTP) which we could not migrate to reactive soon for now, therefore we need to keep CanSendFrom::userCanSendFrom (non-reactive).