### PR TITLE
Setting name for each container when run testcontainer 

### DIFF
--- a/backends-common/elasticsearch-v7/src/test/java/org/apache/james/backends/es/v7/DockerElasticSearch.java
+++ b/backends-common/elasticsearch-v7/src/test/java/org/apache/james/backends/es/v7/DockerElasticSearch.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.UUID;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -137,6 +138,7 @@ public interface DockerElasticSearch {
                 .withEnv("discovery.type", "single-node")
                 .withEnv("ES_JAVA_OPTS", "-Xms" + ES_MEMORY + "m -Xmx" + ES_MEMORY + "m")
                 .withAffinityToContainer()
+                .withName("james-testing-elasticsearch-" + UUID.randomUUID())
                 .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND));
         }
 
@@ -225,7 +227,8 @@ public interface DockerElasticSearch {
                         .withFileFromClasspath("Dockerfile", "auth-es/NginxDockerfile")))
                 .withExposedPorts(ES_HTTP_PORT)
                 .withLogConsumer(frame -> LOGGER.debug("[NGINX] " + frame.getUtf8String()))
-                .withNetwork(network);
+                .withNetwork(network)
+                .withName("james-testing-nginx-" + UUID.randomUUID());
         }
 
 

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainer.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainer.java
@@ -19,6 +19,7 @@
 package org.apache.james.mailbox.tika;
 
 import java.time.Duration;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.james.util.docker.DockerContainer;
@@ -40,7 +41,8 @@ public class TikaContainer extends ExternalResource {
         tika = DockerContainer.fromName(Images.TIKA)
                 .withExposedPorts(DEFAULT_TIKA_PORT)
                 .waitingFor(Wait.forHttp("/tika").withRateLimiter(RateLimiters.TWENTIES_PER_SECOND))
-                .withStartupTimeout(Duration.ofSeconds(30));
+                .withStartupTimeout(Duration.ofSeconds(30))
+                .withName("james-testing-tika-" + UUID.randomUUID());
     }
 
     @Override

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
@@ -76,6 +76,7 @@ public class LdapGenericContainer extends ExternalResource {
                 .withEnv("SLAPD_PASSWORD", password)
                 .withEnv("SLAPD_CONFIG_PASSWORD", password)
                 .withExposedPorts(LdapGenericContainer.DEFAULT_LDAP_PORT)
+                .withName("james-testing-openldap-" + UUID.randomUUID())
                 .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND));
         }
     }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinIntegrationTest.java
@@ -29,6 +29,7 @@ import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMin
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.util.UUID;
 
 import javax.mail.MessagingException;
 
@@ -63,7 +64,9 @@ class SpamAssassinIntegrationTest {
     public static DockerContainer spamAssassinContainer = DockerContainer.fromName(Images.SPAMASSASSIN)
         .withExposedPorts(783)
         .withAffinityToContainer()
-        .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND));
+        .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND))
+        .withName("james-testing-spamassassin-" + UUID.randomUUID());
+
     @RegisterExtension
     public TestIMAPClient messageReader = new TestIMAPClient();
     @RegisterExtension

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/testing/MockSmtpServerExtension.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/testing/MockSmtpServerExtension.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mock.smtp.server.testing;
 
+import java.util.UUID;
+
 import org.apache.james.mock.smtp.server.ConfigurationClient;
 import org.apache.james.util.Host;
 import org.apache.james.util.docker.DockerContainer;
@@ -46,7 +48,8 @@ public class MockSmtpServerExtension implements AfterEachCallback, BeforeAllCall
             mockSmtpServer = DockerContainer.fromName(Images.MOCK_SMTP_SERVER)
                 .withLogConsumer(outputFrame -> LOGGER.debug("MockSMTP: " + outputFrame.getUtf8String()))
                 .withExposedPorts(25, 8000)
-                .waitingFor(Wait.forLogMessage(".*Mock SMTP server started.*", 1));
+                .waitingFor(Wait.forLogMessage(".*Mock SMTP server started.*", 1))
+                .withName("james-testing-mock-smtp-server-" + UUID.randomUUID());
         }
 
         void start() {

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/ContainerTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/ContainerTest.java
@@ -36,7 +36,7 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 public class ContainerTest {
 
     @Rule
-    public DockerContainer container = DockerContainer.fromName(Images.NGINX)
+    public DockerContainer container = DockerContainer.fromName("nginx:1.22")
         .withAffinityToContainer()
         .withExposedPorts(80)
         .waitingFor(new HttpWaitStrategy()

--- a/server/testing/src/main/java/org/apache/james/util/docker/DockerContainer.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/DockerContainer.java
@@ -131,6 +131,11 @@ public class DockerContainer implements TestRule, BeforeAllCallback, AfterAllCal
         return this;
     }
 
+    public DockerContainer withName(String containerName) {
+        container.withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName(containerName));
+        return this;
+    }
+
     public Container.ExecResult exec(String... command) throws IOException, InterruptedException {
        return container.execInContainer(command);
     }

--- a/server/testing/src/main/java/org/apache/james/util/docker/Images.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/Images.java
@@ -22,10 +22,8 @@ package org.apache.james.util.docker;
 public interface Images {
     String FAKE_SMTP = "weave/rest-smtp-sink:latest";
     String RABBITMQ = "rabbitmq:3.9.18-management";
-    String ELASTICSEARCH_2 = "elasticsearch:2.4.6";
     String ELASTICSEARCH_6 = "docker.elastic.co/elasticsearch/elasticsearch:6.3.2";
     String ELASTICSEARCH_7 = "docker.elastic.co/elasticsearch/elasticsearch:7.10.2";
-    String NGINX = "nginx:1.22";
     String TIKA = "apache/tika:1.28.2";
     String SPAMASSASSIN = "instantlinux/spamassassin:3.4.6-1";
     String MOCK_SMTP_SERVER = "linagora/mock-smtp-server:0.4";

--- a/server/testing/src/main/java/org/apache/james/util/docker/Images.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/Images.java
@@ -22,6 +22,7 @@ package org.apache.james.util.docker;
 public interface Images {
     String FAKE_SMTP = "weave/rest-smtp-sink:latest";
     String RABBITMQ = "rabbitmq:3.9.18-management";
+    String ELASTICSEARCH_2 = "elasticsearch:2.4.6";
     String ELASTICSEARCH_6 = "docker.elastic.co/elasticsearch/elasticsearch:6.3.2";
     String ELASTICSEARCH_7 = "docker.elastic.co/elasticsearch/elasticsearch:7.10.2";
     String TIKA = "apache/tika:1.28.2";

--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -25,6 +25,7 @@ import static io.restassured.config.RestAssuredConfig.newConfig;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 import org.apache.james.util.docker.DockerContainer;
@@ -77,8 +78,8 @@ public class FakeSmtp implements TestRule, BeforeAllCallback, AfterAllCallback, 
             .withAffinityToContainer()
             .waitingFor(new HostPortWaitStrategy()
                 .withRateLimiter(RateLimiters.TWENTIES_PER_SECOND)
-                .withStartupTimeout(Duration.ofMinutes(1))
-            );
+                .withStartupTimeout(Duration.ofMinutes(1)))
+            .withName("james-testing-fake-smtp" + UUID.randomUUID());
     }
 
     private static final int SMTP_PORT = 25;


### PR DESCRIPTION
- By default, the testcontainer randomize the name for each container when start new.
The assign name of container will be easier to track on local when development