### PR TITLE
JAMES-3791 Remote Delivery uses a pool of SMTP sessions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2527,6 +2527,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>2.11.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>1.9</version>
             </dependency>

--- a/server/mailet/mailets/pom.xml
+++ b/server/mailet/mailets/pom.xml
@@ -216,6 +216,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mime4j-dom</artifactId>
         </dependency>


### PR DESCRIPTION
Remote Delivery now uses pools of SMTP and SMTPS sessions. This prevents a race condition in setting per-delivery properties.

The pools replace the former shared session objects. During tryDeliveryToHost(), the selectSession() method now borrows a session from the appropriate pool. Its properties can be changed as necessary for the current delivery. Once delivery is done, the new method releaseSession() finally returns this session to its pool. The pool resets any delivery specific properties to prevent information leaks.

The session pools are unbounded, so they can scale to whatever maximum thread concurrency is required. Otherwise, the default pool configuration should be fine.