### PR TITLE
JAMES-3791 Remote Delivery uses a pool of SMTP sessions (3.7.x)

### DIFF
--- a/server/mailet/mailets/pom.xml
+++ b/server/mailet/mailets/pom.xml
@@ -216,6 +216,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mime4j-dom</artifactId>
         </dependency>


### PR DESCRIPTION
Straight cherry-pick from master. As a critical bug fix, this should be in 3.7.x too.