### PR TITLE
JAMES-3792 Remote and Local delivery should log MIME MessageId

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/SimpleMailStore.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/SimpleMailStore.java
@@ -100,12 +100,21 @@ public class SimpleMailStore implements MailStore {
             return Mono.from(mailboxAppender.append(mail.getMessage(), username, locatedFolder))
                 .doOnSuccess(ids -> {
                     metric.increment();
-                    LOGGER.info("Local delivered mail {} successfully from {} to {} in folder {} with composedMessageId {}", mail.getName(),
-                        mail.getMaybeSender().asString(), recipient.asPrettyString(), locatedFolder, ids);
+                    LOGGER.info("Local delivered mail {} with messageId {} successfully from {} to {} in folder {} with composedMessageId {}",
+                        mail.getName(), getMessageId(mail), mail.getMaybeSender().asString(), recipient.asPrettyString(), locatedFolder, ids);
                 })
                 .then();
         } catch (MessagingException e) {
             throw new RuntimeException("Could not retrieve mail message content", e);
+        }
+    }
+    
+    private String getMessageId(Mail mail) {
+        try {
+            return mail.getMessage().getMessageID();
+        } catch (MessagingException e) {
+            LOGGER.debug("failed to extract messageId from message {}", mail.getName(), e);
+            return null;
         }
     }
 


### PR DESCRIPTION
[JAMES-3770](https://issues.apache.org/jira/browse/JAMES-3770) added the MIME MessageId on spooling, making it easier to communicate with other mail server operators in diagnosing inbound delivery issues ("Did you receive this message from us?").

It seems useful to log the MessageId on remote delivery too, covering the outbound direction of relaying as well. Likewise, we should log it on local delivery for the local-to-local path.

Together, this lets us track all paths by which a mail can cross the boundaries of our realm of responsibility.