### PR TITLE
JAMES-3791 Remote delivery pooling supports SMTPS

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
@@ -159,7 +159,7 @@ public class MailDelivrerToHost {
     }
 
     private String inContext(Session session, String name) {
-        if (session.getProperties().containsKey("mail.smtps.ssl.enable")) {
+        if ("true".equals(session.getProperties().getProperty("mail.smtps.ssl.enable"))) {
             return name.replace("smtp", "smtps");
         } else {
             return name;


### PR DESCRIPTION
When developing the pooling solution, I missed this line affected by the change. The solution relies on property defaults now, but containsKey() does not fall back to defaults. Hence need to use getProperty() here, which does.

Only affects SMTPS transports. Without this, Java Mail will not see the enveloper sender we set, but tries to extract it from the From: header. And I have seen people put rather strange things into From: headers...