### PR TITLE
JAMES-3796 Guice support the custom task in extension

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/extensions.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/extensions.adoc
@@ -1,11 +1,11 @@
 = Distributed James Server &mdash; extensions.properties
 :navtitle: extensions.properties
 
-This files enables an operator to define additional bindings used to instanciate others extensions
+This files enables an operator to define additional bindings used to instantiate others extensions
 
-*guice.extension.module*:  come separated list of fully qualified class name. These classes needs to implement Guice modules.
+*guice.extension.module*:  come separated list of fully qualified class name. These classes need to implement Guice modules.
 
-Here is an exemple of such a class :
+Here is an example of such a class :
 
 ....
 public class MyServiceModule extends AbstractModule {
@@ -24,5 +24,38 @@ guice.extension.module=com.project.MyServiceModule
 ....
 
 Enables to inject MyService into your extensions.
+
+
+*guice.extension.tasks*: come separated list of fully qualified class name.
+
+The extension can rely on the Task manager to supervise long-running task execution (progress, await, cancellation, scheduling...).
+These extensions need to implement Task extension modules.
+
+Here is an example of such a class :
+
+....
+public class RSpamDTaskExtensionModule implements TaskExtensionModule {
+
+    @Inject
+    public RSpamDTaskExtensionModule() {
+    }
+
+    @Override
+    public Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> taskDTOModules() {
+        return Set.of(...);
+    }
+
+    @Override
+    public Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> taskAdditionalInformationDTOModules() {
+        return Set.of(...);
+    }
+}
+....
+
+Recording it in extensions.properties :
+
+....
+guice.extension.tasks=com.project.RSpamDTaskExtensionModule
+....
 
 Read xref:extending/index.adoc#_defining_custom_injections_for_your_extensions[this page] for more details.

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/extending/index.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/extending/index.adoc
@@ -83,7 +83,7 @@ However, to inject an interface into your extension, you will need additional in
 
 To to so:
 
- * 1. Given an interface defined in a additional JAR:
+ * 1. Given an interface defined in an additional JAR:
 
 ....
 public interface MyService {}

--- a/server/container/guice/common/src/main/java/org/apache/james/modules/server/TaskSerializationModule.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/modules/server/TaskSerializationModule.java
@@ -19,30 +19,91 @@
 
 package org.apache.james.modules.server;
 
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.james.json.DTOConverter;
+import org.apache.james.server.task.json.TaskExtensionModule;
+import org.apache.james.server.task.json.TaskModuleInjectionKeys;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 import org.apache.james.server.task.json.dto.TaskDTO;
 import org.apache.james.server.task.json.dto.TaskDTOModule;
 import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.utils.ExtensionConfiguration;
+import org.apache.james.utils.GuiceGenericLoader;
+import org.apache.james.utils.NamingScheme;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 
 public class TaskSerializationModule extends AbstractModule {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(TaskSerializationModule.class);
+
+    @Provides
+    @Named(TaskModuleInjectionKeys.ADDITIONAL_INFORMATION_DTO)
+    @Singleton
+    public Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> provideAdditionalInformationDTOModules(
+        Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> additionalInformationDTOModules,
+        ExtensionConfiguration extensionConfiguration,
+        GuiceGenericLoader loader) {
+
+        Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> extensionAdditionalInformationDTOModules = extensionConfiguration.getTaskExtensions()
+            .stream()
+            .map(Throwing.function(loader.<TaskExtensionModule>withNamingSheme(NamingScheme.IDENTITY)::instantiate))
+            .map(TaskExtensionModule::taskAdditionalInformationDTOModules)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+
+        LOGGER.debug("TaskSerialization/AdditionalInformationDTOModule size = {}", extensionAdditionalInformationDTOModules.size());
+
+        return ImmutableSet.<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>>builder()
+            .addAll(additionalInformationDTOModules)
+            .addAll(extensionAdditionalInformationDTOModules)
+            .build();
+    }
+
+    @Provides
+    @Named(TaskModuleInjectionKeys.TASK_DTO)
+    @Singleton
+    public Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> provideTaskDTOModules(
+        Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> taskDTOModules,
+        ExtensionConfiguration extensionConfiguration,
+        GuiceGenericLoader loader) {
+
+        Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> extensionTaskDTOModules = extensionConfiguration.getTaskExtensions()
+            .stream()
+            .map(Throwing.function(loader.<TaskExtensionModule>withNamingSheme(NamingScheme.IDENTITY)::instantiate))
+            .map(TaskExtensionModule::taskDTOModules)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+
+        LOGGER.debug("TaskSerialization/TaskDTOModule size = {}", extensionTaskDTOModules.size());
+
+        return ImmutableSet.<TaskDTOModule<? extends Task, ? extends TaskDTO>>builder()
+            .addAll(taskDTOModules)
+            .addAll(extensionTaskDTOModules)
+            .build();
+    }
+
     @Provides
     @Singleton
-    public DTOConverter<TaskExecutionDetails.AdditionalInformation, AdditionalInformationDTO> additionalInformationDTOConverter(Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> modules) {
+    public DTOConverter<TaskExecutionDetails.AdditionalInformation, AdditionalInformationDTO> additionalInformationDTOConverter(@Named(TaskModuleInjectionKeys.ADDITIONAL_INFORMATION_DTO) Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> modules) {
         return new DTOConverter<>(modules);
     }
 
     @Provides
     @Singleton
-    public DTOConverter<Task, TaskDTO> taskDTOConverter(Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> taskDTOModules) {
+    public DTOConverter<Task, TaskDTO> taskDTOConverter(@Named(TaskModuleInjectionKeys.TASK_DTO) Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> taskDTOModules) {
         return new DTOConverter<>(taskDTOModules);
     }
 }

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/DistributedTaskSerializationModule.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/DistributedTaskSerializationModule.java
@@ -30,6 +30,7 @@ import org.apache.james.json.DTOConverter;
 import org.apache.james.json.DTOModule;
 import org.apache.james.modules.mailbox.ReIndexingTaskSerializationModule;
 import org.apache.james.server.task.json.JsonTaskSerializer;
+import org.apache.james.server.task.json.TaskModuleInjectionKeys;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 import org.apache.james.server.task.json.dto.TaskDTO;
@@ -100,8 +101,8 @@ public class DistributedTaskSerializationModule extends AbstractModule {
 
     @Named(EventNestedTypes.EVENT_NESTED_TYPES_INJECTION_NAME)
     @Provides
-    public Set<DTOModule<?, ? extends org.apache.james.json.DTO>> eventNestedTypes(Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends  AdditionalInformationDTO>> additionalInformationDTOModules,
-                                                                                   Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> taskDTOModules) {
+    public Set<DTOModule<?, ? extends org.apache.james.json.DTO>> eventNestedTypes(@Named(TaskModuleInjectionKeys.ADDITIONAL_INFORMATION_DTO) Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> additionalInformationDTOModules,
+                                                                                   @Named(TaskModuleInjectionKeys.TASK_DTO) Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> taskDTOModules) {
         return Sets.union(additionalInformationDTOModules, taskDTOModules);
     }
 }

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/TaskRoutesModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/TaskRoutesModule.java
@@ -29,6 +29,7 @@ import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.dto.DTOModuleInjections;
 import org.apache.james.webadmin.routes.TasksRoutes;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
@@ -48,9 +49,11 @@ public class TaskRoutesModule extends AbstractModule {
     @Named(DTOModuleInjections.WEBADMIN_DTO)
     @Provides
     @Singleton
-    public DTOConverter<TaskExecutionDetails.AdditionalInformation, AdditionalInformationDTO> additionalInformationDTOConverter(
-            @Named(DTOModuleInjections.WEBADMIN_DTO) Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> modules) {
-
-        return new DTOConverter<>(modules);
+    public DTOConverter<TaskExecutionDetails.AdditionalInformation, AdditionalInformationDTO> additionalInformationDTOConverter(@Named(DTOModuleInjections.WEBADMIN_DTO) Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> modules,
+                                                                                                                                @Named(DTOModuleInjections.CUSTOM_WEBADMIN_DTO) Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> customModules) {
+        return new DTOConverter<>(ImmutableSet.<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>>builder()
+            .addAll(modules)
+            .addAll(customModules)
+            .build());
     }
 }

--- a/server/container/guice/utils/src/main/java/org/apache/james/utils/ExtensionConfiguration.java
+++ b/server/container/guice/utils/src/main/java/org/apache/james/utils/ExtensionConfiguration.java
@@ -36,15 +36,24 @@ public class ExtensionConfiguration {
                 .collect(ImmutableList.toImmutableList()),
             Arrays.stream(configuration.getStringArray("guice.extension.startable"))
                 .map(ClassName::new)
+                .collect(ImmutableList.toImmutableList()),
+            Arrays.stream(configuration.getStringArray("guice.extension.task"))
+                .map(ClassName::new)
                 .collect(ImmutableList.toImmutableList()));
     }
 
     private final List<ClassName> additionalGuiceModulesForExtensions;
+    private final List<ClassName> taskExtensions;
     private final List<ClassName> startables;
 
     public ExtensionConfiguration(List<ClassName> additionalGuiceModulesForExtensions, List<ClassName> startables) {
+        this(additionalGuiceModulesForExtensions, startables, List.of());
+    }
+
+    public ExtensionConfiguration(List<ClassName> additionalGuiceModulesForExtensions, List<ClassName> startables, List<ClassName> taskExtensions) {
         this.additionalGuiceModulesForExtensions = additionalGuiceModulesForExtensions;
         this.startables = startables;
+        this.taskExtensions = taskExtensions;
     }
 
     public List<ClassName> getAdditionalGuiceModulesForExtensions() {
@@ -53,5 +62,9 @@ public class ExtensionConfiguration {
 
     public List<ClassName> getStartables() {
         return startables;
+    }
+
+    public List<ClassName> getTaskExtensions() {
+        return taskExtensions;
     }
 }

--- a/server/task/task-json/src/main/java/org/apache/james/server/task/json/JsonTaskAdditionalInformationSerializer.java
+++ b/server/task/task-json/src/main/java/org/apache/james/server/task/json/JsonTaskAdditionalInformationSerializer.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Set;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.apache.james.json.JsonGenericSerializer;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
@@ -52,7 +53,7 @@ public class JsonTaskAdditionalInformationSerializer {
     private JsonGenericSerializer<TaskExecutionDetails.AdditionalInformation, AdditionalInformationDTO> jsonGenericSerializer;
 
     @Inject
-    private JsonTaskAdditionalInformationSerializer(Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> modules) {
+    private JsonTaskAdditionalInformationSerializer(@Named(TaskModuleInjectionKeys.ADDITIONAL_INFORMATION_DTO) Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> modules) {
         jsonGenericSerializer = JsonGenericSerializer.forModules(modules).withoutNestedType();
     }
 

--- a/server/task/task-json/src/main/java/org/apache/james/server/task/json/JsonTaskSerializer.java
+++ b/server/task/task-json/src/main/java/org/apache/james/server/task/json/JsonTaskSerializer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Set;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.apache.james.json.JsonGenericSerializer;
 import org.apache.james.server.task.json.dto.TaskDTO;
@@ -55,7 +56,7 @@ public class JsonTaskSerializer {
 
     @Inject
     @VisibleForTesting
-    public JsonTaskSerializer(Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> modules) {
+    public JsonTaskSerializer(@Named(TaskModuleInjectionKeys.TASK_DTO) Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> modules) {
         jsonGenericSerializer = JsonGenericSerializer.forModules(modules).withoutNestedType();
     }
 

--- a/server/task/task-json/src/main/java/org/apache/james/server/task/json/TaskExtensionModule.java
+++ b/server/task/task-json/src/main/java/org/apache/james/server/task/json/TaskExtensionModule.java
@@ -17,9 +17,21 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.webadmin.dto;
+package org.apache.james.server.task.json;
 
-public interface DTOModuleInjections {
-    String WEBADMIN_DTO = "webadmin-dto";
-    String CUSTOM_WEBADMIN_DTO = "custom-webadmin-dto";
+import java.util.Set;
+
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+
+public interface TaskExtensionModule {
+
+    Set<TaskDTOModule<? extends Task, ? extends TaskDTO>> taskDTOModules();
+
+    Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> taskAdditionalInformationDTOModules();
+
 }

--- a/server/task/task-json/src/main/java/org/apache/james/server/task/json/TaskModuleInjectionKeys.java
+++ b/server/task/task-json/src/main/java/org/apache/james/server/task/json/TaskModuleInjectionKeys.java
@@ -17,9 +17,12 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.webadmin.dto;
+package org.apache.james.server.task.json;
 
-public interface DTOModuleInjections {
-    String WEBADMIN_DTO = "webadmin-dto";
-    String CUSTOM_WEBADMIN_DTO = "custom-webadmin-dto";
+public interface TaskModuleInjectionKeys {
+
+    String ADDITIONAL_INFORMATION_DTO = "additional_information_dto";
+
+    String TASK_DTO = "task_dto";
+
 }


### PR DESCRIPTION
## Why
- James is supporting the custom web admin (https://james.apache.org/howTo/custom-webadmin-routes.html), but It does not yet support the `task-json` in the extension. 

We got an error when trying to guice bind more `AdditionalInformationDTOModule` to Set in the extension module. 
Eg:

```java
    @Named(DTOModuleInjections.WEBADMIN_DTO)
    @ProvidesIntoSet
    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> webAdminFeedHamAdditionalInformation() {
        return FeedHamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE;
    }
```

-> It will be better if have a mechanism for support that 

## How 
- Add one more configure for `webadmin-dto` guice in `webadmin.properties`. Eg: `extensions.dtos=org.apache.james.modules.server.WebAdminDTOExtensionModuleImpl` 
- Add one more configure for `task-json` guice in `extensions.properties` 
Eg: `guice.extension.task=org.apache.james.server.task.json.TaskExtensionModuleImpl` 

