### PR TITLE
JAMES-3791 Increase FakeSmtp timeout

### DIFF
--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -111,7 +111,7 @@ public class FakeSmtp implements TestRule, BeforeAllCallback, AfterAllCallback, 
     }
 
     public void assertEmailReceived(Consumer<ValidatableResponse> expectations) {
-        Awaitility.await().atMost(Duration.ofSeconds(15))
+        Awaitility.await().atMost(Duration.ofMinutes(2))
             .untilAsserted(() -> expectations.accept(
                 given(requestSpecification(), RESPONSE_SPECIFICATION)
                     .get("/api/email")


### PR DESCRIPTION
GatewayRemoteDeliveryIntegrationTest::mailFromShouldBePreservedUponConcurrency
can take more than 15 secondes on the Apache CI.