### PR TITLE
JAMES-3799 Get rid of Body FetchType

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
@@ -50,7 +50,7 @@ public class AttachmentLoader {
     }
 
     private Mono<List<MessageAttachmentMetadata>> loadAttachments(Stream<MessageAttachmentRepresentation> messageAttachmentRepresentations, MessageMapper.FetchType fetchType) {
-        if (fetchType == MessageMapper.FetchType.BODY || fetchType == MessageMapper.FetchType.FULL) {
+        if (fetchType == MessageMapper.FetchType.FULL) {
             return getAttachments(messageAttachmentRepresentations.collect(ImmutableList.toImmutableList()));
         } else {
             return Mono.just(ImmutableList.of());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -331,9 +331,6 @@ public class CassandraMessageDAO {
                 return getFullContent(headerId, bodyId);
             case HEADERS:
                 return getContent(headerId, SIZE_BASED);
-            case BODY:
-                return getContent(bodyId, LOW_COST)
-                    .map(data -> Bytes.concat(new byte[bodyStartOctet], data));
             case METADATA:
                 return Mono.just(EMPTY_BYTE_ARRAY);
             default:

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
@@ -404,9 +404,6 @@ public class CassandraMessageDAOV3 {
                 return getFullContent(headerId, bodyId);
             case HEADERS:
                 return getContent(headerId, SIZE_BASED);
-            case BODY:
-                return getContent(bodyId, LOW_COST)
-                    .map(data -> Bytes.concat(new byte[bodyStartOctet], data));
             case METADATA:
                 return Mono.just(EMPTY_BYTE_ARRAY);
             default:

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
@@ -74,8 +74,7 @@ class CassandraMessageDAOTest {
             CassandraSchemaVersionModule.MODULE);
 
     @RegisterExtension
-    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
-            MODULES);
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULES);
 
     private CassandraMessageDAO testee;
     private CassandraMessageId.Factory messageIdFactory;
@@ -146,22 +145,6 @@ class CassandraMessageDAOTest {
 
         assertThat(IOUtils.toString(attachmentRepresentation.getContent().getInputStream(), StandardCharsets.UTF_8))
             .isEqualTo(CONTENT);
-    }
-
-    @Test
-    void saveShouldStoreMessageWithBodyContent() throws Exception {
-        message = createMessage(messageId, threadId, CONTENT, BODY_START, new PropertyBuilder(), NO_ATTACHMENT);
-
-        testee.save(message).block();
-
-        MessageRepresentation attachmentRepresentation =
-            toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.BODY));
-
-        byte[] expected = Bytes.concat(
-            new byte[BODY_START],
-            CONTENT.substring(BODY_START).getBytes(StandardCharsets.UTF_8));
-        assertThat(IOUtils.toString(attachmentRepresentation.getContent().getInputStream(), StandardCharsets.UTF_8))
-            .isEqualTo(IOUtils.toString(new ByteArrayInputStream(expected), StandardCharsets.UTF_8));
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3Test.java
@@ -20,7 +20,6 @@ package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
@@ -58,7 +57,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Bytes;
 
 import reactor.core.publisher.Mono;
 
@@ -151,22 +149,6 @@ class CassandraMessageDAOV3Test {
 
         assertThat(IOUtils.toString(attachmentRepresentation.getContent().getInputStream(), StandardCharsets.UTF_8))
             .isEqualTo(CONTENT);
-    }
-
-    @Test
-    void saveShouldStoreMessageWithBodyContent() throws Exception {
-        message = createMessage(messageId, threadId, CONTENT, BODY_START, new PropertyBuilder(), NO_ATTACHMENT);
-
-        testee.save(message).block();
-
-        MessageRepresentation attachmentRepresentation =
-            toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.BODY));
-
-        byte[] expected = Bytes.concat(
-            new byte[BODY_START],
-            CONTENT.substring(BODY_START).getBytes(StandardCharsets.UTF_8));
-        assertThat(IOUtils.toString(attachmentRepresentation.getContent().getInputStream(), StandardCharsets.UTF_8))
-            .isEqualTo(IOUtils.toString(new ByteArrayInputStream(expected), StandardCharsets.UTF_8));
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -78,7 +78,6 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             CassandraConfiguration.DEFAULT_CONFIGURATION,
             BatchSizes.builder()
                 .fetchMetadata(3)
-                .fetchBody(3)
                 .fetchHeaders(3)
                 .fetchFull(3)
                 .build());
@@ -115,7 +114,6 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             CassandraConfiguration.DEFAULT_CONFIGURATION,
             BatchSizes.builder()
                 .fetchMetadata(3)
-                .fetchBody(3)
                 .fetchHeaders(3)
                 .fetchFull(3)
                 .build());

--- a/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndexTest.java
+++ b/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndexTest.java
@@ -229,24 +229,16 @@ class SimpleMessageSearchIndexTest extends AbstractMessageSearchIndexTest {
     
     @Test
     public void canCompareFetchTypes() {
-        assertThat(FetchType.values()).containsExactly(FetchType.METADATA, FetchType.HEADERS, FetchType.BODY, FetchType.FULL);
+        assertThat(FetchType.values()).containsExactly(FetchType.METADATA, FetchType.HEADERS, FetchType.FULL);
         
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.METADATA, FetchType.METADATA)).isEqualTo(FetchType.METADATA);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.METADATA, FetchType.HEADERS)).isEqualTo(FetchType.HEADERS);
-        assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.METADATA, FetchType.BODY)).isEqualTo(FetchType.BODY);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.METADATA, FetchType.FULL)).isEqualTo(FetchType.FULL);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.HEADERS, FetchType.HEADERS)).isEqualTo(FetchType.HEADERS);
-        assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.HEADERS, FetchType.BODY)).isEqualTo(FetchType.BODY);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.HEADERS, FetchType.FULL)).isEqualTo(FetchType.FULL);
-        assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.BODY, FetchType.BODY)).isEqualTo(FetchType.BODY);
-        assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.BODY, FetchType.FULL)).isEqualTo(FetchType.FULL);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.FULL, FetchType.FULL)).isEqualTo(FetchType.FULL);
-
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.HEADERS, FetchType.METADATA)).isEqualTo(FetchType.HEADERS);
-        assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.BODY, FetchType.METADATA)).isEqualTo(FetchType.BODY);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.FULL, FetchType.METADATA)).isEqualTo(FetchType.FULL);
-        assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.BODY, FetchType.HEADERS)).isEqualTo(FetchType.BODY);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.FULL, FetchType.HEADERS)).isEqualTo(FetchType.FULL);
-        assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.FULL, FetchType.BODY)).isEqualTo(FetchType.FULL);
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/BatchSizes.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/BatchSizes.java
@@ -38,7 +38,6 @@ public class BatchSizes {
         return new Builder()
                 .fetchMetadata(batchSize)
                 .fetchHeaders(batchSize)
-                .fetchBody(batchSize)
                 .fetchFull(batchSize)
                 .copyBatchSize(batchSize)
                 .moveBatchSize(batchSize)
@@ -53,7 +52,6 @@ public class BatchSizes {
 
         private Optional<Integer> fetchMetadata;
         private Optional<Integer> fetchHeaders;
-        private Optional<Integer> fetchBody;
         private Optional<Integer> fetchFull;
         private Optional<Integer> copyBatchSize;
         private Optional<Integer> moveBatchSize;
@@ -61,7 +59,6 @@ public class BatchSizes {
         private Builder() {
             fetchMetadata = Optional.empty();
             fetchHeaders = Optional.empty();
-            fetchBody = Optional.empty();
             fetchFull = Optional.empty();
             copyBatchSize = Optional.empty();
             moveBatchSize = Optional.empty();
@@ -76,12 +73,6 @@ public class BatchSizes {
         public Builder fetchHeaders(int batchSize) {
             Preconditions.checkArgument(batchSize > 0, "'fetchHeaders' must be greater than zero");
             this.fetchHeaders = Optional.of(batchSize);
-            return this;
-        }
-
-        public Builder fetchBody(int batchSize) {
-            Preconditions.checkArgument(batchSize > 0, "'fetchBody' must be greater than zero");
-            this.fetchBody = Optional.of(batchSize);
             return this;
         }
 
@@ -107,7 +98,6 @@ public class BatchSizes {
             return new BatchSizes(
                     fetchMetadata.orElse(DEFAULT_BATCH_SIZE),
                     fetchHeaders.orElse(DEFAULT_BATCH_SIZE),
-                    fetchBody.orElse(DEFAULT_BATCH_SIZE),
                     fetchFull.orElse(DEFAULT_BATCH_SIZE),
                     copyBatchSize,
                     moveBatchSize);
@@ -116,15 +106,13 @@ public class BatchSizes {
 
     private final int fetchMetadata;
     private final int fetchHeaders;
-    private final int fetchBody;
     private final int fetchFull;
     private final Optional<Integer> copyBatchSize;
     private final Optional<Integer> moveBatchSize;
 
-    private BatchSizes(int fetchMetadata, int fetchHeaders, int fetchBody, int fetchFull, Optional<Integer> copyBatchSize, Optional<Integer> moveBatchSize) {
+    private BatchSizes(int fetchMetadata, int fetchHeaders, int fetchFull, Optional<Integer> copyBatchSize, Optional<Integer> moveBatchSize) {
         this.fetchMetadata = fetchMetadata;
         this.fetchHeaders = fetchHeaders;
-        this.fetchBody = fetchBody;
         this.fetchFull = fetchFull;
         this.copyBatchSize = copyBatchSize;
         this.moveBatchSize = moveBatchSize;
@@ -138,10 +126,6 @@ public class BatchSizes {
         return fetchHeaders;
     }
 
-    public int getFetchBody() {
-        return fetchBody;
-    }
-
     public int getFetchFull() {
         return fetchFull;
     }
@@ -152,8 +136,6 @@ public class BatchSizes {
                 return fetchMetadata;
             case HEADERS:
                 return fetchHeaders;
-            case BODY:
-                return fetchBody;
             case FULL:
                 return fetchFull;
         }
@@ -174,7 +156,6 @@ public class BatchSizes {
             BatchSizes other = (BatchSizes) obj;
             return Objects.equal(this.fetchMetadata, other.fetchMetadata)
                 && Objects.equal(this.fetchHeaders, other.fetchHeaders)
-                && Objects.equal(this.fetchBody, other.fetchBody)
                 && Objects.equal(this.fetchFull, other.fetchFull)
                 && Objects.equal(this.copyBatchSize, other.copyBatchSize)
                 && Objects.equal(this.moveBatchSize, other.moveBatchSize);
@@ -184,7 +165,7 @@ public class BatchSizes {
 
     @Override
     public final int hashCode() {
-        return Objects.hashCode(this.fetchMetadata, this.fetchHeaders, this.fetchBody, this.fetchFull, this.copyBatchSize, this.moveBatchSize);
+        return Objects.hashCode(this.fetchMetadata, this.fetchHeaders, this.fetchFull, this.copyBatchSize, this.moveBatchSize);
     }
 
     @Override
@@ -192,7 +173,6 @@ public class BatchSizes {
         return MoreObjects.toStringHelper(BatchSizes.class)
                 .add("fetchMetadata", fetchMetadata)
                 .add("fetchHeaders", fetchHeaders)
-                .add("fetchBody", fetchBody)
                 .add("fetchFull", fetchFull)
                 .add("copyBatchSize", copyBatchSize)
                 .add("moveBatchSize", moveBatchSize)

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/FetchGroupConverter.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/FetchGroupConverter.java
@@ -54,19 +54,12 @@ public class FetchGroupConverter {
     public static MessageMapper.FetchType reduce(Collection<MessageMapper.FetchType> fetchTypes) {
         boolean full = fetchTypes.contains(MessageMapper.FetchType.FULL);
         boolean headers = fetchTypes.contains(MessageMapper.FetchType.HEADERS);
-        boolean body = fetchTypes.contains(MessageMapper.FetchType.BODY);
 
         if (full) {
             return MessageMapper.FetchType.FULL;
         }
-        if (headers && body) {
-            return MessageMapper.FetchType.FULL;
-        }
         if (headers) {
             return MessageMapper.FetchType.HEADERS;
-        }
-        if (body) {
-            return MessageMapper.FetchType.BODY;
         }
         return MessageMapper.FetchType.METADATA;
     }
@@ -76,7 +69,6 @@ public class FetchGroupConverter {
             case HEADERS:
                 return MessageMapper.FetchType.HEADERS;
             case BODY_CONTENT:
-                return MessageMapper.FetchType.BODY;
             case FULL_CONTENT:
             case MIME_CONTENT:
             case MIME_HEADERS:

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -306,14 +306,6 @@ public interface MessageMapper extends Mapper {
          * </p>
          */
         HEADERS,
-        /**
-         * Fetch the {@link #METADATA} and the Body for the {@link MailboxMessage}. This includes:
-         * 
-         * <p>
-         *  {@link MailboxMessage#getBodyContent()}
-         * </p>
-         */
-        BODY,
         
         /**
          * Fetch the complete {@link MailboxMessage}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/BatchSizesTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/BatchSizesTest.java
@@ -37,7 +37,6 @@ class BatchSizesTest {
         BatchSizes batchSizes = BatchSizes.defaultValues();
         assertThat(batchSizes.getFetchMetadata()).isEqualTo(BatchSizes.DEFAULT_BATCH_SIZE);
         assertThat(batchSizes.getFetchHeaders()).isEqualTo(BatchSizes.DEFAULT_BATCH_SIZE);
-        assertThat(batchSizes.getFetchBody()).isEqualTo(BatchSizes.DEFAULT_BATCH_SIZE);
         assertThat(batchSizes.getFetchFull()).isEqualTo(BatchSizes.DEFAULT_BATCH_SIZE);
         assertThat(batchSizes.getCopyBatchSize()).isEmpty();
         assertThat(batchSizes.getMoveBatchSize()).isEmpty();
@@ -49,7 +48,6 @@ class BatchSizesTest {
         BatchSizes batchSizes = BatchSizes.uniqueBatchSize(batchSize);
         assertThat(batchSizes.getFetchMetadata()).isEqualTo(batchSize);
         assertThat(batchSizes.getFetchHeaders()).isEqualTo(batchSize);
-        assertThat(batchSizes.getFetchBody()).isEqualTo(batchSize);
         assertThat(batchSizes.getFetchFull()).isEqualTo(batchSize);
         assertThat(batchSizes.getCopyBatchSize()).contains(batchSize);
         assertThat(batchSizes.getMoveBatchSize()).contains(batchSize);
@@ -80,20 +78,6 @@ class BatchSizesTest {
     void fetchHeadersShouldThrowWhenZero() {
         assertThatThrownBy(() -> BatchSizes.builder()
                 .fetchHeaders(0))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void fetchBodyShouldThrowWhenNegative() {
-        assertThatThrownBy(() -> BatchSizes.builder()
-                .fetchBody(-1))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void fetchBodyShouldThrowWhenZero() {
-        assertThatThrownBy(() -> BatchSizes.builder()
-                .fetchBody(0))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -169,22 +153,6 @@ class BatchSizesTest {
                 .fetchHeaders(expected)
                 .build();
         assertThat(batchSizes.getFetchHeaders()).isEqualTo(expected);
-    }
-
-    @Test
-    void buildShouldSetDefaultValueToFetchBodyWhenNotGiven() {
-        BatchSizes batchSizes = BatchSizes.builder()
-                .build();
-        assertThat(batchSizes.getFetchBody()).isEqualTo(BatchSizes.DEFAULT_BATCH_SIZE);
-    }
-
-    @Test
-    void buildShouldSetValueToFetchBodyWhenGiven() {
-        int expected = 123;
-        BatchSizes batchSizes = BatchSizes.builder()
-                .fetchBody(expected)
-                .build();
-        assertThat(batchSizes.getFetchBody()).isEqualTo(expected);
     }
 
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/FetchGroupConverterTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/FetchGroupConverterTest.java
@@ -39,7 +39,7 @@ class FetchGroupConverterTest {
         return Stream.of(
             Arguments.arguments(FetchGroup.MINIMAL, FetchType.METADATA),
             Arguments.arguments(FetchGroup.HEADERS, FetchType.HEADERS),
-            Arguments.arguments(FetchGroup.BODY_CONTENT, FetchType.BODY),
+            Arguments.arguments(FetchGroup.BODY_CONTENT, FetchType.FULL),
             Arguments.arguments(FetchGroup.FULL_CONTENT, FetchType.FULL),
             Arguments.arguments(FetchGroup.BODY_CONTENT.with(Profile.HEADERS), FetchType.FULL),
             Arguments.arguments(FetchGroup.MINIMAL.with(Profile.MIME_CONTENT), FetchType.FULL),

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMessageAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMessageAssertTest.java
@@ -79,7 +79,7 @@ class MailboxMessageAssertTest {
     }
 
     @Test
-    void messageAssertShouldFailWhenBodyMismatchInFetchBodyMode() {
+    void messageAssertShouldFailWhenBodyMismatchInFetchFullMode() {
         String headerString = "name: headerName\n\n";
         String bodyString = "body\n.\n";
         Date date = new Date();
@@ -93,7 +93,7 @@ class MailboxMessageAssertTest {
             headerString.length(), new ByteContent((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message2.setUid(UID);
 
-        assertThatThrownBy(() -> MessageAssert.assertThat(message1).isEqualTo(message2, MessageMapper.FetchType.BODY))
+        assertThatThrownBy(() -> MessageAssert.assertThat(message1).isEqualTo(message2, MessageMapper.FetchType.FULL))
             .isInstanceOf(AssertionError.class);
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageAssert.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageAssert.java
@@ -59,7 +59,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, MailboxMessage>
 
     public MessageAssert isEqualToWithoutUid(MailboxMessage expected, MessageMapper.FetchType usedFetchType) throws IOException {
         isEqualToWithoutUidAndAttachment(expected, usedFetchType);
-        if (usedFetchType == MessageMapper.FetchType.FULL || usedFetchType == MessageMapper.FetchType.BODY) {
+        if (usedFetchType == MessageMapper.FetchType.FULL) {
             if (!Objects.equal(actual.getAttachments(), expected.getAttachments())) {
                 failWithMessage("Expected attachments to be <%s> but was <%s>", expected.getAttachments(), actual.getAttachments());
             }
@@ -97,7 +97,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, MailboxMessage>
                 failWithMessage("Expected Header content to be <%s> but was <%s>", IOUtils.toString(expected.getHeaderContent(), StandardCharsets.UTF_8), IOUtils.toString(actual.getHeaderContent(), StandardCharsets.UTF_8));
             }
         }
-        if (usedFetchType == MessageMapper.FetchType.FULL || usedFetchType == MessageMapper.FetchType.BODY) {
+        if (usedFetchType == MessageMapper.FetchType.FULL) {
             if (!Objects.equal(IOUtils.toString(actual.getBodyContent(), StandardCharsets.UTF_8), IOUtils.toString(expected.getBodyContent(), StandardCharsets.UTF_8))) {
                 failWithMessage("Expected Body content to be <%s> but was <%s>", IOUtils.toString(expected.getBodyContent(), StandardCharsets.UTF_8), IOUtils.toString(actual.getBodyContent(), StandardCharsets.UTF_8));
             }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -443,7 +443,7 @@ public abstract class MessageIdMapperTest {
 
         sut.setFlags(messageId, ImmutableList.of(message1.getMailboxId()), newFlags, FlagsUpdateMode.REMOVE).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).isRecent()).isTrue();
         assertThat(messages.get(0).isFlagged()).isFalse();
@@ -543,7 +543,7 @@ public abstract class MessageIdMapperTest {
         MessageId messageId = message1.getMessageId();
         sut.setFlags(messageId, ImmutableList.of(message1.getMailboxId()), new Flags(Flag.ANSWERED), FlagsUpdateMode.ADD).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).isAnswered()).isTrue();
     }
@@ -559,7 +559,7 @@ public abstract class MessageIdMapperTest {
         Flags newFlags = new Flags(Flag.ANSWERED);
         sut.setFlags(messageId, ImmutableList.of(), newFlags, FlagsUpdateMode.REMOVE).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).getModSeq()).isEqualTo(modSeq);
     }
@@ -574,7 +574,7 @@ public abstract class MessageIdMapperTest {
         MessageId messageId = message1.getMessageId();
         sut.setFlags(messageId, ImmutableList.of(message1.getMailboxId()), new Flags(Flag.ANSWERED), FlagsUpdateMode.ADD).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).getModSeq()).isGreaterThan(modSeq);
     }
@@ -592,7 +592,7 @@ public abstract class MessageIdMapperTest {
         Flags newFlags = new Flags(Flag.ANSWERED);
         sut.setFlags(messageId, ImmutableList.of(), newFlags, FlagsUpdateMode.REMOVE).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).createFlags()).isEqualTo(initialFlags);
     }
@@ -611,7 +611,7 @@ public abstract class MessageIdMapperTest {
         MessageId messageId = message1.getMessageId();
         sut.setFlags(messageId, ImmutableList.of(message1.getMailboxId(), message1InOtherMailbox.getMailboxId()), new Flags(Flag.ANSWERED), FlagsUpdateMode.ADD).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(2);
         assertThat(messages.get(0).isAnswered()).isTrue();
         assertThat(messages.get(1).isAnswered()).isTrue();
@@ -635,7 +635,7 @@ public abstract class MessageIdMapperTest {
         MessageId messageId = message1.getMessageId();
         sut.setFlags(messageId, ImmutableList.of(message1.getMailboxId()), new Flags(Flag.ANSWERED), FlagsUpdateMode.ADD).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).isAnswered()).isTrue();
     }
@@ -658,7 +658,7 @@ public abstract class MessageIdMapperTest {
         MessageId messageId = message1.getMessageId();
         sut.setFlags(messageId, ImmutableList.of(message1.getMailboxId(), message1.getMailboxId()), new Flags(Flag.ANSWERED), FlagsUpdateMode.ADD).block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(messageId), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).isAnswered()).isTrue();
     }
@@ -681,7 +681,7 @@ public abstract class MessageIdMapperTest {
             .operationCount(updateCount)
             .runSuccessfullyWithin(Duration.ofMinutes(1));
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).createFlags().getUserFlags()).hasSize(threadCount * updateCount);
     }
@@ -715,7 +715,7 @@ public abstract class MessageIdMapperTest {
             .operationCount(updateCount)
             .runSuccessfullyWithin(Duration.ofMinutes(1));
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).createFlags().getUserFlags()).isEmpty();
     }
@@ -823,7 +823,7 @@ public abstract class MessageIdMapperTest {
             FlagsUpdateMode.ADD)
             .block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).getModSeq()).isEqualTo(modSeq);
     }
@@ -843,7 +843,7 @@ public abstract class MessageIdMapperTest {
             FlagsUpdateMode.ADD)
             .block();
 
-        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.BODY);
+        List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), FetchType.FULL);
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).createFlags()).isEqualTo(flags);
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -281,17 +281,6 @@ public abstract class MessageMapperTest {
     }
 
     @Test
-    void messagesRetrievedUsingFetchTypeBodyShouldHaveBodyDataLoaded() throws MailboxException, IOException {
-        saveMessages();
-        MessageMapper.FetchType fetchType = MessageMapper.FetchType.BODY;
-        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message1.getUid()), fetchType, LIMIT);
-        assertThat(retrievedMessageIterator.next()).isEqualToWithoutAttachment(message1, fetchType);
-        assertThat(retrievedMessageIterator)
-            .toIterable()
-            .isEmpty();
-    }
-
-    @Test
     void messagesRetrievedUsingFetchTypeFullShouldHaveBodyDataLoaded() throws MailboxException, IOException {
         saveMessages();
         MessageMapper.FetchType fetchType = FetchType.FULL;
@@ -819,7 +808,7 @@ public abstract class MessageMapperTest {
 
         MailboxMessage messageWithProperties = createMessage(benwaInboxMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStored \n\nBody\n.\n", BODY_START, propBuilder);
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
-        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.BODY, 1).next();
+        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.FULL, 1).next();
 
         assertProperties(message.getProperties().toProperties()).containsOnly(propBuilder.toProperties());
     }
@@ -831,7 +820,7 @@ public abstract class MessageMapperTest {
 
         MailboxMessage messageWithProperties = createMessage(benwaInboxMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStoredWhenDuplicateEntries \n\nBody\n.\n", BODY_START, propBuilder);
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
-        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.BODY, 1).next();
+        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.FULL, 1).next();
 
         assertProperties(message.getProperties().toProperties()).containsOnly(propBuilder.toProperties());
     }
@@ -840,7 +829,7 @@ public abstract class MessageMapperTest {
     void messagePropertiesShouldBeStoredWhenNoProperty() throws Exception {
         MailboxMessage messageWithProperties = createMessage(benwaInboxMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStoredWhenNoProperty \n\nBody\n.\n", BODY_START, new PropertyBuilder());
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
-        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.BODY, 1).next();
+        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.FULL, 1).next();
         assertThat(message.getProperties().toProperties()).isEmpty();
     }
 
@@ -852,7 +841,7 @@ public abstract class MessageMapperTest {
 
         MailboxMessage messageWithProperties = createMessage(benwaInboxMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStoredWhenDuplicateEntries \n\nBody\n.\n", BODY_START, propBuilder);
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
-        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.BODY, 1).next();
+        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.FULL, 1).next();
         assertThat(message.getTextualLineCount()).isEqualTo(textualLineCount);
     }
 
@@ -864,7 +853,7 @@ public abstract class MessageMapperTest {
 
         MailboxMessage messageWithProperties = createMessage(benwaInboxMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStoredWhenDuplicateEntries \n\nBody\n.\n", BODY_START, propBuilder);
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
-        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.BODY, 1).next();
+        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.FULL, 1).next();
         assertThat(message.getMediaType()).isEqualTo(mediaType);
     }
 
@@ -876,7 +865,7 @@ public abstract class MessageMapperTest {
 
         MailboxMessage messageWithProperties = createMessage(benwaInboxMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStoredWhenDuplicateEntries \n\nBody\n.\n", BODY_START, propBuilder);
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
-        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.BODY, 1).next();
+        MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.FULL, 1).next();
         assertThat(message.getSubType()).isEqualTo(subType);
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -134,14 +134,6 @@ public abstract class MessageWithAttachmentMapperTest {
     }
 
     @Test
-    void messagesRetrievedUsingFetchTypeBodyShouldHaveAttachmentsLoadedWhenOneAttachment() throws MailboxException {
-        saveMessages();
-        MessageMapper.FetchType fetchType = MessageMapper.FetchType.BODY;
-        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(messageWith1Attachment.getUid()), fetchType, LIMIT);
-        assertThat(retrievedMessageIterator.next().getAttachments()).isEqualTo(messageWith1Attachment.getAttachments());
-    }
-
-    @Test
     void messagesRetrievedUsingFetchTypeHeadersShouldHaveAttachmentsEmptyWhenOneAttachment() throws MailboxException {
         Assumptions.assumeTrue(mapperProvider.supportPartialAttachmentFetch());
         saveMessages();
@@ -173,16 +165,6 @@ public abstract class MessageWithAttachmentMapperTest {
         MessageMapper.FetchType fetchType = MessageMapper.FetchType.FULL;
         assertThat(messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(messageWith1Attachment.getUid()), fetchType, LIMIT).next())
             .isEqualTo(messageWith1Attachment, fetchType);
-    }
-
-    @Test
-    void messagesRetrievedUsingFetchTypeBodyShouldHaveBodyDataLoaded() throws MailboxException, IOException {
-        saveMessages();
-        MessageMapper.FetchType fetchType = MessageMapper.FetchType.BODY;
-        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(messageWith1Attachment.getUid()), fetchType, LIMIT);
-        assertThat(retrievedMessageIterator.next()).isEqualTo(messageWith1Attachment, fetchType);
-        assertThat(retrievedMessageIterator).toIterable()
-            .isEmpty();
     }
 
     private Mailbox createMailbox(MailboxPath mailboxPath) {

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -105,7 +105,6 @@ public class CassandraSessionModule extends AbstractModule {
             BatchSizes batchSizes = BatchSizes.builder()
                 .fetchMetadata(configuration.getInt("fetch.metadata", BatchSizes.DEFAULT_BATCH_SIZE))
                 .fetchHeaders(configuration.getInt("fetch.headers", BatchSizes.DEFAULT_BATCH_SIZE))
-                .fetchBody(configuration.getInt("fetch.body", BatchSizes.DEFAULT_BATCH_SIZE))
                 .fetchFull(configuration.getInt("fetch.full", BatchSizes.DEFAULT_BATCH_SIZE))
                 .copyBatchSize(configuration.getInt("copy", BatchSizes.DEFAULT_BATCH_SIZE))
                 .moveBatchSize(configuration.getInt("move", BatchSizes.DEFAULT_BATCH_SIZE))


### PR DESCRIPTION
This value is unused and creates confusion. If body is accessed,
 headers are accessed too, and accessing headers is cheap.
 
 See https://github.com/apache/james-project/pull/1111