### PR TITLE
[BUILD] Improve Mailbox creation stability

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -360,7 +360,10 @@ public class StoreMailboxManager implements MailboxManager {
                         } else {
                             return createMailboxesForPath(mailboxSession, sanitizedMailboxPath).takeLast(1).next();
                         }
-                    });
+                    })
+                    .retryWhen(Retry.backoff(5, Duration.ofMillis(100))
+                        .jitter(0.5)
+                        .maxBackoff(Duration.ofSeconds(1)));
             } catch (MailboxNameException e) {
                 return Mono.error(e);
             }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -362,6 +362,7 @@ public class StoreMailboxManager implements MailboxManager {
                         }
                     })
                     .retryWhen(Retry.backoff(5, Duration.ofMillis(100))
+                        .modifyErrorFilter(old -> old.and(e -> !(e instanceof MailboxException)))
                         .jitter(0.5)
                         .maxBackoff(Duration.ofSeconds(1)));
             } catch (MailboxNameException e) {


### PR DESCRIPTION
MailboxManagerTest::creatingConcurrentlyMailboxesWithSameParentShouldNotFail was hitting the limit of what the ASF CI can hold.

Reproduced locally with 64 concurrent processes, exponential
retries improved stability without reworking the test.