### PR TITLE
JAMES-3775 ClamAV integration

### DIFF
--- a/third-party/rspamd/docker-compose-distributed.yml
+++ b/third-party/rspamd/docker-compose-distributed.yml
@@ -31,8 +31,8 @@ services:
       - "993:993"
       - "8000:8000"
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:2.1.0
     environment:
       - discovery.type=single-node
 

--- a/third-party/rspamd/docker-compose-distributed.yml
+++ b/third-party/rspamd/docker-compose-distributed.yml
@@ -1,0 +1,82 @@
+version: '3'
+
+services:
+
+  james:
+    depends_on:
+      - elasticsearch
+      - cassandra
+      - tika
+      - rabbitmq
+      - s3
+      - rspamd
+    image: apache/james:distributed-latest
+    container_name: james
+    hostname: james.local
+    volumes:
+      - $PWD/target/apache-james-rspamd-3.8.0-SNAPSHOT-jar-with-dependencies.jar:/root/extensions-jars/james-server-rspamd.jar
+      - $PWD/sample-configuration/keystore:/root/conf/keystore
+      - $PWD/sample-configuration/extensions.properties:/root/conf/extensions.properties
+      - $PWD/sample-configuration/mailetcontainer_distributed.xml:/root/conf/mailetcontainer.xml
+      - $PWD/sample-configuration/listeners.xml:/root/conf/listeners.xml
+      - $PWD/sample-configuration/rspamd.properties:/root/conf/rspamd.properties
+      - $PWD/sample-configuration/webadmin.properties:/root/conf/webadmin.properties
+    ports:
+      - "80:80"
+      - "25:25"
+      - "110:110"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+      - "8000:8000"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    environment:
+      - discovery.type=single-node
+
+  cassandra:
+    image: cassandra:3.11.10
+    ports:
+      - "9042:9042"
+
+  tika:
+    image: apache/tika:1.26
+
+  rabbitmq:
+    image: rabbitmq:3.8.18-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  s3:
+    image: zenko/cloudserver:8.2.6
+    container_name: s3.docker.test
+    environment:
+      - SCALITY_ACCESS_KEY_ID=accessKey1
+      - SCALITY_SECRET_ACCESS_KEY=secretKey1
+      - S3BACKEND=mem
+      - LOG_LEVEL=trace
+      - REMOTE_MANAGEMENT_DISABLE=1
+
+  redis:
+    image: redis:6.2.6
+
+  clamav:
+    image: clamav/clamav:0.105
+
+  rspamd:
+    depends_on:
+      - redis
+      - clamav
+    container_name: rspamd
+    image: a16bitsysop/rspamd:3.2-r2-alpine3.16.0-r0
+    environment:
+      - REDIS:redis
+      - CLAMAV:clamav
+      - PASSWORD:admin
+    volumes:
+      - $PWD/sample-configuration/antivirus.conf:/etc/rspamd/override.d/antivirus.conf
+    ports:
+      - 11334:11334

--- a/third-party/rspamd/docker-compose.yml
+++ b/third-party/rspamd/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3'
+
+services:
+
+  james:
+    depends_on:
+      - rspamd
+    image: apache/james:memory-latest
+    container_name: james
+    hostname: james.local
+    volumes:
+      - $PWD/target/apache-james-rspamd-3.8.0-SNAPSHOT-jar-with-dependencies.jar:/root/extensions-jars/james-server-rspamd.jar
+      - $PWD/sample-configuration/keystore:/root/conf/keystore
+      - $PWD/sample-configuration/extensions.properties:/root/conf/extensions.properties
+      - $PWD/sample-configuration/mailetcontainer_memory.xml:/root/conf/mailetcontainer.xml
+      - $PWD/sample-configuration/listeners.xml:/root/conf/listeners.xml
+      - $PWD/sample-configuration/rspamd.properties:/root/conf/rspamd.properties
+      - $PWD/sample-configuration/webadmin.properties:/root/conf/webadmin.properties
+    ports:
+      - "80:80"
+      - "25:25"
+      - "110:110"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+      - "8000:8000"
+
+  redis:
+    image: redis:6.2.6
+
+  clamav:
+    image: clamav/clamav:0.105
+
+  rspamd:
+    depends_on:
+      - redis
+      - clamav
+    container_name: rspamd
+    image: a16bitsysop/rspamd:3.2-r2-alpine3.16.0-r0
+    environment:
+      - REDIS:redis
+      - CLAMAV:clamav
+      - PASSWORD:admin
+    volumes:
+      - $PWD/sample-configuration/antivirus.conf:/etc/rspamd/override.d/antivirus.conf
+    ports:
+      - 11334:11334

--- a/third-party/rspamd/sample-configuration/antivirus.conf
+++ b/third-party/rspamd/sample-configuration/antivirus.conf
@@ -1,0 +1,21 @@
+clamav {
+  # Scan mime_parts seperately - otherwise the complete mail will be transfered to AV Scanner
+  #attachments_only = true; # Before 1.8.1
+  scan_mime_parts = true; # After 1.8.1
+  # Scanning Text is suitable for some av scanner databases (e.g. Sanesecurity)
+  scan_text_mime = true; # 1.8.1 +
+  scan_image_mime = true; # 1.8.1 +
+  # If set force this action if any virus is found (default unset: no action is forced)
+  # action = "reject";
+  message = '${SCANNER}: virus found: "${VIRUS}"';
+  # If set true, log message is emitted for clean messages
+  log_clean = false;
+  # symbol to add (add it to metric if you want non-zero weight)
+  symbol = CLAM_VIRUS;
+  # type of scanner: "clamav", "fprot", "sophos" or "savapi"
+  type = clamav;
+  servers = "clamav:3310";
+  patterns {
+    JUST_EICAR = '^Eicar-Test-Signature$';
+  }
+}

--- a/third-party/rspamd/sample-configuration/mailetcontainer_distributed.xml
+++ b/third-party/rspamd/sample-configuration/mailetcontainer_distributed.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-mailetcontainer.html for further details -->
+
+<mailetcontainer enableJmx="true">
+
+    <context>
+        <!-- When the domain part of the postmaster mailAddress is missing, the default domain is appended.
+        You can configure it to (for example) <postmaster>postmaster@myDomain.com</postmaster> -->
+        <postmaster>postmaster</postmaster>
+    </context>
+
+    <spooler>
+        <threads>20</threads>
+        <errorRepository>cassandra://var/mail/error/</errorRepository>
+    </spooler>
+
+    <processors>
+        <processor state="root" enableJmx="true">
+            <mailet match="All" class="PostmasterAlias"/>
+            <mailet match="RelayLimit=30" class="Null"/>
+            <mailet match="All" class="ToProcessor">
+                <processor>transport</processor>
+            </mailet>
+        </processor>
+
+        <processor state="error" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerErrors</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/error/</repositoryPath>
+                <onMailetException>propagate</onMailetException>
+            </mailet>
+        </processor>
+
+        <processor state="transport" enableJmx="true">
+            <matcher name="relay-allowed" match="org.apache.james.mailetcontainer.impl.matchers.Or">
+                <matcher match="SMTPAuthSuccessful"/>
+                <matcher match="SMTPIsAuthNetwork"/>
+                <matcher match="SentByMailet"/>
+                <matcher match="org.apache.james.jmap.mailet.SentByJmap"/>
+            </matcher>
+
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>bcc</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="ToProcessor">
+                <processor>local-delivery</processor>
+            </mailet>
+            <mailet match="HostIsLocal" class="ToProcessor">
+                <processor>local-address-error</processor>
+                <notice>550 - Requested action not taken: no such user here</notice>
+            </mailet>
+            <mailet match="relay-allowed" class="ToProcessor">
+                <processor>relay</processor>
+            </mailet>
+            <mailet match="All" class="ToProcessor">
+                <processor>relay-denied</processor>
+            </mailet>
+        </processor>
+
+        <processor state="local-delivery" enableJmx="true">
+            <mailet match="All" class="org.apache.james.rspamd.RSpamDScanner">
+                <rewriteSubject>true</rewriteSubject>
+                <virusProcessor>virus</virusProcessor>
+            </mailet>
+            <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
+                <targetFolderName>Spam</targetFolderName>
+            </mailet>
+            <mailet match="All" class="VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="AddDeliveredToHeader"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="LocalDelivery"/>
+        </processor>
+
+        <processor state="relay" enableJmx="true">
+            <mailet match="All" class="RemoteDelivery">
+                <outgoingQueue>outgoing</outgoingQueue>
+                <delayTime>5000, 100000, 500000</delayTime>
+                <maxRetries>3</maxRetries>
+                <maxDnsProblemRetries>0</maxDnsProblemRetries>
+                <deliveryThreads>10</deliveryThreads>
+                <sendpartial>true</sendpartial>
+                <bounceProcessor>bounces</bounceProcessor>
+            </mailet>
+        </processor>
+
+        <processor state="local-address-error" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerLocalAddressError</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <attachment>none</attachment>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/address-error/</repositoryPath>
+            </mailet>
+        </processor>
+
+        <processor state="relay-denied" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerRelayDenied</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <attachment>none</attachment>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/relay-denied/</repositoryPath>
+                <notice>Warning: You are sending an e-mail to a remote server. You must be authenticated to perform such an operation</notice>
+            </mailet>
+        </processor>
+
+        <processor state="bounces" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>bounces</metricName>
+            </mailet>
+            <mailet match="All" class="DSNBounce">
+                <passThrough>false</passThrough>
+            </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
+        </processor>
+
+        <processor state="virus" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/virus/</repositoryPath>
+            </mailet>
+        </processor>
+
+    </processors>
+
+</mailetcontainer>
+

--- a/third-party/rspamd/sample-configuration/mailetcontainer_memory.xml
+++ b/third-party/rspamd/sample-configuration/mailetcontainer_memory.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-mailetcontainer.html for further details -->
+
+<mailetcontainer enableJmx="true">
+
+    <context>
+        <!-- When the domain part of the postmaster mailAddress is missing, the default domain is appended.
+        You can configure it to (for example) <postmaster>postmaster@myDomain.com</postmaster> -->
+        <postmaster>postmaster</postmaster>
+    </context>
+
+    <spooler>
+        <threads>20</threads>
+        <errorRepository>memory://var/mail/error/</errorRepository>
+    </spooler>
+
+    <processors>
+        <processor state="root" enableJmx="true">
+            <mailet match="All" class="PostmasterAlias"/>
+            <mailet match="RelayLimit=30" class="Null"/>
+            <mailet match="All" class="ToProcessor">
+                <processor>transport</processor>
+            </mailet>
+        </processor>
+
+        <processor state="error" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerErrors</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/error/</repositoryPath>
+                <onMailetException>propagate</onMailetException>
+            </mailet>
+        </processor>
+
+        <processor state="transport" enableJmx="true">
+            <matcher name="relay-allowed" match="org.apache.james.mailetcontainer.impl.matchers.Or">
+                <matcher match="SMTPAuthSuccessful"/>
+                <matcher match="SMTPIsAuthNetwork"/>
+                <matcher match="SentByMailet"/>
+                <matcher match="org.apache.james.jmap.mailet.SentByJmap"/>
+            </matcher>
+
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>bcc</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
+            <mailet match="RecipientIsLocal" class="ToProcessor">
+                <processor>local-delivery</processor>
+            </mailet>
+            <mailet match="HostIsLocal" class="ToProcessor">
+                <processor>local-address-error</processor>
+                <notice>550 - Requested action not taken: no such user here</notice>
+            </mailet>
+            <mailet match="relay-allowed" class="ToProcessor">
+                <processor>relay</processor>
+            </mailet>
+            <mailet match="All" class="ToProcessor">
+                <processor>relay-denied</processor>
+            </mailet>
+        </processor>
+
+        <processor state="local-delivery" enableJmx="true">
+            <mailet match="All" class="org.apache.james.rspamd.RSpamDScanner">
+                <rewriteSubject>true</rewriteSubject>
+                <virusProcessor>virus</virusProcessor>
+            </mailet>
+            <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
+                <targetFolderName>Spam</targetFolderName>
+            </mailet>
+            <mailet match="All" class="VacationMailet">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="Sieve">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="AddDeliveredToHeader"/>
+            <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering">
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="LocalDelivery"/>
+        </processor>
+
+        <processor state="relay" enableJmx="true">
+            <mailet match="All" class="RemoteDelivery">
+                <outgoingQueue>outgoing</outgoingQueue>
+                <delayTime>5000, 100000, 500000</delayTime>
+                <maxRetries>3</maxRetries>
+                <maxDnsProblemRetries>0</maxDnsProblemRetries>
+                <deliveryThreads>10</deliveryThreads>
+                <sendpartial>true</sendpartial>
+                <bounceProcessor>bounces</bounceProcessor>
+            </mailet>
+        </processor>
+
+        <processor state="local-address-error" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerLocalAddressError</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <attachment>none</attachment>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/address-error/</repositoryPath>
+            </mailet>
+        </processor>
+
+        <processor state="relay-denied" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>mailetContainerRelayDenied</metricName>
+            </mailet>
+            <mailet match="All" class="Bounce">
+                <attachment>none</attachment>
+            </mailet>
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/relay-denied/</repositoryPath>
+                <notice>Warning: You are sending an e-mail to a remote server. You must be authenticated to perform such an operation</notice>
+            </mailet>
+        </processor>
+
+        <processor state="bounces" enableJmx="true">
+            <mailet match="All" class="MetricsMailet">
+                <metricName>bounces</metricName>
+            </mailet>
+            <mailet match="All" class="DSNBounce">
+                <passThrough>false</passThrough>
+            </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
+        </processor>
+
+        <processor state="virus" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>memory://var/mail/virus/</repositoryPath>
+            </mailet>
+        </processor>
+
+    </processors>
+
+</mailetcontainer>
+

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/RSpamDScanner.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/RSpamDScanner.java
@@ -49,7 +49,7 @@ public class RSpamDScanner extends GenericMailet {
 
     private final RSpamDHttpClient rSpamDHttpClient;
     private boolean rewriteSubject;
-    private Optional<String> spamProcessor;
+    private Optional<String> virusProcessor;
 
     @Inject
     public RSpamDScanner(RSpamDHttpClient rSpamDHttpClient) {
@@ -59,7 +59,7 @@ public class RSpamDScanner extends GenericMailet {
     @Override
     public void init() {
         rewriteSubject = getBooleanParameter(getInitParameter("rewriteSubject"), false);
-        spamProcessor = getInitParameterAsOptional("spamProcessor");
+        virusProcessor = getInitParameterAsOptional("virusProcessor");
     }
 
     @Override
@@ -75,10 +75,10 @@ public class RSpamDScanner extends GenericMailet {
         }
 
         if (rSpamDResult.getHasVirus()) {
-            if (isDebug()) {
-                LOGGER.debug("Detected a mail containing virus. Sending mail {} to {}", mail, spamProcessor);
-            }
-            spamProcessor.ifPresent(mail::setState);
+            virusProcessor.ifPresent(state -> {
+                LOGGER.info("Detected a mail containing virus. Sending mail {} to {}", mail, virusProcessor);
+                mail.setState(state);
+            });
         }
     }
 
@@ -104,9 +104,5 @@ public class RSpamDScanner extends GenericMailet {
                 + " actions=" + rSpamDResult.getAction().getDescription()
                 + " score=" + rSpamDResult.getScore()
                 + " requiredScore=" + rSpamDResult.getRequiredScore())));
-    }
-
-    private boolean isDebug() {
-        return getInitParameter("debug", false);
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/RSpamDScanner.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/RSpamDScanner.java
@@ -74,7 +74,7 @@ public class RSpamDScanner extends GenericMailet {
                 .ifPresent(Throwing.consumer(desiredRewriteSubject -> mail.getMessage().setSubject(desiredRewriteSubject)));
         }
 
-        if (rSpamDResult.getHasVirus()) {
+        if (rSpamDResult.hasVirus()) {
             virusProcessor.ifPresent(state -> {
                 LOGGER.info("Detected a mail containing virus. Sending mail {} to {}", mail, virusProcessor);
                 mail.setState(state);

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RSpamDClientConfiguration.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RSpamDClientConfiguration.java
@@ -23,7 +23,7 @@ import java.net.URL;
 import java.util.Optional;
 
 public class RSpamDClientConfiguration {
-    public static final Integer DEFAULT_TIMEOUT_IN_SECONDS = 10;
+    public static final Integer DEFAULT_TIMEOUT_IN_SECONDS = 15;
 
     private final URL url;
     private final String password;

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/model/AnalysisResult.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/model/AnalysisResult.java
@@ -22,13 +22,10 @@ package org.apache.james.rspamd.model;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonDeserialize(using = AnalysisResultDeserializer.class)
 public class AnalysisResult {
 
@@ -80,12 +77,12 @@ public class AnalysisResult {
     }
 
     public enum Action {
-        @JsonProperty("no action") NO_ACTION("no action"), // message is likely ham
-        @JsonProperty("greylist") GREY_LIST("greylist"), // message should be grey listed
-        @JsonProperty("add header") ADD_HEADER("add header"), // message is suspicious and should be marked as spam
-        @JsonProperty("rewrite subject") REWRITE_SUBJECT("rewrite subject"), // message is suspicious and should have subject rewritten
-        @JsonProperty("soft reject") SOFT_REJECT("soft reject"), // message should be temporary rejected (for example, due to rate limit exhausting)
-        @JsonProperty("reject") REJECT("reject"); // message should be rejected as spam
+        NO_ACTION("no action"), // message is likely ham
+        GREY_LIST("greylist"), // message should be grey listed
+        ADD_HEADER("add header"), // message is suspicious and should be marked as spam
+        REWRITE_SUBJECT("rewrite subject"), // message is suspicious and should have subject rewritten
+        SOFT_REJECT("soft reject"), // message should be temporary rejected (for example, due to rate limit exhausting)
+        REJECT("reject"); // message should be rejected as spam
 
         private final String description;
 
@@ -104,11 +101,7 @@ public class AnalysisResult {
     private final Optional<String> desiredRewriteSubject;
     private final boolean hasVirus;
 
-    public AnalysisResult(@JsonProperty("action") Action action,
-                          @JsonProperty("score") float score,
-                          @JsonProperty("required_score") float requiredScore,
-                          @JsonProperty("subject") Optional<String> desiredRewriteSubject,
-                          boolean hasVirus) {
+    public AnalysisResult(Action action, float score, float requiredScore, Optional<String> desiredRewriteSubject, boolean hasVirus) {
         this.action = action;
         this.score = score;
         this.requiredScore = requiredScore;
@@ -132,7 +125,7 @@ public class AnalysisResult {
         return desiredRewriteSubject;
     }
 
-    public boolean getHasVirus() {
+    public boolean hasVirus() {
         return hasVirus;
     }
 

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/model/AnalysisResult.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/model/AnalysisResult.java
@@ -24,10 +24,12 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = AnalysisResultDeserializer.class)
 public class AnalysisResult {
 
     public static Builder builder() {
@@ -39,6 +41,7 @@ public class AnalysisResult {
         private float score;
         private float requiredScore;
         private Optional<String> desiredRewriteSubject;
+        private boolean hasVirus;
 
         public Builder() {
             desiredRewriteSubject = Optional.empty();
@@ -64,10 +67,15 @@ public class AnalysisResult {
             return this;
         }
 
+        public Builder hasVirus(boolean hasVirus) {
+            this.hasVirus = hasVirus;
+            return this;
+        }
+
         public AnalysisResult build() {
             Preconditions.checkNotNull(action);
 
-            return new AnalysisResult(action, score, requiredScore, desiredRewriteSubject);
+            return new AnalysisResult(action, score, requiredScore, desiredRewriteSubject, hasVirus);
         }
     }
 
@@ -94,15 +102,18 @@ public class AnalysisResult {
     private final float score;
     private final float requiredScore;
     private final Optional<String> desiredRewriteSubject;
+    private final boolean hasVirus;
 
     public AnalysisResult(@JsonProperty("action") Action action,
                           @JsonProperty("score") float score,
                           @JsonProperty("required_score") float requiredScore,
-                          @JsonProperty("subject") Optional<String> desiredRewriteSubject) {
+                          @JsonProperty("subject") Optional<String> desiredRewriteSubject,
+                          boolean hasVirus) {
         this.action = action;
         this.score = score;
         this.requiredScore = requiredScore;
         this.desiredRewriteSubject = desiredRewriteSubject;
+        this.hasVirus = hasVirus;
     }
 
     public Action getAction() {
@@ -121,6 +132,10 @@ public class AnalysisResult {
         return desiredRewriteSubject;
     }
 
+    public boolean getHasVirus() {
+        return hasVirus;
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof AnalysisResult) {
@@ -129,14 +144,15 @@ public class AnalysisResult {
             return Objects.equals(this.score, that.score)
                 && Objects.equals(this.requiredScore, that.requiredScore)
                 && Objects.equals(this.action, that.action)
-                && Objects.equals(this.desiredRewriteSubject, that.desiredRewriteSubject);
+                && Objects.equals(this.desiredRewriteSubject, that.desiredRewriteSubject)
+                && Objects.equals(this.hasVirus, that.hasVirus);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(action, score, requiredScore, desiredRewriteSubject);
+        return Objects.hash(action, score, requiredScore, desiredRewriteSubject, hasVirus);
     }
 
     @Override
@@ -146,6 +162,7 @@ public class AnalysisResult {
             .add("score", score)
             .add("requiredScore", requiredScore)
             .add("desiredRewriteSubject", desiredRewriteSubject)
+            .add("hasVirus", hasVirus)
             .toString();
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/model/AnalysisResultDeserializer.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/model/AnalysisResultDeserializer.java
@@ -1,0 +1,74 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.rspamd.model;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+public class AnalysisResultDeserializer extends StdDeserializer<AnalysisResult> {
+
+    public AnalysisResultDeserializer() {
+        this(null);
+    }
+
+    protected AnalysisResultDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public AnalysisResult deserialize(JsonParser jp, DeserializationContext deserializationContext) throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        AnalysisResult.Action action = deserializeAction(node.get("action").asText());
+        float score = node.get("score").floatValue();
+        float requiredScore = node.get("required_score").floatValue();
+        Optional<String> desiredRewriteSubject = deserializeRewriteSubject(node);
+        boolean hasVirus = deserializeClamVirus(node);
+
+        return new AnalysisResult(action,score, requiredScore, desiredRewriteSubject, hasVirus);
+    }
+
+    private AnalysisResult.Action deserializeAction(String actionAsString) {
+        for (AnalysisResult.Action action : AnalysisResult.Action.values()) {
+            if (action.getDescription().equals(actionAsString)) {
+                return action;
+            }
+        }
+        throw new RuntimeException("There is no match deserialized action.");
+    }
+
+    private Optional<String> deserializeRewriteSubject(JsonNode node) {
+        JsonNode rewriteSubjectJsonNode = node.get("subject");
+        if (rewriteSubjectJsonNode == null) {
+            return Optional.empty();
+        }
+        return Optional.of(rewriteSubjectJsonNode.asText());
+    }
+
+    private boolean deserializeClamVirus(JsonNode node) {
+        JsonNode clamVirusJsonNode = node.get("symbols").get("CLAM_VIRUS");
+        return clamVirusJsonNode != null;
+    }
+
+}

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RSpamDScannerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RSpamDScannerTest.java
@@ -254,9 +254,9 @@ class RSpamDScannerTest {
     }
 
     @Test
-    void shouldSendMailToSpamProcessorWhenMailHasAVirusAndConfigSpamProcessor() throws Exception {
+    void shouldSendMailToSpamProcessorWhenMailHasAVirusAndConfigVirusProcessor() throws Exception {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty("spamProcessor", "spam")
+            .setProperty("virusProcessor", "virus")
             .build();
 
         MimeMessage mimeMessage = MimeMessageUtil.mimeMessageFromStream(
@@ -271,13 +271,13 @@ class RSpamDScannerTest {
         mailet.init(mailetConfig);
         mailet.service(mail);
 
-        assertThat(mail.getState()).isEqualTo("spam");
+        assertThat(mail.getState()).isEqualTo("virus");
     }
 
     @Test
-    void shouldNotSendMailToSpamProcessorWhenMailHasNoVirus() throws Exception {
+    void shouldNotSendMailToVirusProcessorWhenMailHasNoVirus() throws Exception {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty("spamProcessor", "spam")
+            .setProperty("virusProcessor", "virus")
             .build();
 
         MimeMessage mimeMessage = MimeMessageUtil.mimeMessageFromStream(
@@ -296,7 +296,7 @@ class RSpamDScannerTest {
     }
 
     @Test
-    void shouldNotSendMailToSpamProcessorWhenMailHasAVirusByDefault() throws Exception {
+    void shouldNotSendMailToVirusProcessorWhenMailHasAVirusByDefault() throws Exception {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder().build();
         MimeMessage mimeMessage = MimeMessageUtil.mimeMessageFromStream(
             ClassLoader.getSystemResourceAsStream("mail/attachment/inlineVirusTextAttachment.eml"));

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RSpamDScannerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RSpamDScannerTest.java
@@ -252,4 +252,64 @@ class RSpamDScannerTest {
 
         assertThat(mail.getMessage().getSubject()).isEqualTo(INIT_SUBJECT);
     }
+
+    @Test
+    void shouldSendMailToSpamProcessorWhenMailHasAVirusAndConfigSpamProcessor() throws Exception {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty("spamProcessor", "spam")
+            .build();
+
+        MimeMessage mimeMessage = MimeMessageUtil.mimeMessageFromStream(
+            ClassLoader.getSystemResourceAsStream("mail/attachment/inlineVirusTextAttachment.eml"));
+
+        Mail mail = FakeMail.builder()
+            .name("name")
+            .recipient("user1@exemple.com")
+            .mimeMessage(mimeMessage)
+            .build();
+
+        mailet.init(mailetConfig);
+        mailet.service(mail);
+
+        assertThat(mail.getState()).isEqualTo("spam");
+    }
+
+    @Test
+    void shouldNotSendMailToSpamProcessorWhenMailHasNoVirus() throws Exception {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty("spamProcessor", "spam")
+            .build();
+
+        MimeMessage mimeMessage = MimeMessageUtil.mimeMessageFromStream(
+            ClassLoader.getSystemResourceAsStream("mail/attachment/inlineNonVirusTextAttachment.eml"));
+
+        Mail mail = FakeMail.builder()
+            .name("name")
+            .recipient("user1@exemple.com")
+            .mimeMessage(mimeMessage)
+            .build();
+
+        mailet.init(mailetConfig);
+        mailet.service(mail);
+
+        assertThat(mail.getState()).isNull();
+    }
+
+    @Test
+    void shouldNotSendMailToSpamProcessorWhenMailHasAVirusByDefault() throws Exception {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder().build();
+        MimeMessage mimeMessage = MimeMessageUtil.mimeMessageFromStream(
+            ClassLoader.getSystemResourceAsStream("mail/attachment/inlineVirusTextAttachment.eml"));
+
+        Mail mail = FakeMail.builder()
+            .name("name")
+            .recipient("user1@exemple.com")
+            .mimeMessage(mimeMessage)
+            .build();
+
+        mailet.init(mailetConfig);
+        mailet.service(mail);
+
+        assertThat(mail.getState()).isNull();
+    }
 }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RSpamDHttpClientTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RSpamDHttpClientTest.java
@@ -130,7 +130,7 @@ class RSpamDHttpClientTest {
             softly.assertThat(analysisResult.getAction()).isEqualTo(AnalysisResult.Action.NO_ACTION);
             softly.assertThat(analysisResult.getRequiredScore()).isEqualTo(14.0F);
             softly.assertThat(analysisResult.getDesiredRewriteSubject()).isEqualTo(Optional.empty());
-            softly.assertThat(analysisResult.getHasVirus()).isEqualTo(false);
+            softly.assertThat(analysisResult.hasVirus()).isEqualTo(false);
         });
 
         RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
@@ -169,7 +169,7 @@ class RSpamDHttpClientTest {
         RSpamDHttpClient client = new RSpamDHttpClient(configuration);
 
         AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(virusMessage)).block();
-        assertThat(analysisResult.getHasVirus()).isTrue();
+        assertThat(analysisResult.hasVirus()).isTrue();
     }
 
     @Test
@@ -178,7 +178,7 @@ class RSpamDHttpClientTest {
         RSpamDHttpClient client = new RSpamDHttpClient(configuration);
 
         AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(nonVirusMessage)).block();
-        assertThat(analysisResult.getHasVirus()).isFalse();
+        assertThat(analysisResult.hasVirus()).isFalse();
     }
 
     private void reportAsSpam(RSpamDHttpClient client, InputStream inputStream) {

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RSpamDHttpClientTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RSpamDHttpClientTest.java
@@ -51,17 +51,23 @@ import io.restassured.specification.RequestSpecification;
 class RSpamDHttpClientTest {
     private final static String SPAM_MESSAGE_PATH = "mail/spam/spam8.eml";
     private final static String HAM_MESSAGE_PATH = "mail/ham/ham1.eml";
+    private final static String VIRUS_MESSAGE_PATH = "mail/attachment/inlineVirusTextAttachment.eml";
+    private final static String NON_VIRUS_MESSAGE_PATH = "mail/attachment/inlineNonVirusTextAttachment.eml";
 
     @RegisterExtension
     static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
 
     private byte[] spamMessage;
     private byte[] hamMessage;
+    private byte[] virusMessage;
+    private byte[] nonVirusMessage;
 
     @BeforeEach
     void setup() {
         spamMessage = ClassLoaderUtils.getSystemResourceAsByteArray(SPAM_MESSAGE_PATH);
         hamMessage = ClassLoaderUtils.getSystemResourceAsByteArray(HAM_MESSAGE_PATH);
+        virusMessage = ClassLoaderUtils.getSystemResourceAsByteArray(VIRUS_MESSAGE_PATH);
+        nonVirusMessage = ClassLoaderUtils.getSystemResourceAsByteArray(NON_VIRUS_MESSAGE_PATH);
     }
 
     @Test
@@ -124,6 +130,7 @@ class RSpamDHttpClientTest {
             softly.assertThat(analysisResult.getAction()).isEqualTo(AnalysisResult.Action.NO_ACTION);
             softly.assertThat(analysisResult.getRequiredScore()).isEqualTo(14.0F);
             softly.assertThat(analysisResult.getDesiredRewriteSubject()).isEqualTo(Optional.empty());
+            softly.assertThat(analysisResult.getHasVirus()).isEqualTo(false);
         });
 
         RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
@@ -154,6 +161,24 @@ class RSpamDHttpClientTest {
 
         assertThatCode(() -> client.reportAsHam(new ByteArrayInputStream(hamMessage)).block())
             .doesNotThrowAnyException();
+    }
+
+    @Test
+    void checkVirusMailUsingRSpamDClientWithExactPasswordShouldReturnHasVirus() {
+        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+
+        AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(virusMessage)).block();
+        assertThat(analysisResult.getHasVirus()).isTrue();
+    }
+
+    @Test
+    void checkNonVirusMailUsingRSpamDClientWithExactPasswordShouldReturnHasNoVirus() {
+        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+
+        AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(nonVirusMessage)).block();
+        assertThat(analysisResult.getHasVirus()).isFalse();
     }
 
     private void reportAsSpam(RSpamDHttpClient client, InputStream inputStream) {

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/model/AnalysisResultDeserializationTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/model/AnalysisResultDeserializationTest.java
@@ -58,6 +58,7 @@ public class AnalysisResultDeserializationTest {
             .action(AnalysisResult.Action.ADD_HEADER)
             .score(5.2F)
             .requiredScore(7.0F)
+            .hasVirus(false)
             .build());
     }
 
@@ -93,6 +94,140 @@ public class AnalysisResultDeserializationTest {
             .score(5.2F)
             .requiredScore(7.0F)
             .desiredRewriteSubject("A rewritten ham subject")
+            .hasVirus(false)
+            .build());
+    }
+
+    @Test
+    void shouldBeDeserializedWellWhenHasClamVirusSymbol() throws JsonProcessingException {
+        String json = "{\n" +
+            "  \"is_skipped\": false,\n" +
+            "  \"score\": 3.500000,\n" +
+            "  \"required_score\": 14.0,\n" +
+            "  \"action\": \"no action\",\n" +
+            "  \"symbols\": {\n" +
+            "    \"ARC_NA\": {\n" +
+            "      \"name\": \"ARC_NA\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"description\": \"ARC signature absent\"\n" +
+            "    },\n" +
+            "    \"FROM_HAS_DN\": {\n" +
+            "      \"name\": \"FROM_HAS_DN\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"description\": \"From header has a display name\"\n" +
+            "    },\n" +
+            "    \"MIME_GOOD\": {\n" +
+            "      \"name\": \"MIME_GOOD\",\n" +
+            "      \"score\": -0.100000,\n" +
+            "      \"metric_score\": -0.100000,\n" +
+            "      \"description\": \"Known content-type\",\n" +
+            "      \"options\": [\n" +
+            "        \"multipart/mixed\",\n" +
+            "        \"text/plain\"\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"TO_DN_NONE\": {\n" +
+            "      \"name\": \"TO_DN_NONE\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"description\": \"None of the recipients have display names\"\n" +
+            "    },\n" +
+            "    \"RCPT_COUNT_ONE\": {\n" +
+            "      \"name\": \"RCPT_COUNT_ONE\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"description\": \"One recipient\",\n" +
+            "      \"options\": [\n" +
+            "        \"1\"\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"CLAM_VIRUS\": {\n" +
+            "      \"name\": \"CLAM_VIRUS\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"options\": [\n" +
+            "        \"Eicar-Signature\"\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"RCVD_COUNT_ZERO\": {\n" +
+            "      \"name\": \"RCVD_COUNT_ZERO\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"description\": \"Message has no Received headers\",\n" +
+            "      \"options\": [\n" +
+            "        \"0\"\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"TO_EQ_FROM\": {\n" +
+            "      \"name\": \"TO_EQ_FROM\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"description\": \"To address matches the From address\"\n" +
+            "    },\n" +
+            "    \"R_DKIM_NA\": {\n" +
+            "      \"name\": \"R_DKIM_NA\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"description\": \"Missing DKIM signature\"\n" +
+            "    },\n" +
+            "    \"DATE_IN_PAST\": {\n" +
+            "      \"name\": \"DATE_IN_PAST\",\n" +
+            "      \"score\": 1.0,\n" +
+            "      \"metric_score\": 1.0,\n" +
+            "      \"description\": \"Message date is in past\",\n" +
+            "      \"options\": [\n" +
+            "        \"51163\"\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"MIME_TRACE\": {\n" +
+            "      \"name\": \"MIME_TRACE\",\n" +
+            "      \"score\": 0.0,\n" +
+            "      \"metric_score\": 0.0,\n" +
+            "      \"options\": [\n" +
+            "        \"0:+\",\n" +
+            "        \"1:+\",\n" +
+            "        \"2:+\"\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"HFILTER_HOSTNAME_UNKNOWN\": {\n" +
+            "      \"name\": \"HFILTER_HOSTNAME_UNKNOWN\",\n" +
+            "      \"score\": 2.500000,\n" +
+            "      \"metric_score\": 2.500000,\n" +
+            "      \"description\": \"Unknown client hostname (PTR or FCrDNS verification failed)\"\n" +
+            "    },\n" +
+            "    \"DMARC_POLICY_SOFTFAIL\": {\n" +
+            "      \"name\": \"DMARC_POLICY_SOFTFAIL\",\n" +
+            "      \"score\": 0.100000,\n" +
+            "      \"metric_score\": 0.100000,\n" +
+            "      \"description\": \"DMARC failed\",\n" +
+            "      \"options\": [\n" +
+            "        \"linagora.com : No valid SPF, No valid DKIM\",\n" +
+            "        \"none\"\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"messages\": {\n" +
+            "\n" +
+            "  },\n" +
+            "  \"message-id\": \"befd8cab-9c9c-5537-4e77-937f32326087@any.com\",\n" +
+            "  \"time_real\": 0.381197,\n" +
+            "  \"milter\": {\n" +
+            "    \"remove_headers\": {\n" +
+            "      \"X-Spam\": 0\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
+        AnalysisResult analysisResult = objectMapper.readValue(json, AnalysisResult.class);
+
+        assertThat(analysisResult).isEqualTo(AnalysisResult.builder()
+            .action(AnalysisResult.Action.NO_ACTION)
+            .score(3.5F)
+            .requiredScore(14.0F)
+            .hasVirus(true)
             .build());
     }
 }

--- a/third-party/rspamd/src/test/resources/mail/attachment/inlineNonVirusTextAttachment.eml
+++ b/third-party/rspamd/src/test/resources/mail/attachment/inlineNonVirusTextAttachment.eml
@@ -1,0 +1,24 @@
+To: me@linagora.com
+From: Benoit Tellier <me@linagora.com>
+Subject: Mail with text attachment
+Message-ID: <befd8cab-9c9c-5537-4e77-937f32326087@any.com>
+Date: Thu, 13 Oct 2016 10:26:20 +0200
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------4FD2D252DB453546C22C25B2"
+
+This is a multi-part message in MIME format.
+--------------4FD2D252DB453546C22C25B2
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+I'm the body!
+
+--------------4FD2D252DB453546C22C25B2
+Content-Disposition: inline
+Content-Type: text/plain; charset=UTF-8;
+ name="attachment.txt"
+Content-ID: <id>
+
+Non virus text
+--------------4FD2D252DB453546C22C25B2--

--- a/third-party/rspamd/src/test/resources/mail/attachment/inlineVirusTextAttachment.eml
+++ b/third-party/rspamd/src/test/resources/mail/attachment/inlineVirusTextAttachment.eml
@@ -1,0 +1,24 @@
+To: me@linagora.com
+From: Benoit Tellier <me@linagora.com>
+Subject: Mail with text attachment
+Message-ID: <befd8cab-9c9c-5537-4e77-937f32326087@any.com>
+Date: Thu, 13 Oct 2016 10:26:20 +0200
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------4FD2D252DB453546C22C25B2"
+
+This is a multi-part message in MIME format.
+--------------4FD2D252DB453546C22C25B2
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+I'm the body!
+
+--------------4FD2D252DB453546C22C25B2
+Content-Disposition: inline
+Content-Type: text/plain; charset=UTF-8;
+ name="attachment.txt"
+Content-ID: <id>
+
+X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
+--------------4FD2D252DB453546C22C25B2--

--- a/third-party/rspamd/src/test/resources/rspamd-config/antivirus.conf
+++ b/third-party/rspamd/src/test/resources/rspamd-config/antivirus.conf
@@ -1,0 +1,21 @@
+clamav {
+  # Scan mime_parts seperately - otherwise the complete mail will be transfered to AV Scanner
+  #attachments_only = true; # Before 1.8.1
+  scan_mime_parts = true; # After 1.8.1
+  # Scanning Text is suitable for some av scanner databases (e.g. Sanesecurity)
+  scan_text_mime = true; # 1.8.1 +
+  scan_image_mime = true; # 1.8.1 +
+  # If set force this action if any virus is found (default unset: no action is forced)
+#   action = "reject";
+  message = '${SCANNER}: virus found: "${VIRUS}"';
+  # If set true, log message is emitted for clean messages
+  log_clean = false;
+  # symbol to add (add it to metric if you want non-zero weight)
+  symbol = CLAM_VIRUS;
+  # type of scanner: "clamav", "fprot", "sophos" or "savapi"
+  type = clamav;
+  servers = "clamav:3310";
+  patterns {
+    JUST_EICAR = '^Eicar-Test-Signature$';
+  }
+}


### PR DESCRIPTION
As a user, I should NEVER receive an email containing a Virus.
RSpamDScanner mailet should push virus mail to `virusProcessor` for further processing (configurable).

E.g:
- Hard reject processing (store them in a mail repository and not deliver them):
```xml
      <processor state="virus" enableJmx="false">
        <mailet match="All" class="ToRepository">
          <repositoryPath>file://var/mail/virus/</repositoryPath>
        </mailet>
      </processor>
```
- Soft reject processing (Remove attachment, modify the subject with [VIRUS] and add headers...):
```xml
      <processor state="virus" enableJmx="false">
        <mailet match="All" class="StripAttachment">
          <remove>all</remove>
          <pattern>.*</pattern>
        </mailet>
        <mailet match="All" class="AddSubjectPrefix">
          <subjectPrefix>[VIRUS]</subjectPrefix>
        </mailet>
      </processor>
```
