### PR TITLE
JAMES-3775 Fix typo RSpamD -> Rspamd

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/architecture/index.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/architecture/index.adoc
@@ -19,7 +19,7 @@ patterns. ElasticSearch throughtput do not however match the one of Cassandra th
  * *RabbitMQ* enables James nodes of a same cluster to collaborate together. It is used to implement connected protocols,
 notification patterns as well as distributed resilient work queues and mail queue.
  * *Tika* (optional) enables text extraction from attachments, thus improving full text search results.
- * *link:https://spamassassin.apache.org/[SpamAssassin] or link:https://rspamd.com/[RSpamD]* (optional) can be used for Spam detection and user feedback is supported.
+ * *link:https://spamassassin.apache.org/[SpamAssassin] or link:https://rspamd.com/[Rspamd]* (optional) can be used for Spam detection and user feedback is supported.
 
 xref:architecture/consistency-model.adoc[This page] further details Distributed James consistency model.
 

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/extensions.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/extensions.adoc
@@ -34,10 +34,10 @@ These extensions need to implement Task extension modules.
 Here is an example of such a class :
 
 ....
-public class RSpamDTaskExtensionModule implements TaskExtensionModule {
+public class RspamdTaskExtensionModule implements TaskExtensionModule {
 
     @Inject
-    public RSpamDTaskExtensionModule() {
+    public RspamdTaskExtensionModule() {
     }
 
     @Override
@@ -55,7 +55,7 @@ public class RSpamDTaskExtensionModule implements TaskExtensionModule {
 Recording it in extensions.properties :
 
 ....
-guice.extension.tasks=com.project.RSpamDTaskExtensionModule
+guice.extension.tasks=com.project.RspamdTaskExtensionModule
 ....
 
 Read xref:extending/index.adoc#_defining_custom_injections_for_your_extensions[this page] for more details.

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/index.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/index.adoc
@@ -60,7 +60,7 @@ By omitting these files, no extra behaviour is added.
 ** xref:configure/listeners.adoc[*listeners.xml*] enables configuration of Mailbox Listeners link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/listeners.xml[example]
 ** xref:configure/extensions.adoc[*extensions.properties*] allows to extend James behaviour by loading your extensions in it link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/extensions.properties[example]
 ** xref:configure/jvm.adoc[*jvm.properties*] lets you specify additional system properties without cluttering your command line
-** xref:configure/spam.adoc[This page] documents Anti-Spam setup with SpamAssassin, RSpamD.
+** xref:configure/spam.adoc[This page] documents Anti-Spam setup with SpamAssassin, Rspamd.
 ** xref:configure/remote-delivery-error-handling.adoc[This page] proposes a simple strategy for RemoteDelivery error handling.
 ** xref:configure/collecting-contacts.adoc[This page] documents contact collection
 ** xref:configure/collecting-events.adoc[This page] documents event collection

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/listeners.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/listeners.adoc
@@ -52,9 +52,9 @@ Example:
 Please note that a `spamassassin.properties` file is needed. Read also
 xref:configure/spam.adoc[this page] for extra configuration required to support this feature.
 
-=== RSpamDListener
+=== RspamdListener
 
-Provides HAM/SPAM feedback to a RSpamD server depending on user actions.
+Provides HAM/SPAM feedback to a Rspamd server depending on user actions.
 
 This MailboxListener is supported.
 
@@ -64,7 +64,7 @@ Example:
 <listeners>
   <!-- ... -->
   <listener>
-    <class>org.apache.james.rspamd.RSpamDListener</class>
+    <class>org.apache.james.rspamd.RspamdListener</class>
   </listener>
 </listeners>
 ....

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
@@ -21,10 +21,10 @@ detection is not supported by this hook.
 
 == AntiSpam Mailets
 
-James' repository provide two AntiSpam mailets: SpamAssassin and RSpamDScanner.
+James' repository provide two AntiSpam mailets: SpamAssassin and RspamdScanner.
 We can select one in them for filtering spam mail.
 
-* *SpamAssassin and RSpamDScanner* Mailet is designed to classify the messages as spam or not
+* *SpamAssassin and RspamdScanner* Mailet is designed to classify the messages as spam or not
 with a configurable score threshold. Usually a message will only be
 considered as spam if it matches multiple criteria; matching just a single test
 will not usually be enough to reach the threshold. Note that this mailet is executed on a per-user basis.
@@ -93,44 +93,44 @@ Example:
 </listeners>
 ....
 
-== RSpamD
+== Rspamd
 
-The RSpamD extension (optional) requires an extra configuration file `rspamd.properties` to configure RSpamd connection
+The Rspamd extension (optional) requires an extra configuration file `rspamd.properties` to configure RSpamd connection
 
 .rspamd.properties content
 |===
 | Property name | explanation
 
-| rSpamDUrl
-| URL defining the RSpamD's server. Eg: http://rspamd:11334
+| rSpamdUrl
+| URL defining the Rspamd's server. Eg: http://rspamd:11334
 
-| rSpamDPassword
-| Password for pass authentication when request to RSpamD's server. Eg: admin
+| rSpamdPassword
+| Password for pass authentication when request to Rspamd's server. Eg: admin
 |===
 
 
-Here is an example of mailet pipeline conducting out RSpamDScanner execution:
+Here is an example of mailet pipeline conducting out RspamdScanner execution:
 
 ....
-<mailet match="All" class="org.apache.james.rspamd.RSpamDScanner">
+<mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
 </mailet>
 <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
     <targetFolderName>Spam</targetFolderName>
 </mailet>
 ....
 
-=== Feedback for RSpamD
-If enabled, the `RSpamDListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to RSpamD
-The RSpamD listener needs to explicitly be registered with xref:configure/listeners.adoc[listeners.xml].
+=== Feedback for Rspamd
+If enabled, the `RspamdListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to Rspamd
+The Rspamd listener needs to explicitly be registered with xref:configure/listeners.adoc[listeners.xml].
 
 Example:
 
 ....
 <listeners>
     <listener>
-        <class>org.apache.james.rspamd.RSpamDListener</class>
+        <class>org.apache.james.rspamd.RspamdListener</class>
     </listener>
 </listeners>
 ....
 
-For more detail about how to use RSpamD's extension: `third-party/rspamd/index.md`
+For more detail about how to use Rspamd's extension: `third-party/rspamd/index.md`

--- a/server/apps/distributed-app/docs/modules/ROOT/partials/IsMarkedAsSpam.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/partials/IsMarkedAsSpam.adoc
@@ -17,12 +17,12 @@ As an example, here is a part of a mailet pipeline which can be used in your Loc
 ....
 
 In order to use this with `rspamd`, we need to declare a condition for the matcher
-and drop the RSpamD jar (*third-party/rspamd*) in the James extensions-jars folder.
-Eg: With the recipient header for RSpamD being *org.apache.james.rspamd.status*,
+and drop the Rspamd jar (*third-party/rspamd*) in the James extensions-jars folder.
+Eg: With the recipient header for Rspamd being *org.apache.james.rspamd.status*,
 then the configuration would be:
 
 ....
-<!-- RSpamD mailets pipeline -->
+<!-- Rspamd mailets pipeline -->
     <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
         <targetFolderName>Spam</targetFolderName>
     </mailet>

--- a/src/adr/0055-rspamd-spam-filtering.md
+++ b/src/adr/0055-rspamd-spam-filtering.md
@@ -21,9 +21,9 @@ If we want to analyse deeper in each message content, we need a more complex sys
 Currently, James is integrated with [SpamAssassin](https://spamassassin.apache.org/) to tackle this problem.
 We found it hard to operate SpamAssassin, and we had a performance issue.
 
-For more selection, James's repository provides the RSpamD extension, which provides the same way as SpamAssassin but another system - [RSpamD](https://github.com/rspamd/rspamd)
+For more selection, James's repository provides the Rspamd extension, which provides the same way as SpamAssassin but another system - [Rspamd](https://github.com/rspamd/rspamd)
 
-A quick introduction about RSpamD:
+A quick introduction about Rspamd:
 
 ```
 Rspamd is an advanced spam filtering system and email processing framework that allows evaluation of messages by a number of rules including regular expressions, statistical analysis and custom services such as URL black lists. Each message is analysed by Rspamd and given a verdict that might be used by MTA for further processing (e.g. to reject a message, or add a special header indicating spam) along with other information, such as possible DKIM signature or modifications suggested for a message.
@@ -38,25 +38,25 @@ Rspamd is designed to process hundreds of messages per second simultaneously, an
 Set up a new maven project dedicated to rspamd extension. This allows to be embedded in a James server as a soft dependency
 using the external-jar loading mechanism. With this way, the extension could be dropped in one's James installation, and not a runtime dependency.
 
-Based on James' support for custom mailets, listeners, web admin routes, RSpamD extension can be done via:
+Based on James' support for custom mailets, listeners, web admin routes, Rspamd extension can be done via:
 
-- `RSpamDScanner` mailet: with each mail income, this mailet will query to RSpamD for getting a spam or ham result, then append new headers to the mail with status/flag spam.
+- `RspamdScanner` mailet: with each mail income, this mailet will query to Rspamd for getting a spam or ham result, then append new headers to the mail with status/flag spam.
 By setting up with `IsMarkedAsSpam` matcher, the mail will be rejected or not.
 This mailet will be configured in [mailetcontainer.xml](/server/apps/distributed-app/sample-configuration/mailetcontainer.xml).
 
 - Web admin route: to create feeding ham/spam messages task (batch mechanism). It helps spam classify learning.
 
-- `RSpamDListener`: the listener will handle mailbox events, based on `MessageMoveEvent`, `MailboxEvents.Added` to detect if the mail is spam or ham, then report to RSpamD,
-enrich data to RSpamD, thus we will get more exact results in the next query.
+- `RspamdListener`: the listener will handle mailbox events, based on `MessageMoveEvent`, `MailboxEvents.Added` to detect if the mail is spam or ham, then report to Rspamd,
+enrich data to Rspamd, thus we will get more exact results in the next query.
 This listener will be configured in [mailetcontainer.xml](/server/apps/distributed-app/sample-configuration/listeners.xml).
 
-To connect to RSpamD, we use http protocol with reactor http client. 
+To connect to Rspamd, we use http protocol with reactor http client. 
 
 ## Consequences
 
-- For higher performance, lower latency, the RSpamD should run in same network with James.
-- The query to RSpamD will get different score for same message. 
-- A distributed mode for RSpamD is allowed by the use of Redis.
+- For higher performance, lower latency, the Rspamd should run in same network with James.
+- The query to Rspamd will get different score for same message. 
+- A distributed mode for Rspamd is allowed by the use of Redis.
 
 ## Alternatives
 

--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -1,38 +1,38 @@
-# James' extensions for RSpamD
+# James' extensions for Rspamd
 
-This module is for developing and delivering extensions to James for the [RSpamD](https://rspamd.com/) (the spam filtering system)
+This module is for developing and delivering extensions to James for the [Rspamd](https://rspamd.com/) (the spam filtering system)
 and [ClamAV](https://www.clamav.net/) (the antivirus engine).
 
 ## How to run
 
-- The RSpamD extension requires an extra configuration file `rspamd.properties` to configure RSpamd connection
+- The Rspamd extension requires an extra configuration file `rspamd.properties` to configure Rspamd connection
 Configuration parameters:
-    - `rSpamDUrl` : URL defining the RSpamD's server. Eg: http://rspamd:11334
-    - `rSpamDPassword` : Password for pass authentication when request to RSpamD's server. Eg: admin
+    - `rSpamdUrl` : URL defining the Rspamd's server. Eg: http://rspamd:11334
+    - `rSpamdPassword` : Password for pass authentication when request to Rspamd's server. Eg: admin
   
 - Declare the `extensions.properties` for this module.
 
 ```
-guice.extension.module=org.apache.james.rspamd.module.RSpamDModule
-guice.extension.task=org.apache.james.rspamd.module.RSpamDTaskExtensionModule
+guice.extension.module=org.apache.james.rspamd.module.RspamdModule
+guice.extension.task=org.apache.james.rspamd.module.RspamdTaskExtensionModule
 ```
 
-- Declare the RSpamD mailbox listeners in `listeners.xml`. Eg:
+- Declare the Rspamd mailbox listeners in `listeners.xml`. Eg:
 
 ```
 <listener>
-    <class>org.apache.james.rspamd.RSpamDListener</class>
+    <class>org.apache.james.rspamd.RspamdListener</class>
 </listener>
 ```
 
-- Declare the RSpamD mailet for custom mail processing. 
+- Declare the Rspamd mailet for custom mail processing. 
 
   You can specify the `virusProcessor` if you want to enable virus scanning for mail. Upon configurable `virusProcessor`
 you can specify how James process mail virus. We provide a sample Rspamd mailet and `virusProcessor` configuration:
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
-    <mailet match="All" class="org.apache.james.rspamd.RSpamDScanner">
+    <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
         <rewriteSubject>true</rewriteSubject>
         <virusProcessor>virus</virusProcessor>
     </mailet>
@@ -60,7 +60,7 @@ you can specify how James process mail virus. We provide a sample Rspamd mailet 
 </processor>
 ```
 
-- Declare the webadmin for RSpamD in `webadmin.properties`
+- Declare the webadmin for Rspamd in `webadmin.properties`
 
 ```
 extensions.routes=org.apache.james.rspamd.route.FeedMessageRoute
@@ -80,8 +80,8 @@ then run it: `docker-compose up`
 
 ## Additional webadmin endpoints
 
-### Report spam messages to RSpamD
-One can use this route to schedule a task that reports spam messages to RSpamD for its spam classify learning.
+### Report spam messages to Rspamd
+One can use this route to schedule a task that reports spam messages to Rspamd for its spam classify learning.
 
 ```bash
 curl -XPOST 'http://ip:port/rspamd?action=reportSpam
@@ -89,11 +89,11 @@ curl -XPOST 'http://ip:port/rspamd?action=reportSpam
 
 This endpoint has the following param:
 - `action` (required): need to be `reportSpam`
-- `messagesPerSecond` (optional): Concurrent learns performed for RSpamD, default to 10
+- `messagesPerSecond` (optional): Concurrent learns performed for Rspamd, default to 10
 - `period` (optional): duration (support many time units, default in seconds), only messages between `now` and `now - duration` are reported. By default, 
 all messages are reported. 
    These inputs represent the same duration: `1d`, `1day`, `86400 seconds`, `86400`...
-- `samplingProbability` (optional): float between 0 and 1, represent the chance to report each given message to RSpamD. 
+- `samplingProbability` (optional): float between 0 and 1, represent the chance to report each given message to Rspamd. 
 By default, all messages are reported.
 
 Will return the task id. E.g:
@@ -109,7 +109,7 @@ Response codes:
 
 [More details about endpoints returning a task](https://james.apache.org/server/manage-webadmin.html#Endpoints_returning_a_task).
 
-The scheduled task will have the following type `FeedSpamToRSpamDTask` and the following additionalInformation:
+The scheduled task will have the following type `FeedSpamToRspamdTask` and the following additionalInformation:
 
 ```json
 {
@@ -122,12 +122,12 @@ The scheduled task will have the following type `FeedSpamToRSpamDTask` and the f
   },
   "spamMessageCount": 4,
   "timestamp": "2007-12-03T10:15:30Z",
-  "type": "FeedSpamToRSpamDTask"
+  "type": "FeedSpamToRspamdTask"
 }
 ```
 
-### Report ham messages to RSpamD
-One can use this route to schedule a task that reports ham messages to RSpamD for its spam classify learning.
+### Report ham messages to Rspamd
+One can use this route to schedule a task that reports ham messages to Rspamd for its spam classify learning.
 
 ```bash
 curl -XPOST 'http://ip:port/rspamd?action=reportHam
@@ -135,11 +135,11 @@ curl -XPOST 'http://ip:port/rspamd?action=reportHam
 
 This endpoint has the following param:
 - `action` (required): need to be `reportHam`
-- `messagesPerSecond` (optional): Concurrent learns performed for RSpamD, default to 10
+- `messagesPerSecond` (optional): Concurrent learns performed for Rspamd, default to 10
 - `period` (optional): duration (support many time units, default in seconds), only messages between `now` and `now - duration` are reported. By default,
   all messages are reported.
   These inputs represent the same duration: `1d`, `1day`, `86400 seconds`, `86400`...
-- `samplingProbability` (optional): float between 0 and 1, represent the chance to report each given message to RSpamD.
+- `samplingProbability` (optional): float between 0 and 1, represent the chance to report each given message to Rspamd.
   By default, all messages are reported.
 
 Will return the task id. E.g:
@@ -155,7 +155,7 @@ Response codes:
 
 [More details about endpoints returning a task](https://james.apache.org/server/manage-webadmin.html#Endpoints_returning_a_task).
 
-The scheduled task will have the following type `FeedHamToRSpamDTask` and the following additionalInformation:
+The scheduled task will have the following type `FeedHamToRspamdTask` and the following additionalInformation:
 
 ```json
 {
@@ -168,6 +168,6 @@ The scheduled task will have the following type `FeedHamToRSpamDTask` and the fo
   },
   "hamMessageCount": 4,
   "timestamp": "2007-12-03T10:15:30Z",
-  "type": "FeedHamToRSpamDTask"
+  "type": "FeedHamToRspamdTask"
 }
 ```

--- a/third-party/rspamd/pom.xml
+++ b/third-party/rspamd/pom.xml
@@ -29,8 +29,8 @@
     </parent>
 
     <artifactId>apache-james-rspamd</artifactId>
-    <name>Apache James :: Third Party :: RSpamD</name>
-    <description>RSpamD Java client (HTTP) and testing utilities</description>
+    <name>Apache James :: Third Party :: Rspamd</name>
+    <description>Rspamd Java client (HTTP) and testing utilities</description>
 
     <properties>
         <james.baseVersion>${project.version}</james.baseVersion>

--- a/third-party/rspamd/sample-configuration/extensions.properties
+++ b/third-party/rspamd/sample-configuration/extensions.properties
@@ -1,2 +1,2 @@
-guice.extension.module=org.apache.james.rspamd.module.RSpamDModule
-guice.extension.task=org.apache.james.rspamd.module.RSpamDTaskExtensionModule
+guice.extension.module=org.apache.james.rspamd.module.RspamdModule
+guice.extension.task=org.apache.james.rspamd.module.RspamdTaskExtensionModule

--- a/third-party/rspamd/sample-configuration/listeners.xml
+++ b/third-party/rspamd/sample-configuration/listeners.xml
@@ -22,7 +22,7 @@
 
 <listeners>
     <listener>
-        <class>org.apache.james.rspamd.RSpamDListener</class>
+        <class>org.apache.james.rspamd.RspamdListener</class>
         <async>true</async>
     </listener>
 </listeners>

--- a/third-party/rspamd/sample-configuration/mailetcontainer_distributed.xml
+++ b/third-party/rspamd/sample-configuration/mailetcontainer_distributed.xml
@@ -87,7 +87,7 @@
         </processor>
 
         <processor state="local-delivery" enableJmx="true">
-            <mailet match="All" class="org.apache.james.rspamd.RSpamDScanner">
+            <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
                 <rewriteSubject>true</rewriteSubject>
                 <virusProcessor>virus</virusProcessor>
             </mailet>

--- a/third-party/rspamd/sample-configuration/mailetcontainer_memory.xml
+++ b/third-party/rspamd/sample-configuration/mailetcontainer_memory.xml
@@ -87,7 +87,7 @@
         </processor>
 
         <processor state="local-delivery" enableJmx="true">
-            <mailet match="All" class="org.apache.james.rspamd.RSpamDScanner">
+            <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
                 <rewriteSubject>true</rewriteSubject>
                 <virusProcessor>virus</virusProcessor>
             </mailet>

--- a/third-party/rspamd/sample-configuration/rspamd.properties
+++ b/third-party/rspamd/sample-configuration/rspamd.properties
@@ -1,2 +1,2 @@
-rSpamDUrl=http://rspamd:11334
-rSpamDPassword=admin
+rspamdUrl=http://rspamd:11334
+rspamdPassword=admin

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdClientConfiguration.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdClientConfiguration.java
@@ -27,30 +27,30 @@ import org.apache.commons.configuration2.Configuration;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
 
-public class RSpamDClientConfiguration {
+public class RspamdClientConfiguration {
     public static final Integer DEFAULT_TIMEOUT_IN_SECONDS = 15;
 
-    public static RSpamDClientConfiguration from(Configuration config) {
-        URL rSpamDUrl = Optional.ofNullable(config.getString("rSpamDUrl", null))
+    public static RspamdClientConfiguration from(Configuration config) {
+        URL rspamdUrl = Optional.ofNullable(config.getString("rspamdUrl", null))
             .filter(s -> !s.isEmpty())
             .map(Throwing.function(URL::new))
-            .orElseThrow(() -> new IllegalArgumentException("RSpamD's url is invalid."));
+            .orElseThrow(() -> new IllegalArgumentException("Rspamd's url is invalid."));
 
-        Optional<Integer> rSpamDTimeoutConfigure = Optional.ofNullable(config.getInteger("rSpamDTimeout", null))
+        Optional<Integer> rspamdTimeoutConfigure = Optional.ofNullable(config.getInteger("rspamdTimeout", null))
             .map(i -> {
-                Preconditions.checkArgument(i > 0, "rSpamDTimeout should be positive number");
+                Preconditions.checkArgument(i > 0, "rspamdTimeout should be positive number");
                 return i;
             });
 
-        String rSpamDPassword = config.getString("rSpamDPassword", "");
-        return new RSpamDClientConfiguration(rSpamDUrl, rSpamDPassword, rSpamDTimeoutConfigure);
+        String rspamdPassword = config.getString("rspamdPassword", "");
+        return new RspamdClientConfiguration(rspamdUrl, rspamdPassword, rspamdTimeoutConfigure);
     }
 
     private final URL url;
     private final String password;
     private final Optional<Integer> timeout;
 
-    public RSpamDClientConfiguration(URL url, String password, Optional<Integer> timeout) {
+    public RspamdClientConfiguration(URL url, String password, Optional<Integer> timeout) {
         this.url = url;
         this.password = password;
         this.timeout = timeout;

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdHttpClient.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdHttpClient.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.rspamd.client;
 
-import static org.apache.james.rspamd.client.RSpamDClientConfiguration.DEFAULT_TIMEOUT_IN_SECONDS;
+import static org.apache.james.rspamd.client.RspamdClientConfiguration.DEFAULT_TIMEOUT_IN_SECONDS;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -27,7 +27,7 @@ import java.time.Duration;
 
 import javax.inject.Inject;
 
-import org.apache.james.rspamd.exception.RSpamDUnexpectedException;
+import org.apache.james.rspamd.exception.RspamdUnexpectedException;
 import org.apache.james.rspamd.exception.UnauthorizedException;
 import org.apache.james.rspamd.model.AnalysisResult;
 import org.apache.james.util.ReactorUtils;
@@ -43,7 +43,7 @@ import reactor.netty.ByteBufMono;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 
-public class RSpamDHttpClient {
+public class RspamdHttpClient {
     public static final String CHECK_V2_ENDPOINT = "/checkV2";
     public static final String LEARN_SPAM_ENDPOINT = "/learnspam";
     public static final String LEARN_HAM_ENDPOINT = "/learnham";
@@ -55,7 +55,7 @@ public class RSpamDHttpClient {
     private final ObjectMapper objectMapper;
 
     @Inject
-    public RSpamDHttpClient(RSpamDClientConfiguration configuration) {
+    public RspamdHttpClient(RspamdClientConfiguration configuration) {
         httpClient = buildReactorNettyHttpClient(configuration);
         this.objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
     }
@@ -77,7 +77,7 @@ public class RSpamDHttpClient {
         return reportMail(content, LEARN_HAM_ENDPOINT);
     }
 
-    private HttpClient buildReactorNettyHttpClient(RSpamDClientConfiguration configuration) {
+    private HttpClient buildReactorNettyHttpClient(RspamdClientConfiguration configuration) {
         return HttpClient.create()
             .disableRetry(true)
             .responseTimeout(Duration.ofSeconds(configuration.getTimeout().orElse(DEFAULT_TIMEOUT_IN_SECONDS)))
@@ -104,7 +104,7 @@ public class RSpamDHttpClient {
                     .flatMap(responseBody -> Mono.error(() -> new UnauthorizedException(responseBody)));
             default:
                 return byteBufMono.asString(StandardCharsets.UTF_8)
-                    .flatMap(responseBody -> Mono.error(() -> new RSpamDUnexpectedException(responseBody)));
+                    .flatMap(responseBody -> Mono.error(() -> new RspamdUnexpectedException(responseBody)));
         }
     }
 
@@ -117,7 +117,7 @@ public class RSpamDHttpClient {
                     .flatMap(responseBody -> Mono.error(() -> new UnauthorizedException(responseBody)));
             default:
                 return byteBufMono.asString(StandardCharsets.UTF_8)
-                    .flatMap(responseBody -> Mono.error(() -> new RSpamDUnexpectedException(responseBody)));
+                    .flatMap(responseBody -> Mono.error(() -> new RspamdUnexpectedException(responseBody)));
         }
     }
 

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/exception/RspamdUnexpectedException.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/exception/RspamdUnexpectedException.java
@@ -19,11 +19,11 @@
 
 package org.apache.james.rspamd.exception;
 
-public class RSpamDUnexpectedException extends RuntimeException {
-    public RSpamDUnexpectedException() {
+public class RspamdUnexpectedException extends RuntimeException {
+    public RspamdUnexpectedException() {
     }
 
-    public RSpamDUnexpectedException(String message) {
+    public RspamdUnexpectedException(String message) {
         super(message);
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/module/RspamdModule.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/module/RspamdModule.java
@@ -22,25 +22,25 @@ package org.apache.james.rspamd.module;
 import java.io.FileNotFoundException;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.james.rspamd.client.RSpamDClientConfiguration;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
+import org.apache.james.rspamd.client.RspamdClientConfiguration;
+import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.utils.PropertiesProvider;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
-public class RSpamDModule extends AbstractModule {
+public class RspamdModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public RSpamDClientConfiguration rSpamDClientConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException, FileNotFoundException {
-        return RSpamDClientConfiguration.from(propertiesProvider.getConfiguration("rspamd"));
+    public RspamdClientConfiguration rspamdClientConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException, FileNotFoundException {
+        return RspamdClientConfiguration.from(propertiesProvider.getConfiguration("rspamd"));
     }
 
     @Provides
     @Singleton
-    public RSpamDHttpClient rSpamDHttpClient(RSpamDClientConfiguration rSpamDClientConfiguration) {
-        return new RSpamDHttpClient(rSpamDClientConfiguration);
+    public RspamdHttpClient rspamdHttpClient(RspamdClientConfiguration rspamdClientConfiguration) {
+        return new RspamdHttpClient(rspamdClientConfiguration);
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/module/RspamdTaskExtensionModule.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/module/RspamdTaskExtensionModule.java
@@ -25,13 +25,13 @@ import java.util.Set;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
-import org.apache.james.rspamd.task.FeedHamToRSpamDTask;
-import org.apache.james.rspamd.task.FeedHamToRSpamDTaskAdditionalInformationDTO;
-import org.apache.james.rspamd.task.FeedHamToRSpamDTaskDTO;
-import org.apache.james.rspamd.task.FeedSpamToRSpamDTask;
-import org.apache.james.rspamd.task.FeedSpamToRSpamDTaskAdditionalInformationDTO;
-import org.apache.james.rspamd.task.FeedSpamToRSpamDTaskDTO;
+import org.apache.james.rspamd.client.RspamdHttpClient;
+import org.apache.james.rspamd.task.FeedHamToRspamdTask;
+import org.apache.james.rspamd.task.FeedHamToRspamdTaskAdditionalInformationDTO;
+import org.apache.james.rspamd.task.FeedHamToRspamdTaskDTO;
+import org.apache.james.rspamd.task.FeedSpamToRspamdTask;
+import org.apache.james.rspamd.task.FeedSpamToRspamdTaskAdditionalInformationDTO;
+import org.apache.james.rspamd.task.FeedSpamToRspamdTaskDTO;
 import org.apache.james.server.task.json.TaskExtensionModule;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
@@ -43,20 +43,20 @@ import org.apache.james.user.api.UsersRepository;
 
 import com.google.inject.Inject;
 
-public class RSpamDTaskExtensionModule implements TaskExtensionModule {
+public class RspamdTaskExtensionModule implements TaskExtensionModule {
 
-    private final TaskDTOModule<FeedSpamToRSpamDTask, FeedSpamToRSpamDTaskDTO> feedSpamTaskDTOModule;
-    private final TaskDTOModule<FeedHamToRSpamDTask, FeedHamToRSpamDTaskDTO> feedHamTaskDTOModule;
+    private final TaskDTOModule<FeedSpamToRspamdTask, FeedSpamToRspamdTaskDTO> feedSpamTaskDTOModule;
+    private final TaskDTOModule<FeedHamToRspamdTask, FeedHamToRspamdTaskDTO> feedHamTaskDTOModule;
 
     @Inject
-    public RSpamDTaskExtensionModule(MailboxManager mailboxManager,
+    public RspamdTaskExtensionModule(MailboxManager mailboxManager,
                                      UsersRepository usersRepository,
                                      MessageIdManager messageIdManager,
                                      MailboxSessionMapperFactory mapperFactory,
-                                     RSpamDHttpClient rSpamDHttpClient,
+                                     RspamdHttpClient rspamdHttpClient,
                                      Clock clock) {
-        this.feedSpamTaskDTOModule = FeedSpamToRSpamDTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rSpamDHttpClient, clock);
-        this.feedHamTaskDTOModule = FeedHamToRSpamDTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rSpamDHttpClient, clock);
+        this.feedSpamTaskDTOModule = FeedSpamToRspamdTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, clock);
+        this.feedHamTaskDTOModule = FeedHamToRspamdTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, clock);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class RSpamDTaskExtensionModule implements TaskExtensionModule {
 
     @Override
     public Set<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>> taskAdditionalInformationDTOModules() {
-        return Set.of(FeedSpamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE,
-            FeedHamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE);
+        return Set.of(FeedSpamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE,
+            FeedHamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE);
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
@@ -29,9 +29,9 @@ import javax.inject.Inject;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
-import org.apache.james.rspamd.task.FeedHamToRSpamDTask;
-import org.apache.james.rspamd.task.FeedSpamToRSpamDTask;
+import org.apache.james.rspamd.client.RspamdHttpClient;
+import org.apache.james.rspamd.task.FeedHamToRspamdTask;
+import org.apache.james.rspamd.task.FeedSpamToRspamdTask;
 import org.apache.james.task.Task;
 import org.apache.james.task.TaskManager;
 import org.apache.james.user.api.UsersRepository;
@@ -55,17 +55,17 @@ public class FeedMessageRoute implements Routes {
     private final MessageIdManager messageIdManager;
     private final MailboxSessionMapperFactory mapperFactory;
     private final UsersRepository usersRepository;
-    private final RSpamDHttpClient rSpamDHttpClient;
+    private final RspamdHttpClient rspamdHttpClient;
     private final JsonTransformer jsonTransformer;
     private final Clock clock;
 
     @Inject
-    public FeedMessageRoute(TaskManager taskManager, MailboxManager mailboxManager, UsersRepository usersRepository, RSpamDHttpClient rSpamDHttpClient,
+    public FeedMessageRoute(TaskManager taskManager, MailboxManager mailboxManager, UsersRepository usersRepository, RspamdHttpClient rspamdHttpClient,
                             JsonTransformer jsonTransformer, Clock clock, MessageIdManager messageIdManager, MailboxSessionMapperFactory mapperFactory) {
         this.taskManager = taskManager;
         this.mailboxManager = mailboxManager;
         this.usersRepository = usersRepository;
-        this.rSpamDHttpClient = rSpamDHttpClient;
+        this.rspamdHttpClient = rspamdHttpClient;
         this.jsonTransformer = jsonTransformer;
         this.clock = clock;
         this.messageIdManager = messageIdManager;
@@ -90,22 +90,22 @@ public class FeedMessageRoute implements Routes {
 
         return Optional.ofNullable(request.queryParams("action"))
             .filter(action -> action.equals(REPORT_SPAM_PARAM))
-            .map(any -> (Task) new FeedSpamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rSpamDHttpClient, getFeedSpamTaskRunningOptions(request), clock))
-            .orElse(new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rSpamDHttpClient, getFeedHamTaskRunningOptions(request), clock));
+            .map(any -> (Task) new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, getFeedSpamTaskRunningOptions(request), clock))
+            .orElse(new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, getFeedHamTaskRunningOptions(request), clock));
     }
 
-    private FeedSpamToRSpamDTask.RunningOptions getFeedSpamTaskRunningOptions(Request request) {
+    private FeedSpamToRspamdTask.RunningOptions getFeedSpamTaskRunningOptions(Request request) {
         Optional<Long> periodInSecond = getPeriod(request);
-        int messagesPerSecond = getMessagesPerSecond(request).orElse(FeedSpamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
-        double samplingProbability = getSamplingProbability(request).orElse(FeedSpamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
-        return new FeedSpamToRSpamDTask.RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
+        int messagesPerSecond = getMessagesPerSecond(request).orElse(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
+        double samplingProbability = getSamplingProbability(request).orElse(FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
+        return new FeedSpamToRspamdTask.RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
     }
 
-    private FeedHamToRSpamDTask.RunningOptions getFeedHamTaskRunningOptions(Request request) {
+    private FeedHamToRspamdTask.RunningOptions getFeedHamTaskRunningOptions(Request request) {
         Optional<Long> periodInSecond = getPeriod(request);
-        int messagesPerSecond = getMessagesPerSecond(request).orElse(FeedHamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
-        double samplingProbability = getSamplingProbability(request).orElse(FeedHamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
-        return new FeedHamToRSpamDTask.RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
+        int messagesPerSecond = getMessagesPerSecond(request).orElse(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
+        double samplingProbability = getSamplingProbability(request).orElse(FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
+        return new FeedHamToRspamdTask.RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
     }
 
     private Optional<Long> getPeriod(Request req) {

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTask.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTask.java
@@ -31,7 +31,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
+import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
@@ -46,9 +46,8 @@ import com.google.common.base.MoreObjects;
 
 import reactor.core.publisher.Mono;
 
-public class FeedSpamToRSpamDTask implements Task {
-    public static final String SPAM_MAILBOX_NAME = "Spam";
-    public static final TaskType TASK_TYPE = TaskType.of("FeedSpamToRSpamDTask");
+public class FeedHamToRspamdTask implements Task {
+    public static final TaskType TASK_TYPE = TaskType.of("FeedHamToRspamdTask");
 
     public static class RunningOptions {
         public static final Optional<Long> DEFAULT_PERIOD = Optional.empty();
@@ -88,8 +87,8 @@ public class FeedSpamToRSpamDTask implements Task {
             Context.Snapshot snapshot = context.snapshot();
             return new AdditionalInformation(
                 Clock.systemUTC().instant(),
-                snapshot.getSpamMessageCount(),
-                snapshot.getReportedSpamMessageCount(),
+                snapshot.getHamMessageCount(),
+                snapshot.getReportedHamMessageCount(),
                 snapshot.getErrorCount(),
                 snapshot.getMessagesPerSecond(),
                 snapshot.getPeriod(),
@@ -97,29 +96,29 @@ public class FeedSpamToRSpamDTask implements Task {
         }
 
         private final Instant timestamp;
-        private final long spamMessageCount;
-        private final long reportedSpamMessageCount;
+        private final long hamMessageCount;
+        private final long reportedHamMessageCount;
         private final long errorCount;
         private final int messagesPerSecond;
         private final Optional<Long> period;
         private final double samplingProbability;
 
-        public AdditionalInformation(Instant timestamp, long spamMessageCount, long reportedSpamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period, double samplingProbability) {
+        public AdditionalInformation(Instant timestamp, long hamMessageCount, long reportedHamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period, double samplingProbability) {
             this.timestamp = timestamp;
-            this.spamMessageCount = spamMessageCount;
-            this.reportedSpamMessageCount = reportedSpamMessageCount;
+            this.hamMessageCount = hamMessageCount;
+            this.reportedHamMessageCount = reportedHamMessageCount;
             this.errorCount = errorCount;
             this.messagesPerSecond = messagesPerSecond;
             this.period = period;
             this.samplingProbability = samplingProbability;
         }
 
-        public long getSpamMessageCount() {
-            return spamMessageCount;
+        public long getHamMessageCount() {
+            return hamMessageCount;
         }
 
-        public long getReportedSpamMessageCount() {
-            return reportedSpamMessageCount;
+        public long getReportedHamMessageCount() {
+            return reportedHamMessageCount;
         }
 
         public long getErrorCount() {
@@ -153,16 +152,16 @@ public class FeedSpamToRSpamDTask implements Task {
             }
 
             static class Builder {
-                private Optional<Long> spamMessageCount;
-                private Optional<Long> reportedSpamMessageCount;
+                private Optional<Long> hamMessageCount;
+                private Optional<Long> reportedHamMessageCount;
                 private Optional<Long> errorCount;
                 private Optional<Integer> messagesPerSecond;
                 private Optional<Long> period;
                 private Optional<Double> samplingProbability;
 
                 Builder() {
-                    spamMessageCount = Optional.empty();
-                    reportedSpamMessageCount = Optional.empty();
+                    hamMessageCount = Optional.empty();
+                    reportedHamMessageCount = Optional.empty();
                     errorCount = Optional.empty();
                     messagesPerSecond = Optional.empty();
                     period = Optional.empty();
@@ -171,21 +170,21 @@ public class FeedSpamToRSpamDTask implements Task {
 
                 public Snapshot build() {
                     return new Snapshot(
-                        spamMessageCount.orElse(0L),
-                        reportedSpamMessageCount.orElse(0L),
+                        hamMessageCount.orElse(0L),
+                        reportedHamMessageCount.orElse(0L),
                         errorCount.orElse(0L),
                         messagesPerSecond.orElse(0),
                         period,
                         samplingProbability.orElse(1D));
                 }
 
-                public Builder spamMessageCount(long spamMessageCount) {
-                    this.spamMessageCount = Optional.of(spamMessageCount);
+                public Builder hamMessageCount(long hamMessageCount) {
+                    this.hamMessageCount = Optional.of(hamMessageCount);
                     return this;
                 }
 
-                public Builder reportedSpamMessageCount(long reportedSpamMessageCount) {
-                    this.reportedSpamMessageCount = Optional.of(reportedSpamMessageCount);
+                public Builder reportedHamMessageCount(long reportedHamMessageCount) {
+                    this.reportedHamMessageCount = Optional.of(reportedHamMessageCount);
                     return this;
                 }
 
@@ -210,29 +209,29 @@ public class FeedSpamToRSpamDTask implements Task {
                 }
             }
 
-            private final long spamMessageCount;
-            private final long reportedSpamMessageCount;
+            private final long hamMessageCount;
+            private final long reportedHamMessageCount;
             private final long errorCount;
             private final int messagesPerSecond;
             private final Optional<Long> period;
             private final double samplingProbability;
 
-            public Snapshot(long spamMessageCount, long reportedSpamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period,
+            public Snapshot(long hamMessageCount, long reportedHamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period,
                             double samplingProbability) {
-                this.spamMessageCount = spamMessageCount;
-                this.reportedSpamMessageCount = reportedSpamMessageCount;
+                this.hamMessageCount = hamMessageCount;
+                this.reportedHamMessageCount = reportedHamMessageCount;
                 this.errorCount = errorCount;
                 this.messagesPerSecond = messagesPerSecond;
                 this.period = period;
                 this.samplingProbability = samplingProbability;
             }
 
-            public long getSpamMessageCount() {
-                return spamMessageCount;
+            public long getHamMessageCount() {
+                return hamMessageCount;
             }
 
-            public long getReportedSpamMessageCount() {
-                return reportedSpamMessageCount;
+            public long getReportedHamMessageCount() {
+                return reportedHamMessageCount;
             }
 
             public long getErrorCount() {
@@ -256,8 +255,8 @@ public class FeedSpamToRSpamDTask implements Task {
                 if (o instanceof Snapshot) {
                     Snapshot snapshot = (Snapshot) o;
 
-                    return Objects.equals(this.spamMessageCount, snapshot.spamMessageCount)
-                        && Objects.equals(this.reportedSpamMessageCount, snapshot.reportedSpamMessageCount)
+                    return Objects.equals(this.hamMessageCount, snapshot.hamMessageCount)
+                        && Objects.equals(this.reportedHamMessageCount, snapshot.reportedHamMessageCount)
                         && Objects.equals(this.errorCount, snapshot.errorCount)
                         && Objects.equals(this.messagesPerSecond, snapshot.messagesPerSecond)
                         && Objects.equals(this.samplingProbability, snapshot.samplingProbability)
@@ -268,14 +267,14 @@ public class FeedSpamToRSpamDTask implements Task {
 
             @Override
             public final int hashCode() {
-                return Objects.hash(spamMessageCount, reportedSpamMessageCount, errorCount, messagesPerSecond, period, samplingProbability);
+                return Objects.hash(hamMessageCount, reportedHamMessageCount, errorCount, messagesPerSecond, period, samplingProbability);
             }
 
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(this)
-                    .add("spamMessageCount", spamMessageCount)
-                    .add("reportedSpamMessageCount", reportedSpamMessageCount)
+                    .add("hamMessageCount", hamMessageCount)
+                    .add("reportedHamMessageCount", reportedHamMessageCount)
                     .add("errorCount", errorCount)
                     .add("messagesPerSecond", messagesPerSecond)
                     .add("period", period)
@@ -284,28 +283,28 @@ public class FeedSpamToRSpamDTask implements Task {
             }
         }
 
-        private final AtomicLong spamMessageCount;
-        private final AtomicLong reportedSpamMessageCount;
+        private final AtomicLong hamMessageCount;
+        private final AtomicLong reportedHamMessageCount;
         private final AtomicLong errorCount;
         private final Integer messagesPerSecond;
         private final Optional<Long> period;
         private final Double samplingProbability;
 
         public Context(RunningOptions runningOptions) {
-            this.spamMessageCount = new AtomicLong();
-            this.reportedSpamMessageCount = new AtomicLong();
+            this.hamMessageCount = new AtomicLong();
+            this.reportedHamMessageCount = new AtomicLong();
             this.errorCount = new AtomicLong();
             this.messagesPerSecond = runningOptions.messagesPerSecond;
             this.period = runningOptions.periodInSecond;
             this.samplingProbability = runningOptions.samplingProbability;
         }
 
-        public void incrementSpamMessageCount() {
-            spamMessageCount.incrementAndGet();
+        public void incrementHamMessageCount() {
+            hamMessageCount.incrementAndGet();
         }
 
-        public void incrementReportedSpamMessageCount(int count) {
-            reportedSpamMessageCount.addAndGet(count);
+        public void incrementReportedHamMessageCount(int count) {
+            reportedHamMessageCount.addAndGet(count);
         }
 
         public void incrementErrorCount() {
@@ -314,8 +313,8 @@ public class FeedSpamToRSpamDTask implements Task {
 
         public Snapshot snapshot() {
             return Snapshot.builder()
-                .spamMessageCount(spamMessageCount.get())
-                .reportedSpamMessageCount(reportedSpamMessageCount.get())
+                .hamMessageCount(hamMessageCount.get())
+                .reportedHamMessageCount(reportedHamMessageCount.get())
                 .errorCount(errorCount.get())
                 .messagesPerSecond(messagesPerSecond)
                 .period(period)
@@ -325,16 +324,16 @@ public class FeedSpamToRSpamDTask implements Task {
     }
 
     private final GetMailboxMessagesService messagesService;
-    private final RSpamDHttpClient rSpamDHttpClient;
+    private final RspamdHttpClient rspamdHttpClient;
     private final RunningOptions runningOptions;
     private final Context context;
     private final Clock clock;
 
-    public FeedSpamToRSpamDTask(MailboxManager mailboxManager, UsersRepository usersRepository, MessageIdManager messageIdManager, MailboxSessionMapperFactory mapperFactory,
-                                RSpamDHttpClient rSpamDHttpClient, RunningOptions runningOptions, Clock clock) {
+    public FeedHamToRspamdTask(MailboxManager mailboxManager, UsersRepository usersRepository, MessageIdManager messageIdManager, MailboxSessionMapperFactory mapperFactory,
+                               RspamdHttpClient rspamdHttpClient, RunningOptions runningOptions, Clock clock) {
         this.runningOptions = runningOptions;
         this.messagesService = new GetMailboxMessagesService(mailboxManager, usersRepository, mapperFactory, messageIdManager);
-        this.rSpamDHttpClient = rSpamDHttpClient;
+        this.rspamdHttpClient = rspamdHttpClient;
         this.context = new Context(runningOptions);
         this.clock = clock;
     }
@@ -343,17 +342,17 @@ public class FeedSpamToRSpamDTask implements Task {
     public Result run() {
         Optional<Date> afterDate = runningOptions.periodInSecond.map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
         try {
-            return messagesService.getMailboxMessagesOfAllUser(SPAM_MAILBOX_NAME, afterDate, runningOptions.getSamplingProbability(), context)
-                .transform(ReactorUtils.<MessageResult, Task.Result>throttle()
+            return messagesService.getHamMessagesOfAllUser(afterDate, runningOptions.getSamplingProbability(), context)
+                .transform(ReactorUtils.<MessageResult, Result>throttle()
                     .elements(runningOptions.messagesPerSecond)
                     .per(Duration.ofSeconds(1))
-                    .forOperation(messageResult -> Mono.fromSupplier(Throwing.supplier(() -> rSpamDHttpClient.reportAsSpam(messageResult.getFullContent().getInputStream())))
+                    .forOperation(messageResult -> Mono.fromSupplier(Throwing.supplier(() -> rspamdHttpClient.reportAsHam(messageResult.getFullContent().getInputStream())))
                         .then(Mono.fromCallable(() -> {
-                            context.incrementReportedSpamMessageCount(1);
+                            context.incrementReportedHamMessageCount(1);
                             return Result.COMPLETED;
                         }))
                         .onErrorResume(error -> {
-                            LOGGER.error("Error when report spam message to RSpamD", error);
+                            LOGGER.error("Error when report ham message to Rspamd", error);
                             context.incrementErrorCount();
                             return Mono.just(Result.PARTIAL);
                         })))
@@ -362,7 +361,7 @@ public class FeedSpamToRSpamDTask implements Task {
                 .block();
         } catch (UsersRepositoryException e) {
             LOGGER.error("Error while accessing users from repository", e);
-            return Task.Result.PARTIAL;
+            return Result.PARTIAL;
         }
     }
 

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTO.java
@@ -27,17 +27,17 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class FeedHamToRSpamDTaskAdditionalInformationDTO implements AdditionalInformationDTO {
-    public static final AdditionalInformationDTOModule<FeedHamToRSpamDTask.AdditionalInformation, FeedHamToRSpamDTaskAdditionalInformationDTO> SERIALIZATION_MODULE =
-        DTOModule.forDomainObject(FeedHamToRSpamDTask.AdditionalInformation.class)
-            .convertToDTO(FeedHamToRSpamDTaskAdditionalInformationDTO.class)
-            .toDomainObjectConverter(FeedHamToRSpamDTaskAdditionalInformationDTO::toDomainObject)
-            .toDTOConverter(FeedHamToRSpamDTaskAdditionalInformationDTO::toDto)
-            .typeName(FeedHamToRSpamDTask.TASK_TYPE.asString())
+public class FeedHamToRspamdTaskAdditionalInformationDTO implements AdditionalInformationDTO {
+    public static final AdditionalInformationDTOModule<FeedHamToRspamdTask.AdditionalInformation, FeedHamToRspamdTaskAdditionalInformationDTO> SERIALIZATION_MODULE =
+        DTOModule.forDomainObject(FeedHamToRspamdTask.AdditionalInformation.class)
+            .convertToDTO(FeedHamToRspamdTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(FeedHamToRspamdTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(FeedHamToRspamdTaskAdditionalInformationDTO::toDto)
+            .typeName(FeedHamToRspamdTask.TASK_TYPE.asString())
             .withFactory(AdditionalInformationDTOModule::new);
 
-    private static FeedHamToRSpamDTask.AdditionalInformation toDomainObject(FeedHamToRSpamDTaskAdditionalInformationDTO dto) {
-        return new FeedHamToRSpamDTask.AdditionalInformation(
+    private static FeedHamToRspamdTask.AdditionalInformation toDomainObject(FeedHamToRspamdTaskAdditionalInformationDTO dto) {
+        return new FeedHamToRspamdTask.AdditionalInformation(
             dto.timestamp,
             dto.hamMessageCount,
             dto.reportedHamMessageCount,
@@ -47,14 +47,14 @@ public class FeedHamToRSpamDTaskAdditionalInformationDTO implements AdditionalIn
             dto.runningOptions.getSamplingProbability());
     }
 
-    private static FeedHamToRSpamDTaskAdditionalInformationDTO toDto(FeedHamToRSpamDTask.AdditionalInformation domainObject, String type) {
-        return new FeedHamToRSpamDTaskAdditionalInformationDTO(
+    private static FeedHamToRspamdTaskAdditionalInformationDTO toDto(FeedHamToRspamdTask.AdditionalInformation domainObject, String type) {
+        return new FeedHamToRspamdTaskAdditionalInformationDTO(
             type,
             domainObject.timestamp(),
             domainObject.getHamMessageCount(),
             domainObject.getReportedHamMessageCount(),
             domainObject.getErrorCount(),
-            new FeedHamToRSpamDTask.RunningOptions(domainObject.getPeriod(), domainObject.getMessagesPerSecond(), domainObject.getSamplingProbability()));
+            new FeedHamToRspamdTask.RunningOptions(domainObject.getPeriod(), domainObject.getMessagesPerSecond(), domainObject.getSamplingProbability()));
     }
 
     private final String type;
@@ -62,14 +62,14 @@ public class FeedHamToRSpamDTaskAdditionalInformationDTO implements AdditionalIn
     private final long hamMessageCount;
     private final long reportedHamMessageCount;
     private final long errorCount;
-    private final FeedHamToRSpamDTask.RunningOptions runningOptions;
+    private final FeedHamToRspamdTask.RunningOptions runningOptions;
 
-    public FeedHamToRSpamDTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+    public FeedHamToRspamdTaskAdditionalInformationDTO(@JsonProperty("type") String type,
                                                        @JsonProperty("timestamp") Instant timestamp,
                                                        @JsonProperty("hamMessageCount") long hamMessageCount,
                                                        @JsonProperty("reportedHamMessageCount") long reportedHamMessageCount,
                                                        @JsonProperty("errorCount") long errorCount,
-                                                       @JsonProperty("runningOptions") FeedHamToRSpamDTask.RunningOptions runningOptions) {
+                                                       @JsonProperty("runningOptions") FeedHamToRspamdTask.RunningOptions runningOptions) {
         this.type = type;
         this.timestamp = timestamp;
         this.hamMessageCount = hamMessageCount;
@@ -100,7 +100,7 @@ public class FeedHamToRSpamDTaskAdditionalInformationDTO implements AdditionalIn
         return errorCount;
     }
 
-    public FeedHamToRSpamDTask.RunningOptions getRunningOptions() {
+    public FeedHamToRspamdTask.RunningOptions getRunningOptions() {
         return runningOptions;
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
@@ -26,50 +26,49 @@ import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
+import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.server.task.json.dto.TaskDTO;
 import org.apache.james.server.task.json.dto.TaskDTOModule;
 import org.apache.james.user.api.UsersRepository;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class FeedSpamToRSpamDTaskDTO implements TaskDTO {
-    public static TaskDTOModule<FeedSpamToRSpamDTask, FeedSpamToRSpamDTaskDTO> module(MailboxManager mailboxManager,
-                                                                                      UsersRepository usersRepository,
-                                                                                      MessageIdManager messageIdManager,
-                                                                                      MailboxSessionMapperFactory mapperFactory,
-                                                                                      RSpamDHttpClient rSpamDHttpClient,
-                                                                                      Clock clock) {
-        return DTOModule.forDomainObject(FeedSpamToRSpamDTask.class)
-            .convertToDTO(FeedSpamToRSpamDTaskDTO.class)
-            .toDomainObjectConverter(dto -> new FeedSpamToRSpamDTask(mailboxManager,
+public class FeedHamToRspamdTaskDTO implements TaskDTO {
+    public static TaskDTOModule<FeedHamToRspamdTask, FeedHamToRspamdTaskDTO> module(MailboxManager mailboxManager,
+                                                                                    UsersRepository usersRepository,
+                                                                                    MessageIdManager messageIdManager,
+                                                                                    MailboxSessionMapperFactory mapperFactory,
+                                                                                    RspamdHttpClient rspamdHttpClient,
+                                                                                    Clock clock) {
+        return DTOModule.forDomainObject(FeedHamToRspamdTask.class)
+            .convertToDTO(FeedHamToRspamdTaskDTO.class)
+            .toDomainObjectConverter(dto -> new FeedHamToRspamdTask(mailboxManager,
                 usersRepository,
                 messageIdManager,
                 mapperFactory,
-                rSpamDHttpClient,
-                new FeedSpamToRSpamDTask.RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
+                rspamdHttpClient,
+                new FeedHamToRspamdTask.RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
                     dto.getMessagesPerSecond(),
                     dto.getSamplingProbability()),
                 clock))
-            .toDTOConverter((domain, type) -> new FeedSpamToRSpamDTaskDTO(
-                type,
+            .toDTOConverter((domain, type) -> new FeedHamToRspamdTaskDTO(type,
                 domain.getRunningOptions().getPeriodInSecond().orElse(null),
                 domain.getRunningOptions().getMessagesPerSecond(),
                 domain.getRunningOptions().getSamplingProbability()))
-            .typeName(FeedSpamToRSpamDTask.TASK_TYPE.asString())
+            .typeName(FeedHamToRspamdTask.TASK_TYPE.asString())
             .withFactory(TaskDTOModule::new);
     }
+
 
     private final String type;
     private final Long periodInSecond;
     private final int messagesPerSecond;
     private final double samplingProbability;
 
-
-    public FeedSpamToRSpamDTaskDTO(@JsonProperty("type") String type,
-                                   @JsonProperty("periodInSecond") Long periodInSecond,
-                                   @JsonProperty("messagesPerSecond") int messagesPerSecond,
-                                   @JsonProperty("samplingProbability") double samplingProbability) {
+    public FeedHamToRspamdTaskDTO(@JsonProperty("type") String type,
+                                  @JsonProperty("periodInSecond") Long periodInSecond,
+                                  @JsonProperty("messagesPerSecond") int messagesPerSecond,
+                                  @JsonProperty("samplingProbability") double samplingProbability) {
         this.type = type;
         this.periodInSecond = periodInSecond;
         this.messagesPerSecond = messagesPerSecond;

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
@@ -31,7 +31,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
+import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
@@ -46,8 +46,9 @@ import com.google.common.base.MoreObjects;
 
 import reactor.core.publisher.Mono;
 
-public class FeedHamToRSpamDTask implements Task {
-    public static final TaskType TASK_TYPE = TaskType.of("FeedHamToRSpamDTask");
+public class FeedSpamToRspamdTask implements Task {
+    public static final String SPAM_MAILBOX_NAME = "Spam";
+    public static final TaskType TASK_TYPE = TaskType.of("FeedSpamToRspamdTask");
 
     public static class RunningOptions {
         public static final Optional<Long> DEFAULT_PERIOD = Optional.empty();
@@ -87,8 +88,8 @@ public class FeedHamToRSpamDTask implements Task {
             Context.Snapshot snapshot = context.snapshot();
             return new AdditionalInformation(
                 Clock.systemUTC().instant(),
-                snapshot.getHamMessageCount(),
-                snapshot.getReportedHamMessageCount(),
+                snapshot.getSpamMessageCount(),
+                snapshot.getReportedSpamMessageCount(),
                 snapshot.getErrorCount(),
                 snapshot.getMessagesPerSecond(),
                 snapshot.getPeriod(),
@@ -96,29 +97,29 @@ public class FeedHamToRSpamDTask implements Task {
         }
 
         private final Instant timestamp;
-        private final long hamMessageCount;
-        private final long reportedHamMessageCount;
+        private final long spamMessageCount;
+        private final long reportedSpamMessageCount;
         private final long errorCount;
         private final int messagesPerSecond;
         private final Optional<Long> period;
         private final double samplingProbability;
 
-        public AdditionalInformation(Instant timestamp, long hamMessageCount, long reportedHamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period, double samplingProbability) {
+        public AdditionalInformation(Instant timestamp, long spamMessageCount, long reportedSpamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period, double samplingProbability) {
             this.timestamp = timestamp;
-            this.hamMessageCount = hamMessageCount;
-            this.reportedHamMessageCount = reportedHamMessageCount;
+            this.spamMessageCount = spamMessageCount;
+            this.reportedSpamMessageCount = reportedSpamMessageCount;
             this.errorCount = errorCount;
             this.messagesPerSecond = messagesPerSecond;
             this.period = period;
             this.samplingProbability = samplingProbability;
         }
 
-        public long getHamMessageCount() {
-            return hamMessageCount;
+        public long getSpamMessageCount() {
+            return spamMessageCount;
         }
 
-        public long getReportedHamMessageCount() {
-            return reportedHamMessageCount;
+        public long getReportedSpamMessageCount() {
+            return reportedSpamMessageCount;
         }
 
         public long getErrorCount() {
@@ -152,16 +153,16 @@ public class FeedHamToRSpamDTask implements Task {
             }
 
             static class Builder {
-                private Optional<Long> hamMessageCount;
-                private Optional<Long> reportedHamMessageCount;
+                private Optional<Long> spamMessageCount;
+                private Optional<Long> reportedSpamMessageCount;
                 private Optional<Long> errorCount;
                 private Optional<Integer> messagesPerSecond;
                 private Optional<Long> period;
                 private Optional<Double> samplingProbability;
 
                 Builder() {
-                    hamMessageCount = Optional.empty();
-                    reportedHamMessageCount = Optional.empty();
+                    spamMessageCount = Optional.empty();
+                    reportedSpamMessageCount = Optional.empty();
                     errorCount = Optional.empty();
                     messagesPerSecond = Optional.empty();
                     period = Optional.empty();
@@ -170,21 +171,21 @@ public class FeedHamToRSpamDTask implements Task {
 
                 public Snapshot build() {
                     return new Snapshot(
-                        hamMessageCount.orElse(0L),
-                        reportedHamMessageCount.orElse(0L),
+                        spamMessageCount.orElse(0L),
+                        reportedSpamMessageCount.orElse(0L),
                         errorCount.orElse(0L),
                         messagesPerSecond.orElse(0),
                         period,
                         samplingProbability.orElse(1D));
                 }
 
-                public Builder hamMessageCount(long hamMessageCount) {
-                    this.hamMessageCount = Optional.of(hamMessageCount);
+                public Builder spamMessageCount(long spamMessageCount) {
+                    this.spamMessageCount = Optional.of(spamMessageCount);
                     return this;
                 }
 
-                public Builder reportedHamMessageCount(long reportedHamMessageCount) {
-                    this.reportedHamMessageCount = Optional.of(reportedHamMessageCount);
+                public Builder reportedSpamMessageCount(long reportedSpamMessageCount) {
+                    this.reportedSpamMessageCount = Optional.of(reportedSpamMessageCount);
                     return this;
                 }
 
@@ -209,29 +210,29 @@ public class FeedHamToRSpamDTask implements Task {
                 }
             }
 
-            private final long hamMessageCount;
-            private final long reportedHamMessageCount;
+            private final long spamMessageCount;
+            private final long reportedSpamMessageCount;
             private final long errorCount;
             private final int messagesPerSecond;
             private final Optional<Long> period;
             private final double samplingProbability;
 
-            public Snapshot(long hamMessageCount, long reportedHamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period,
+            public Snapshot(long spamMessageCount, long reportedSpamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period,
                             double samplingProbability) {
-                this.hamMessageCount = hamMessageCount;
-                this.reportedHamMessageCount = reportedHamMessageCount;
+                this.spamMessageCount = spamMessageCount;
+                this.reportedSpamMessageCount = reportedSpamMessageCount;
                 this.errorCount = errorCount;
                 this.messagesPerSecond = messagesPerSecond;
                 this.period = period;
                 this.samplingProbability = samplingProbability;
             }
 
-            public long getHamMessageCount() {
-                return hamMessageCount;
+            public long getSpamMessageCount() {
+                return spamMessageCount;
             }
 
-            public long getReportedHamMessageCount() {
-                return reportedHamMessageCount;
+            public long getReportedSpamMessageCount() {
+                return reportedSpamMessageCount;
             }
 
             public long getErrorCount() {
@@ -255,8 +256,8 @@ public class FeedHamToRSpamDTask implements Task {
                 if (o instanceof Snapshot) {
                     Snapshot snapshot = (Snapshot) o;
 
-                    return Objects.equals(this.hamMessageCount, snapshot.hamMessageCount)
-                        && Objects.equals(this.reportedHamMessageCount, snapshot.reportedHamMessageCount)
+                    return Objects.equals(this.spamMessageCount, snapshot.spamMessageCount)
+                        && Objects.equals(this.reportedSpamMessageCount, snapshot.reportedSpamMessageCount)
                         && Objects.equals(this.errorCount, snapshot.errorCount)
                         && Objects.equals(this.messagesPerSecond, snapshot.messagesPerSecond)
                         && Objects.equals(this.samplingProbability, snapshot.samplingProbability)
@@ -267,14 +268,14 @@ public class FeedHamToRSpamDTask implements Task {
 
             @Override
             public final int hashCode() {
-                return Objects.hash(hamMessageCount, reportedHamMessageCount, errorCount, messagesPerSecond, period, samplingProbability);
+                return Objects.hash(spamMessageCount, reportedSpamMessageCount, errorCount, messagesPerSecond, period, samplingProbability);
             }
 
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(this)
-                    .add("hamMessageCount", hamMessageCount)
-                    .add("reportedHamMessageCount", reportedHamMessageCount)
+                    .add("spamMessageCount", spamMessageCount)
+                    .add("reportedSpamMessageCount", reportedSpamMessageCount)
                     .add("errorCount", errorCount)
                     .add("messagesPerSecond", messagesPerSecond)
                     .add("period", period)
@@ -283,28 +284,28 @@ public class FeedHamToRSpamDTask implements Task {
             }
         }
 
-        private final AtomicLong hamMessageCount;
-        private final AtomicLong reportedHamMessageCount;
+        private final AtomicLong spamMessageCount;
+        private final AtomicLong reportedSpamMessageCount;
         private final AtomicLong errorCount;
         private final Integer messagesPerSecond;
         private final Optional<Long> period;
         private final Double samplingProbability;
 
         public Context(RunningOptions runningOptions) {
-            this.hamMessageCount = new AtomicLong();
-            this.reportedHamMessageCount = new AtomicLong();
+            this.spamMessageCount = new AtomicLong();
+            this.reportedSpamMessageCount = new AtomicLong();
             this.errorCount = new AtomicLong();
             this.messagesPerSecond = runningOptions.messagesPerSecond;
             this.period = runningOptions.periodInSecond;
             this.samplingProbability = runningOptions.samplingProbability;
         }
 
-        public void incrementHamMessageCount() {
-            hamMessageCount.incrementAndGet();
+        public void incrementSpamMessageCount() {
+            spamMessageCount.incrementAndGet();
         }
 
-        public void incrementReportedHamMessageCount(int count) {
-            reportedHamMessageCount.addAndGet(count);
+        public void incrementReportedSpamMessageCount(int count) {
+            reportedSpamMessageCount.addAndGet(count);
         }
 
         public void incrementErrorCount() {
@@ -313,8 +314,8 @@ public class FeedHamToRSpamDTask implements Task {
 
         public Snapshot snapshot() {
             return Snapshot.builder()
-                .hamMessageCount(hamMessageCount.get())
-                .reportedHamMessageCount(reportedHamMessageCount.get())
+                .spamMessageCount(spamMessageCount.get())
+                .reportedSpamMessageCount(reportedSpamMessageCount.get())
                 .errorCount(errorCount.get())
                 .messagesPerSecond(messagesPerSecond)
                 .period(period)
@@ -324,16 +325,16 @@ public class FeedHamToRSpamDTask implements Task {
     }
 
     private final GetMailboxMessagesService messagesService;
-    private final RSpamDHttpClient rSpamDHttpClient;
+    private final RspamdHttpClient rspamdHttpClient;
     private final RunningOptions runningOptions;
     private final Context context;
     private final Clock clock;
 
-    public FeedHamToRSpamDTask(MailboxManager mailboxManager, UsersRepository usersRepository, MessageIdManager messageIdManager, MailboxSessionMapperFactory mapperFactory,
-                               RSpamDHttpClient rSpamDHttpClient, RunningOptions runningOptions, Clock clock) {
+    public FeedSpamToRspamdTask(MailboxManager mailboxManager, UsersRepository usersRepository, MessageIdManager messageIdManager, MailboxSessionMapperFactory mapperFactory,
+                                RspamdHttpClient rspamdHttpClient, RunningOptions runningOptions, Clock clock) {
         this.runningOptions = runningOptions;
         this.messagesService = new GetMailboxMessagesService(mailboxManager, usersRepository, mapperFactory, messageIdManager);
-        this.rSpamDHttpClient = rSpamDHttpClient;
+        this.rspamdHttpClient = rspamdHttpClient;
         this.context = new Context(runningOptions);
         this.clock = clock;
     }
@@ -342,17 +343,17 @@ public class FeedHamToRSpamDTask implements Task {
     public Result run() {
         Optional<Date> afterDate = runningOptions.periodInSecond.map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
         try {
-            return messagesService.getHamMessagesOfAllUser(afterDate, runningOptions.getSamplingProbability(), context)
-                .transform(ReactorUtils.<MessageResult, Result>throttle()
+            return messagesService.getMailboxMessagesOfAllUser(SPAM_MAILBOX_NAME, afterDate, runningOptions.getSamplingProbability(), context)
+                .transform(ReactorUtils.<MessageResult, Task.Result>throttle()
                     .elements(runningOptions.messagesPerSecond)
                     .per(Duration.ofSeconds(1))
-                    .forOperation(messageResult -> Mono.fromSupplier(Throwing.supplier(() -> rSpamDHttpClient.reportAsHam(messageResult.getFullContent().getInputStream())))
+                    .forOperation(messageResult -> Mono.fromSupplier(Throwing.supplier(() -> rspamdHttpClient.reportAsSpam(messageResult.getFullContent().getInputStream())))
                         .then(Mono.fromCallable(() -> {
-                            context.incrementReportedHamMessageCount(1);
+                            context.incrementReportedSpamMessageCount(1);
                             return Result.COMPLETED;
                         }))
                         .onErrorResume(error -> {
-                            LOGGER.error("Error when report ham message to RSpamD", error);
+                            LOGGER.error("Error when report spam message to Rspamd", error);
                             context.incrementErrorCount();
                             return Mono.just(Result.PARTIAL);
                         })))
@@ -361,7 +362,7 @@ public class FeedHamToRSpamDTask implements Task {
                 .block();
         } catch (UsersRepositoryException e) {
             LOGGER.error("Error while accessing users from repository", e);
-            return Result.PARTIAL;
+            return Task.Result.PARTIAL;
         }
     }
 

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTO.java
@@ -27,17 +27,17 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class FeedSpamToRSpamDTaskAdditionalInformationDTO implements AdditionalInformationDTO {
-    public static final AdditionalInformationDTOModule<FeedSpamToRSpamDTask.AdditionalInformation, FeedSpamToRSpamDTaskAdditionalInformationDTO> SERIALIZATION_MODULE =
-        DTOModule.forDomainObject(FeedSpamToRSpamDTask.AdditionalInformation.class)
-            .convertToDTO(FeedSpamToRSpamDTaskAdditionalInformationDTO.class)
-            .toDomainObjectConverter(FeedSpamToRSpamDTaskAdditionalInformationDTO::toDomainObject)
-            .toDTOConverter(FeedSpamToRSpamDTaskAdditionalInformationDTO::toDto)
-            .typeName(FeedSpamToRSpamDTask.TASK_TYPE.asString())
+public class FeedSpamToRspamdTaskAdditionalInformationDTO implements AdditionalInformationDTO {
+    public static final AdditionalInformationDTOModule<FeedSpamToRspamdTask.AdditionalInformation, FeedSpamToRspamdTaskAdditionalInformationDTO> SERIALIZATION_MODULE =
+        DTOModule.forDomainObject(FeedSpamToRspamdTask.AdditionalInformation.class)
+            .convertToDTO(FeedSpamToRspamdTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(FeedSpamToRspamdTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(FeedSpamToRspamdTaskAdditionalInformationDTO::toDto)
+            .typeName(FeedSpamToRspamdTask.TASK_TYPE.asString())
             .withFactory(AdditionalInformationDTOModule::new);
 
-    private static FeedSpamToRSpamDTask.AdditionalInformation toDomainObject(FeedSpamToRSpamDTaskAdditionalInformationDTO dto) {
-        return new FeedSpamToRSpamDTask.AdditionalInformation(
+    private static FeedSpamToRspamdTask.AdditionalInformation toDomainObject(FeedSpamToRspamdTaskAdditionalInformationDTO dto) {
+        return new FeedSpamToRspamdTask.AdditionalInformation(
             dto.timestamp,
             dto.spamMessageCount,
             dto.reportedSpamMessageCount,
@@ -47,14 +47,14 @@ public class FeedSpamToRSpamDTaskAdditionalInformationDTO implements AdditionalI
             dto.runningOptions.getSamplingProbability());
     }
 
-    private static FeedSpamToRSpamDTaskAdditionalInformationDTO toDto(FeedSpamToRSpamDTask.AdditionalInformation domainObject, String type) {
-        return new FeedSpamToRSpamDTaskAdditionalInformationDTO(
+    private static FeedSpamToRspamdTaskAdditionalInformationDTO toDto(FeedSpamToRspamdTask.AdditionalInformation domainObject, String type) {
+        return new FeedSpamToRspamdTaskAdditionalInformationDTO(
             type,
             domainObject.timestamp(),
             domainObject.getSpamMessageCount(),
             domainObject.getReportedSpamMessageCount(),
             domainObject.getErrorCount(),
-            new FeedSpamToRSpamDTask.RunningOptions(domainObject.getPeriod(), domainObject.getMessagesPerSecond(), domainObject.getSamplingProbability()));
+            new FeedSpamToRspamdTask.RunningOptions(domainObject.getPeriod(), domainObject.getMessagesPerSecond(), domainObject.getSamplingProbability()));
     }
 
     private final String type;
@@ -62,14 +62,14 @@ public class FeedSpamToRSpamDTaskAdditionalInformationDTO implements AdditionalI
     private final long spamMessageCount;
     private final long reportedSpamMessageCount;
     private final long errorCount;
-    private final FeedSpamToRSpamDTask.RunningOptions runningOptions;
+    private final FeedSpamToRspamdTask.RunningOptions runningOptions;
 
-    public FeedSpamToRSpamDTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+    public FeedSpamToRspamdTaskAdditionalInformationDTO(@JsonProperty("type") String type,
                                                         @JsonProperty("timestamp") Instant timestamp,
                                                         @JsonProperty("spamMessageCount") long spamMessageCount,
                                                         @JsonProperty("reportedSpamMessageCount") long reportedSpamMessageCount,
                                                         @JsonProperty("errorCount") long errorCount,
-                                                        @JsonProperty("runningOptions") FeedSpamToRSpamDTask.RunningOptions runningOptions) {
+                                                        @JsonProperty("runningOptions") FeedSpamToRspamdTask.RunningOptions runningOptions) {
         this.type = type;
         this.timestamp = timestamp;
         this.spamMessageCount = spamMessageCount;
@@ -100,7 +100,7 @@ public class FeedSpamToRSpamDTaskAdditionalInformationDTO implements AdditionalI
         return errorCount;
     }
 
-    public FeedSpamToRSpamDTask.RunningOptions getRunningOptions() {
+    public FeedSpamToRspamdTask.RunningOptions getRunningOptions() {
         return runningOptions;
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
@@ -26,49 +26,50 @@ import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
+import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.server.task.json.dto.TaskDTO;
 import org.apache.james.server.task.json.dto.TaskDTOModule;
 import org.apache.james.user.api.UsersRepository;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class FeedHamToRSpamDTaskDTO implements TaskDTO {
-    public static TaskDTOModule<FeedHamToRSpamDTask, FeedHamToRSpamDTaskDTO> module(MailboxManager mailboxManager,
-                                                                                    UsersRepository usersRepository,
-                                                                                    MessageIdManager messageIdManager,
-                                                                                    MailboxSessionMapperFactory mapperFactory,
-                                                                                    RSpamDHttpClient rSpamDHttpClient,
-                                                                                    Clock clock) {
-        return DTOModule.forDomainObject(FeedHamToRSpamDTask.class)
-            .convertToDTO(FeedHamToRSpamDTaskDTO.class)
-            .toDomainObjectConverter(dto -> new FeedHamToRSpamDTask(mailboxManager,
+public class FeedSpamToRspamdTaskDTO implements TaskDTO {
+    public static TaskDTOModule<FeedSpamToRspamdTask, FeedSpamToRspamdTaskDTO> module(MailboxManager mailboxManager,
+                                                                                      UsersRepository usersRepository,
+                                                                                      MessageIdManager messageIdManager,
+                                                                                      MailboxSessionMapperFactory mapperFactory,
+                                                                                      RspamdHttpClient rspamdHttpClient,
+                                                                                      Clock clock) {
+        return DTOModule.forDomainObject(FeedSpamToRspamdTask.class)
+            .convertToDTO(FeedSpamToRspamdTaskDTO.class)
+            .toDomainObjectConverter(dto -> new FeedSpamToRspamdTask(mailboxManager,
                 usersRepository,
                 messageIdManager,
                 mapperFactory,
-                rSpamDHttpClient,
-                new FeedHamToRSpamDTask.RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
+                rspamdHttpClient,
+                new FeedSpamToRspamdTask.RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
                     dto.getMessagesPerSecond(),
                     dto.getSamplingProbability()),
                 clock))
-            .toDTOConverter((domain, type) -> new FeedHamToRSpamDTaskDTO(type,
+            .toDTOConverter((domain, type) -> new FeedSpamToRspamdTaskDTO(
+                type,
                 domain.getRunningOptions().getPeriodInSecond().orElse(null),
                 domain.getRunningOptions().getMessagesPerSecond(),
                 domain.getRunningOptions().getSamplingProbability()))
-            .typeName(FeedHamToRSpamDTask.TASK_TYPE.asString())
+            .typeName(FeedSpamToRspamdTask.TASK_TYPE.asString())
             .withFactory(TaskDTOModule::new);
     }
-
 
     private final String type;
     private final Long periodInSecond;
     private final int messagesPerSecond;
     private final double samplingProbability;
 
-    public FeedHamToRSpamDTaskDTO(@JsonProperty("type") String type,
-                                  @JsonProperty("periodInSecond") Long periodInSecond,
-                                  @JsonProperty("messagesPerSecond") int messagesPerSecond,
-                                  @JsonProperty("samplingProbability") double samplingProbability) {
+
+    public FeedSpamToRspamdTaskDTO(@JsonProperty("type") String type,
+                                   @JsonProperty("periodInSecond") Long periodInSecond,
+                                   @JsonProperty("messagesPerSecond") int messagesPerSecond,
+                                   @JsonProperty("samplingProbability") double samplingProbability) {
         this.type = type;
         this.periodInSecond = periodInSecond;
         this.messagesPerSecond = messagesPerSecond;

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/GetMailboxMessagesService.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/GetMailboxMessagesService.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.rspamd.task;
 
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTask.SPAM_MAILBOX_NAME;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.SPAM_MAILBOX_NAME;
 
 import java.util.Date;
 import java.util.Optional;
@@ -63,13 +63,13 @@ public class GetMailboxMessagesService {
     }
 
     public Flux<MessageResult> getMailboxMessagesOfAllUser(String mailboxName, Optional<Date> afterDate, double samplingProbability,
-                                                           FeedSpamToRSpamDTask.Context context) throws UsersRepositoryException {
+                                                           FeedSpamToRspamdTask.Context context) throws UsersRepositoryException {
         return Iterators.toFlux(userRepository.list())
             .flatMap(username -> getMailboxMessagesOfAUser(username, mailboxName, afterDate, samplingProbability, context), ReactorUtils.DEFAULT_CONCURRENCY);
     }
 
     public Flux<MessageResult> getHamMessagesOfAllUser(Optional<Date> afterDate, double samplingProbability,
-                                                       FeedHamToRSpamDTask.Context context) throws UsersRepositoryException {
+                                                       FeedHamToRspamdTask.Context context) throws UsersRepositoryException {
         return Iterators.toFlux(userRepository.list())
             .flatMap(Throwing.function(username -> Flux.fromIterable(mailboxManager.list(mailboxManager.createSystemSession(username)))
                 .filter(this::hamMailboxesPredicate)
@@ -77,7 +77,7 @@ public class GetMailboxMessagesService {
     }
 
     private Flux<MessageResult> getMailboxMessagesOfAUser(Username username, String mailboxName, Optional<Date> afterDate,
-                                                          double samplingProbability, FeedSpamToRSpamDTask.Context context) {
+                                                          double samplingProbability, FeedSpamToRspamdTask.Context context) {
         MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
 
         return Mono.from(mailboxManager.getMailboxReactive(MailboxPath.forUser(username, mailboxName), mailboxSession))
@@ -92,7 +92,7 @@ public class GetMailboxMessagesService {
     }
 
     private Flux<MessageResult> getMailboxMessagesOfAUser(Username username, MailboxPath mailboxPath, Optional<Date> afterDate,
-                                                          double samplingProbability, FeedHamToRSpamDTask.Context context) {
+                                                          double samplingProbability, FeedHamToRspamdTask.Context context) {
         MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
 
         return Mono.from(mailboxManager.getMailboxReactive(mailboxPath, mailboxSession))

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamd.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamd.java
@@ -27,7 +27,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-public class DockerRSpamD {
+public class DockerRspamd {
     public static final String PASSWORD = "admin";
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("a16bitsysop/rspamd");
     private static final String DEFAULT_TAG = "3.2-r2-alpine3.16.0-r0";
@@ -38,7 +38,7 @@ public class DockerRSpamD {
     private final GenericContainer<?> container;
     private final Network network;
 
-    public DockerRSpamD() {
+    public DockerRspamd() {
         this.network = Network.newNetwork();
         this.dockerRedis = new DockerRedis(network);
         this.dockerClamAV = new DockerClamAV(network);

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamdExtension.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamdExtension.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 
-public class DockerRSpamDExtension implements GuiceModuleTestExtension {
-    private static final DockerRSpamD DOCKER_RSPAMD_SINGLETON = new DockerRSpamD();
+public class DockerRspamdExtension implements GuiceModuleTestExtension {
+    private static final DockerRspamd DOCKER_RSPAMD_SINGLETON = new DockerRspamd();
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
@@ -42,23 +42,23 @@ public class DockerRSpamDExtension implements GuiceModuleTestExtension {
         DOCKER_RSPAMD_SINGLETON.flushAll();
     }
 
-    public DockerRSpamD dockerRSpamD() {
+    public DockerRspamd dockerRspamd() {
         return DOCKER_RSPAMD_SINGLETON;
     }
 
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return parameterContext.getParameter().getType() == DockerRSpamD.class;
+        return parameterContext.getParameter().getType() == DockerRspamd.class;
     }
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return dockerRSpamD();
+        return dockerRspamd();
     }
 
     public URL getBaseUrl() {
         try {
-            return new URL("http://127.0.0.1:" + dockerRSpamD().getPort());
+            return new URL("http://127.0.0.1:" + dockerRspamd().getPort());
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamdExtensionTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamdExtensionTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.rspamd;
 
-import static org.apache.james.rspamd.DockerRSpamD.PASSWORD;
+import static org.apache.james.rspamd.DockerRspamd.PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -39,13 +39,13 @@ import io.restassured.http.Header;
 import io.restassured.specification.RequestSpecification;
 
 @Tag(Unstable.TAG)
-class DockerRSpamDExtensionTest {
+class DockerRspamdExtensionTest {
     @RegisterExtension
-    static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
+    static DockerRspamdExtension rspamdExtension = new DockerRspamdExtension();
 
     @Test
-    void dockerRSpamDExtensionShouldWork() {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+    void dockerRspamdExtensionShouldWork() {
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
 
         String response = rspamdApi
             .get("ping")
@@ -61,7 +61,7 @@ class DockerRSpamDExtensionTest {
 
     @Test
     void checkSpamEmailWithExactPasswordHeaderShouldWork() {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
 
         rspamdApi
             .header(new Header("Password", PASSWORD))
@@ -74,7 +74,7 @@ class DockerRSpamDExtensionTest {
 
     @Test
     void checkHamEmailWithExactPasswordHeaderShouldWork() {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
         rspamdApi
             .header(new Header("Password", PASSWORD))
             .body(ClassLoader.getSystemResourceAsStream("mail/ham/ham1.eml"))
@@ -86,7 +86,7 @@ class DockerRSpamDExtensionTest {
 
     @Test
     void learnSpamEmailWithExactPasswordHeaderShouldWork() {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
 
         rspamdApi
             .header(new Header("Password", PASSWORD))
@@ -99,7 +99,7 @@ class DockerRSpamDExtensionTest {
 
     @Test
     void learnHamEmailWithExactPasswordHeaderShouldWork() {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
 
         rspamdApi
             .header(new Header("Password", PASSWORD))
@@ -113,7 +113,7 @@ class DockerRSpamDExtensionTest {
     @ParameterizedTest
     @ValueSource(strings = {"checkv2", "learnspam", "learnham"})
     void endpointsWithWrongPasswordHeaderShouldReturnUnauthorized(String endpoint) {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
 
         rspamdApi
             .header(new Header("Password", "wrongPassword"))
@@ -126,7 +126,7 @@ class DockerRSpamDExtensionTest {
 
     @Test
     void checkVirusEmailWithExactPasswordHeaderShouldReturnClamVirusSymbol() {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
 
         rspamdApi
             .header(new Header("Password", PASSWORD))
@@ -140,7 +140,7 @@ class DockerRSpamDExtensionTest {
 
     @Test
     void checkNonVirusEmailWithExactPasswordHeaderShouldNotReturnClamVirusSymbol() {
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
 
         rspamdApi
             .header(new Header("Password", PASSWORD))

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdListenerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdListenerTest.java
@@ -58,21 +58,21 @@ import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
+import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Mono;
 
-public class RSpamDListenerTest {
+public class RspamdListenerTest {
     static final Username USER = Username.of("user");
     static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
     static final UidValidity UID_VALIDITY = UidValidity.of(43);
     static final TestMessageId MESSAGE_ID = TestMessageId.of(45);
     static final ThreadId THREAD_ID = ThreadId.fromBaseMessageId(MESSAGE_ID);
 
-    private RSpamDHttpClient rSpamDHttpClient;
-    private RSpamDListener listener;
+    private RspamdHttpClient rspamdHttpClient;
+    private RspamdListener listener;
     private MailboxSessionMapperFactory mapperFactory;
 
     private Mailbox inbox;
@@ -86,10 +86,10 @@ public class RSpamDListenerTest {
 
     @BeforeEach
     void setup() {
-        rSpamDHttpClient = mock(RSpamDHttpClient.class);
+        rspamdHttpClient = mock(RspamdHttpClient.class);
 
-        when(rSpamDHttpClient.reportAsHam(any())).thenReturn(Mono.empty());
-        when(rSpamDHttpClient.reportAsSpam(any())).thenReturn(Mono.empty());
+        when(rspamdHttpClient.reportAsHam(any())).thenReturn(Mono.empty());
+        when(rspamdHttpClient.reportAsSpam(any())).thenReturn(Mono.empty());
 
         StoreMailboxManager mailboxManager = spy(InMemoryIntegrationResources.defaultResources().getMailboxManager());
         SystemMailboxesProviderImpl systemMailboxesProvider = new SystemMailboxesProviderImpl(mailboxManager);
@@ -106,13 +106,13 @@ public class RSpamDListenerTest {
         spamCapitalMailboxId = mailboxMapper.create(MailboxPath.forUser(USER, "SPAM"), UID_VALIDITY).block().getMailboxId();
         trashMailboxId = mailboxMapper.create(MailboxPath.forUser(USER, "Trash"), UID_VALIDITY).block().getMailboxId();
 
-        listener = new RSpamDListener(rSpamDHttpClient, mailboxManager, mapperFactory, systemMailboxesProvider);
+        listener = new RspamdListener(rspamdHttpClient, mailboxManager, mapperFactory, systemMailboxesProvider);
     }
 
     @Test
     void deserializeListenerGroup() throws Exception {
-        assertThat(Group.deserialize("org.apache.james.rspamd.RSpamDListener$RSpamDListenerGroup"))
-            .isEqualTo(new RSpamDListener.RSpamDListenerGroup());
+        assertThat(Group.deserialize("org.apache.james.rspamd.RspamdListener$RspamdListenerGroup"))
+            .isEqualTo(new RspamdListener.RspamdListenerGroup());
     }
 
     @Test
@@ -228,7 +228,7 @@ public class RSpamDListenerTest {
 
         listener.event(messageMoveEvent);
 
-        verify(rSpamDHttpClient).reportAsSpam(any());
+        verify(rspamdHttpClient).reportAsSpam(any());
     }
 
     @Test
@@ -246,7 +246,7 @@ public class RSpamDListenerTest {
 
         listener.event(messageMoveEvent);
 
-        verify(rSpamDHttpClient).reportAsHam(any());
+        verify(rspamdHttpClient).reportAsHam(any());
     }
 
     @Test
@@ -262,7 +262,7 @@ public class RSpamDListenerTest {
 
         listener.event(addedEvent);
 
-        verify(rSpamDHttpClient).reportAsHam(any());
+        verify(rspamdHttpClient).reportAsHam(any());
     }
 
     @Test
@@ -278,7 +278,7 @@ public class RSpamDListenerTest {
 
         listener.event(addedEvent);
 
-        verify(rSpamDHttpClient, never()).reportAsHam(any());
+        verify(rspamdHttpClient, never()).reportAsHam(any());
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox) throws MailboxException {

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RspamdHttpClientTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RspamdHttpClientTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.rspamd.client;
 
-import static org.apache.james.rspamd.DockerRSpamD.PASSWORD;
+import static org.apache.james.rspamd.DockerRspamd.PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.util.Optional;
 
 import org.apache.james.junit.categories.Unstable;
-import org.apache.james.rspamd.DockerRSpamDExtension;
+import org.apache.james.rspamd.DockerRspamdExtension;
 import org.apache.james.rspamd.exception.UnauthorizedException;
 import org.apache.james.rspamd.model.AnalysisResult;
 import org.apache.james.util.ClassLoaderUtils;
@@ -48,14 +48,14 @@ import io.restassured.http.Header;
 import io.restassured.specification.RequestSpecification;
 
 @Tag(Unstable.TAG)
-class RSpamDHttpClientTest {
+class RspamdHttpClientTest {
     private final static String SPAM_MESSAGE_PATH = "mail/spam/spam8.eml";
     private final static String HAM_MESSAGE_PATH = "mail/ham/ham1.eml";
     private final static String VIRUS_MESSAGE_PATH = "mail/attachment/inlineVirusTextAttachment.eml";
     private final static String NON_VIRUS_MESSAGE_PATH = "mail/attachment/inlineNonVirusTextAttachment.eml";
 
     @RegisterExtension
-    static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
+    static DockerRspamdExtension rspamdExtension = new DockerRspamdExtension();
 
     private byte[] spamMessage;
     private byte[] hamMessage;
@@ -72,8 +72,8 @@ class RSpamDHttpClientTest {
 
     @Test
     void checkMailWithWrongPasswordShouldThrowUnauthorizedExceptionException() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), "wrongPassword", Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), "wrongPassword", Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         assertThatThrownBy(() -> client.checkV2(new ByteArrayInputStream(spamMessage)).block())
             .hasMessage("{\"error\":\"Unauthorized\"}")
@@ -82,8 +82,8 @@ class RSpamDHttpClientTest {
 
     @Test
     void learnSpamWithWrongPasswordShouldThrowUnauthorizedExceptionException() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), "wrongPassword", Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), "wrongPassword", Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         assertThatThrownBy(() -> reportAsSpam(client, new ByteArrayInputStream(spamMessage)))
             .hasMessage("{\"error\":\"Unauthorized\"}")
@@ -92,8 +92,8 @@ class RSpamDHttpClientTest {
 
     @Test
     void learnHamWithWrongPasswordShouldThrowUnauthorizedExceptionException() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), "wrongPassword", Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), "wrongPassword", Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         assertThatThrownBy(() -> reportAsHam(client, new ByteArrayInputStream(spamMessage)))
             .hasMessage("{\"error\":\"Unauthorized\"}")
@@ -101,14 +101,14 @@ class RSpamDHttpClientTest {
     }
 
     @Test
-    void checkSpamMailUsingRSpamDClientWithExactPasswordShouldReturnAnalysisResultAsSameAsUsingRawClient() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+    void checkSpamMailUsingRspamdClientWithExactPasswordShouldReturnAnalysisResultAsSameAsUsingRawClient() {
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(spamMessage)).block();
         assertThat(analysisResult.getAction()).isEqualTo(AnalysisResult.Action.REJECT);
 
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
         rspamdApi
             .header(new Header("Password", PASSWORD))
             .body(ClassLoader.getSystemResourceAsStream(SPAM_MESSAGE_PATH))
@@ -121,9 +121,9 @@ class RSpamDHttpClientTest {
     }
 
     @Test
-    void checkHamMailUsingRSpamDClientWithExactPasswordShouldReturnAnalysisResultAsSameAsUsingRawClient() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+    void checkHamMailUsingRspamdClientWithExactPasswordShouldReturnAnalysisResultAsSameAsUsingRawClient() {
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(hamMessage)).block();
         SoftAssertions.assertSoftly(softly -> {
@@ -133,7 +133,7 @@ class RSpamDHttpClientTest {
             softly.assertThat(analysisResult.hasVirus()).isEqualTo(false);
         });
 
-        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rSpamDExtension.dockerRSpamD().getPort()));
+        RequestSpecification rspamdApi = WebAdminUtils.spec(Port.of(rspamdExtension.dockerRspamd().getPort()));
         rspamdApi
             .header(new Header("Password", PASSWORD))
             .body(ClassLoader.getSystemResourceAsStream(HAM_MESSAGE_PATH))
@@ -146,46 +146,46 @@ class RSpamDHttpClientTest {
     }
 
     @Test
-    void learnSpamMailUsingRSpamDClientWithExactPasswordShouldWork() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+    void learnSpamMailUsingRspamdClientWithExactPasswordShouldWork() {
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         assertThatCode(() -> client.reportAsSpam(new ByteArrayInputStream(spamMessage)).block())
             .doesNotThrowAnyException();
     }
 
     @Test
-    void learnHamMailUsingRSpamDClientWithExactPasswordShouldWork() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+    void learnHamMailUsingRspamdClientWithExactPasswordShouldWork() {
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         assertThatCode(() -> client.reportAsHam(new ByteArrayInputStream(hamMessage)).block())
             .doesNotThrowAnyException();
     }
 
     @Test
-    void checkVirusMailUsingRSpamDClientWithExactPasswordShouldReturnHasVirus() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+    void checkVirusMailUsingRspamdClientWithExactPasswordShouldReturnHasVirus() {
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(virusMessage)).block();
         assertThat(analysisResult.hasVirus()).isTrue();
     }
 
     @Test
-    void checkNonVirusMailUsingRSpamDClientWithExactPasswordShouldReturnHasNoVirus() {
-        RSpamDClientConfiguration configuration = new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty());
-        RSpamDHttpClient client = new RSpamDHttpClient(configuration);
+    void checkNonVirusMailUsingRspamdClientWithExactPasswordShouldReturnHasNoVirus() {
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         AnalysisResult analysisResult = client.checkV2(new ByteArrayInputStream(nonVirusMessage)).block();
         assertThat(analysisResult.hasVirus()).isFalse();
     }
 
-    private void reportAsSpam(RSpamDHttpClient client, InputStream inputStream) {
+    private void reportAsSpam(RspamdHttpClient client, InputStream inputStream) {
         client.reportAsSpam(inputStream).block();
     }
 
-    private void reportAsHam(RSpamDHttpClient client, InputStream inputStream) {
+    private void reportAsHam(RspamdHttpClient client, InputStream inputStream) {
         client.reportAsHam(inputStream).block();
     }
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/route/FeedMessageRouteTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/route/FeedMessageRouteTest.java
@@ -21,18 +21,18 @@ package org.apache.james.rspamd.route;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static org.apache.james.rspamd.DockerRSpamD.PASSWORD;
+import static org.apache.james.rspamd.DockerRspamd.PASSWORD;
 import static org.apache.james.rspamd.route.FeedMessageRoute.BASE_PATH;
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTaskTest.ALICE_INBOX_MAILBOX;
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTaskTest.BOB_INBOX_MAILBOX;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.ALICE;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.ALICE_SPAM_MAILBOX;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.BOB;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.BOB_SPAM_MAILBOX;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.NOW;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.ONE_DAY_IN_SECOND;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.THREE_DAYS_IN_SECOND;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.TWO_DAYS_IN_SECOND;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTaskTest.ALICE_INBOX_MAILBOX;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTaskTest.BOB_INBOX_MAILBOX;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.ALICE;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.ALICE_SPAM_MAILBOX;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.BOB;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.BOB_SPAM_MAILBOX;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.NOW;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.ONE_DAY_IN_SECOND;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.THREE_DAYS_IN_SECOND;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.TWO_DAYS_IN_SECOND;
 import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -62,13 +62,13 @@ import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.DockerRSpamDExtension;
-import org.apache.james.rspamd.client.RSpamDClientConfiguration;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
-import org.apache.james.rspamd.task.FeedHamToRSpamDTask;
-import org.apache.james.rspamd.task.FeedHamToRSpamDTaskAdditionalInformationDTO;
-import org.apache.james.rspamd.task.FeedSpamToRSpamDTask;
-import org.apache.james.rspamd.task.FeedSpamToRSpamDTaskAdditionalInformationDTO;
+import org.apache.james.rspamd.DockerRspamdExtension;
+import org.apache.james.rspamd.client.RspamdClientConfiguration;
+import org.apache.james.rspamd.client.RspamdHttpClient;
+import org.apache.james.rspamd.task.FeedHamToRspamdTask;
+import org.apache.james.rspamd.task.FeedHamToRspamdTaskAdditionalInformationDTO;
+import org.apache.james.rspamd.task.FeedSpamToRspamdTask;
+import org.apache.james.rspamd.task.FeedSpamToRspamdTaskAdditionalInformationDTO;
 import org.apache.james.task.Hostname;
 import org.apache.james.task.MemoryTaskManager;
 import org.apache.james.user.api.UsersRepository;
@@ -97,7 +97,7 @@ import io.restassured.RestAssured;
 @Tag(Unstable.TAG)
 public class FeedMessageRouteTest {
     @RegisterExtension
-    static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
+    static DockerRspamdExtension rspamdExtension = new DockerRspamdExtension();
 
     private InMemoryMailboxManager mailboxManager;
     private WebAdminServer webAdminServer;
@@ -120,12 +120,12 @@ public class FeedMessageRouteTest {
         taskManager = new MemoryTaskManager(new Hostname("foo"));
         UpdatableTickingClock clock = new UpdatableTickingClock(NOW);
         JsonTransformer jsonTransformer = new JsonTransformer();
-        RSpamDHttpClient client = new RSpamDHttpClient(new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty()));
+        RspamdHttpClient client = new RspamdHttpClient(new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty()));
         MessageIdManager messageIdManager = inMemoryIntegrationResources.getMessageIdManager();
         MailboxSessionMapperFactory mapperFactory = mailboxManager.getMapperFactory();
 
-        TasksRoutes tasksRoutes = new TasksRoutes(taskManager, jsonTransformer, DTOConverter.of(FeedSpamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE,
-            FeedHamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE));
+        TasksRoutes tasksRoutes = new TasksRoutes(taskManager, jsonTransformer, DTOConverter.of(FeedSpamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE,
+            FeedHamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE));
         FeedMessageRoute feedMessageRoute = new FeedMessageRoute(taskManager, mailboxManager, usersRepository, client, jsonTransformer, clock,
             messageIdManager, mapperFactory);
 
@@ -171,13 +171,13 @@ public class FeedMessageRouteTest {
                 .get(taskId + "/await")
             .then()
                 .body("status", is("completed"))
-                .body("additionalInformation.type", is(FeedSpamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedSpamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.spamMessageCount", is(2))
                 .body("additionalInformation.reportedSpamMessageCount", is(2))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -198,13 +198,13 @@ public class FeedMessageRouteTest {
                 .get(taskId + "/await")
             .then()
                 .body("status", is("completed"))
-                .body("additionalInformation.type", is(FeedSpamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedSpamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.spamMessageCount", is(2))
                 .body("additionalInformation.reportedSpamMessageCount", is(1))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(172800))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -225,11 +225,11 @@ public class FeedMessageRouteTest {
                 .get(taskId + "/await")
             .then()
                 .body("status", is("completed"))
-                .body("additionalInformation.type", is(FeedSpamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedSpamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.spamMessageCount", is(10))
                 .body("additionalInformation.reportedSpamMessageCount", is(allOf(greaterThan(0), lessThan(10))))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
                 .body("additionalInformation.runningOptions.samplingProbability", is(0.5F));
         }
@@ -286,18 +286,18 @@ public class FeedMessageRouteTest {
             .then()
                 .body("status", is("completed"))
                 .body("taskId", is(notNullValue()))
-                .body("type", is(FeedSpamToRSpamDTask.TASK_TYPE.asString()))
+                .body("type", is(FeedSpamToRspamdTask.TASK_TYPE.asString()))
                 .body("startedDate", is(notNullValue()))
                 .body("submitDate", is(notNullValue()))
                 .body("completedDate", is(notNullValue()))
-                .body("additionalInformation.type", is(FeedSpamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedSpamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.timestamp", is(notNullValue()))
                 .body("additionalInformation.spamMessageCount", is(0))
                 .body("additionalInformation.reportedSpamMessageCount", is(0))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @ParameterizedTest
@@ -419,13 +419,13 @@ public class FeedMessageRouteTest {
                 .get(taskId + "/await")
             .then()
                 .body("status", is("completed"))
-                .body("additionalInformation.type", is(FeedHamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedHamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.hamMessageCount", is(2))
                 .body("additionalInformation.reportedHamMessageCount", is(2))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -446,13 +446,13 @@ public class FeedMessageRouteTest {
                 .get(taskId + "/await")
             .then()
                 .body("status", is("completed"))
-                .body("additionalInformation.type", is(FeedHamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedHamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.hamMessageCount", is(2))
                 .body("additionalInformation.reportedHamMessageCount", is(1))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(172800))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -473,11 +473,11 @@ public class FeedMessageRouteTest {
                 .get(taskId + "/await")
             .then()
                 .body("status", is("completed"))
-                .body("additionalInformation.type", is(FeedHamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedHamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.hamMessageCount", is(10))
                 .body("additionalInformation.reportedHamMessageCount", is(allOf(greaterThan(0), lessThan(10))))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
                 .body("additionalInformation.runningOptions.samplingProbability", is(0.5F));
         }
@@ -534,18 +534,18 @@ public class FeedMessageRouteTest {
             .then()
                 .body("status", is("completed"))
                 .body("taskId", is(notNullValue()))
-                .body("type", is(FeedHamToRSpamDTask.TASK_TYPE.asString()))
+                .body("type", is(FeedHamToRspamdTask.TASK_TYPE.asString()))
                 .body("startedDate", is(notNullValue()))
                 .body("submitDate", is(notNullValue()))
                 .body("completedDate", is(notNullValue()))
-                .body("additionalInformation.type", is(FeedHamToRSpamDTask.TASK_TYPE.asString()))
+                .body("additionalInformation.type", is(FeedHamToRspamdTask.TASK_TYPE.asString()))
                 .body("additionalInformation.timestamp", is(notNullValue()))
                 .body("additionalInformation.hamMessageCount", is(0))
                 .body("additionalInformation.reportedHamMessageCount", is(0))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @ParameterizedTest

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTOTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTOTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.james.rspamd.task;
 
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTask.RunningOptions.DEFAULT_PERIOD;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_PERIOD;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -30,11 +30,11 @@ import org.apache.james.JsonSerializationVerifier;
 import org.apache.james.util.ClassLoaderUtils;
 import org.junit.jupiter.api.Test;
 
-class FeedSpamToRSpamDTaskAdditionalInformationDTOTest {
+class FeedHamToRspamdTaskAdditionalInformationDTOTest {
     @Test
     void shouldMatchJsonSerializationContractWhenEmptyPeriod() throws Exception {
-        JsonSerializationVerifier.dtoModule(FeedSpamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
-            .bean(new FeedSpamToRSpamDTask.AdditionalInformation(
+        JsonSerializationVerifier.dtoModule(FeedHamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
+            .bean(new FeedHamToRspamdTask.AdditionalInformation(
                 Instant.parse("2007-12-03T10:15:30.00Z"),
                 4,
                 2,
@@ -42,14 +42,14 @@ class FeedSpamToRSpamDTaskAdditionalInformationDTOTest {
                 DEFAULT_MESSAGES_PER_SECOND,
                 DEFAULT_PERIOD,
                 DEFAULT_SAMPLING_PROBABILITY))
-            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamEmptyPeriod.additionalInformation.json"))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamEmptyPeriod.additionalInformation.json"))
             .verify();
     }
 
     @Test
     void shouldMatchJsonSerializationContractWhenNonEmptyPeriod() throws Exception {
-        JsonSerializationVerifier.dtoModule(FeedSpamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
-            .bean(new FeedSpamToRSpamDTask.AdditionalInformation(
+        JsonSerializationVerifier.dtoModule(FeedHamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
+            .bean(new FeedHamToRspamdTask.AdditionalInformation(
                 Instant.parse("2007-12-03T10:15:30.00Z"),
                 4,
                 2,
@@ -57,7 +57,7 @@ class FeedSpamToRSpamDTaskAdditionalInformationDTOTest {
                 DEFAULT_MESSAGES_PER_SECOND,
                 Optional.of(3600L),
                 DEFAULT_SAMPLING_PROBABILITY))
-            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamNonEmptyPeriod.additionalInformation.json"))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamNonEmptyPeriod.additionalInformation.json"))
             .verify();
     }
 }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
@@ -19,11 +19,11 @@
 
 package org.apache.james.rspamd.task;
 
-import static org.apache.james.rspamd.DockerRSpamD.PASSWORD;
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTask.RunningOptions.DEFAULT_PERIOD;
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
-import static org.apache.james.rspamd.task.FeedSpamToRSpamDTaskTest.BOB_SPAM_MAILBOX;
+import static org.apache.james.rspamd.DockerRspamd.PASSWORD;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_PERIOD;
+import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.BOB_SPAM_MAILBOX;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -49,9 +49,9 @@ import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.DockerRSpamDExtension;
-import org.apache.james.rspamd.client.RSpamDClientConfiguration;
-import org.apache.james.rspamd.client.RSpamDHttpClient;
+import org.apache.james.rspamd.DockerRspamdExtension;
+import org.apache.james.rspamd.client.RspamdClientConfiguration;
+import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.task.Task;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.memory.MemoryUsersRepository;
@@ -66,9 +66,9 @@ import org.mockito.Mockito;
 import com.github.fge.lambdas.Throwing;
 
 @Tag(Unstable.TAG)
-public class FeedHamToRSpamDTaskTest {
+public class FeedHamToRspamdTaskTest {
     @RegisterExtension
-    static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
+    static DockerRspamdExtension rspamdExtension = new DockerRspamdExtension();
 
     public static final String INBOX_MAILBOX_NAME = "INBOX";
     public static final Domain DOMAIN = Domain.of("domain.tld");
@@ -88,8 +88,8 @@ public class FeedHamToRSpamDTaskTest {
     private MailboxSessionMapperFactory mapperFactory;
     private UsersRepository usersRepository;
     private Clock clock;
-    private RSpamDHttpClient client;
-    private FeedHamToRSpamDTask task;
+    private RspamdHttpClient client;
+    private FeedHamToRspamdTask task;
 
     @BeforeEach
     void setup() throws Exception {
@@ -107,10 +107,10 @@ public class FeedHamToRSpamDTaskTest {
         mailboxManager.createMailbox(ALICE_INBOX_MAILBOX, mailboxManager.createSystemSession(ALICE));
 
         clock = new UpdatableTickingClock(NOW);
-        client = new RSpamDHttpClient(new RSpamDClientConfiguration(rSpamDExtension.getBaseUrl(), PASSWORD, Optional.empty()));
+        client = new RspamdHttpClient(new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty()));
         messageIdManager = inMemoryIntegrationResources.getMessageIdManager();
         mapperFactory = mailboxManager.getMapperFactory();
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, FeedHamToRSpamDTask.RunningOptions.DEFAULT, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, FeedHamToRspamdTask.RunningOptions.DEFAULT, clock);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(0)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
@@ -138,7 +138,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(2)
                 .reportedHamMessageCount(2)
                 .errorCount(0)
@@ -150,9 +150,9 @@ public class FeedHamToRSpamDTaskTest {
 
     @Test
     void taskShouldReportHamMessageInPeriod() throws MailboxException {
-        FeedHamToRSpamDTask.RunningOptions runningOptions = new FeedHamToRSpamDTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)));
 
@@ -160,7 +160,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(1)
                 .reportedHamMessageCount(1)
                 .errorCount(0)
@@ -172,9 +172,9 @@ public class FeedHamToRSpamDTaskTest {
 
     @Test
     void taskShouldNotReportHamMessageNotInPeriod() throws MailboxException {
-        FeedHamToRSpamDTask.RunningOptions runningOptions = new FeedHamToRSpamDTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(THREE_DAYS_IN_SECOND)));
 
@@ -182,7 +182,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(1)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
@@ -194,9 +194,9 @@ public class FeedHamToRSpamDTaskTest {
 
     @Test
     void mixedInternalDateCase() throws MailboxException {
-        FeedHamToRSpamDTask.RunningOptions runningOptions = new FeedHamToRSpamDTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(THREE_DAYS_IN_SECOND)));
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)));
@@ -205,7 +205,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(2)
                 .reportedHamMessageCount(1)
                 .errorCount(0)
@@ -217,9 +217,9 @@ public class FeedHamToRSpamDTaskTest {
 
     @Test
     void taskWithSamplingProbabilityIsZeroShouldReportNonHamMessage() {
-        FeedHamToRSpamDTask.RunningOptions runningOptions = new FeedHamToRSpamDTask.RunningOptions(Optional.empty(),
+        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0);
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
         IntStream.range(0, 10)
             .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -228,7 +228,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(10)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
@@ -247,7 +247,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(10)
                 .reportedHamMessageCount(10)
                 .errorCount(0)
@@ -259,9 +259,9 @@ public class FeedHamToRSpamDTaskTest {
 
     @Test
     void taskWithVeryLowSamplingProbabilityShouldReportNotAllHamMessages() {
-        FeedHamToRSpamDTask.RunningOptions runningOptions = new FeedHamToRSpamDTask.RunningOptions(Optional.empty(),
+        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.01);
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
         IntStream.range(0, 10)
                 .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -278,9 +278,9 @@ public class FeedHamToRSpamDTaskTest {
 
     @Test
     void taskWithVeryHighSamplingProbabilityShouldReportMoreThanZeroMessage() {
-        FeedHamToRSpamDTask.RunningOptions runningOptions = new FeedHamToRSpamDTask.RunningOptions(Optional.empty(),
+        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.99);
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
         IntStream.range(0, 10)
             .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -297,9 +297,9 @@ public class FeedHamToRSpamDTaskTest {
 
     @Test
     void taskWithAverageSamplingProbabilityShouldReportSomeMessages() {
-        FeedHamToRSpamDTask.RunningOptions runningOptions = new FeedHamToRSpamDTask.RunningOptions(Optional.empty(),
+        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.5);
-        task = new FeedHamToRSpamDTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
         IntStream.range(0, 10)
             .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -323,7 +323,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(0)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
@@ -342,7 +342,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(2)
                 .reportedHamMessageCount(2)
                 .errorCount(0)
@@ -363,7 +363,7 @@ public class FeedHamToRSpamDTaskTest {
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(task.snapshot())
-            .isEqualTo(FeedHamToRSpamDTask.Context.Snapshot.builder()
+            .isEqualTo(FeedHamToRspamdTask.Context.Snapshot.builder()
                 .hamMessageCount(2)
                 .reportedHamMessageCount(2)
                 .errorCount(0)

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTOTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTOTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.james.rspamd.task;
 
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTask.RunningOptions.DEFAULT_PERIOD;
-import static org.apache.james.rspamd.task.FeedHamToRSpamDTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_PERIOD;
+import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -30,11 +30,11 @@ import org.apache.james.JsonSerializationVerifier;
 import org.apache.james.util.ClassLoaderUtils;
 import org.junit.jupiter.api.Test;
 
-class FeedHamToRSpamDTaskAdditionalInformationDTOTest {
+class FeedSpamToRspamdTaskAdditionalInformationDTOTest {
     @Test
     void shouldMatchJsonSerializationContractWhenEmptyPeriod() throws Exception {
-        JsonSerializationVerifier.dtoModule(FeedHamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
-            .bean(new FeedHamToRSpamDTask.AdditionalInformation(
+        JsonSerializationVerifier.dtoModule(FeedSpamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
+            .bean(new FeedSpamToRspamdTask.AdditionalInformation(
                 Instant.parse("2007-12-03T10:15:30.00Z"),
                 4,
                 2,
@@ -42,14 +42,14 @@ class FeedHamToRSpamDTaskAdditionalInformationDTOTest {
                 DEFAULT_MESSAGES_PER_SECOND,
                 DEFAULT_PERIOD,
                 DEFAULT_SAMPLING_PROBABILITY))
-            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamEmptyPeriod.additionalInformation.json"))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamEmptyPeriod.additionalInformation.json"))
             .verify();
     }
 
     @Test
     void shouldMatchJsonSerializationContractWhenNonEmptyPeriod() throws Exception {
-        JsonSerializationVerifier.dtoModule(FeedHamToRSpamDTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
-            .bean(new FeedHamToRSpamDTask.AdditionalInformation(
+        JsonSerializationVerifier.dtoModule(FeedSpamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
+            .bean(new FeedSpamToRspamdTask.AdditionalInformation(
                 Instant.parse("2007-12-03T10:15:30.00Z"),
                 4,
                 2,
@@ -57,7 +57,7 @@ class FeedHamToRSpamDTaskAdditionalInformationDTOTest {
                 DEFAULT_MESSAGES_PER_SECOND,
                 Optional.of(3600L),
                 DEFAULT_SAMPLING_PROBABILITY))
-            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamNonEmptyPeriod.additionalInformation.json"))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamNonEmptyPeriod.additionalInformation.json"))
             .verify();
     }
 }

--- a/third-party/rspamd/src/test/resources/json/feedHamEmptyPeriod.additionalInformation.json
+++ b/third-party/rspamd/src/test/resources/json/feedHamEmptyPeriod.additionalInformation.json
@@ -7,5 +7,5 @@
   },
   "hamMessageCount": 4,
   "timestamp": "2007-12-03T10:15:30Z",
-  "type": "FeedHamToRSpamDTask"
+  "type": "FeedHamToRspamdTask"
 }

--- a/third-party/rspamd/src/test/resources/json/feedHamNonEmptyPeriod.additionalInformation.json
+++ b/third-party/rspamd/src/test/resources/json/feedHamNonEmptyPeriod.additionalInformation.json
@@ -8,5 +8,5 @@
   },
   "hamMessageCount": 4,
   "timestamp": "2007-12-03T10:15:30Z",
-  "type": "FeedHamToRSpamDTask"
+  "type": "FeedHamToRspamdTask"
 }

--- a/third-party/rspamd/src/test/resources/json/feedSpamEmptyPeriod.additionalInformation.json
+++ b/third-party/rspamd/src/test/resources/json/feedSpamEmptyPeriod.additionalInformation.json
@@ -7,5 +7,5 @@
   },
   "spamMessageCount": 4,
   "timestamp": "2007-12-03T10:15:30Z",
-  "type": "FeedSpamToRSpamDTask"
+  "type": "FeedSpamToRspamdTask"
 }

--- a/third-party/rspamd/src/test/resources/json/feedSpamNonEmptyPeriod.additionalInformation.json
+++ b/third-party/rspamd/src/test/resources/json/feedSpamNonEmptyPeriod.additionalInformation.json
@@ -8,5 +8,5 @@
   },
   "spamMessageCount": 4,
   "timestamp": "2007-12-03T10:15:30Z",
-  "type": "FeedSpamToRSpamDTask"
+  "type": "FeedSpamToRspamdTask"
 }


### PR DESCRIPTION
https://rspamd.com/doc/faq.html#how-is-rspamd-spelled-and-capitalized
```
Rspamd as a spam-filtering system or as a project is spelled with a capital R followed by a lower-case spamd, but when referring to the process or application it is not capitalized.
```