### PR TITLE
JAMES-3800 / JAMES-3801 S3/RabbitMQ fix for 3.7.x

### DIFF
--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -202,7 +202,8 @@ public class S3BlobStoreDAO implements BlobStoreDAO, Startable, Closeable {
                         response.flux = Flux.from(publisher);
                         response.supportingCompletableFuture.complete(response);
                     }
-                }));
+                }))
+            .switchIfEmpty(Mono.error(() -> new ObjectStoreIOException("Request was unexpectedly canceled, no GetObjectResponse")));
     }
 
 


### PR DESCRIPTION
Straight cherry-pick of https://github.com/apache/james-project/pull/1114
I think this is an important fix, and at the same time a trivial backport to 3.7.x. Everybody wins!
