### PR TITLE
[BUILD] GlobalRateLimitIntegrationTest::sendMessageShouldFailWhenReci…

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GlobalRateLimitIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GlobalRateLimitIntegrationTest.java
@@ -223,6 +223,7 @@ public class GlobalRateLimitIntegrationTest {
                 .mimeMessage(message)
                 .sender(SENDER1)
                 .recipient(RECIPIENT1));
+        Thread.sleep(100);
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .authenticate(SENDER2, PASSWORD)
             .sendMessage(FakeMail.builder()


### PR DESCRIPTION
…pientsLimitExceeded was unstable

https://ci-builds.apache.org/job/james/job/ApacheJames/job/PR-1127/4/testReport/junit/org.apache.james.transport.mailets/GlobalRateLimitIntegrationTest/sendMessageShouldFailWhenRecipientsLimitExceeded/