### PR TITLE
JAMES-3775 Fasten Rspamd test suite

### DIFF
--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
@@ -39,17 +39,9 @@ public class DockerClamAV {
             .withNetworkAliases("clamav");
     }
 
-    public Integer getPort() {
-        return container.getMappedPort(DEFAULT_PORT);
-    }
-
     public void start() {
         if (!container.isRunning()) {
             container.start();
         }
-    }
-
-    public void stop() {
-        container.stop();
     }
 }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
@@ -33,6 +33,8 @@ public class DockerClamAV {
     public DockerClamAV(Network network) {
         this.container = new GenericContainer<>(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG))
             .withExposedPorts(DEFAULT_PORT)
+            .withEnv("CLAMAV_NO_FRESHCLAMD", "true")
+            .withEnv("CLAMAV_NO_MILTERD", "true")
             .withNetwork(network)
             .withNetworkAliases("clamav");
     }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamD.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamD.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.rspamd;
 
+import java.util.stream.Stream;
+
 import org.apache.james.rate.limiter.DockerRedis;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -59,8 +61,10 @@ public class DockerRSpamD {
     }
 
     public void start() {
-        dockerClamAV.start();
-        dockerRedis.start();
+        Stream.<Runnable>of(dockerClamAV::start, dockerRedis::start)
+            .parallel()
+            .forEach(Runnable::run);
+
         if (!container.isRunning()) {
             container.start();
         }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamD.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamD.java
@@ -45,6 +45,10 @@ public class DockerRSpamD {
         this.container = createRspamD();
     }
 
+    public boolean isRunning() {
+        return container.isRunning();
+    }
+
     private GenericContainer<?> createRspamD() {
         return new GenericContainer<>(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG))
             .withExposedPorts(DEFAULT_PORT)
@@ -68,12 +72,6 @@ public class DockerRSpamD {
         if (!container.isRunning()) {
             container.start();
         }
-    }
-
-    public void stop() {
-        container.stop();
-        dockerRedis.stop();
-        dockerClamAV.stop();
     }
 
     public void flushAll() {

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamDExtension.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamDExtension.java
@@ -32,16 +32,13 @@ public class DockerRSpamDExtension implements GuiceModuleTestExtension {
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
-        DOCKER_RSPAMD_SINGLETON.start();
+        if (!DOCKER_RSPAMD_SINGLETON.isRunning()) {
+            DOCKER_RSPAMD_SINGLETON.start();
+        }
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) {
-        DOCKER_RSPAMD_SINGLETON.stop();
-    }
-
-    @Override
-    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    public void beforeEach(ExtensionContext extensionContext) {
         DOCKER_RSPAMD_SINGLETON.flushAll();
     }
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamDExtensionTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRSpamDExtensionTest.java
@@ -39,7 +39,7 @@ import io.restassured.http.Header;
 import io.restassured.specification.RequestSpecification;
 
 @Tag(Unstable.TAG)
-public class DockerRSpamDExtensionTest {
+class DockerRSpamDExtensionTest {
     @RegisterExtension
     static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRSpamDTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRSpamDTaskTest.java
@@ -41,6 +41,7 @@ import javax.mail.Flags;
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.junit.categories.Unstable;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -57,13 +58,15 @@ import org.apache.james.user.memory.MemoryUsersRepository;
 import org.apache.james.utils.UpdatableTickingClock;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import com.github.fge.lambdas.Throwing;
 
-public class FeedHamToRSpamDTaskTest {
+@Tag(Unstable.TAG)
+class FeedHamToRSpamDTaskTest {
     @RegisterExtension
     static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRSpamDTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRSpamDTaskTest.java
@@ -66,7 +66,7 @@ import org.mockito.Mockito;
 import com.github.fge.lambdas.Throwing;
 
 @Tag(Unstable.TAG)
-class FeedHamToRSpamDTaskTest {
+public class FeedHamToRSpamDTaskTest {
     @RegisterExtension
     static DockerRSpamDExtension rSpamDExtension = new DockerRSpamDExtension();
 


### PR DESCRIPTION
 - Avoid restarting containers for each test class
 - Start ClamAV and Redis in parallel
 - Disable ClamFresh anti-virus database updates
 - Tag tests as unstable as scoring is pretty much machine dependant