### PR TITLE
[BUILD] SslConcurrentConnections should use a random port

### DIFF
--- a/server/protocols/protocols-imap4/src/test/resources/imapSSL.xml
+++ b/server/protocols/protocols-imap4/src/test/resources/imapSSL.xml
@@ -1,6 +1,6 @@
 <imapserver enabled="true">
     <jmxName>imapserver</jmxName>
-    <bind>0.0.0.0:9993</bind>
+    <bind>0.0.0.0:0</bind>
     <tls socketTLS="true" startTLS="false">
         <privateKey>private.key</privateKey>
         <certificates>certs.self-signed.csr</certificates>


### PR DESCRIPTION
Not doing so means port conflicts

CF https://ci-builds.apache.org/job/james/job/ApacheJames/job/PR-1142/1/