### PR TITLE
JAMES-3793 Prevent needless defensive copies within S3BlobStoreDAO

### DIFF
--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -227,7 +227,7 @@ public class S3BlobStoreDAO implements BlobStoreDAO, Startable, Closeable {
             .onErrorMap(NoSuchBucketException.class, e -> new ObjectNotFoundException("Bucket not found " + resolvedBucketName.asString(), e))
             .onErrorMap(NoSuchKeyException.class, e -> new ObjectNotFoundException("Blob not found " + blobId.asString() + " in bucket " + resolvedBucketName.asString(), e))
             .publishOn(Schedulers.parallel())
-            .map(BytesWrapper::asByteArray);
+            .map(BytesWrapper::asByteArrayUnsafe);
     }
 
     @Override


### PR DESCRIPTION
 The S3 driver guaranties not to mutate the byte[] which is
 good enough given that james don't do it either. Preventing
 needless copies of MBs of large mail definitely give a nice
 performance boost as well as decrease the impact of handling
 very large emails...