### PR TITLE
[BUILD] Fasten OpenSearch tests

### DIFF
--- a/backends-common/opensearch/src/main/java/org/apache/james/backends/opensearch/DeleteByQueryPerformer.java
+++ b/backends-common/opensearch/src/main/java/org/apache/james/backends/opensearch/DeleteByQueryPerformer.java
@@ -43,4 +43,12 @@ public class DeleteByQueryPerformer {
         return client.deleteByQuery(deleteRequest, RequestOptions.DEFAULT)
             .then();
     }
+
+    public Mono<Void> perform(QueryBuilder queryBuilder) {
+        DeleteByQueryRequest deleteRequest = new DeleteByQueryRequest(aliasName.getValue());
+        deleteRequest.setQuery(queryBuilder);
+
+        return client.deleteByQuery(deleteRequest, RequestOptions.DEFAULT)
+            .then();
+    }
 }

--- a/backends-common/opensearch/src/test/java/org/apache/james/backends/opensearch/DockerOpenSearch.java
+++ b/backends-common/opensearch/src/test/java/org/apache/james/backends/opensearch/DockerOpenSearch.java
@@ -133,7 +133,7 @@ public interface DockerOpenSearch {
 
         static DockerContainer defaultContainer(String imageName) {
             return DockerContainer.fromName(imageName)
-                .withTmpFs(ImmutableMap.of("/usr/share/elasticsearch/data", "rw,size=200m"))
+                .withTmpFs(ImmutableMap.of("/usr/share/opensearch/data/nodes/0", "rw,size=200m"))
                 .withExposedPorts(ES_HTTP_PORT)
                 .withEnv("discovery.type", "single-node")
                 .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
@@ -228,6 +228,7 @@ public interface DockerOpenSearch {
                         .withFileFromClasspath("conf/default.key", "auth-es/default.key")
                         .withFileFromClasspath("Dockerfile", "auth-es/NginxDockerfile")))
                 .withExposedPorts(ES_HTTP_PORT)
+                .withTmpFs(ImmutableMap.of("/usr/share/opensearch/data/nodes/0", "rw,size=200m"))
                 .withLogConsumer(frame -> LOGGER.debug("[NGINX] " + frame.getUtf8String()))
                 .withNetwork(network)
                 .withName("james-testing-nginx-" + UUID.randomUUID());
@@ -342,7 +343,9 @@ public interface DockerOpenSearch {
     default OpenSearchConfiguration.Builder configurationBuilder(Optional<Duration> requestTimeout) {
         return OpenSearchConfiguration.builder()
             .addHost(getHttpHost())
-            .requestTimeout(requestTimeout);
+            .requestTimeout(requestTimeout)
+            .nbReplica(0)
+            .nbShards(1);
     }
 
     default OpenSearchConfiguration configuration() {

--- a/backends-common/opensearch/src/test/java/org/apache/james/backends/opensearch/OpenSearchHealthCheckConnectionTest.java
+++ b/backends-common/opensearch/src/test/java/org/apache/james/backends/opensearch/OpenSearchHealthCheckConnectionTest.java
@@ -32,7 +32,7 @@ class OpenSearchHealthCheckConnectionTest {
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
 
     @RegisterExtension
-    public DockerOpenSearchExtension openSearch = new DockerOpenSearchExtension();
+    public DockerOpenSearchExtension openSearch = new DockerOpenSearchExtension(DockerOpenSearchExtension.CleanupStrategy.NONE);
     private OpenSearchHealthCheck openSearchHealthCheck;
 
     @BeforeEach

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcherTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcherTest.java
@@ -32,6 +32,7 @@ import java.util.stream.IntStream;
 import org.apache.james.backends.opensearch.DockerOpenSearchExtension;
 import org.apache.james.backends.opensearch.OpenSearchIndexer;
 import org.apache.james.backends.opensearch.ReactorOpenSearchClient;
+import org.apache.james.backends.opensearch.WriteAliasName;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
@@ -89,7 +90,8 @@ class OpenSearchSearcherTest {
     static TikaExtension tika = new TikaExtension();
 
     @RegisterExtension
-    DockerOpenSearchExtension openSearch = new DockerOpenSearchExtension();
+    static DockerOpenSearchExtension openSearch = new DockerOpenSearchExtension(
+        new DockerOpenSearchExtension.DeleteAllIndexDocumentsCleanupStrategy(new WriteAliasName("mailboxWriteAlias")));
 
     TikaTextExtractor textExtractor;
     ReactorOpenSearchClient client;

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -58,6 +58,7 @@ import javax.mail.Flags;
 import org.apache.james.backends.opensearch.DockerOpenSearchExtension;
 import org.apache.james.backends.opensearch.OpenSearchIndexer;
 import org.apache.james.backends.opensearch.ReactorOpenSearchClient;
+import org.apache.james.backends.opensearch.WriteAliasName;
 import org.apache.james.core.Username;
 import org.apache.james.json.DTOConverter;
 import org.apache.james.mailbox.MailboxManager;
@@ -1448,7 +1449,8 @@ class UserMailboxesRoutesTest {
         static final int SEARCH_SIZE = 1;
 
         @RegisterExtension
-        DockerOpenSearchExtension elasticSearch = new DockerOpenSearchExtension();
+        DockerOpenSearchExtension openSearch = new DockerOpenSearchExtension(
+            new DockerOpenSearchExtension.DeleteAllIndexDocumentsCleanupStrategy(new WriteAliasName("mailboxWriteAlias")));
 
         private InMemoryMailboxManager mailboxManager;
         private ListeningMessageSearchIndex searchIndex;
@@ -1457,8 +1459,8 @@ class UserMailboxesRoutesTest {
         @BeforeEach
         void setUp() throws Exception {
             ReactorOpenSearchClient client = MailboxIndexCreationUtil.prepareDefaultClient(
-                elasticSearch.getDockerOpenSearch().clientProvider().get(),
-                elasticSearch.getDockerOpenSearch().configuration());
+                openSearch.getDockerOpenSearch().clientProvider().get(),
+                openSearch.getDockerOpenSearch().configuration());
 
             InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
             MailboxIdRoutingKeyFactory routingKeyFactory = new MailboxIdRoutingKeyFactory();


### PR DESCRIPTION
 - Mount tmpfs within the containers
 - Use deleteByQuery where possible to cleanup data as it is faster


Gains :
 - OpenSearchIntegrationTest 3 minutes -> 88 seconds locally