### PR TITLE
[BUILD_TIME] Slightly faster Cassandra container startup

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/SessionWithInitializedTablesFactoryTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/SessionWithInitializedTablesFactoryTest.java
@@ -129,7 +129,7 @@ class SessionWithInitializedTablesFactoryTest {
             .build();
         KeyspaceConfiguration keyspaceConfiguration = DockerCassandra.mainKeyspaceConfiguration();
         CqlSession cluster = ClusterFactory.create(clusterConfiguration, keyspaceConfiguration);
-        KeyspaceFactory.createKeyspace(keyspaceConfiguration, cluster);
+        KeyspaceFactory.createKeyspace(keyspaceConfiguration, cluster).block();
 
         return () -> new SessionWithInitializedTablesFactory( cluster, MODULE).get();
     }

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraCacheSessionModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraCacheSessionModule.java
@@ -76,7 +76,7 @@ public class CassandraCacheSessionModule extends AbstractModule {
             this.cluster = cluster;
 
             if (clusterConfiguration.shouldCreateKeyspace()) {
-                KeyspaceFactory.createKeyspace(keyspacesConfiguration.cacheKeyspaceConfiguration(), cluster);
+                KeyspaceFactory.createKeyspace(keyspacesConfiguration.cacheKeyspaceConfiguration(), cluster).block();
             }
         }
     }

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -167,7 +167,7 @@ public class CassandraSessionModule extends AbstractModule {
             this.cluster = sessionProvider.get();
 
             if (clusterConfiguration.shouldCreateKeyspace()) {
-                KeyspaceFactory.createKeyspace(keyspacesConfiguration.mainKeyspaceConfiguration(), cluster);
+                KeyspaceFactory.createKeyspace(keyspacesConfiguration.mainKeyspaceConfiguration(), cluster).block();
             }
         }
     }


### PR DESCRIPTION
20% speed up measured locally by:

 - Using a single session for all resource creation
 - Closing it async
 - Creating keyspaces sequentially
 - Avoid creating the user twice
 - Using a faster check method than container exec