### PR TITLE
JAMES-3775 Rspamd Scanner should distinguish reject from add_header

### DIFF
--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -69,7 +69,7 @@ might not even be desirable.
 </processor>
 
 <!--Store rejected spam emails (with a very high score) -->
-<processor state="virus" enableJmx="false">
+<processor state="spam" enableJmx="false">
     <mailet match="All" class="ToRepository">
         <repositoryPath>cassandra://var/mail/spam</repositoryPath>
     </mailet>

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
@@ -137,6 +137,9 @@ class RspamdScannerTest {
             .mimeMessage(mimeMessage)
             .build();
 
+        mailet.init(FakeMailetConfig.builder()
+            .setProperty("rewriteSubject", "true")
+            .build());
         mailet.service(mail);
 
 
@@ -190,6 +193,104 @@ class RspamdScannerTest {
         mailet.service(mail);
 
         assertThat(mail.getMessage().getSubject()).isEqualTo(REWRITE_SUBJECT);
+    }
+
+    @Test
+    void serviceShouldMoveRejetedEmailToTheSpamProcessor() throws Exception {
+        RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+        when(rspamdHttpClient.checkV2(any())).thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.REJECT)
+                .score(12.1F)
+                .requiredScore(14F)
+            .build()));
+
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty("rejectSpamProcessor", "spam")
+            .build();
+
+        mailet = new RspamdScanner(rspamdHttpClient);
+
+        Mail mail = FakeMail.builder()
+            .name("name")
+            .state("initial")
+            .recipient("user1@exemple.com")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .addToRecipient("user1@exemple.com")
+                .addFrom("sender@exemple.com")
+                .setSubject(INIT_SUBJECT)
+                .setText("Please!")
+                .build())
+            .build();
+
+        mailet.init(mailetConfig);
+        mailet.service(mail);
+
+        assertThat(mail.getState()).isEqualTo("spam");
+    }
+
+    @Test
+    void serviceShouldNotMoveRejetedEmailWhenNoSpamProcessor() throws Exception {
+        RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+        when(rspamdHttpClient.checkV2(any())).thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.REJECT)
+                .score(12.1F)
+                .requiredScore(14F)
+            .build()));
+
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .build();
+
+        mailet = new RspamdScanner(rspamdHttpClient);
+
+        Mail mail = FakeMail.builder()
+            .name("name")
+            .state("initial")
+            .recipient("user1@exemple.com")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .addToRecipient("user1@exemple.com")
+                .addFrom("sender@exemple.com")
+                .setSubject(INIT_SUBJECT)
+                .setText("Please!")
+                .build())
+            .build();
+
+        mailet.init(mailetConfig);
+        mailet.service(mail);
+
+        assertThat(mail.getState()).isEqualTo("initial");
+    }
+
+    @Test
+    void serviceShouldNotMoveLegitimateEmailToSpamProcessor() throws Exception {
+        RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+        when(rspamdHttpClient.checkV2(any())).thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.ADD_HEADER)
+                .score(12.1F)
+                .requiredScore(14F)
+            .build()));
+
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty("rejectSpamProcessor", "spam")
+            .build();
+        
+        mailet = new RspamdScanner(rspamdHttpClient);
+
+        Mail mail = FakeMail.builder()
+            .name("name")
+            .state("initial")
+            .recipient("user1@exemple.com")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .addToRecipient("user1@exemple.com")
+                .addFrom("sender@exemple.com")
+                .setSubject(INIT_SUBJECT)
+                .setText("Please!")
+                .build())
+            .build();
+
+        mailet.init(mailetConfig);
+        mailet.service(mail);
+
+        assertThat(mail.getState()).isEqualTo("initial");
     }
 
     @Test


### PR DESCRIPTION
Now positions headers on `add header` action (which would end up moving the email in user spam box) and distinguish reject action (email not delivered).

Scores threshold are configurable on RspamD side.