### PR TITLE
JAMES-3737 Upon IMAP deselect registration.get() can be null

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -192,7 +192,10 @@ public class SelectedMailboxImpl implements SelectedMailbox, EventListener.React
 
     @Override
     public Mono<Void> deselect() {
-        return Mono.from(registration.get().unregister())
+        return Mono.from(
+            Optional.ofNullable(registration.get())
+                .map(Registration::unregister)
+                .orElse(Mono.empty()))
             .then(Mono.fromRunnable(this::clearInternalStructures)
                 .subscribeOn(Schedulers.boundedElastic()))
             .then();


### PR DESCRIPTION
This happens for instance when an error happens before the session is
fully selected eg upon IMAP error, or partial select completion.

```
java.lang.NullPointerException: Cannot invoke "org.apache.james.events.Registration.unregister()" because the return value of "java.util.concurrent.atomic.AtomicReference.get()" is null
at org.apache.james.imap.processor.base.SelectedMailboxImpl.deselect(SelectedMailboxImpl.java:196)
at org.apache.james.imapserver.netty.NettyImapSession.closeMailbox(NettyImapSession.java:153)
at org.apache.james.imapserver.netty.NettyImapSession.selected(NettyImapSession.java:127)
at org.apache.james.imap.processor.AbstractSelectionProcessor.selectMailbox(AbstractSelectionProcessor.java:409)
at org.apache.james.imap.processor.AbstractSelectionProcessor.lambda$selectMailbox$20(AbstractSelectionProcessor.java:383)
```