### PR TITLE
JAMES-3810: Backport of fixes to 3.7.x

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
@@ -134,7 +134,7 @@ public class CassandraMailQueueBrowser {
 
     Flux<EnqueuedItemWithSlicingContext> browseReferences(MailQueueName queueName, Instant browseStart) {
         return allSlicesStartingAt(browseStart)
-            .flatMapSequential(slice -> browseSlice(queueName, slice));
+            .flatMapSequential(slice -> browseSlice(queueName, slice), 4);
     }
 
     private Mono<Pair<EnqueuedItem, Mail>> toMailFuture(EnqueuedItemWithSlicingContext enqueuedItemWithSlicingContext) {


### PR DESCRIPTION
This is mostly a cherry pick of the respective commits from JAMES-3810. The only "backport" is the use of Schedulers.elastic() instead of ReaktorUtils.BLOCKING_CALL_WRAPPER since the latter does not exist yet in 3.7.x.

Note: Merging this should probably wait until the pending 3.7.1 release is decided.