### PR TITLE
JAMES-3668 Add absolute paths for extra properties file in docker image

### DIFF
--- a/server/apps/cassandra-app/docker-configuration/jvm.properties
+++ b/server/apps/cassandra-app/docker-configuration/jvm.properties
@@ -1,0 +1,48 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever
+
+# Required to locate Cassandra driver configuration
+config.file=/root/conf/cassandra-driver.conf
+
+# (Optional). String (size, integer + size units, example: `12 KIB`, supported units are bytes KIB MIB GIB TIB). Defaults to 100KIB.
+# This governs the threshold MimeMessageInputStreamSource relies on for storing MimeMessage content on disk.
+# Below, data is stored in memory. Above data is stored on disk.
+# Lower values will lead to longer processing time but will minimize heap memory usage. Modern SSD hardware
+# should however support a high throughput. Higher values will lead to faster single mail processing at the cost
+# of higher heap usage.
+#james.message.memory.threshold=12K
+
+# Optional. Boolean. Defaults to false. Recommended value is false.
+# Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
+# be copied to temporary files?
+#james.message.usememorycopy=false
+
+# Mode level of resource leak detection. It is used to detect a resource not be disposed of before it's garbage-collected.
+# Example `MimeMessageInputStreamSource`
+# Optional. Allowed values are: none, simple, advanced, testing
+#   - none: Disables resource leak detection.
+#   - simple: Enables output a simplistic error log if a leak is encountered and would free the resources (default).
+#   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
+#   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
+#james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true
+
+# Manage netty leak detection level see https://netty.io/wiki/reference-counted-objects.html#leak-detection-levels
+# io.netty.leakDetection.level=SIMPLE
+
+# Should James exit on Startup error? Boolean, defaults to true. This prevents partial startup.
+# james.exit.on.startup.error=true
+
+# Fails explicitly on missing configuration file rather that taking implicit values. Defautls to false.
+# james.fail.on.missing.configuration=true
+
+# JMX, when enable causes RMI to plan System.gc every hour. Set this instead to once every 1000h.
+sun.rmi.dgc.server.gcInterval=3600000000
+sun.rmi.dgc.client.gcInterval=3600000000

--- a/server/apps/cassandra-app/pom.xml
+++ b/server/apps/cassandra-app/pom.xml
@@ -365,6 +365,7 @@
                             <jvmFlag>-Dworking.directory=/root/</jvmFlag>
                             <!-- Prevents Logjam (CVE-2015-4000) -->
                             <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
+                            <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
                         </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
 

--- a/server/apps/distributed-app/docker-configuration/jvm.properties
+++ b/server/apps/distributed-app/docker-configuration/jvm.properties
@@ -1,0 +1,48 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Required to locate Cassandra driver configuration
+config.file=/root/conf/cassandra-driver.conf
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever
+
+# (Optional). String (size, integer + size units, example: `12 KIB`, supported units are bytes KIB MIB GIB TIB). Defaults to 100KIB.
+# This governs the threshold MimeMessageInputStreamSource relies on for storing MimeMessage content on disk.
+# Below, data is stored in memory. Above data is stored on disk.
+# Lower values will lead to longer processing time but will minimize heap memory usage. Modern SSD hardware
+# should however support a high throughput. Higher values will lead to faster single mail processing at the cost
+# of higher heap usage.
+#james.message.memory.threshold=12K
+
+# Optional. Boolean. Defaults to false. Recommended value is false.
+# Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
+# be copied to temporary files?
+#james.message.usememorycopy=false
+
+# Mode level of resource leak detection. It is used to detect a resource not be disposed of before it's garbage-collected.
+# Example `MimeMessageInputStreamSource`
+# Optional. Allowed values are: none, simple, advanced, testing
+#   - none: Disables resource leak detection.
+#   - simple: Enables output a simplistic error log if a leak is encountered and would free the resources (default).
+#   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
+#   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
+#james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true
+
+# Manage netty leak detection level see https://netty.io/wiki/reference-counted-objects.html#leak-detection-levels
+# io.netty.leakDetection.level=SIMPLE
+
+# Should James exit on Startup error? Boolean, defaults to true. This prevents partial startup.
+# james.exit.on.startup.error=true
+
+# Fails explicitly on missing configuration file rather that taking implicit values. Defautls to false.
+# james.fail.on.missing.configuration=true
+
+# JMX, when enable causes RMI to plan System.gc every hour. Set this instead to once every 1000h.
+sun.rmi.dgc.server.gcInterval=3600000000
+sun.rmi.dgc.client.gcInterval=3600000000

--- a/server/apps/distributed-app/pom.xml
+++ b/server/apps/distributed-app/pom.xml
@@ -409,6 +409,7 @@
                             <jvmFlag>-Dworking.directory=/root/</jvmFlag>
                             <!-- Prevents Logjam (CVE-2015-4000) -->
                             <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
+                            <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
                         </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         <volumes>

--- a/server/apps/distributed-pop3-app/docker-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/docker-configuration/jvm.properties
@@ -1,0 +1,48 @@
+# ============================================= Extra JVM System Properties ===========================================
+# To avoid clutter on the command line, any properties in this file will be added as system properties on server start.
+
+# Example: If you need an option -Dmy.property=whatever, you can instead add it here as
+# my.property=whatever
+
+# Required to locate Cassandra driver configuration
+config.file=/root/conf/cassandra-driver.conf
+
+# (Optional). String (size, integer + size units, example: `12 KIB`, supported units are bytes KIB MIB GIB TIB). Defaults to 100KIB.
+# This governs the threshold MimeMessageInputStreamSource relies on for storing MimeMessage content on disk.
+# Below, data is stored in memory. Above data is stored on disk.
+# Lower values will lead to longer processing time but will minimize heap memory usage. Modern SSD hardware
+# should however support a high throughput. Higher values will lead to faster single mail processing at the cost
+# of higher heap usage.
+#james.message.memory.threshold=12K
+
+# Optional. Boolean. Defaults to false. Recommended value is false.
+# Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
+# be copied to temporary files?
+#james.message.usememorycopy=false
+
+# Mode level of resource leak detection. It is used to detect a resource not be disposed of before it's garbage-collected.
+# Example `MimeMessageInputStreamSource`
+# Optional. Allowed values are: none, simple, advanced, testing
+#   - none: Disables resource leak detection.
+#   - simple: Enables output a simplistic error log if a leak is encountered and would free the resources (default).
+#   - advanced: Enables output an advanced error log implying the place of allocation of the underlying object and would free resources.
+#   - testing: Enables output an advanced error log implying the place of allocation of the underlying object and rethrow an error, that action is being taken by the development team.
+#james.lifecycle.leak.detection.mode=simple
+
+# Should we add the host in the MDC logging context for incoming IMAP, SMTP, POP3? Doing so, a DNS resolution
+# is attempted for each incoming connection, which can be costly. Remote IP is always added to the logging context.
+# Optional. Boolean. Defaults to true.
+#james.protocols.mdc.hostname=true
+
+# Manage netty leak detection level see https://netty.io/wiki/reference-counted-objects.html#leak-detection-levels
+# io.netty.leakDetection.level=SIMPLE
+
+# Should James exit on Startup error? Boolean, defaults to true. This prevents partial startup.
+# james.exit.on.startup.error=true
+
+# Fails explicitly on missing configuration file rather that taking implicit values. Defautls to false.
+# james.fail.on.missing.configuration=true
+
+# JMX, when enable causes RMI to plan System.gc every hour. Set this instead to once every 1000h.
+sun.rmi.dgc.server.gcInterval=3600000000
+sun.rmi.dgc.client.gcInterval=3600000000

--- a/server/apps/distributed-pop3-app/pom.xml
+++ b/server/apps/distributed-pop3-app/pom.xml
@@ -418,6 +418,7 @@
                         <jvmFlags>
                             <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
                             <jvmFlag>-Dworking.directory=/root/</jvmFlag>
+                            <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
                         </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         <volumes>

--- a/server/container/guice/common/src/main/java/org/apache/james/ExtraProperties.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/ExtraProperties.java
@@ -32,10 +32,9 @@ public class ExtraProperties {
         String propsPath = System.getProperty(OVERRIDE_PROPERTY, DEFAULT_PATH);
         try (FileInputStream in = new FileInputStream(propsPath)) {
             System.getProperties().load(in);
+            JamesServerMain.LOGGER.info("Load extra system properties file {}", propsPath);
         } catch (FileNotFoundException e) {
-            if (!DEFAULT_PATH.equals(propsPath)) {
-                JamesServerMain.LOGGER.warn("Could not find extra system properties file {}", propsPath);
-            }
+            JamesServerMain.LOGGER.warn("Could not find extra system properties file {}", propsPath);
         } catch (IOException e) {
             JamesServerMain.LOGGER.warn(
                     "Failed to load extra system properties from file {} : {}", propsPath, e.getMessage());


### PR DESCRIPTION
We had issues with the relative path not working with Docker and James not being able to find the file.
Overriding to absolute path should ensure it finds it in this particular case.