### PR TITLE
JAMES-3732 Fix a typo in poms regarding the leak detector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3243,7 +3243,7 @@
                     <configuration>
                         <systemPropertyVariables>
                             <!--https://issues.apache.org/jira/browse/JAMES-3724-->
-                            <james.ligecycle.leak.detection.mode>testing</james.ligecycle.leak.detection.mode>
+                            <james.lifecycle.leak.detection.mode>NONE</james.lifecycle.leak.detection.mode>
                             <james.exit.on.startup.error>false</james.exit.on.startup.error>
                         </systemPropertyVariables>
                         <argLine>-Xms512m -Xmx1024m</argLine>

--- a/server/protocols/protocols-imap4/pom.xml
+++ b/server/protocols/protocols-imap4/pom.xml
@@ -191,7 +191,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <!--https://issues.apache.org/jira/browse/JAMES-3724-->
-                        <james.ligecycle.leak.detection.mode>testing</james.ligecycle.leak.detection.mode>
+                        <james.lifecycle.leak.detection.mode>testing</james.lifecycle.leak.detection.mode>
                         <!--https://netty.io/wiki/reference-counted-objects.html#best-practices-to-avoid-leaks -->
                         <io.netty.leakDetection.level>PARANOID</io.netty.leakDetection.level>
                     </systemPropertyVariables>

--- a/server/protocols/protocols-lmtp/pom.xml
+++ b/server/protocols/protocols-lmtp/pom.xml
@@ -184,7 +184,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <!--https://issues.apache.org/jira/browse/JAMES-3724-->
-                        <james.ligecycle.leak.detection.mode>testing</james.ligecycle.leak.detection.mode>
+                        <james.lifecycle.leak.detection.mode>NONE</james.lifecycle.leak.detection.mode>
                         <!--https://netty.io/wiki/reference-counted-objects.html#best-practices-to-avoid-leaks -->
                         <io.netty.leakDetection.level>PARANOID</io.netty.leakDetection.level>
                     </systemPropertyVariables>

--- a/server/protocols/protocols-pop3/pom.xml
+++ b/server/protocols/protocols-pop3/pom.xml
@@ -173,7 +173,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <!--https://issues.apache.org/jira/browse/JAMES-3724-->
-                        <james.ligecycle.leak.detection.mode>testing</james.ligecycle.leak.detection.mode>
+                        <james.lifecycle.leak.detection.mode>testing</james.lifecycle.leak.detection.mode>
                         <!--https://netty.io/wiki/reference-counted-objects.html#best-practices-to-avoid-leaks -->
                         <io.netty.leakDetection.level>PARANOID</io.netty.leakDetection.level>
                     </systemPropertyVariables>

--- a/server/protocols/protocols-smtp/pom.xml
+++ b/server/protocols/protocols-smtp/pom.xml
@@ -220,7 +220,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <!--https://issues.apache.org/jira/browse/JAMES-3724-->
-                        <james.ligecycle.leak.detection.mode>testing</james.ligecycle.leak.detection.mode>
+                        <james.lifecycle.leak.detection.mode>NONE</james.lifecycle.leak.detection.mode>
                         <!--https://netty.io/wiki/reference-counted-objects.html#best-practices-to-avoid-leaks -->
                         <io.netty.leakDetection.level>PARANOID</io.netty.leakDetection.level>
                     </systemPropertyVariables>


### PR DESCRIPTION
Disable leak detector in tests as we do not achieve good resource management in
those tests. Enable it selectively in a few relevant projects.