### PR TITLE
JAMES-3755 Refactor Rspamd ham/spam routes

### DIFF
--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
@@ -91,18 +91,11 @@ public class FeedMessageRoute implements Routes {
 
         return Optional.ofNullable(request.queryParams("action"))
             .filter(action -> action.equals(REPORT_SPAM_PARAM))
-            .map(any -> (Task) new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, getFeedSpamTaskRunningOptions(request), clock))
-            .orElse(new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, getFeedHamTaskRunningOptions(request), clock));
+            .map(any -> (Task) new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, getRunningOptions(request), clock))
+            .orElse(new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, getRunningOptions(request), clock));
     }
 
-    private RunningOptions getFeedSpamTaskRunningOptions(Request request) {
-        Optional<Long> periodInSecond = getPeriod(request);
-        int messagesPerSecond = getMessagesPerSecond(request).orElse(RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
-        double samplingProbability = getSamplingProbability(request).orElse(RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
-        return new RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
-    }
-
-    private RunningOptions getFeedHamTaskRunningOptions(Request request) {
+    private RunningOptions getRunningOptions(Request request) {
         Optional<Long> periodInSecond = getPeriod(request);
         int messagesPerSecond = getMessagesPerSecond(request).orElse(RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
         double samplingProbability = getSamplingProbability(request).orElse(RunningOptions.DEFAULT_SAMPLING_PROBABILITY);

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
@@ -32,6 +32,7 @@ import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.rspamd.task.FeedHamToRspamdTask;
 import org.apache.james.rspamd.task.FeedSpamToRspamdTask;
+import org.apache.james.rspamd.task.RunningOptions;
 import org.apache.james.task.Task;
 import org.apache.james.task.TaskManager;
 import org.apache.james.user.api.UsersRepository;
@@ -94,18 +95,18 @@ public class FeedMessageRoute implements Routes {
             .orElse(new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, getFeedHamTaskRunningOptions(request), clock));
     }
 
-    private FeedSpamToRspamdTask.RunningOptions getFeedSpamTaskRunningOptions(Request request) {
+    private RunningOptions getFeedSpamTaskRunningOptions(Request request) {
         Optional<Long> periodInSecond = getPeriod(request);
-        int messagesPerSecond = getMessagesPerSecond(request).orElse(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
-        double samplingProbability = getSamplingProbability(request).orElse(FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
-        return new FeedSpamToRspamdTask.RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
+        int messagesPerSecond = getMessagesPerSecond(request).orElse(RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
+        double samplingProbability = getSamplingProbability(request).orElse(RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
+        return new RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
     }
 
-    private FeedHamToRspamdTask.RunningOptions getFeedHamTaskRunningOptions(Request request) {
+    private RunningOptions getFeedHamTaskRunningOptions(Request request) {
         Optional<Long> periodInSecond = getPeriod(request);
-        int messagesPerSecond = getMessagesPerSecond(request).orElse(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
-        double samplingProbability = getSamplingProbability(request).orElse(FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
-        return new FeedHamToRspamdTask.RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
+        int messagesPerSecond = getMessagesPerSecond(request).orElse(RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
+        double samplingProbability = getSamplingProbability(request).orElse(RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
+        return new RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
     }
 
     private Optional<Long> getPeriod(Request req) {

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTask.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTask.java
@@ -39,7 +39,6 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.util.ReactorUtils;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -49,68 +48,30 @@ import reactor.core.publisher.Mono;
 public class FeedHamToRspamdTask implements Task {
     public static final TaskType TASK_TYPE = TaskType.of("FeedHamToRspamdTask");
 
-    public static class RunningOptions {
-        public static final Optional<Long> DEFAULT_PERIOD = Optional.empty();
-        public static final int DEFAULT_MESSAGES_PER_SECOND = 10;
-        public static final double DEFAULT_SAMPLING_PROBABILITY = 1;
-        public static final RunningOptions DEFAULT = new RunningOptions(DEFAULT_PERIOD, DEFAULT_MESSAGES_PER_SECOND,
-            DEFAULT_SAMPLING_PROBABILITY);
-
-        private final Optional<Long> periodInSecond;
-        private final int messagesPerSecond;
-        private final double samplingProbability;
-
-        public RunningOptions(@JsonProperty("periodInSecond") Optional<Long> periodInSecond,
-                              @JsonProperty("messagesPerSecond") int messagesPerSecond,
-                              @JsonProperty("samplingProbability") double samplingProbability) {
-            this.periodInSecond = periodInSecond;
-            this.messagesPerSecond = messagesPerSecond;
-            this.samplingProbability = samplingProbability;
-        }
-
-        public Optional<Long> getPeriodInSecond() {
-            return periodInSecond;
-        }
-
-        public int getMessagesPerSecond() {
-            return messagesPerSecond;
-        }
-
-        public double getSamplingProbability() {
-            return samplingProbability;
-        }
-    }
-
     public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
 
-        private static AdditionalInformation from(Context context) {
+        private static AdditionalInformation from(Context context, RunningOptions runningOptions) {
             Context.Snapshot snapshot = context.snapshot();
             return new AdditionalInformation(
                 Clock.systemUTC().instant(),
                 snapshot.getHamMessageCount(),
                 snapshot.getReportedHamMessageCount(),
                 snapshot.getErrorCount(),
-                snapshot.getMessagesPerSecond(),
-                snapshot.getPeriod(),
-                snapshot.getSamplingProbability());
+                runningOptions);
         }
 
         private final Instant timestamp;
         private final long hamMessageCount;
         private final long reportedHamMessageCount;
         private final long errorCount;
-        private final int messagesPerSecond;
-        private final Optional<Long> period;
-        private final double samplingProbability;
+        private final RunningOptions runningOptions;
 
-        public AdditionalInformation(Instant timestamp, long hamMessageCount, long reportedHamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period, double samplingProbability) {
+        public AdditionalInformation(Instant timestamp, long hamMessageCount, long reportedHamMessageCount, long errorCount, RunningOptions runningOptions) {
             this.timestamp = timestamp;
             this.hamMessageCount = hamMessageCount;
             this.reportedHamMessageCount = reportedHamMessageCount;
             this.errorCount = errorCount;
-            this.messagesPerSecond = messagesPerSecond;
-            this.period = period;
-            this.samplingProbability = samplingProbability;
+            this.runningOptions = runningOptions;
         }
 
         public long getHamMessageCount() {
@@ -125,16 +86,8 @@ public class FeedHamToRspamdTask implements Task {
             return errorCount;
         }
 
-        public int getMessagesPerSecond() {
-            return messagesPerSecond;
-        }
-
-        public Optional<Long> getPeriod() {
-            return period;
-        }
-
-        public double getSamplingProbability() {
-            return samplingProbability;
+        public RunningOptions getRunningOptions() {
+            return runningOptions;
         }
 
         @Override
@@ -155,27 +108,18 @@ public class FeedHamToRspamdTask implements Task {
                 private Optional<Long> hamMessageCount;
                 private Optional<Long> reportedHamMessageCount;
                 private Optional<Long> errorCount;
-                private Optional<Integer> messagesPerSecond;
-                private Optional<Long> period;
-                private Optional<Double> samplingProbability;
 
                 Builder() {
                     hamMessageCount = Optional.empty();
                     reportedHamMessageCount = Optional.empty();
                     errorCount = Optional.empty();
-                    messagesPerSecond = Optional.empty();
-                    period = Optional.empty();
-                    samplingProbability = Optional.empty();
                 }
 
                 public Snapshot build() {
                     return new Snapshot(
                         hamMessageCount.orElse(0L),
                         reportedHamMessageCount.orElse(0L),
-                        errorCount.orElse(0L),
-                        messagesPerSecond.orElse(0),
-                        period,
-                        samplingProbability.orElse(1D));
+                        errorCount.orElse(0L));
                 }
 
                 public Builder hamMessageCount(long hamMessageCount) {
@@ -192,38 +136,16 @@ public class FeedHamToRspamdTask implements Task {
                     this.errorCount = Optional.of(errorCount);
                     return this;
                 }
-
-                public Builder messagesPerSecond(int messagesPerSecond) {
-                    this.messagesPerSecond = Optional.of(messagesPerSecond);
-                    return this;
-                }
-
-                public Builder period(Optional<Long> period) {
-                    this.period = period;
-                    return this;
-                }
-
-                public Builder samplingProbability(double samplingProbability) {
-                    this.samplingProbability = Optional.of(samplingProbability);
-                    return this;
-                }
             }
 
             private final long hamMessageCount;
             private final long reportedHamMessageCount;
             private final long errorCount;
-            private final int messagesPerSecond;
-            private final Optional<Long> period;
-            private final double samplingProbability;
 
-            public Snapshot(long hamMessageCount, long reportedHamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period,
-                            double samplingProbability) {
+            public Snapshot(long hamMessageCount, long reportedHamMessageCount, long errorCount) {
                 this.hamMessageCount = hamMessageCount;
                 this.reportedHamMessageCount = reportedHamMessageCount;
                 this.errorCount = errorCount;
-                this.messagesPerSecond = messagesPerSecond;
-                this.period = period;
-                this.samplingProbability = samplingProbability;
             }
 
             public long getHamMessageCount() {
@@ -238,18 +160,6 @@ public class FeedHamToRspamdTask implements Task {
                 return errorCount;
             }
 
-            public int getMessagesPerSecond() {
-                return messagesPerSecond;
-            }
-
-            public Optional<Long> getPeriod() {
-                return period;
-            }
-
-            public double getSamplingProbability() {
-                return samplingProbability;
-            }
-
             @Override
             public final boolean equals(Object o) {
                 if (o instanceof Snapshot) {
@@ -257,17 +167,14 @@ public class FeedHamToRspamdTask implements Task {
 
                     return Objects.equals(this.hamMessageCount, snapshot.hamMessageCount)
                         && Objects.equals(this.reportedHamMessageCount, snapshot.reportedHamMessageCount)
-                        && Objects.equals(this.errorCount, snapshot.errorCount)
-                        && Objects.equals(this.messagesPerSecond, snapshot.messagesPerSecond)
-                        && Objects.equals(this.samplingProbability, snapshot.samplingProbability)
-                        && Objects.equals(this.period, snapshot.period);
+                        && Objects.equals(this.errorCount, snapshot.errorCount);
                 }
                 return false;
             }
 
             @Override
             public final int hashCode() {
-                return Objects.hash(hamMessageCount, reportedHamMessageCount, errorCount, messagesPerSecond, period, samplingProbability);
+                return Objects.hash(hamMessageCount, reportedHamMessageCount, errorCount);
             }
 
             @Override
@@ -276,9 +183,6 @@ public class FeedHamToRspamdTask implements Task {
                     .add("hamMessageCount", hamMessageCount)
                     .add("reportedHamMessageCount", reportedHamMessageCount)
                     .add("errorCount", errorCount)
-                    .add("messagesPerSecond", messagesPerSecond)
-                    .add("period", period)
-                    .add("samplingProbability", samplingProbability)
                     .toString();
             }
         }
@@ -286,17 +190,11 @@ public class FeedHamToRspamdTask implements Task {
         private final AtomicLong hamMessageCount;
         private final AtomicLong reportedHamMessageCount;
         private final AtomicLong errorCount;
-        private final Integer messagesPerSecond;
-        private final Optional<Long> period;
-        private final Double samplingProbability;
 
-        public Context(RunningOptions runningOptions) {
+        public Context() {
             this.hamMessageCount = new AtomicLong();
             this.reportedHamMessageCount = new AtomicLong();
             this.errorCount = new AtomicLong();
-            this.messagesPerSecond = runningOptions.messagesPerSecond;
-            this.period = runningOptions.periodInSecond;
-            this.samplingProbability = runningOptions.samplingProbability;
         }
 
         public void incrementHamMessageCount() {
@@ -316,9 +214,6 @@ public class FeedHamToRspamdTask implements Task {
                 .hamMessageCount(hamMessageCount.get())
                 .reportedHamMessageCount(reportedHamMessageCount.get())
                 .errorCount(errorCount.get())
-                .messagesPerSecond(messagesPerSecond)
-                .period(period)
-                .samplingProbability(samplingProbability)
                 .build();
         }
     }
@@ -334,17 +229,17 @@ public class FeedHamToRspamdTask implements Task {
         this.runningOptions = runningOptions;
         this.messagesService = new GetMailboxMessagesService(mailboxManager, usersRepository, mapperFactory, messageIdManager);
         this.rspamdHttpClient = rspamdHttpClient;
-        this.context = new Context(runningOptions);
+        this.context = new Context();
         this.clock = clock;
     }
 
     @Override
     public Result run() {
-        Optional<Date> afterDate = runningOptions.periodInSecond.map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
+        Optional<Date> afterDate = runningOptions.getPeriodInSecond().map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
         try {
             return messagesService.getHamMessagesOfAllUser(afterDate, runningOptions.getSamplingProbability(), context)
                 .transform(ReactorUtils.<MessageResult, Result>throttle()
-                    .elements(runningOptions.messagesPerSecond)
+                    .elements(runningOptions.getMessagesPerSecond())
                     .per(Duration.ofSeconds(1))
                     .forOperation(messageResult -> Mono.fromSupplier(Throwing.supplier(() -> rspamdHttpClient.reportAsHam(messageResult.getFullContent().getInputStream())))
                         .then(Mono.fromCallable(() -> {
@@ -372,7 +267,7 @@ public class FeedHamToRspamdTask implements Task {
 
     @Override
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
-        return Optional.of(AdditionalInformation.from(context));
+        return Optional.of(AdditionalInformation.from(context, runningOptions));
     }
 
     @VisibleForTesting

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTO.java
@@ -42,9 +42,7 @@ public class FeedHamToRspamdTaskAdditionalInformationDTO implements AdditionalIn
             dto.hamMessageCount,
             dto.reportedHamMessageCount,
             dto.errorCount,
-            dto.runningOptions.getMessagesPerSecond(),
-            dto.runningOptions.getPeriodInSecond(),
-            dto.runningOptions.getSamplingProbability());
+            dto.runningOptions);
     }
 
     private static FeedHamToRspamdTaskAdditionalInformationDTO toDto(FeedHamToRspamdTask.AdditionalInformation domainObject, String type) {
@@ -54,7 +52,7 @@ public class FeedHamToRspamdTaskAdditionalInformationDTO implements AdditionalIn
             domainObject.getHamMessageCount(),
             domainObject.getReportedHamMessageCount(),
             domainObject.getErrorCount(),
-            new FeedHamToRspamdTask.RunningOptions(domainObject.getPeriod(), domainObject.getMessagesPerSecond(), domainObject.getSamplingProbability()));
+            domainObject.getRunningOptions());
     }
 
     private final String type;
@@ -62,14 +60,14 @@ public class FeedHamToRspamdTaskAdditionalInformationDTO implements AdditionalIn
     private final long hamMessageCount;
     private final long reportedHamMessageCount;
     private final long errorCount;
-    private final FeedHamToRspamdTask.RunningOptions runningOptions;
+    private final RunningOptions runningOptions;
 
     public FeedHamToRspamdTaskAdditionalInformationDTO(@JsonProperty("type") String type,
                                                        @JsonProperty("timestamp") Instant timestamp,
                                                        @JsonProperty("hamMessageCount") long hamMessageCount,
                                                        @JsonProperty("reportedHamMessageCount") long reportedHamMessageCount,
                                                        @JsonProperty("errorCount") long errorCount,
-                                                       @JsonProperty("runningOptions") FeedHamToRspamdTask.RunningOptions runningOptions) {
+                                                       @JsonProperty("runningOptions") RunningOptions runningOptions) {
         this.type = type;
         this.timestamp = timestamp;
         this.hamMessageCount = hamMessageCount;
@@ -100,7 +98,7 @@ public class FeedHamToRspamdTaskAdditionalInformationDTO implements AdditionalIn
         return errorCount;
     }
 
-    public FeedHamToRspamdTask.RunningOptions getRunningOptions() {
+    public RunningOptions getRunningOptions() {
         return runningOptions;
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
@@ -47,7 +47,7 @@ public class FeedHamToRspamdTaskDTO implements TaskDTO {
                 messageIdManager,
                 mapperFactory,
                 rspamdHttpClient,
-                new FeedHamToRspamdTask.RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
+                new RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
                     dto.getMessagesPerSecond(),
                     dto.getSamplingProbability()),
                 clock))

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
@@ -39,7 +39,6 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.util.ReactorUtils;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -50,68 +49,30 @@ public class FeedSpamToRspamdTask implements Task {
     public static final String SPAM_MAILBOX_NAME = "Spam";
     public static final TaskType TASK_TYPE = TaskType.of("FeedSpamToRspamdTask");
 
-    public static class RunningOptions {
-        public static final Optional<Long> DEFAULT_PERIOD = Optional.empty();
-        public static final int DEFAULT_MESSAGES_PER_SECOND = 10;
-        public static final double DEFAULT_SAMPLING_PROBABILITY = 1;
-        public static final RunningOptions DEFAULT = new RunningOptions(DEFAULT_PERIOD, DEFAULT_MESSAGES_PER_SECOND,
-            DEFAULT_SAMPLING_PROBABILITY);
-
-        private final Optional<Long> periodInSecond;
-        private final int messagesPerSecond;
-        private final double samplingProbability;
-
-        public RunningOptions(@JsonProperty("periodInSecond") Optional<Long> periodInSecond,
-                              @JsonProperty("messagesPerSecond") int messagesPerSecond,
-                              @JsonProperty("samplingProbability") double samplingProbability) {
-            this.periodInSecond = periodInSecond;
-            this.messagesPerSecond = messagesPerSecond;
-            this.samplingProbability = samplingProbability;
-        }
-
-        public Optional<Long> getPeriodInSecond() {
-            return periodInSecond;
-        }
-
-        public int getMessagesPerSecond() {
-            return messagesPerSecond;
-        }
-
-        public double getSamplingProbability() {
-            return samplingProbability;
-        }
-    }
-
     public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
 
-        private static AdditionalInformation from(Context context) {
+        private static AdditionalInformation from(Context context, RunningOptions runningOptions) {
             Context.Snapshot snapshot = context.snapshot();
             return new AdditionalInformation(
                 Clock.systemUTC().instant(),
                 snapshot.getSpamMessageCount(),
                 snapshot.getReportedSpamMessageCount(),
                 snapshot.getErrorCount(),
-                snapshot.getMessagesPerSecond(),
-                snapshot.getPeriod(),
-                snapshot.getSamplingProbability());
+                runningOptions);
         }
 
         private final Instant timestamp;
         private final long spamMessageCount;
         private final long reportedSpamMessageCount;
         private final long errorCount;
-        private final int messagesPerSecond;
-        private final Optional<Long> period;
-        private final double samplingProbability;
+        private final RunningOptions runningOptions;
 
-        public AdditionalInformation(Instant timestamp, long spamMessageCount, long reportedSpamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period, double samplingProbability) {
+        public AdditionalInformation(Instant timestamp, long spamMessageCount, long reportedSpamMessageCount, long errorCount, RunningOptions runningOptions) {
             this.timestamp = timestamp;
             this.spamMessageCount = spamMessageCount;
             this.reportedSpamMessageCount = reportedSpamMessageCount;
             this.errorCount = errorCount;
-            this.messagesPerSecond = messagesPerSecond;
-            this.period = period;
-            this.samplingProbability = samplingProbability;
+            this.runningOptions = runningOptions;
         }
 
         public long getSpamMessageCount() {
@@ -126,16 +87,8 @@ public class FeedSpamToRspamdTask implements Task {
             return errorCount;
         }
 
-        public int getMessagesPerSecond() {
-            return messagesPerSecond;
-        }
-
-        public Optional<Long> getPeriod() {
-            return period;
-        }
-
-        public double getSamplingProbability() {
-            return samplingProbability;
+        public RunningOptions getRunningOptions() {
+            return runningOptions;
         }
 
         @Override
@@ -156,27 +109,18 @@ public class FeedSpamToRspamdTask implements Task {
                 private Optional<Long> spamMessageCount;
                 private Optional<Long> reportedSpamMessageCount;
                 private Optional<Long> errorCount;
-                private Optional<Integer> messagesPerSecond;
-                private Optional<Long> period;
-                private Optional<Double> samplingProbability;
 
                 Builder() {
                     spamMessageCount = Optional.empty();
                     reportedSpamMessageCount = Optional.empty();
                     errorCount = Optional.empty();
-                    messagesPerSecond = Optional.empty();
-                    period = Optional.empty();
-                    samplingProbability = Optional.empty();
                 }
 
                 public Snapshot build() {
                     return new Snapshot(
                         spamMessageCount.orElse(0L),
                         reportedSpamMessageCount.orElse(0L),
-                        errorCount.orElse(0L),
-                        messagesPerSecond.orElse(0),
-                        period,
-                        samplingProbability.orElse(1D));
+                        errorCount.orElse(0L));
                 }
 
                 public Builder spamMessageCount(long spamMessageCount) {
@@ -193,38 +137,16 @@ public class FeedSpamToRspamdTask implements Task {
                     this.errorCount = Optional.of(errorCount);
                     return this;
                 }
-
-                public Builder messagesPerSecond(int messagesPerSecond) {
-                    this.messagesPerSecond = Optional.of(messagesPerSecond);
-                    return this;
-                }
-
-                public Builder period(Optional<Long> period) {
-                    this.period = period;
-                    return this;
-                }
-
-                public Builder samplingProbability(double samplingProbability) {
-                    this.samplingProbability = Optional.of(samplingProbability);
-                    return this;
-                }
             }
 
             private final long spamMessageCount;
             private final long reportedSpamMessageCount;
             private final long errorCount;
-            private final int messagesPerSecond;
-            private final Optional<Long> period;
-            private final double samplingProbability;
 
-            public Snapshot(long spamMessageCount, long reportedSpamMessageCount, long errorCount, int messagesPerSecond, Optional<Long> period,
-                            double samplingProbability) {
+            public Snapshot(long spamMessageCount, long reportedSpamMessageCount, long errorCount) {
                 this.spamMessageCount = spamMessageCount;
                 this.reportedSpamMessageCount = reportedSpamMessageCount;
                 this.errorCount = errorCount;
-                this.messagesPerSecond = messagesPerSecond;
-                this.period = period;
-                this.samplingProbability = samplingProbability;
             }
 
             public long getSpamMessageCount() {
@@ -239,18 +161,6 @@ public class FeedSpamToRspamdTask implements Task {
                 return errorCount;
             }
 
-            public int getMessagesPerSecond() {
-                return messagesPerSecond;
-            }
-
-            public Optional<Long> getPeriod() {
-                return period;
-            }
-
-            public double getSamplingProbability() {
-                return samplingProbability;
-            }
-
             @Override
             public final boolean equals(Object o) {
                 if (o instanceof Snapshot) {
@@ -258,17 +168,14 @@ public class FeedSpamToRspamdTask implements Task {
 
                     return Objects.equals(this.spamMessageCount, snapshot.spamMessageCount)
                         && Objects.equals(this.reportedSpamMessageCount, snapshot.reportedSpamMessageCount)
-                        && Objects.equals(this.errorCount, snapshot.errorCount)
-                        && Objects.equals(this.messagesPerSecond, snapshot.messagesPerSecond)
-                        && Objects.equals(this.samplingProbability, snapshot.samplingProbability)
-                        && Objects.equals(this.period, snapshot.period);
+                        && Objects.equals(this.errorCount, snapshot.errorCount);
                 }
                 return false;
             }
 
             @Override
             public final int hashCode() {
-                return Objects.hash(spamMessageCount, reportedSpamMessageCount, errorCount, messagesPerSecond, period, samplingProbability);
+                return Objects.hash(spamMessageCount, reportedSpamMessageCount, errorCount);
             }
 
             @Override
@@ -277,9 +184,6 @@ public class FeedSpamToRspamdTask implements Task {
                     .add("spamMessageCount", spamMessageCount)
                     .add("reportedSpamMessageCount", reportedSpamMessageCount)
                     .add("errorCount", errorCount)
-                    .add("messagesPerSecond", messagesPerSecond)
-                    .add("period", period)
-                    .add("samplingProbability", samplingProbability)
                     .toString();
             }
         }
@@ -287,17 +191,11 @@ public class FeedSpamToRspamdTask implements Task {
         private final AtomicLong spamMessageCount;
         private final AtomicLong reportedSpamMessageCount;
         private final AtomicLong errorCount;
-        private final Integer messagesPerSecond;
-        private final Optional<Long> period;
-        private final Double samplingProbability;
 
-        public Context(RunningOptions runningOptions) {
+        public Context() {
             this.spamMessageCount = new AtomicLong();
             this.reportedSpamMessageCount = new AtomicLong();
             this.errorCount = new AtomicLong();
-            this.messagesPerSecond = runningOptions.messagesPerSecond;
-            this.period = runningOptions.periodInSecond;
-            this.samplingProbability = runningOptions.samplingProbability;
         }
 
         public void incrementSpamMessageCount() {
@@ -317,9 +215,6 @@ public class FeedSpamToRspamdTask implements Task {
                 .spamMessageCount(spamMessageCount.get())
                 .reportedSpamMessageCount(reportedSpamMessageCount.get())
                 .errorCount(errorCount.get())
-                .messagesPerSecond(messagesPerSecond)
-                .period(period)
-                .samplingProbability(samplingProbability)
                 .build();
         }
     }
@@ -335,17 +230,17 @@ public class FeedSpamToRspamdTask implements Task {
         this.runningOptions = runningOptions;
         this.messagesService = new GetMailboxMessagesService(mailboxManager, usersRepository, mapperFactory, messageIdManager);
         this.rspamdHttpClient = rspamdHttpClient;
-        this.context = new Context(runningOptions);
+        this.context = new Context();
         this.clock = clock;
     }
 
     @Override
     public Result run() {
-        Optional<Date> afterDate = runningOptions.periodInSecond.map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
+        Optional<Date> afterDate = runningOptions.getPeriodInSecond().map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
         try {
             return messagesService.getMailboxMessagesOfAllUser(SPAM_MAILBOX_NAME, afterDate, runningOptions.getSamplingProbability(), context)
                 .transform(ReactorUtils.<MessageResult, Task.Result>throttle()
-                    .elements(runningOptions.messagesPerSecond)
+                    .elements(runningOptions.getMessagesPerSecond())
                     .per(Duration.ofSeconds(1))
                     .forOperation(messageResult -> Mono.fromSupplier(Throwing.supplier(() -> rspamdHttpClient.reportAsSpam(messageResult.getFullContent().getInputStream())))
                         .then(Mono.fromCallable(() -> {
@@ -373,7 +268,7 @@ public class FeedSpamToRspamdTask implements Task {
 
     @Override
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
-        return Optional.of(AdditionalInformation.from(context));
+        return Optional.of(AdditionalInformation.from(context, runningOptions));
     }
 
     @VisibleForTesting

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTO.java
@@ -42,9 +42,7 @@ public class FeedSpamToRspamdTaskAdditionalInformationDTO implements AdditionalI
             dto.spamMessageCount,
             dto.reportedSpamMessageCount,
             dto.errorCount,
-            dto.runningOptions.getMessagesPerSecond(),
-            dto.runningOptions.getPeriodInSecond(),
-            dto.runningOptions.getSamplingProbability());
+            dto.runningOptions);
     }
 
     private static FeedSpamToRspamdTaskAdditionalInformationDTO toDto(FeedSpamToRspamdTask.AdditionalInformation domainObject, String type) {
@@ -54,7 +52,7 @@ public class FeedSpamToRspamdTaskAdditionalInformationDTO implements AdditionalI
             domainObject.getSpamMessageCount(),
             domainObject.getReportedSpamMessageCount(),
             domainObject.getErrorCount(),
-            new FeedSpamToRspamdTask.RunningOptions(domainObject.getPeriod(), domainObject.getMessagesPerSecond(), domainObject.getSamplingProbability()));
+            domainObject.getRunningOptions());
     }
 
     private final String type;
@@ -62,14 +60,14 @@ public class FeedSpamToRspamdTaskAdditionalInformationDTO implements AdditionalI
     private final long spamMessageCount;
     private final long reportedSpamMessageCount;
     private final long errorCount;
-    private final FeedSpamToRspamdTask.RunningOptions runningOptions;
+    private final RunningOptions runningOptions;
 
     public FeedSpamToRspamdTaskAdditionalInformationDTO(@JsonProperty("type") String type,
                                                         @JsonProperty("timestamp") Instant timestamp,
                                                         @JsonProperty("spamMessageCount") long spamMessageCount,
                                                         @JsonProperty("reportedSpamMessageCount") long reportedSpamMessageCount,
                                                         @JsonProperty("errorCount") long errorCount,
-                                                        @JsonProperty("runningOptions") FeedSpamToRspamdTask.RunningOptions runningOptions) {
+                                                        @JsonProperty("runningOptions") RunningOptions runningOptions) {
         this.type = type;
         this.timestamp = timestamp;
         this.spamMessageCount = spamMessageCount;
@@ -100,7 +98,7 @@ public class FeedSpamToRspamdTaskAdditionalInformationDTO implements AdditionalI
         return errorCount;
     }
 
-    public FeedSpamToRspamdTask.RunningOptions getRunningOptions() {
+    public RunningOptions getRunningOptions() {
         return runningOptions;
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
@@ -47,7 +47,7 @@ public class FeedSpamToRspamdTaskDTO implements TaskDTO {
                 messageIdManager,
                 mapperFactory,
                 rspamdHttpClient,
-                new FeedSpamToRspamdTask.RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
+                new RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
                     dto.getMessagesPerSecond(),
                     dto.getSamplingProbability()),
                 clock))

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/RunningOptions.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/RunningOptions.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.rspamd.task;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RunningOptions {
+    public static final Optional<Long> DEFAULT_PERIOD = Optional.empty();
+    public static final int DEFAULT_MESSAGES_PER_SECOND = 10;
+    public static final double DEFAULT_SAMPLING_PROBABILITY = 1;
+    public static final RunningOptions DEFAULT = new RunningOptions(DEFAULT_PERIOD, DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
+
+    private final Optional<Long> periodInSecond;
+    private final int messagesPerSecond;
+    private final double samplingProbability;
+
+    public RunningOptions(@JsonProperty("periodInSecond") Optional<Long> periodInSecond,
+                          @JsonProperty("messagesPerSecond") int messagesPerSecond,
+                          @JsonProperty("samplingProbability") double samplingProbability) {
+        this.periodInSecond = periodInSecond;
+        this.messagesPerSecond = messagesPerSecond;
+        this.samplingProbability = samplingProbability;
+    }
+
+    public Optional<Long> getPeriodInSecond() {
+        return periodInSecond;
+    }
+
+    public int getMessagesPerSecond() {
+        return messagesPerSecond;
+    }
+
+    public double getSamplingProbability() {
+        return samplingProbability;
+    }
+}

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/route/FeedMessageRouteTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/route/FeedMessageRouteTest.java
@@ -69,6 +69,7 @@ import org.apache.james.rspamd.task.FeedHamToRspamdTask;
 import org.apache.james.rspamd.task.FeedHamToRspamdTaskAdditionalInformationDTO;
 import org.apache.james.rspamd.task.FeedSpamToRspamdTask;
 import org.apache.james.rspamd.task.FeedSpamToRspamdTaskAdditionalInformationDTO;
+import org.apache.james.rspamd.task.RunningOptions;
 import org.apache.james.task.Hostname;
 import org.apache.james.task.MemoryTaskManager;
 import org.apache.james.user.api.UsersRepository;
@@ -175,9 +176,9 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.spamMessageCount", is(2))
                 .body("additionalInformation.reportedSpamMessageCount", is(2))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -202,9 +203,9 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.spamMessageCount", is(2))
                 .body("additionalInformation.reportedSpamMessageCount", is(1))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(172800))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -229,7 +230,7 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.spamMessageCount", is(10))
                 .body("additionalInformation.reportedSpamMessageCount", is(allOf(greaterThan(0), lessThan(10))))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
                 .body("additionalInformation.runningOptions.samplingProbability", is(0.5F));
         }
@@ -295,9 +296,9 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.spamMessageCount", is(0))
                 .body("additionalInformation.reportedSpamMessageCount", is(0))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @ParameterizedTest
@@ -423,9 +424,9 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.hamMessageCount", is(2))
                 .body("additionalInformation.reportedHamMessageCount", is(2))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -450,9 +451,9 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.hamMessageCount", is(2))
                 .body("additionalInformation.reportedHamMessageCount", is(1))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(172800))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @Test
@@ -477,7 +478,7 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.hamMessageCount", is(10))
                 .body("additionalInformation.reportedHamMessageCount", is(allOf(greaterThan(0), lessThan(10))))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
                 .body("additionalInformation.runningOptions.samplingProbability", is(0.5F));
         }
@@ -543,9 +544,9 @@ public class FeedMessageRouteTest {
                 .body("additionalInformation.hamMessageCount", is(0))
                 .body("additionalInformation.reportedHamMessageCount", is(0))
                 .body("additionalInformation.errorCount", is(0))
-                .body("additionalInformation.runningOptions.messagesPerSecond", is(FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
+                .body("additionalInformation.runningOptions.messagesPerSecond", is(RunningOptions.DEFAULT_MESSAGES_PER_SECOND))
                 .body("additionalInformation.runningOptions.periodInSecond", is(nullValue()))
-                .body("additionalInformation.runningOptions.samplingProbability", is((float) FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
+                .body("additionalInformation.runningOptions.samplingProbability", is((float) RunningOptions.DEFAULT_SAMPLING_PROBABILITY));
         }
 
         @ParameterizedTest

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTOTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTOTest.java
@@ -19,10 +19,6 @@
 
 package org.apache.james.rspamd.task;
 
-import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
-import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_PERIOD;
-import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
-
 import java.time.Instant;
 import java.util.Optional;
 
@@ -39,9 +35,7 @@ class FeedHamToRspamdTaskAdditionalInformationDTOTest {
                 4,
                 2,
                 1,
-                DEFAULT_MESSAGES_PER_SECOND,
-                DEFAULT_PERIOD,
-                DEFAULT_SAMPLING_PROBABILITY))
+                RunningOptions.DEFAULT))
             .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamEmptyPeriod.additionalInformation.json"))
             .verify();
     }
@@ -54,9 +48,10 @@ class FeedHamToRspamdTaskAdditionalInformationDTOTest {
                 4,
                 2,
                 1,
-                DEFAULT_MESSAGES_PER_SECOND,
-                Optional.of(3600L),
-                DEFAULT_SAMPLING_PROBABILITY))
+                new RunningOptions(
+                    Optional.of(3600L),
+                    RunningOptions.DEFAULT_MESSAGES_PER_SECOND,
+                    RunningOptions.DEFAULT_SAMPLING_PROBABILITY)))
             .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamNonEmptyPeriod.additionalInformation.json"))
             .verify();
     }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
@@ -20,10 +20,9 @@
 package org.apache.james.rspamd.task;
 
 import static org.apache.james.rspamd.DockerRspamd.PASSWORD;
-import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
-import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_PERIOD;
-import static org.apache.james.rspamd.task.FeedHamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
 import static org.apache.james.rspamd.task.FeedSpamToRspamdTaskTest.BOB_SPAM_MAILBOX;
+import static org.apache.james.rspamd.task.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
+import static org.apache.james.rspamd.task.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -110,7 +109,7 @@ public class FeedHamToRspamdTaskTest {
         client = new RspamdHttpClient(new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty()));
         messageIdManager = inMemoryIntegrationResources.getMessageIdManager();
         mapperFactory = mailboxManager.getMapperFactory();
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, FeedHamToRspamdTask.RunningOptions.DEFAULT, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, RunningOptions.DEFAULT, clock);
     }
 
     @Test
@@ -123,9 +122,6 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(0)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
@@ -142,15 +138,12 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(2)
                 .reportedHamMessageCount(2)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskShouldReportHamMessageInPeriod() throws MailboxException {
-        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
         task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -164,15 +157,12 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(1)
                 .reportedHamMessageCount(1)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(Optional.of(TWO_DAYS_IN_SECOND))
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskShouldNotReportHamMessageNotInPeriod() throws MailboxException {
-        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
         task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -186,15 +176,12 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(1)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(Optional.of(TWO_DAYS_IN_SECOND))
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void mixedInternalDateCase() throws MailboxException {
-        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
         task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -209,15 +196,12 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(2)
                 .reportedHamMessageCount(1)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(Optional.of(TWO_DAYS_IN_SECOND))
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskWithSamplingProbabilityIsZeroShouldReportNonHamMessage() {
-        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0);
         task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -232,9 +216,6 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(10)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(0)
                 .build());
     }
 
@@ -251,15 +232,12 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(10)
                 .reportedHamMessageCount(10)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskWithVeryLowSamplingProbabilityShouldReportNotAllHamMessages() {
-        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.01);
         task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -278,7 +256,7 @@ public class FeedHamToRspamdTaskTest {
 
     @Test
     void taskWithVeryHighSamplingProbabilityShouldReportMoreThanZeroMessage() {
-        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.99);
         task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -297,7 +275,7 @@ public class FeedHamToRspamdTaskTest {
 
     @Test
     void taskWithAverageSamplingProbabilityShouldReportSomeMessages() {
-        FeedHamToRspamdTask.RunningOptions runningOptions = new FeedHamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.5);
         task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -327,9 +305,6 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(0)
                 .reportedHamMessageCount(0)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
@@ -346,9 +321,6 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(2)
                 .reportedHamMessageCount(2)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
@@ -367,9 +339,6 @@ public class FeedHamToRspamdTaskTest {
                 .hamMessageCount(2)
                 .reportedHamMessageCount(2)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTOTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTOTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.james.rspamd.task;
 
-import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
-import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_PERIOD;
-import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
+import static org.apache.james.rspamd.task.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
+import static org.apache.james.rspamd.task.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -39,9 +38,7 @@ class FeedSpamToRspamdTaskAdditionalInformationDTOTest {
                 4,
                 2,
                 1,
-                DEFAULT_MESSAGES_PER_SECOND,
-                DEFAULT_PERIOD,
-                DEFAULT_SAMPLING_PROBABILITY))
+                RunningOptions.DEFAULT))
             .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamEmptyPeriod.additionalInformation.json"))
             .verify();
     }
@@ -54,9 +51,10 @@ class FeedSpamToRspamdTaskAdditionalInformationDTOTest {
                 4,
                 2,
                 1,
-                DEFAULT_MESSAGES_PER_SECOND,
-                Optional.of(3600L),
-                DEFAULT_SAMPLING_PROBABILITY))
+                new RunningOptions(
+                    Optional.of(3600L),
+                    DEFAULT_MESSAGES_PER_SECOND,
+                    DEFAULT_SAMPLING_PROBABILITY)))
             .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamNonEmptyPeriod.additionalInformation.json"))
             .verify();
     }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskTest.java
@@ -20,10 +20,9 @@
 package org.apache.james.rspamd.task;
 
 import static org.apache.james.rspamd.DockerRspamd.PASSWORD;
-import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
-import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_PERIOD;
-import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
 import static org.apache.james.rspamd.task.FeedSpamToRspamdTask.SPAM_MAILBOX_NAME;
+import static org.apache.james.rspamd.task.RunningOptions.DEFAULT_MESSAGES_PER_SECOND;
+import static org.apache.james.rspamd.task.RunningOptions.DEFAULT_SAMPLING_PROBABILITY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -103,7 +102,7 @@ public class FeedSpamToRspamdTaskTest {
         client = new RspamdHttpClient(new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty()));
         messageIdManager = inMemoryIntegrationResources.getMessageIdManager();
         mapperFactory = mailboxManager.getMapperFactory();
-        task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, FeedSpamToRspamdTask.RunningOptions.DEFAULT, clock);
+        task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, RunningOptions.DEFAULT, clock);
     }
 
     @Test
@@ -116,9 +115,6 @@ public class FeedSpamToRspamdTaskTest {
                 .spamMessageCount(0)
                 .reportedSpamMessageCount(0)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
@@ -135,15 +131,12 @@ public class FeedSpamToRspamdTaskTest {
                 .spamMessageCount(2)
                 .reportedSpamMessageCount(2)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskShouldReportSpamMessageInPeriod() throws MailboxException {
-        FeedSpamToRspamdTask.RunningOptions runningOptions = new FeedSpamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
         task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -157,15 +150,12 @@ public class FeedSpamToRspamdTaskTest {
                 .spamMessageCount(1)
                 .reportedSpamMessageCount(1)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(Optional.of(TWO_DAYS_IN_SECOND))
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskShouldNotReportSpamMessageNotInPeriod() throws MailboxException {
-        FeedSpamToRspamdTask.RunningOptions runningOptions = new FeedSpamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
         task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -179,15 +169,12 @@ public class FeedSpamToRspamdTaskTest {
                 .spamMessageCount(1)
                 .reportedSpamMessageCount(0)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(Optional.of(TWO_DAYS_IN_SECOND))
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void mixedInternalDateCase() throws MailboxException {
-        FeedSpamToRspamdTask.RunningOptions runningOptions = new FeedSpamToRspamdTask.RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
+        RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY);
         task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -202,15 +189,12 @@ public class FeedSpamToRspamdTaskTest {
                 .spamMessageCount(2)
                 .reportedSpamMessageCount(1)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(Optional.of(TWO_DAYS_IN_SECOND))
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskWithSamplingProbabilityIsZeroShouldReportNonSpamMessage() {
-        FeedSpamToRspamdTask.RunningOptions runningOptions = new FeedSpamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0);
         task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -225,9 +209,6 @@ public class FeedSpamToRspamdTaskTest {
                 .spamMessageCount(10)
                 .reportedSpamMessageCount(0)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(0)
                 .build());
     }
 
@@ -244,15 +225,12 @@ public class FeedSpamToRspamdTaskTest {
                 .spamMessageCount(10)
                 .reportedSpamMessageCount(10)
                 .errorCount(0)
-                .messagesPerSecond(DEFAULT_MESSAGES_PER_SECOND)
-                .period(DEFAULT_PERIOD)
-                .samplingProbability(DEFAULT_SAMPLING_PROBABILITY)
                 .build());
     }
 
     @Test
     void taskWithVeryLowSamplingProbabilityShouldReportNotAllSpamMessages() {
-        FeedSpamToRspamdTask.RunningOptions runningOptions = new FeedSpamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.01);
         task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -271,7 +249,7 @@ public class FeedSpamToRspamdTaskTest {
 
     @Test
     void taskWithVeryHighSamplingProbabilityShouldReportMoreThanZeroMessage() {
-        FeedSpamToRspamdTask.RunningOptions runningOptions = new FeedSpamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.99);
         task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 
@@ -290,7 +268,7 @@ public class FeedSpamToRspamdTaskTest {
 
     @Test
     void taskWithAverageSamplingProbabilityShouldReportSomeMessages() {
-        FeedSpamToRspamdTask.RunningOptions runningOptions = new FeedSpamToRspamdTask.RunningOptions(Optional.empty(),
+        RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.5);
         task = new FeedSpamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
 


### PR DESCRIPTION
 - Avoid intermediate flattening of RunningOptions within additionInformations (we
 were doing RunningOptions (in the task) => flat (in the additionalInformation) =>
 reconstruct the RunningOptions (in the DTOs); everything is simpler by just
 keeping running options everywhere in that chain.
 - Tasks context/snapshot capture what changes during the task execution, we do
 not need to ship running options (which are immutable) within it.
 - Extract RunningOptions to a common class as it is the same between Ham / Spam
 
Kills 228 lines of boiler plate.