### PR TITLE
JAMES-3755 Add a classifiedAsSpam parameter to Rspamd routes

### DIFF
--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -111,6 +111,8 @@ all messages are reported.
    These inputs represent the same duration: `1d`, `1day`, `86400 seconds`, `86400`...
 - `samplingProbability` (optional): float between 0 and 1, represent the chance to report each given message to Rspamd. 
 By default, all messages are reported.
+- `classifiedAsSpam` (optional): Boolean, true to only include messages tagged as Spam by Rspamd, false for only
+messages tagged as ham by Rspamd. If omitted all messages are included.
 
 Will return the task id. E.g:
 ```
@@ -157,6 +159,8 @@ This endpoint has the following param:
   These inputs represent the same duration: `1d`, `1day`, `86400 seconds`, `86400`...
 - `samplingProbability` (optional): float between 0 and 1, represent the chance to report each given message to Rspamd.
   By default, all messages are reported.
+- `classifiedAsSpam` (optional): Boolean, true to only include messages tagged as Spam by Rspamd, false for only
+messages tagged as ham by Rspamd. If omitted all messages are included.
 
 Will return the task id. E.g:
 ```

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/route/FeedMessageRoute.java
@@ -99,7 +99,8 @@ public class FeedMessageRoute implements Routes {
         Optional<Long> periodInSecond = getPeriod(request);
         int messagesPerSecond = getMessagesPerSecond(request).orElse(RunningOptions.DEFAULT_MESSAGES_PER_SECOND);
         double samplingProbability = getSamplingProbability(request).orElse(RunningOptions.DEFAULT_SAMPLING_PROBABILITY);
-        return new RunningOptions(periodInSecond, messagesPerSecond, samplingProbability);
+        Optional<Boolean> classifiedAsSpam = getClassifiedAsSpam(request);
+        return new RunningOptions(periodInSecond, messagesPerSecond, samplingProbability, classifiedAsSpam);
     }
 
     private Optional<Long> getPeriod(Request req) {
@@ -138,6 +139,15 @@ public class FeedMessageRoute implements Routes {
                 });
         } catch (NumberFormatException ex) {
             throw new IllegalArgumentException("'samplingProbability' must be numeric");
+        }
+    }
+
+    private Optional<Boolean> getClassifiedAsSpam(Request req) {
+        try {
+            return Optional.ofNullable(req.queryParams("classifiedAsSpam"))
+                .map(Boolean::parseBoolean);
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("'classifiedAsSpam' must be a boolean (true|false)");
         }
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTask.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTask.java
@@ -237,7 +237,7 @@ public class FeedHamToRspamdTask implements Task {
     public Result run() {
         Optional<Date> afterDate = runningOptions.getPeriodInSecond().map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
         try {
-            return messagesService.getHamMessagesOfAllUser(afterDate, runningOptions.getSamplingProbability(), context)
+            return messagesService.getHamMessagesOfAllUser(afterDate, runningOptions, context)
                 .transform(ReactorUtils.<MessageResult, Result>throttle()
                     .elements(runningOptions.getMessagesPerSecond())
                     .per(Duration.ofSeconds(1))

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
@@ -49,12 +49,14 @@ public class FeedHamToRspamdTaskDTO implements TaskDTO {
                 rspamdHttpClient,
                 new RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
                     dto.getMessagesPerSecond(),
-                    dto.getSamplingProbability()),
+                    dto.getSamplingProbability(),
+                    dto.getClassifiedAsSpam()),
                 clock))
             .toDTOConverter((domain, type) -> new FeedHamToRspamdTaskDTO(type,
                 domain.getRunningOptions().getPeriodInSecond().orElse(null),
                 domain.getRunningOptions().getMessagesPerSecond(),
-                domain.getRunningOptions().getSamplingProbability()))
+                domain.getRunningOptions().getSamplingProbability(),
+                domain.getRunningOptions().getClassifiedAsSpam()))
             .typeName(FeedHamToRspamdTask.TASK_TYPE.asString())
             .withFactory(TaskDTOModule::new);
     }
@@ -64,20 +66,27 @@ public class FeedHamToRspamdTaskDTO implements TaskDTO {
     private final Long periodInSecond;
     private final int messagesPerSecond;
     private final double samplingProbability;
+    private final Optional<Boolean> classifiedAsSpam;
 
     public FeedHamToRspamdTaskDTO(@JsonProperty("type") String type,
                                   @JsonProperty("periodInSecond") Long periodInSecond,
                                   @JsonProperty("messagesPerSecond") int messagesPerSecond,
-                                  @JsonProperty("samplingProbability") double samplingProbability) {
+                                  @JsonProperty("samplingProbability") double samplingProbability,
+                                  @JsonProperty("classifiedAsSpam") Optional<Boolean> classifiedAsSpam) {
         this.type = type;
         this.periodInSecond = periodInSecond;
         this.messagesPerSecond = messagesPerSecond;
         this.samplingProbability = samplingProbability;
+        this.classifiedAsSpam = classifiedAsSpam;
     }
 
     @Override
     public String getType() {
         return type;
+    }
+
+    public Optional<Boolean> getClassifiedAsSpam() {
+        return classifiedAsSpam;
     }
 
     public Long getPeriodInSecond() {

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
@@ -238,7 +238,7 @@ public class FeedSpamToRspamdTask implements Task {
     public Result run() {
         Optional<Date> afterDate = runningOptions.getPeriodInSecond().map(periodInSecond -> Date.from(clock.instant().minusSeconds(periodInSecond)));
         try {
-            return messagesService.getMailboxMessagesOfAllUser(SPAM_MAILBOX_NAME, afterDate, runningOptions.getSamplingProbability(), context)
+            return messagesService.getMailboxMessagesOfAllUser(SPAM_MAILBOX_NAME, afterDate, runningOptions, context)
                 .transform(ReactorUtils.<MessageResult, Task.Result>throttle()
                     .elements(runningOptions.getMessagesPerSecond())
                     .per(Duration.ofSeconds(1))

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
@@ -49,13 +49,15 @@ public class FeedSpamToRspamdTaskDTO implements TaskDTO {
                 rspamdHttpClient,
                 new RunningOptions(Optional.ofNullable(dto.getPeriodInSecond()),
                     dto.getMessagesPerSecond(),
-                    dto.getSamplingProbability()),
+                    dto.getSamplingProbability(),
+                    dto.getClassifiedAsSpam()),
                 clock))
             .toDTOConverter((domain, type) -> new FeedSpamToRspamdTaskDTO(
                 type,
                 domain.getRunningOptions().getPeriodInSecond().orElse(null),
                 domain.getRunningOptions().getMessagesPerSecond(),
-                domain.getRunningOptions().getSamplingProbability()))
+                domain.getRunningOptions().getSamplingProbability(),
+                domain.getRunningOptions().getClassifiedAsSpam()))
             .typeName(FeedSpamToRspamdTask.TASK_TYPE.asString())
             .withFactory(TaskDTOModule::new);
     }
@@ -64,16 +66,19 @@ public class FeedSpamToRspamdTaskDTO implements TaskDTO {
     private final Long periodInSecond;
     private final int messagesPerSecond;
     private final double samplingProbability;
+    private final Optional<Boolean> classifiedAsSpam;
 
 
     public FeedSpamToRspamdTaskDTO(@JsonProperty("type") String type,
                                    @JsonProperty("periodInSecond") Long periodInSecond,
                                    @JsonProperty("messagesPerSecond") int messagesPerSecond,
-                                   @JsonProperty("samplingProbability") double samplingProbability) {
+                                   @JsonProperty("samplingProbability") double samplingProbability,
+                                   @JsonProperty("classifiedAsSpam") Optional<Boolean> classifiedAsSpam) {
         this.type = type;
         this.periodInSecond = periodInSecond;
         this.messagesPerSecond = messagesPerSecond;
         this.samplingProbability = samplingProbability;
+        this.classifiedAsSpam = classifiedAsSpam;
     }
 
     @Override
@@ -91,5 +96,9 @@ public class FeedSpamToRspamdTaskDTO implements TaskDTO {
 
     public double getSamplingProbability() {
         return samplingProbability;
+    }
+
+    public Optional<Boolean> getClassifiedAsSpam() {
+        return classifiedAsSpam;
     }
 }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTOTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskAdditionalInformationDTOTest.java
@@ -41,6 +41,23 @@ class FeedHamToRspamdTaskAdditionalInformationDTOTest {
     }
 
     @Test
+    void shouldMatchJsonSerializationContractWhenClassifiedAsHam() throws Exception {
+        JsonSerializationVerifier.dtoModule(FeedHamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
+            .bean(new FeedHamToRspamdTask.AdditionalInformation(
+                Instant.parse("2007-12-03T10:15:30.00Z"),
+                4,
+                2,
+                1,
+                new RunningOptions(
+                    Optional.empty(),
+                    RunningOptions.DEFAULT_MESSAGES_PER_SECOND,
+                    RunningOptions.DEFAULT_SAMPLING_PROBABILITY,
+                    Optional.of(false))))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamClassifiedAsHam.additionalInformation.json"))
+            .verify();
+    }
+
+    @Test
     void shouldMatchJsonSerializationContractWhenNonEmptyPeriod() throws Exception {
         JsonSerializationVerifier.dtoModule(FeedHamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
             .bean(new FeedHamToRspamdTask.AdditionalInformation(
@@ -51,7 +68,8 @@ class FeedHamToRspamdTaskAdditionalInformationDTOTest {
                 new RunningOptions(
                     Optional.of(3600L),
                     RunningOptions.DEFAULT_MESSAGES_PER_SECOND,
-                    RunningOptions.DEFAULT_SAMPLING_PROBABILITY)))
+                    RunningOptions.DEFAULT_SAMPLING_PROBABILITY,
+                    Optional.empty())))
             .json(ClassLoaderUtils.getSystemResourceAsString("json/feedHamNonEmptyPeriod.additionalInformation.json"))
             .verify();
     }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTOTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskAdditionalInformationDTOTest.java
@@ -44,6 +44,23 @@ class FeedSpamToRspamdTaskAdditionalInformationDTOTest {
     }
 
     @Test
+    void shouldMatchJsonSerializationContractWhenClassifiedAsHam() throws Exception {
+        JsonSerializationVerifier.dtoModule(FeedSpamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
+            .bean(new FeedSpamToRspamdTask.AdditionalInformation(
+                Instant.parse("2007-12-03T10:15:30.00Z"),
+                4,
+                2,
+                1,
+                new RunningOptions(
+                    Optional.empty(),
+                    RunningOptions.DEFAULT_MESSAGES_PER_SECOND,
+                    RunningOptions.DEFAULT_SAMPLING_PROBABILITY,
+                    Optional.of(false))))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamClassifiedAsHam.additionalInformation.json"))
+            .verify();
+    }
+
+    @Test
     void shouldMatchJsonSerializationContractWhenNonEmptyPeriod() throws Exception {
         JsonSerializationVerifier.dtoModule(FeedSpamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE)
             .bean(new FeedSpamToRspamdTask.AdditionalInformation(
@@ -54,7 +71,8 @@ class FeedSpamToRspamdTaskAdditionalInformationDTOTest {
                 new RunningOptions(
                     Optional.of(3600L),
                     DEFAULT_MESSAGES_PER_SECOND,
-                    DEFAULT_SAMPLING_PROBABILITY)))
+                    DEFAULT_SAMPLING_PROBABILITY,
+                    Optional.empty())))
             .json(ClassLoaderUtils.getSystemResourceAsString("json/feedSpamNonEmptyPeriod.additionalInformation.json"))
             .verify();
     }

--- a/third-party/rspamd/src/test/resources/json/feedHamClassifiedAsHam.additionalInformation.json
+++ b/third-party/rspamd/src/test/resources/json/feedHamClassifiedAsHam.additionalInformation.json
@@ -1,0 +1,12 @@
+{
+  "errorCount": 1,
+  "reportedHamMessageCount": 2,
+  "runningOptions": {
+    "messagesPerSecond": 10,
+    "samplingProbability": 1.0,
+    "classifiedAsSpam": false
+  },
+  "hamMessageCount": 4,
+  "timestamp": "2007-12-03T10:15:30Z",
+  "type": "FeedHamToRspamdTask"
+}

--- a/third-party/rspamd/src/test/resources/json/feedSpamClassifiedAsHam.additionalInformation.json
+++ b/third-party/rspamd/src/test/resources/json/feedSpamClassifiedAsHam.additionalInformation.json
@@ -1,0 +1,12 @@
+{
+  "errorCount": 1,
+  "reportedSpamMessageCount": 2,
+  "runningOptions": {
+    "messagesPerSecond": 10,
+    "samplingProbability": 1.0,
+    "classifiedAsSpam": false
+  },
+  "spamMessageCount": 4,
+  "timestamp": "2007-12-03T10:15:30Z",
+  "type": "FeedSpamToRspamdTask"
+}


### PR DESCRIPTION
This allows for instance reporting messages manually reported by the user to the
Spam mailbox with re-reporting messages already classified as Spam by Rspamd,
avoiding creating a positive retro-action loop, and only reporting relevant messages.

Similar for Ham reporting.