### PR TITLE
[PERF] Improve Mailbox/get performance when thousands of mailboxes

### DIFF
--- a/core/src/main/java/org/apache/james/core/Username.java
+++ b/core/src/main/java/org/apache/james/core/Username.java
@@ -143,7 +143,7 @@ public class Username {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(localPart, domainPart);
+        return localPart.hashCode() + 31 * domainPart.hashCode();
     }
 
     @Override

--- a/core/src/test/java/org/apache/james/core/UsernameTest.java
+++ b/core/src/test/java/org/apache/james/core/UsernameTest.java
@@ -33,6 +33,7 @@ class UsernameTest {
     @Test
     void shouldRespectBeanContract() {
         EqualsVerifier.forClass(Username.class)
+            .withNonnullFields("localPart", "domainPart")
             .verify();
     }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -237,7 +237,11 @@ public class MailboxPath {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(namespace, user, name);
+        int result = 1;
+        result += result * 31 + namespace.hashCode();
+        result += result * 31 + Objects.hashCode(user);
+        result += result * 31 + Objects.hashCode(name);
+        return result;
     }
 
     /**

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -41,6 +41,7 @@ class MailboxPathTest {
     @Test
     void shouldMatchBeanContract() {
         EqualsVerifier.forClass(MailboxPath.class)
+            .withNonnullFields("namespace")
             .verify();
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -97,6 +97,7 @@ import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
@@ -731,6 +732,7 @@ public class StoreMailboxManager implements MailboxManager {
         Mono<List<Mailbox>> mailboxesMono = searchMailboxes(expression, session, Right.Lookup).collectList();
 
         return mailboxesMono
+            .publishOn(Schedulers.parallel())
             .flatMapMany(mailboxes -> Flux.fromIterable(mailboxes)
                 .filter(expression::matches)
                 .transform(metadataTransformation(fetchType, session, mailboxes)))

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -57,6 +57,7 @@ import com.google.common.collect.Sets;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public class GetMailboxesMethod implements Method {
 
@@ -154,6 +155,7 @@ public class GetMailboxesMethod implements Method {
         Mono<QuotaLoaderWithDefaultPreloaded> quotaLoaderMono = QuotaLoaderWithDefaultPreloaded.preLoad(quotaRootResolver, quotaManager, mailboxSession);
 
         return userMailboxesMono.zipWith(quotaLoaderMono)
+            .publishOn(Schedulers.parallel())
             .flatMapMany(
                 tuple -> Flux.fromIterable(tuple.getT1().values())
                     .flatMap(mailboxMetaData -> mailboxFactory.builder()


### PR DESCRIPTION
Building maps to retrieve parentIds and know if a mailbox has children is expensive and can be further optimised. Also it is beneficial to switch such operations to a thread dedicated to computations.

Cc @Arsnael 