### PR TITLE
JAMES-2656 - Add initial JPAMailRepository implementation

### DIFF
--- a/server/apps/jpa-app/src/main/resources/META-INF/persistence.xml
+++ b/server/apps/jpa-app/src/main/resources/META-INF/persistence.xml
@@ -33,6 +33,7 @@
 
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
         <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
         <class>org.apache.james.sieve.jpa.model.JPASieveQuota</class>

--- a/server/apps/jpa-app/src/main/resources/META-INF/persistence.xml
+++ b/server/apps/jpa-app/src/main/resources/META-INF/persistence.xml
@@ -32,7 +32,7 @@
         <class>org.apache.james.mailbox.jpa.user.model.JPASubscription</class>
 
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
-        <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAUrl</class>
         <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>

--- a/server/apps/jpa-smtp-app/src/main/resources/META-INF/persistence.xml
+++ b/server/apps/jpa-smtp-app/src/main/resources/META-INF/persistence.xml
@@ -26,6 +26,7 @@
     <persistence-unit name="Global" transaction-type="RESOURCE_LOCAL">
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
         <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
         <properties>

--- a/server/apps/jpa-smtp-app/src/main/resources/META-INF/persistence.xml
+++ b/server/apps/jpa-smtp-app/src/main/resources/META-INF/persistence.xml
@@ -25,7 +25,7 @@
 
     <persistence-unit name="Global" transaction-type="RESOURCE_LOCAL">
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
-        <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAUrl</class>
         <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>

--- a/server/apps/jpa-smtp-app/src/test/java/org/apache/james/JPAJamesServerTest.java
+++ b/server/apps/jpa-smtp-app/src/test/java/org/apache/james/JPAJamesServerTest.java
@@ -32,7 +32,7 @@ import javax.persistence.EntityManagerFactory;
 
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.domainlist.jpa.model.JPADomain;
-import org.apache.james.mailrepository.jpa.JPAUrl;
+import org.apache.james.mailrepository.jpa.model.JPAUrl;
 import org.apache.james.mailrepository.jpa.model.JPAMail;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.rrt.jpa.model.JPARecipientRewrite;

--- a/server/apps/jpa-smtp-app/src/test/java/org/apache/james/JPAJamesServerTest.java
+++ b/server/apps/jpa-smtp-app/src/test/java/org/apache/james/JPAJamesServerTest.java
@@ -33,6 +33,7 @@ import javax.persistence.EntityManagerFactory;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.domainlist.jpa.model.JPADomain;
 import org.apache.james.mailrepository.jpa.JPAUrl;
+import org.apache.james.mailrepository.jpa.model.JPAMail;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.rrt.jpa.model.JPARecipientRewrite;
 import org.apache.james.user.jpa.model.JPAUser;
@@ -66,7 +67,7 @@ public class JPAJamesServerTest {
                 .overrideWith(
                         new TestJPAConfigurationModule(),
                         (binder) -> binder.bind(EntityManagerFactory.class)
-                            .toInstance(JpaTestCluster.create(JPAUser.class, JPADomain.class, JPARecipientRewrite.class, JPAUrl.class)
+                            .toInstance(JpaTestCluster.create(JPAUser.class, JPADomain.class, JPARecipientRewrite.class, JPAUrl.class, JPAMail.class)
                                     .getEntityManagerFactory()));
     }
     

--- a/server/apps/spring-app/src/main/resources/META-INF/persistence.xml
+++ b/server/apps/spring-app/src/main/resources/META-INF/persistence.xml
@@ -34,6 +34,7 @@
         <class>org.apache.james.mailbox.jpa.user.model.JPASubscription</class>
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
         <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
         <class>org.apache.james.sieve.jpa.model.JPASieveQuota</class>

--- a/server/apps/spring-app/src/main/resources/META-INF/persistence.xml
+++ b/server/apps/spring-app/src/main/resources/META-INF/persistence.xml
@@ -33,7 +33,7 @@
         <class>org.apache.james.mailbox.jpa.mail.model.JPAMailboxAnnotation</class>
         <class>org.apache.james.mailbox.jpa.user.model.JPASubscription</class>
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
-        <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAUrl</class>
         <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>

--- a/server/data/data-file/src/main/java/org/apache/james/mailrepository/file/FileMailRepository.java
+++ b/server/data/data-file/src/main/java/org/apache/james/mailrepository/file/FileMailRepository.java
@@ -54,20 +54,7 @@ import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.Iterators;
 
 /**
- * <p>
  * Implementation of a MailRepository on a FileSystem.
- * </p>
- * <p>
- * Requires a configuration element in the .conf.xml file of the form:
- * <p/>
- * <pre>
- *  &lt;repository destinationURL="file://path-to-root-dir-for-repository"
- *              type="MAIL"
- *              model="SYNCHRONOUS"/&gt;
- * </pre>
- * <p/>
- * Requires a logger called MailRepository.
- * </p>
  */
 public class FileMailRepository implements MailRepository, Configurable, Initializable {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileMailRepository.class);

--- a/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -406,14 +407,10 @@ public class JDBCMailRepository implements MailRepository, Configurable, Initial
             } else {
                 insertMessage.setString(5, mc.getMaybeSender().get().toString());
             }
-            StringBuilder recipients = new StringBuilder();
-            for (Iterator<MailAddress> i = mc.getRecipients().iterator(); i.hasNext();) {
-                recipients.append(i.next().toString());
-                if (i.hasNext()) {
-                    recipients.append("\r\n");
-                }
-            }
-            insertMessage.setString(6, recipients.toString());
+            String recipients = mc.getRecipients().stream()
+                .map(MailAddress::toString)
+                .collect(Collectors.joining("\r\n"));
+            insertMessage.setString(6, recipients);
             insertMessage.setString(7, mc.getRemoteHost());
             insertMessage.setString(8, mc.getRemoteAddr());
             if (mc.getPerRecipientSpecificHeaders().getHeadersByRecipient().isEmpty()) {
@@ -494,14 +491,10 @@ public class JDBCMailRepository implements MailRepository, Configurable, Initial
             } else {
                 updateMessage.setString(3, mc.getMaybeSender().get().toString());
             }
-            StringBuilder recipients = new StringBuilder();
-            for (Iterator<MailAddress> i = mc.getRecipients().iterator(); i.hasNext();) {
-                recipients.append(i.next().toString());
-                if (i.hasNext()) {
-                    recipients.append("\r\n");
-                }
-            }
-            updateMessage.setString(4, recipients.toString());
+            String recipients = mc.getRecipients().stream()
+                .map(MailAddress::toString)
+                .collect(Collectors.joining("\r\n"));
+            updateMessage.setString(4, recipients);
             updateMessage.setString(5, mc.getRemoteHost());
             updateMessage.setString(6, mc.getRemoteAddr());
             updateMessage.setTimestamp(7, new java.sql.Timestamp(mc.getLastUpdated().getTime()));

--- a/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
@@ -74,27 +74,6 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * Implementation of a MailRepository on a database.
- * 
- * <p>
- * Requires a configuration element in the .conf.xml file of the form:
- * 
- * <pre>
- *  &lt;repository destinationURL="db://&lt;datasource&gt;/&lt;table_name&gt;/&lt;repository_name&gt;"
- *              type="MAIL"
- *              model="SYNCHRONOUS"/&gt;
- *  &lt;/repository&gt;
- * </pre>
- * 
- * </p>
- * <p>
- * destinationURL specifies..(Serge??) <br>
- * Type can be SPOOL or MAIL <br>
- * Model is currently not used and may be dropped
- * </p>
- * 
- * <p>
- * Requires a logger called MailRepository.
- * </p>
  */
 public class JDBCMailRepository implements MailRepository, Configurable, Initializable {
     private static final Logger LOGGER = LoggerFactory.getLogger(JDBCMailRepository.class);

--- a/server/data/data-jpa/pom.xml
+++ b/server/data/data-jpa/pom.xml
@@ -45,6 +45,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-data-api</artifactId>
         </dependency>
         <dependency>
@@ -84,6 +88,11 @@
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-mailrepository-api</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -151,7 +160,8 @@
                         org/apache/james/user/jpa/model/JPAUser.class,
                         org/apache/james/rrt/jpa/model/JPARecipientRewrite.class,
                         org/apache/james/domainlist/jpa/model/JPADomain.class,
-                        org/apache/james/mailrepository/jpa/JPAUrl.class</includes>
+                        org/apache/james/mailrepository/jpa/JPAUrl.class,
+                        org/apache/james/mailrepository/jpa/model/JPAMail.class</includes>
                     <addDefaultConstructor>true</addDefaultConstructor>
                     <enforcePropertyRestrictions>true</enforcePropertyRestrictions>
                     <toolProperties>
@@ -166,7 +176,8 @@
                                 org.apache.james.user.jpa.model.JPAUser;
                                 org.apache.james.rrt.jpa.model.JPARecipientRewrite;
                                 org.apache.james.domainlist.jpa.model.JPADomain;
-                                org.apache.james.mailrepository.jpa.JPAUrl)</value>
+                                org.apache.james.mailrepository.jpa.JPAUrl;
+                                org.apache.james.mailrepository.jpa.model.JPAMail)</value>
                         </property>
                     </toolProperties>
                 </configuration>

--- a/server/data/data-jpa/pom.xml
+++ b/server/data/data-jpa/pom.xml
@@ -160,7 +160,7 @@
                         org/apache/james/user/jpa/model/JPAUser.class,
                         org/apache/james/rrt/jpa/model/JPARecipientRewrite.class,
                         org/apache/james/domainlist/jpa/model/JPADomain.class,
-                        org/apache/james/mailrepository/jpa/JPAUrl.class,
+                        org/apache/james/mailrepository/jpa/model/JPAUrl.class,
                         org/apache/james/mailrepository/jpa/model/JPAMail.class</includes>
                     <addDefaultConstructor>true</addDefaultConstructor>
                     <enforcePropertyRestrictions>true</enforcePropertyRestrictions>
@@ -176,7 +176,7 @@
                                 org.apache.james.user.jpa.model.JPAUser;
                                 org.apache.james.rrt.jpa.model.JPARecipientRewrite;
                                 org.apache.james.domainlist.jpa.model.JPADomain;
-                                org.apache.james.mailrepository.jpa.JPAUrl;
+                                org.apache.james.mailrepository.jpa.model.JPAUrl;
                                 org.apache.james.mailrepository.jpa.model.JPAMail)</value>
                         </property>
                     </toolProperties>

--- a/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/JPAMailRepository.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/JPAMailRepository.java
@@ -1,0 +1,335 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailrepository.jpa;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.NoResultException;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.commons.lang3.SerializationUtils;
+import org.apache.james.backends.jpa.EntityManagerUtils;
+import org.apache.james.core.MailAddress;
+import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.mailrepository.api.Initializable;
+import org.apache.james.mailrepository.api.MailKey;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.mailrepository.jpa.model.JPAMail;
+import org.apache.james.server.core.MailImpl;
+import org.apache.james.server.core.MimeMessageWrapper;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.Mail;
+import org.apache.mailet.PerRecipientHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Implementation of a MailRepository on a database via JPA.
+ */
+public class JPAMailRepository implements MailRepository, Configurable, Initializable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JPAMailRepository.class);
+
+    private String repositoryName;
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    @Inject
+    public JPAMailRepository(EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+
+    // note: caller must close the returned EntityManager when done using it
+    protected EntityManager entityManager() {
+        return entityManagerFactory.createEntityManager();
+    }
+
+    @Override
+    public void configure(HierarchicalConfiguration<ImmutableNode> configuration) throws ConfigurationException {
+        LOGGER.debug("{}.configure()", getClass().getName());
+        String destination = configuration.getString("[@destinationURL]");
+        MailRepositoryUrl url = MailRepositoryUrl.from(destination); // also validates url and standardizes slashes
+        repositoryName = url.getPath().asString();
+        if (repositoryName.isEmpty()) {
+            throw new ConfigurationException(
+                "Malformed destinationURL - Must be of the format 'jpa://<repositoryName>'.  Was passed " + url);
+        }
+        LOGGER.debug("Parsed URL: repositoryName = '{}'", repositoryName);
+    }
+
+    /**
+     * Initialises the JPA repository.
+     *
+     * @throws Exception if an error occurs
+     */
+    @Override
+    @PostConstruct
+    public void init() throws Exception {
+        LOGGER.debug("{}.initialize()", getClass().getName());
+        list();
+    }
+
+    @Override
+    public MailKey store(Mail mail) throws MessagingException {
+        MailKey key = MailKey.forMail(mail);
+        EntityManager entityManager = entityManager();
+        try {
+            JPAMail jpaMail = new JPAMail();
+            jpaMail.setRepositoryName(repositoryName);
+            jpaMail.setMessageName(mail.getName());
+            jpaMail.setMessageState(mail.getState());
+            jpaMail.setErrorMessage(mail.getErrorMessage());
+            if (!mail.getMaybeSender().isNullSender()) {
+                jpaMail.setSender(mail.getMaybeSender().get().toString());
+            }
+            String recipients = mail.getRecipients().stream()
+                .map(MailAddress::toString)
+                .collect(Collectors.joining("\r\n"));
+            jpaMail.setRecipients(recipients);
+            jpaMail.setRemoteHost(mail.getRemoteHost());
+            jpaMail.setRemoteAddr(mail.getRemoteAddr());
+            jpaMail.setPerRecipientHeaders(serializePerRecipientHeaders(mail.getPerRecipientSpecificHeaders()));
+            jpaMail.setLastUpdated(new Timestamp(mail.getLastUpdated().getTime()));
+            jpaMail.setMessageBody(getBody(mail));
+            jpaMail.setMessageAttributes(serializeAttributes(mail.attributes()));
+            EntityTransaction transaction = entityManager.getTransaction();
+            transaction.begin();
+            jpaMail = entityManager.merge(jpaMail);
+            transaction.commit();
+            return key;
+        } catch (MessagingException e) {
+            LOGGER.error("Exception caught while storing mail {}", key, e);
+            throw e;
+        } catch (Exception e) {
+            LOGGER.error("Exception caught while storing mail {}", key, e);
+            throw new MessagingException("Exception caught while storing mail " + key, e);
+        } finally {
+            EntityManagerUtils.safelyClose(entityManager);
+        }
+    }
+
+    private byte[] getBody(Mail mail) throws MessagingException, IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream((int)mail.getMessageSize());
+        if (mail instanceof MimeMessageWrapper) {
+            // we need to force the loading of the message from the
+            // stream as we want to override the old message
+            ((MimeMessageWrapper) mail).loadMessage();
+            ((MimeMessageWrapper) mail).writeTo(out, out, null, true);
+        } else {
+            mail.getMessage().writeTo(out);
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] serializeAttributes(Stream<Attribute> attributes) {
+        Map<String, Object> map = attributes.collect(Collectors.toMap(
+            attribute -> attribute.getName().asString(),
+            attribute -> attribute.getValue().value()));
+        return SerializationUtils.serialize((Serializable)map);
+    }
+
+    private List<Attribute> deserializeAttributes(byte[] data) {
+        HashMap<String, Object> attributes = SerializationUtils.deserialize(data);
+        return Optional.ofNullable(attributes)
+            .orElse(new HashMap<>())
+            .entrySet()
+            .stream()
+            .map(entry -> Attribute.convertToAttribute(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList());
+    }
+
+    private String serializePerRecipientHeaders(PerRecipientHeaders perRecipientHeaders) {
+        if (perRecipientHeaders == null) {
+            return null;
+        }
+        Map<MailAddress, Collection<PerRecipientHeaders.Header>> map = perRecipientHeaders.getHeadersByRecipient().asMap();
+        if (map.isEmpty()) {
+            return null;
+        }
+        StringBuilder data = new StringBuilder(map.size() * 1024);
+        for (Map.Entry<MailAddress, Collection<PerRecipientHeaders.Header>> entry : map.entrySet()) {
+            data.append(entry.getKey().asString()).append('\n');
+            entry.getValue().forEach(header -> data.append(header.asString()).append('\n'));
+            data.append('\n');
+        }
+        return data.toString();
+    }
+
+    private PerRecipientHeaders deserializePerRecipientHeaders(String data) throws AddressException {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        PerRecipientHeaders perRecipientHeaders = new PerRecipientHeaders();
+        for (String entry : data.split("\n\n")) {
+            String[] lines = entry.split("\n");
+            MailAddress address = new MailAddress(lines[0]);
+            for (int i = 1; i < lines.length; i++) {
+                perRecipientHeaders.addHeaderForRecipient(PerRecipientHeaders.Header.fromString(lines[i]), address);
+            }
+        }
+        return perRecipientHeaders;
+    }
+
+    @Override
+    public Mail retrieve(MailKey key) throws MessagingException {
+        EntityManager entityManager = entityManager();
+        try {
+            JPAMail jpaMail = entityManager.createNamedQuery("findMailMessage", JPAMail.class)
+                .setParameter("repositoryName", repositoryName)
+                .setParameter("messageName", key.asString())
+                .getSingleResult();
+
+            MailImpl.Builder mail = MailImpl.builder().name(key.asString());
+            if (jpaMail.getMessageAttributes() != null) {
+                mail.addAttributes(deserializeAttributes(jpaMail.getMessageAttributes()));
+            }
+            mail.state(jpaMail.getMessageState());
+            mail.errorMessage(jpaMail.getErrorMessage());
+            String sender = jpaMail.getSender();
+            if (sender == null) {
+                mail.sender((MailAddress)null);
+            } else {
+                mail.sender(new MailAddress(sender));
+            }
+            StringTokenizer st = new StringTokenizer(jpaMail.getRecipients(), "\r\n", false);
+            while (st.hasMoreTokens()) {
+                mail.addRecipient(st.nextToken());
+            }
+            mail.remoteHost(jpaMail.getRemoteHost());
+            mail.remoteAddr(jpaMail.getRemoteAddr());
+            PerRecipientHeaders perRecipientHeaders = deserializePerRecipientHeaders(jpaMail.getPerRecipientHeaders());
+            if (perRecipientHeaders != null) {
+                mail.addAllHeadersForRecipients(perRecipientHeaders);
+            }
+            mail.lastUpdated(jpaMail.getLastUpdated());
+
+            MimeMessageJPASource source = new MimeMessageJPASource(this, key.asString(), jpaMail.getMessageBody());
+            MimeMessageWrapper message = new MimeMessageWrapper(source);
+            mail.mimeMessage(message);
+            return mail.build();
+        } catch (NoResultException nre) {
+            LOGGER.debug("Did not find mail {} in repository {}", key, repositoryName);
+            return null;
+        } catch (Exception e) {
+            throw new MessagingException("Exception while retrieving mail: " + e.getMessage(), e);
+        } finally {
+            EntityManagerUtils.safelyClose(entityManager);
+        }
+    }
+
+    @Override
+    public long size() throws MessagingException {
+        EntityManager entityManager = entityManager();
+        try {
+            return entityManager.createNamedQuery("countMailMessages", long.class)
+                .setParameter("repositoryName", repositoryName)
+                .getSingleResult();
+        } catch (Exception me) {
+            throw new MessagingException("Exception while listing messages: " + me.getMessage(), me);
+        } finally {
+            EntityManagerUtils.safelyClose(entityManager);
+        }
+    }
+
+    @Override
+    public Iterator<MailKey> list() throws MessagingException {
+        EntityManager entityManager = entityManager();
+        try {
+            return entityManager.createNamedQuery("listMailMessages", String.class)
+                .setParameter("repositoryName", repositoryName)
+                .getResultStream()
+                .map(MailKey::new)
+                .iterator();
+        } catch (Exception me) {
+            throw new MessagingException("Exception while listing messages: " + me.getMessage(), me);
+        } finally {
+            EntityManagerUtils.safelyClose(entityManager);
+        }
+    }
+
+    @Override
+    public void remove(MailKey key) throws MessagingException {
+        remove(Collections.singleton(key));
+    }
+
+    @Override
+    public void removeAll() throws MessagingException {
+        remove(ImmutableList.copyOf(list()));
+    }
+
+    @Override
+    public void remove(Collection<MailKey> keys) throws MessagingException {
+        Collection<String> messageNames = keys.stream().map(MailKey::asString).collect(Collectors.toList());
+        EntityManager entityManager = entityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+        try {
+            entityManager.createNamedQuery("deleteMailMessages")
+                .setParameter("repositoryName", repositoryName)
+                .setParameter("messageNames", messageNames)
+                .executeUpdate();
+            transaction.commit();
+        } catch (Exception e) {
+            throw new MessagingException("Exception while removing message(s): " + e.getMessage(), e);
+        } finally {
+            EntityManagerUtils.safelyClose(entityManager);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof JPAMailRepository
+            && Objects.equals(repositoryName, ((JPAMailRepository)obj).repositoryName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(repositoryName);
+    }
+}

--- a/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/JPAMailRepositoryUrlStore.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/JPAMailRepositoryUrlStore.java
@@ -27,6 +27,7 @@ import javax.persistence.EntityManagerFactory;
 import org.apache.james.backends.jpa.TransactionRunner;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.mailrepository.api.MailRepositoryUrlStore;
+import org.apache.james.mailrepository.jpa.model.JPAUrl;
 
 public class JPAMailRepositoryUrlStore implements MailRepositoryUrlStore {
     private final TransactionRunner transactionRunner;

--- a/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAMail.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAMail.java
@@ -1,0 +1,244 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailrepository.jpa.model;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.Objects;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Index;
+import javax.persistence.Lob;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
+@Entity(name = "JamesMailStore")
+@IdClass(JPAMail.JPAMailId.class)
+@Table(name = "JAMES_MAIL_STORE", indexes = {
+   @Index(name = "REPOSITORY_NAME_MESSAGE_NAME_INDEX", columnList = "REPOSITORY_NAME, MESSAGE_NAME")
+})
+@NamedQueries({
+    @NamedQuery(name = "listMailMessages",
+        query = "SELECT mail.messageName FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName"),
+    @NamedQuery(name = "countMailMessages",
+        query = "SELECT COUNT(mail) FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName"),
+    @NamedQuery(name = "deleteMailMessages",
+        query = "DELETE FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName AND mail.messageName IN (:messageNames)"),
+    @NamedQuery(name = "findMailMessage",
+        query = "SELECT mail FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName AND mail.messageName = :messageName")
+})
+public class JPAMail {
+
+    static class JPAMailId implements Serializable {
+        public JPAMailId() {
+        }
+
+        String repositoryName;
+        String messageName;
+
+        public boolean equals(Object obj) {
+            return obj instanceof JPAMailId
+                && Objects.equals(messageName, ((JPAMailId) obj).messageName)
+                && Objects.equals(repositoryName, ((JPAMailId) obj).repositoryName);
+        }
+
+        public int hashCode() {
+            return Objects.hash(messageName, repositoryName);
+        }
+    }
+
+    @Id
+    @Basic(optional = false)
+    @Column(name = "REPOSITORY_NAME", nullable = false, length = 255)
+    private String repositoryName;
+
+    @Id
+    @Basic(optional = false)
+    @Column(name = "MESSAGE_NAME", nullable = false, length = 200)
+    private String messageName;
+
+    @Basic(optional = false)
+    @Column(name = "MESSAGE_STATE", nullable = false, length = 30)
+    private String messageState;
+
+    @Basic(optional = true)
+    @Column(name = "ERROR_MESSAGE", nullable = true, length = 200)
+    private String errorMessage;
+
+    @Basic(optional = true)
+    @Column(name = "SENDER", nullable = true, length = 255)
+    private String sender;
+
+    @Basic(optional = false)
+    @Column(name = "RECIPIENTS", nullable = false)
+    private String recipients; // CRLF delimited
+
+    @Basic(optional = false)
+    @Column(name = "REMOTE_HOST", nullable = false, length = 255)
+    private String remoteHost;
+
+    @Basic(optional = false)
+    @Column(name = "REMOTE_ADDR", nullable = false, length = 20)
+    private String remoteAddr;
+
+    @Basic(optional = false)
+    @Column(name = "LAST_UPDATED", nullable = false)
+    private Timestamp lastUpdated;
+
+    @Basic(optional = true, fetch = FetchType.LAZY)
+    @Column(name = "PER_RECIPIENT_HEADERS", nullable = true, length = 10485760)
+    @Lob
+    private String perRecipientHeaders;
+
+    @Basic(optional = false, fetch = FetchType.LAZY)
+    @Column(name = "MESSAGE_BODY", nullable = false, length = 1048576000)
+    @Lob
+    private byte[] messageBody; // TODO: support streaming body where possible (see e.g. JPAStreamingMailboxMessage)
+
+    @Basic(optional = true, fetch = FetchType.LAZY)
+    @Column(name = "MESSAGE_ATTRIBUTES", nullable = true, length = 10485760)
+    @Lob
+    private byte[] messageAttributes; // TODO: replace java serialization (see e.g. JAMES-2578, PR 4110)
+
+    public JPAMail() {
+    }
+
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+
+    public void setRepositoryName(String repositoryName) {
+        this.repositoryName = repositoryName;
+    }
+
+    public String getMessageName() {
+        return messageName;
+    }
+
+    public void setMessageName(String messageName) {
+        this.messageName = messageName;
+    }
+
+    public String getMessageState() {
+        return messageState;
+    }
+
+    public void setMessageState(String messageState) {
+        this.messageState = messageState;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    public String getRecipients() {
+        return recipients;
+    }
+
+    public void setRecipients(String recipients) {
+        this.recipients = recipients;
+    }
+
+    public String getRemoteHost() {
+        return remoteHost;
+    }
+
+    public void setRemoteHost(String remoteHost) {
+        this.remoteHost = remoteHost;
+    }
+
+    public String getRemoteAddr() {
+        return remoteAddr;
+    }
+
+    public void setRemoteAddr(String remoteAddr) {
+        this.remoteAddr = remoteAddr;
+    }
+
+    public Timestamp getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(Timestamp lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    public String getPerRecipientHeaders() {
+        return perRecipientHeaders;
+    }
+
+    public void setPerRecipientHeaders(String perRecipientHeaders) {
+        this.perRecipientHeaders = perRecipientHeaders;
+    }
+
+    public byte[] getMessageBody() {
+        return messageBody;
+    }
+
+    public void setMessageBody(byte[] messageBody) {
+        this.messageBody = messageBody;
+    }
+
+    public byte[] getMessageAttributes() {
+        return messageAttributes;
+    }
+
+    public void setMessageAttributes(byte[] messageAttributes) {
+        this.messageAttributes = messageAttributes;
+    }
+
+    @Override
+    public String toString() {
+        return "JPAMail ( "
+            + "repositoryName = " + repositoryName
+            + ", messageName = " + messageName
+            + " )";
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return obj instanceof JPAMail
+            && Objects.equals(this.repositoryName, ((JPAMail)obj).repositoryName)
+            && Objects.equals(this.messageName, ((JPAMail)obj).messageName);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(repositoryName, messageName);
+    }
+}

--- a/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAMail.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAMail.java
@@ -121,7 +121,7 @@ public class JPAMail {
     @Basic(optional = true, fetch = FetchType.LAZY)
     @Column(name = "MESSAGE_ATTRIBUTES", nullable = true, length = 10485760)
     @Lob
-    private byte[] messageAttributes; // TODO: replace java serialization (see e.g. JAMES-2578, PR 4110)
+    private String messageAttributes;
 
     public JPAMail() {
     }
@@ -214,11 +214,11 @@ public class JPAMail {
         this.messageBody = messageBody;
     }
 
-    public byte[] getMessageAttributes() {
+    public String getMessageAttributes() {
         return messageAttributes;
     }
 
-    public void setMessageAttributes(byte[] messageAttributes) {
+    public void setMessageAttributes(String messageAttributes) {
         this.messageAttributes = messageAttributes;
     }
 

--- a/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAMail.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAMail.java
@@ -47,6 +47,8 @@ import javax.persistence.Table;
         query = "SELECT COUNT(mail) FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName"),
     @NamedQuery(name = "deleteMailMessages",
         query = "DELETE FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName AND mail.messageName IN (:messageNames)"),
+    @NamedQuery(name = "deleteAllMailMessages",
+        query = "DELETE FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName"),
     @NamedQuery(name = "findMailMessage",
         query = "SELECT mail FROM JamesMailStore mail WHERE mail.repositoryName = :repositoryName AND mail.messageName = :messageName")
 })
@@ -108,7 +110,7 @@ public class JPAMail {
     @Column(name = "LAST_UPDATED", nullable = false)
     private Timestamp lastUpdated;
 
-    @Basic(optional = true, fetch = FetchType.LAZY)
+    @Basic(optional = true)
     @Column(name = "PER_RECIPIENT_HEADERS", nullable = true, length = 10485760)
     @Lob
     private String perRecipientHeaders;
@@ -118,7 +120,7 @@ public class JPAMail {
     @Lob
     private byte[] messageBody; // TODO: support streaming body where possible (see e.g. JPAStreamingMailboxMessage)
 
-    @Basic(optional = true, fetch = FetchType.LAZY)
+    @Basic(optional = true)
     @Column(name = "MESSAGE_ATTRIBUTES", nullable = true, length = 10485760)
     @Lob
     private String messageAttributes;

--- a/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAUrl.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/mailrepository/jpa/model/JPAUrl.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mailrepository.jpa;
+package org.apache.james.mailrepository.jpa.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/server/data/data-jpa/src/main/resources/META-INF/persistence.xml
+++ b/server/data/data-jpa/src/main/resources/META-INF/persistence.xml
@@ -29,7 +29,7 @@
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
-        <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAUrl</class>
         <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.sieve.jpa.model.JPASieveQuota</class>
         <class>org.apache.james.sieve.jpa.model.JPASieveScript</class>

--- a/server/data/data-jpa/src/main/resources/META-INF/persistence.xml
+++ b/server/data/data-jpa/src/main/resources/META-INF/persistence.xml
@@ -30,6 +30,7 @@
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
         <class>org.apache.james.mailrepository.jpa.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
         <class>org.apache.james.sieve.jpa.model.JPASieveQuota</class>
         <class>org.apache.james.sieve.jpa.model.JPASieveScript</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>

--- a/server/data/data-jpa/src/test/java/org/apache/james/jpa/healthcheck/JPAHealthCheckTest.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/jpa/healthcheck/JPAHealthCheckTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.fail;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.core.healthcheck.Result;
 import org.apache.james.core.healthcheck.ResultStatus;
-import org.apache.james.mailrepository.jpa.JPAUrl;
+import org.apache.james.mailrepository.jpa.model.JPAUrl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/server/data/data-jpa/src/test/java/org/apache/james/mailrepository/jpa/JPAMailRepositoryTest.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/mailrepository/jpa/JPAMailRepositoryTest.java
@@ -1,0 +1,70 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailrepository.jpa;
+
+import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
+import org.apache.james.backends.jpa.JpaTestCluster;
+import org.apache.james.mailrepository.MailRepositoryContract;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.james.mailrepository.api.MailRepositoryPath;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.mailrepository.api.Protocol;
+import org.apache.james.mailrepository.jpa.model.JPAMail;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
+public class JPAMailRepositoryTest implements MailRepositoryContract {
+
+    final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMail.class);
+
+    private JPAMailRepository mailRepository;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mailRepository = retrieveRepository(MailRepositoryPath.from("testrepo"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        JPA_TEST_CLUSTER.clear("JAMES_MAIL_STORE");
+    }
+
+    @Override
+    public MailRepository retrieveRepository() {
+        return mailRepository;
+    }
+
+    @Override
+    public JPAMailRepository retrieveRepository(MailRepositoryPath url) throws Exception {
+        BaseHierarchicalConfiguration conf = new BaseHierarchicalConfiguration();
+        conf.addProperty("[@destinationURL]", MailRepositoryUrl.fromPathAndProtocol(new Protocol("jpa"), url).asString());
+        JPAMailRepository mailRepository = new JPAMailRepository(JPA_TEST_CLUSTER.getEntityManagerFactory());
+        mailRepository.configure(conf);
+        mailRepository.init();
+        return mailRepository;
+    }
+
+    @Override
+    @Disabled("JAMES-3431 No support for Attribute collection Java serialization yet")
+    public void shouldPreserveDsnParameters() throws Exception {
+        MailRepositoryContract.super.shouldPreserveDsnParameters();
+    }
+}

--- a/server/data/data-jpa/src/test/java/org/apache/james/mailrepository/jpa/JPAMailRepositoryUrlStoreExtension.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/mailrepository/jpa/JPAMailRepositoryUrlStoreExtension.java
@@ -21,6 +21,7 @@ package org.apache.james.mailrepository.jpa;
 
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.mailrepository.api.MailRepositoryUrlStore;
+import org.apache.james.mailrepository.jpa.model.JPAUrl;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -163,6 +163,8 @@ public interface MailRepositoryContract {
             .name(MAIL_1.asString())
             .sender(MailAddress.nullSender())
             .recipient(MailAddressFixture.RECIPIENT1)
+            .lastUpdated(new Date())
+            .state(Mail.DEFAULT)
             .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
                 .setSubject("test")
                 .setText("String body")


### PR DESCRIPTION
Here is an initial implementation of a JPAMailStore, which will hopefully suffice to make the JPA app work fully with a database, a big relief for everyone that migrated from 2.3.x and was shocked to discover they are forced to use file repositories ;-)

This is an initial implementation that is hopefully good enough to be useful, but still has room for improvement. After merging others can help incrementally improve on it as necessary. Specifically:

- It passes MailRepositoryContract as suggested in JAMES-2656, except for two disabled tests (which are both also disabled in JDBCMailRepository, so it's no worse than that):
  - mailRepositoriesShouldBeURLIsolated seems to fail only because the mock Mail has no lastUpdated and state fields set - I'm not sure if these fields are supposed to be set and this is just a bug in the test object itself, or if it's a valid scenario that should be handled (allow nulls in these fields). I currently included also the fix for the test, but awaiting feedback on what the proper solution should be. When adding the two fields in the test, it passes.
  - shouldPreserveDsnParameters fails due to the same issue as with jdbc - because the attributes are not Java-serializeable. See below.

Future improvements:
- The body is currently defined as a byte array, i.e. is held in memory. JPA supports streaming for a handful of databases. I suppose for those we can do something like what was done for JPAMailboxMessage/JPAStreamingMailboxMessage - have two subclasses, one with byte array and one with stream, and somehow configure which to use (I didn't see where that is configured).
- The perRecipientHeaders field is currently Java-serialized into a byte array. I saw some other places migrated to using a string delimited by newlines, so that can be done here as well, but seems bad to re-implement it in every component... should be some main utility somewhere that does this in a standardised way, and all components including this one can just use it as a one-liner.
- The message attributes are currently Java-serialized into a byte array. The Mail interface requires attribute values to be serializeable, but apparently James violated this contract when using DSN parameters, which is why the corresponding test fails. This should probably be fixed in the DSN implementation, since it violates the contract. In any case, I saw some other component moved to json serialization for the attributes, so maybe we can get that to work here as well (I gave it a shot but ran into issues so dropped it for now). Here too, better to have a centralized utility that takes care of everything instead of re-implementing in every component.
- There are resource leak warnings in the console when running the tests. Not sure where they come from, though I see them also when running tests for other repository types, so I don't know if this is really an issue or a false alarm, or how important or not it is at this point.
- It would have been nice to have a separate table per repository, but as far as I can tell, JPA doesn't support dynamic table names that way, so all the repos are in one table, with a column (indexed) specifying the repo name. No biggie.
- I haven't worked with Guice or JPA before, so maybe I missed something. Would be great if someone in the know can give it a review to see if everything is configured and used correctly.
- There may be room for other performance improvements if needed.
- In addition to the contract tests, I ran a few manual tests, and it seems ok. Would be great if someone has a more realistic scenario or production server to run it on as a fuzz test to cover edge cases, concurrency, load, etc.

To summarise, although I detailed my thoughts and dilemmas regarding the implementation, the bottom line is that it's probably good enough for most scenarios and a good starting point for future contributions. It's the big first step that nobody took in a few years, and hopefully once merged it will be easier for other devs and users to improve upon.

Your thoughts?
