### PR TITLE
WIP IMAP throttler

### DIFF
--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ReactiveThrottler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ReactiveThrottler.java
@@ -1,0 +1,94 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imapserver.netty;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.james.metrics.api.GaugeRegistry;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+public class ReactiveThrottler {
+    public static class RejectedException extends RuntimeException {
+        public RejectedException(String message) {
+            super(message);
+        }
+    }
+
+    private static class Throttled {
+        private final Publisher<Void> task;
+
+        private Throttled(Publisher<Void> task) {
+            this.task = task;
+        }
+    }
+
+    private final int maxConcurrentRequests;
+    private final int maxQueueSize;
+    // In flight + executing
+    private final AtomicInteger concurrentRequests = new AtomicInteger(0);
+    private final Queue<Throttled> queue = new ConcurrentLinkedQueue<>();
+
+    public ReactiveThrottler(GaugeRegistry gaugeRegistry, int maxConcurrentRequests, int maxQueueSize) {
+        gaugeRegistry.register("imap.request.queue.size", () -> Math.max(concurrentRequests.get() - maxConcurrentRequests, 0));
+
+        this.maxConcurrentRequests = maxConcurrentRequests;
+        this.maxQueueSize = maxQueueSize;
+    }
+
+    public Publisher<Void> throttle(Publisher<Void> task) {
+        int requestNumber = concurrentRequests.incrementAndGet();
+
+        if (requestNumber < maxConcurrentRequests) {
+            // We have capacity for one more concurrent request
+            return Mono.from(task)
+                .then(onRequestDone());
+        } else if (requestNumber < maxQueueSize + maxConcurrentRequests) {
+            // Queue the request for later
+            Sinks.One<Void> one = Sinks.one();
+            queue.add(new Throttled(Mono.from(task)
+                .then(Mono.fromRunnable(() -> one.emitEmpty(Sinks.EmitFailureHandler.FAIL_FAST)))));
+            // Let the caller await task completion
+            return one.asMono();
+        } else {
+            concurrentRequests.decrementAndGet();
+
+            return Mono.error(new RejectedException(
+                String.format(
+                    "The IMAP server has reached its maximum capacity "
+                        + "(concurrent requests: %d, queue size: %d)",
+                    maxConcurrentRequests, maxQueueSize)));
+        }
+    }
+
+    private Mono<Void> onRequestDone() {
+        concurrentRequests.decrementAndGet();
+        Throttled throttled = queue.poll();
+        if (throttled != null) {
+            return Mono.from(throttled.task)
+                .then(onRequestDone());
+        }
+        return Mono.empty();
+    }
+}


### PR DESCRIPTION
## Prior the "reactive IMAP migration"

IMAP request execution is blocking, there is a thread pool of max "ioThreads" (default 20) taking care of 1 request each.

 -> Bad resource utilisation as IO threads get's sleeping most of the time => this was the motivation to migrate to a "reactive style of code".
 -> QOS: at any given time there is at most IO thread requests processed at once.

While the "resource utilisation" of this model might be detrimental, the QOS part of this model might actually be beneficial.

## After the "reactive IMAP migration"

The model is now fully asynchronous with few threads processing potentially thousands of requests.

 -> Good resource utilisation
 -> No QOS

## Diagnostic

On one of our prod instances we notice IMAP request activity spikes that actually overwhelm the servers:

 -> Exhaust the http concurrency on the S3 driver
 -> SERIAL timeouts on Cassandra side.
 -> Eventually build up as bad as to get an OOM

I believe that this situation was prevented by the QOS bringed in by the "blocking thread pool" execution model.

I believe bringing back in that QOS as an option might be beneficial.

## TODO

QOS (concurrentIMAPRequests option in imapserver.xml) defaults to no QOS (unbounded)

Find a way to implement this with Reactor / Netty

Experiment to see if this stabilizes OpenPaaS.linagora.com. If validated contribute it upstream.