### PR TITLE
JAMES-3815 Handle possible null values in imapUidTable and messageIdTable

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -524,10 +524,10 @@ public class CassandraMessageIdDAO {
                 .modSeq(ModSeq.of(row.getLong(MOD_SEQ_LOWERCASE)))
                 .threadId(getThreadIdFromRow(row, messageId))
                 .build())
-            .bodyStartOctet(row.getInt(BODY_START_OCTET_LOWERCASE))
+            .bodyStartOctet(row.get(BODY_START_OCTET_LOWERCASE, Integer.class))
             .internalDate(Optional.ofNullable(row.getInstant(INTERNAL_DATE_LOWERCASE))
                 .map(Date::from))
-            .size(row.getLong(FULL_CONTENT_OCTETS_LOWERCASE))
+            .size(row.get(FULL_CONTENT_OCTETS_LOWERCASE, Long.class))
             .headerContent(Optional.ofNullable(row.getString(HEADER_CONTENT_LOWERCASE))
                 .map(blobIdFactory::from))
             .build());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
@@ -402,10 +402,10 @@ public class CassandraMessageIdToImapUidDAO {
                 .threadId(getThreadIdFromRow(row, messageId))
                 .modSeq(ModSeq.of(row.getLong(MOD_SEQ_LOWERCASE)))
                 .build())
-            .bodyStartOctet(row.getInt(BODY_START_OCTET_LOWERCASE))
+            .bodyStartOctet(row.get(BODY_START_OCTET_LOWERCASE, Integer.class))
             .internalDate(Optional.ofNullable(row.getInstant(INTERNAL_DATE_LOWERCASE))
                 .map(Date::from))
-            .size(row.getLong(FULL_CONTENT_OCTETS_LOWERCASE))
+            .size(row.get(FULL_CONTENT_OCTETS_LOWERCASE, Long.class))
             .headerContent(Optional.ofNullable(row.getString(HEADER_CONTENT_LOWERCASE))
                 .map(blobIdFactory::from))
             .build();


### PR DESCRIPTION
This NPE likely comes from badly applied [Rework message denormalization migration](https://github.com/apache/james-project/blob/master/upgrade-instructions.md#rework-message-denormalization) which creates in `imapUidTable` and `messageIdTable` a few rows with null `internalDate`, `bodyStartOctet`, `fullContentOctets` and `headerContent`. Now the Cassandra driver 4 code change just triggers that NPE (can not convert a null to Date).

Checked: `bodyStartOctet`, `size`, `headerContent` should be already good from NPE.