### PR TITLE
[REFACTORING] List users the reactive way

### DIFF
--- a/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
+++ b/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
@@ -125,6 +125,8 @@ public interface UsersRepository {
      */
     Iterator<Username> list() throws UsersRepositoryException;
 
+    Publisher<Username> listReactive();
+
     /**
      * Return true if virtualHosting support is enabled, otherwise false
      * 

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
@@ -230,11 +230,16 @@ public class CassandraUsersDAO implements UsersDAO {
 
     @Override
     public Iterator<Username> list() {
-        return executor.executeRows(listStatement.bind())
-            .mapNotNull(row -> row.getString(NAME))
-            .map(Username::of)
+        return listReactive()
             .toIterable()
             .iterator();
+    }
+
+    @Override
+    public Flux<Username> listReactive() {
+        return executor.executeRows(listStatement.bind())
+            .mapNotNull(row -> row.getString(NAME))
+            .map(Username::of);
     }
 
     @Override

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersDAO.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersDAO.java
@@ -28,7 +28,9 @@ import org.apache.james.user.api.model.User;
 import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public interface UsersDAO {
     default boolean getDefaultVirtualHostingValue() {
@@ -51,6 +53,16 @@ public interface UsersDAO {
     int countUsers() throws UsersRepositoryException;
 
     Iterator<Username> list() throws UsersRepositoryException;
+
+    default Publisher<Username> listReactive() {
+        return Flux.fromIterable(() -> {
+            try {
+                return list();
+            } catch (UsersRepositoryException e) {
+                throw new RuntimeException(e);
+            }
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
 
     void addUser(Username username, String password) throws UsersRepositoryException;
 }

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersRepositoryImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/UsersRepositoryImpl.java
@@ -200,6 +200,11 @@ public class UsersRepositoryImpl<T extends UsersDAO> implements UsersRepository,
     }
 
     @Override
+    public Publisher<Username> listReactive() {
+        return usersDAO.listReactive();
+    }
+
+    @Override
     public boolean supportVirtualHosting() {
         return virtualHosting;
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RandomStoring.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RandomStoring.java
@@ -39,8 +39,6 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.transport.mailets.delivery.MailStore;
 import org.apache.james.user.api.UsersRepository;
-import org.apache.james.user.api.UsersRepositoryException;
-import org.apache.james.util.streams.Iterators;
 import org.apache.mailet.Attribute;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
@@ -110,8 +108,8 @@ public class RandomStoring extends GenericMailet {
             .collect(ImmutableSet.toImmutableSet());
     }
 
-    private Mono<List<ReroutingInfos>> retrieveReroutingInfos() throws UsersRepositoryException {
-        return Iterators.toFlux(usersRepository.list())
+    private Mono<List<ReroutingInfos>> retrieveReroutingInfos() {
+        return Flux.from(usersRepository.listReactive())
             .flatMap(this::buildReRoutingInfos)
             .collect(ImmutableList.toImmutableList());
     }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxServiceTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExpireMailboxServiceTest.java
@@ -157,8 +157,8 @@ public class ExpireMailboxServiceTest {
 
 
     @Test
-    public void testIgnoresUserListFailure() throws Exception {
-        when(usersRepository.list()).thenThrow(new UsersRepositoryException("it is broken"));
+    void testIgnoresUserListFailure() {
+        when(usersRepository.listReactive()).thenReturn(Flux.error(new UsersRepositoryException("it is broken")));
 
         ExpireMailboxService.Context context = new ExpireMailboxService.Context();
         Date now = new Date();
@@ -172,8 +172,8 @@ public class ExpireMailboxServiceTest {
     }
 
     @Test
-    public void testIgnoresMissingMailbox() throws Exception {
-        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+    void testIgnoresMissingMailbox() {
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice));
         
         // intentionally no mailbox creation
         
@@ -189,8 +189,8 @@ public class ExpireMailboxServiceTest {
     }
     
     @Test
-    public void testIgnoresEmptyMailbox() throws Exception {
-        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+    void testIgnoresEmptyMailbox() throws Exception {
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice));
        
         mailboxManager.createMailbox(aliceInbox, aliceSession);
 
@@ -207,8 +207,8 @@ public class ExpireMailboxServiceTest {
     }
 
     @Test
-    public void testHandlesMailboxErrors() throws Exception {
-        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+    void testHandlesMailboxErrors() throws Exception {
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice));
 
         mailboxManager.createMailbox(aliceInbox, aliceSession);
         MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);
@@ -228,8 +228,8 @@ public class ExpireMailboxServiceTest {
     }
 
     @Test
-    public void testExpiresMailboxByAge() throws Exception {
-        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+    void testExpiresMailboxByAge() throws Exception {
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice));
 
         mailboxManager.createMailbox(aliceInbox, aliceSession);
         MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);
@@ -249,8 +249,8 @@ public class ExpireMailboxServiceTest {
     }
 
     @Test
-    public void testExpiresMailboxByHeader() throws Exception {
-        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+    void testExpiresMailboxByHeader() throws Exception {
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice));
 
         mailboxManager.createMailbox(aliceInbox, aliceSession);
         MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);
@@ -281,8 +281,8 @@ public class ExpireMailboxServiceTest {
     }
 
     @Test
-    public void testExpiresNamedMailbox() throws Exception {
-        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+    void testExpiresNamedMailbox() throws Exception {
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice));
 
         String mailboxName = "Archived";
         MailboxPath mailboxPath = MailboxPath.forUser(alice, mailboxName);
@@ -305,8 +305,8 @@ public class ExpireMailboxServiceTest {
     }
 
     @Test
-    public void testExpiresNamedMailbox2() throws Exception {
-        when(usersRepository.list()).thenReturn(List.of(alice).iterator());
+    void testExpiresNamedMailbox2() throws Exception {
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice));
 
         ExpireMailboxService.Context context = new ExpireMailboxService.Context();
         ExpireMailboxService.RunningOptions options = new ExpireMailboxService.RunningOptions(1, "NoSuchMailbox", false, Optional.of("1s"));
@@ -321,12 +321,12 @@ public class ExpireMailboxServiceTest {
     }
 
     @Test
-    public void testContinuesAfterFailure() throws Exception {
+    void testContinuesAfterFailure() throws Exception {
         Username bob = Username.of("bob@example.org");
         MailboxPath bobInbox = MailboxPath.inbox(bob);
         MailboxSession bobSession = mailboxManager.createSystemSession(bob);
-        
-        when(usersRepository.list()).thenReturn(List.of(alice, bob).iterator());
+
+        when(usersRepository.listReactive()).thenReturn(Flux.just(alice, bob));
 
         mailboxManager.createMailbox(aliceInbox, aliceSession);
         MessageManager aliceManager = mailboxManager.getMailbox(aliceInbox, aliceSession);

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTask.java
@@ -36,7 +36,6 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 import org.apache.james.user.api.UsersRepository;
-import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.util.ReactorUtils;
 
 import com.github.fge.lambdas.Throwing;


### PR DESCRIPTION
It is very error prone to plug blocking components into a reactive pipeline. Allowing implementations to pass a reactive version reduces this risk.