### PR TITLE
JAMES-3775 Rspamd Deliver-To header

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
@@ -29,6 +29,99 @@ with a configurable score threshold. Usually a message will only be
 considered as spam if it matches multiple criteria; matching just a single test
 will not usually be enough to reach the threshold. Note that this mailet is executed on a per-user basis.
 
+=== Rspamd
+
+The Rspamd extension (optional) requires an extra configuration file `rspamd.properties` to configure RSpamd connection
+
+.rspamd.properties content
+|===
+| Property name | explanation
+
+| rSpamdUrl
+| URL defining the Rspamd's server. Eg: http://rspamd:11334
+
+| rSpamdPassword
+| Password for pass authentication when request to Rspamd's server. Eg: admin
+|===
+
+`RspamdScanner` supports the following options:
+
+* You can specify the `virusProcessor` if you want to enable virus scanning for mail. Upon configurable `virusProcessor`
+you can specify how James process mail virus. We provide a sample Rspamd mailet and `virusProcessor` configuration:
+
+* You can specify the `rejectSpamProcessor`. Emails marked as `rejected` by Rspamd will be redirected to this
+processor. This corresponds to emails with the highest spam score, thus delivering them to users as marked as spam
+might not even be desirable.
+
+* The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.
+
+* The `perUserScans` allows to specify if scans should be done on a per user basis, enabling per user scan results based on
+their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
+will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
+If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
+Defaults to false.
+
+
+Here is an example of mailet pipeline conducting out RspamdScanner execution:
+
+....
+<processor state="local-delivery" enableJmx="true">
+    <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
+        <perUserScans>false</perUserScans>
+        <rewriteSubject>true</rewriteSubject>
+        <virusProcessor>virus</virusProcessor>
+        <rejectSpamProcessor>spam</rejectSpamProcessor>
+    </mailet>
+    <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
+        <targetFolderName>Spam</targetFolderName>
+    </mailet>
+    <mailet match="All" class="LocalDelivery"/>
+</processor>
+<!--Choose one between these two following virus processor, or configure a custom one if you want-->
+<!--Hard reject virus mail-->
+<processor state="virus" enableJmx="false">
+    <mailet match="All" class="ToRepository">
+        <repositoryPath>file://var/mail/virus/</repositoryPath>
+    </mailet>
+</processor>
+<!--Soft reject virus mail-->
+<processor state="virus" enableJmx="false">
+    <mailet match="All" class="StripAttachment">
+        <remove>all</remove>
+        <pattern>.*</pattern>
+    </mailet>
+    <mailet match="All" class="AddSubjectPrefix">
+        <subjectPrefix>[VIRUS]</subjectPrefix>
+    </mailet>
+    <mailet match="All" class="LocalDelivery"/>
+</processor>
+<!--Store rejected spam emails (with a very high score) -->
+<processor state="virus" enableJmx="false">
+    <mailet match="All" class="ToRepository">
+        <repositoryPath>cassandra://var/mail/spam</repositoryPath>
+    </mailet>
+</processor>
+....
+
+==== Feedback for Rspamd
+If enabled, the `RspamdListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to Rspamd
+The Rspamd listener needs to explicitly be registered with xref:configure/listeners.adoc[listeners.xml].
+
+Example:
+
+....
+<listeners>
+    <listener>
+        <class>org.apache.james.rspamd.RspamdListener</class>
+    </listener>
+</listeners>
+....
+
+For more detail about how to use Rspamd's extension: `third-party/rspamd/index.md`
+
+Alternatively, batch reports can be triggered on user mailbox content via webAdmin. link:https://github.com/apache/james-project/tree/master/third-party/rspamd#additional-webadmin-endpoints[Read more].
+
+
 === SpamAssassin
 Here is an example of mailet pipeline conducting out SpamAssassin execution:
 
@@ -59,7 +152,7 @@ the table. Also, the correct approach is to send the original spam or non-spam
 as an attachment to another message sent to the feeder in order to avoid bias from the
 current sender's email header.
 
-=== Feedback for SpamAssassin
+==== Feedback for SpamAssassin
 
 If enabled, the `SpamAssassinListener` will asynchronously report users mails moved to the `Spam` mailbox as Spam,
 and other mails as `Ham`, effectively populating the user database for per user spam detection. This enables a per-user
@@ -92,45 +185,3 @@ Example:
   </listener>
 </listeners>
 ....
-
-== Rspamd
-
-The Rspamd extension (optional) requires an extra configuration file `rspamd.properties` to configure RSpamd connection
-
-.rspamd.properties content
-|===
-| Property name | explanation
-
-| rSpamdUrl
-| URL defining the Rspamd's server. Eg: http://rspamd:11334
-
-| rSpamdPassword
-| Password for pass authentication when request to Rspamd's server. Eg: admin
-|===
-
-
-Here is an example of mailet pipeline conducting out RspamdScanner execution:
-
-....
-<mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
-</mailet>
-<mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
-    <targetFolderName>Spam</targetFolderName>
-</mailet>
-....
-
-=== Feedback for Rspamd
-If enabled, the `RspamdListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to Rspamd
-The Rspamd listener needs to explicitly be registered with xref:configure/listeners.adoc[listeners.xml].
-
-Example:
-
-....
-<listeners>
-    <listener>
-        <class>org.apache.james.rspamd.RspamdListener</class>
-    </listener>
-</listeners>
-....
-
-For more detail about how to use Rspamd's extension: `third-party/rspamd/index.md`

--- a/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/DockerRedis.java
+++ b/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/DockerRedis.java
@@ -46,6 +46,7 @@ public class DockerRedis {
         this.container = new GenericContainer<>(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG))
             .withExposedPorts(DEFAULT_PORT)
             .withNetwork(network)
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("james-redis-test"))
             .withNetworkAliases("redis");
     }
 

--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -40,7 +40,8 @@ might not even be desirable.
   their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
   will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
   If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
-  Defaults to false.
+  Please pay attention that per-user Bayes is only activated when we feed enough (min_learns) spam as well as (min_learns) 
+  ham messages to Rspamd. Defaults to false.
 
 ```xml
 <processor state="local-delivery" enableJmx="true">

--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -34,11 +34,18 @@ you can specify how James process mail virus. We provide a sample Rspamd mailet 
 processor. This corresponds to emails with the highest spam score, thus delivering them to users as marked as spam 
 might not even be desirable.
 
-  The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.
-  
+  The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.  
+
+  The `perUserScans` allows to specify if scans should be done on a per user basis, enabling per user scan results based on
+  their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
+  will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
+  If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
+  Defaults to false.
+
 ```xml
 <processor state="local-delivery" enableJmx="true">
     <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
+        <perUserScans>false</perUserScans>
         <rewriteSubject>true</rewriteSubject>
         <virusProcessor>virus</virusProcessor>
         <rejectSpamProcessor>spam</rejectSpamProcessor>
@@ -67,6 +74,7 @@ might not even be desirable.
     <mailet match="All" class="AddSubjectPrefix">
         <subjectPrefix>[VIRUS]</subjectPrefix>
     </mailet>
+    <mailet match="All" class="LocalDelivery"/>
 </processor>
 
 <!--Store rejected spam emails (with a very high score) -->

--- a/third-party/rspamd/docker-compose-distributed.yml
+++ b/third-party/rspamd/docker-compose-distributed.yml
@@ -78,5 +78,6 @@ services:
       - PASSWORD=admin
     volumes:
       - $PWD/sample-configuration/antivirus.conf:/etc/rspamd/override.d/antivirus.conf
+      - $PWD/sample-configuration/statistic.conf:/etc/rspamd/statistic.conf
     ports:
       - 11334:11334

--- a/third-party/rspamd/docker-compose.yml
+++ b/third-party/rspamd/docker-compose.yml
@@ -44,5 +44,6 @@ services:
       - PASSWORD=admin
     volumes:
       - $PWD/sample-configuration/antivirus.conf:/etc/rspamd/override.d/antivirus.conf
+      - $PWD/sample-configuration/statistic.conf:/etc/rspamd/statistic.conf
     ports:
       - 11334:11334

--- a/third-party/rspamd/pom.xml
+++ b/third-party/rspamd/pom.xml
@@ -179,11 +179,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/third-party/rspamd/sample-configuration/statistic.conf
+++ b/third-party/rspamd/sample-configuration/statistic.conf
@@ -5,20 +5,20 @@ classifier "bayes" {
   cache {
   }
   new_schema = true; # Always use new schema
-  store_tokens = true; # Redefine if storing of tokens is desired
-  signatures = true; # Store learn signatures
+  store_tokens = false; # Redefine if storing of tokens is desired
+  signatures = false; # Store learn signatures
   per_user = true; # Enable per user classifier
   users_enabled = true;
-  min_tokens = 10;
+  min_tokens = 11;
   backend = "redis";
-  min_learns = 0;
+  min_learns = 50; // Should not be bias by too small learning set
 
   statfile {
-    symbol = "BAYES_HAM_USER";
+    symbol = "BAYES_HAM";
     spam = false;
   }
   statfile {
-    symbol = "BAYES_SPAM_USER";
+    symbol = "BAYES_SPAM";
     spam = true;
   }
 

--- a/third-party/rspamd/sample-configuration/statistic.conf
+++ b/third-party/rspamd/sample-configuration/statistic.conf
@@ -1,0 +1,37 @@
+classifier "bayes" {
+  tokenizer {
+    name = "osb";
+  }
+  cache {
+  }
+  new_schema = true; # Always use new schema
+  store_tokens = true; # Redefine if storing of tokens is desired
+  signatures = true; # Store learn signatures
+  per_user = true; # Enable per user classifier
+  users_enabled = true;
+  min_tokens = 10;
+  backend = "redis";
+  min_learns = 0;
+
+  statfile {
+    symbol = "BAYES_HAM_USER";
+    spam = false;
+  }
+  statfile {
+    symbol = "BAYES_SPAM_USER";
+    spam = true;
+  }
+
+  learn_condition = 'return require("lua_bayes_learn").can_learn';
+
+  # Autolearn sample
+  # autolearn {
+  #  spam_threshold = 6.0; # When to learn spam (score >= threshold)
+  #  ham_threshold = -0.5; # When to learn ham (score <= threshold)
+  #  check_balance = true; # Check spam and ham balance
+  #  min_balance = 0.9; # Keep diff for spam/ham learns for at least this value
+  #}
+
+  .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/classifier-bayes.conf"
+  .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/classifier-bayes.conf"
+}

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
@@ -36,6 +36,7 @@ public class DockerClamAV {
             .withEnv("CLAMAV_NO_FRESHCLAMD", "true")
             .withEnv("CLAMAV_NO_MILTERD", "true")
             .withNetwork(network)
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("james-clamav-test"))
             .withNetworkAliases("clamav");
     }
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamd.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamd.java
@@ -42,14 +42,14 @@ public class DockerRspamd {
         this.network = Network.newNetwork();
         this.dockerRedis = new DockerRedis(network);
         this.dockerClamAV = new DockerClamAV(network);
-        this.container = createRspamD();
+        this.container = createRspamd();
     }
 
     public boolean isRunning() {
         return container.isRunning();
     }
 
-    private GenericContainer<?> createRspamD() {
+    private GenericContainer<?> createRspamd() {
         return new GenericContainer<>(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG))
             .withExposedPorts(DEFAULT_PORT)
             .withEnv("REDIS", "redis")
@@ -57,6 +57,8 @@ public class DockerRspamd {
             .withEnv("PASSWORD", PASSWORD)
             .withCopyFileToContainer(MountableFile.forClasspathResource("rspamd-config/antivirus.conf"), "/etc/rspamd/override.d/")
             .withCopyFileToContainer(MountableFile.forClasspathResource("rspamd-config/actions.conf"), "/etc/rspamd/")
+            .withCopyFileToContainer(MountableFile.forClasspathResource("rspamd-config/statistic.conf"), "/etc/rspamd/")
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("james-rspamd-test"))
             .withNetwork(network);
     }
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdListenerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdListenerTest.java
@@ -88,8 +88,8 @@ public class RspamdListenerTest {
     void setup() {
         rspamdHttpClient = mock(RspamdHttpClient.class);
 
-        when(rspamdHttpClient.reportAsHam(any())).thenReturn(Mono.empty());
-        when(rspamdHttpClient.reportAsSpam(any())).thenReturn(Mono.empty());
+        when(rspamdHttpClient.reportAsHam(any(), any())).thenReturn(Mono.empty());
+        when(rspamdHttpClient.reportAsSpam(any(), any())).thenReturn(Mono.empty());
 
         StoreMailboxManager mailboxManager = spy(InMemoryIntegrationResources.defaultResources().getMailboxManager());
         SystemMailboxesProviderImpl systemMailboxesProvider = new SystemMailboxesProviderImpl(mailboxManager);
@@ -228,7 +228,7 @@ public class RspamdListenerTest {
 
         listener.event(messageMoveEvent);
 
-        verify(rspamdHttpClient).reportAsSpam(any());
+        verify(rspamdHttpClient).reportAsSpam(any(), any());
     }
 
     @Test
@@ -246,7 +246,7 @@ public class RspamdListenerTest {
 
         listener.event(messageMoveEvent);
 
-        verify(rspamdHttpClient).reportAsHam(any());
+        verify(rspamdHttpClient).reportAsHam(any(), any());
     }
 
     @Test
@@ -262,7 +262,7 @@ public class RspamdListenerTest {
 
         listener.event(addedEvent);
 
-        verify(rspamdHttpClient).reportAsHam(any());
+        verify(rspamdHttpClient).reportAsHam(any(), any());
     }
 
     @Test
@@ -279,6 +279,7 @@ public class RspamdListenerTest {
         listener.event(addedEvent);
 
         verify(rspamdHttpClient, never()).reportAsHam(any());
+        verify(rspamdHttpClient, never()).reportAsHam(any(), any());
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox) throws MailboxException {

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
@@ -21,18 +21,18 @@ package org.apache.james.rspamd;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collection;
-import java.util.Optional;
 
+import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.Username;
 import org.apache.james.core.builder.MimeMessageBuilder;
-import org.apache.james.junit.categories.Unstable;
-import org.apache.james.rspamd.client.RspamdClientConfiguration;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.rspamd.model.AnalysisResult;
 import org.apache.james.util.MimeMessageUtil;
@@ -42,32 +42,34 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
 import org.apache.mailet.ProcessingState;
 import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMailContext;
 import org.apache.mailet.base.test.FakeMailetConfig;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 
-@Tag(Unstable.TAG)
 class RspamdScannerTest {
-    @RegisterExtension
-    static DockerRspamdExtension rspamdExtension = new DockerRspamdExtension();
-    static final String rspamdPassword = "admin";
     static final String INIT_SUBJECT = "initial subject";
     static final String REWRITE_SUBJECT = "rewrite subject";
 
     private RspamdScanner mailet;
+    private RspamdHttpClient rspamdHttpClient;
 
     @BeforeEach
-    void setup() {
-        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), rspamdPassword, Optional.empty());
-        RspamdHttpClient client = new RspamdHttpClient(configuration);
-        mailet = new RspamdScanner(client);
+    void setup() throws MessagingException {
+        rspamdHttpClient = mock(RspamdHttpClient.class);
+        when(rspamdHttpClient.checkV2(any(Mail.class)))
+            .thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.NO_ACTION)
+                .score(12.1F)
+                .requiredScore(14F)
+                .build()));
+        mailet = new RspamdScanner(rspamdHttpClient);
     }
 
     @Test
@@ -179,6 +181,13 @@ class RspamdScannerTest {
             .recipient("user1@exemple.com")
             .mimeMessage(mimeMessage)
             .build();
+
+        when(rspamdHttpClient.checkV2(any(Mail.class)))
+            .thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.REJECT)
+                .score(15F)
+                .requiredScore(14F)
+                .build()));
 
         mailet.init(FakeMailetConfig.builder()
             .setProperty("rewriteSubject", "true")
@@ -438,6 +447,14 @@ class RspamdScannerTest {
             .mimeMessage(mimeMessage)
             .build();
 
+        when(rspamdHttpClient.checkV2(any(Mail.class)))
+            .thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.REJECT)
+                .score(15F)
+                .requiredScore(14F)
+                .hasVirus(true)
+                .build()));
+
         mailet.init(mailetConfig);
         mailet.service(mail);
 
@@ -481,5 +498,155 @@ class RspamdScannerTest {
         mailet.service(mail);
 
         assertThat(mail.getState()).isNull();
+    }
+
+    @Nested
+    class PerUser {
+        @Test
+        void shouldPositionPerUserHeaders() throws Exception {
+            RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user1@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(1.1F)
+                    .requiredScore(14F)
+                    .build()));
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user2@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.ADD_HEADER)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+
+            mailet = new RspamdScanner(rspamdHttpClient);
+
+            mailet.init(FakeMailetConfig.builder()
+                .setProperty("perUserScans", "true")
+                .setProperty("virusProcessor", "virus")
+                .setProperty("rejectSpamProcessor", "spam")
+                .build());
+
+            Mail mail = FakeMail.builder()
+                .name("name")
+                .recipients("user1@exemple.com", "user2@exemple.com")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient("user1@exemple.com")
+                    .addFrom("sender@exemple.com")
+                    .setSubject(INIT_SUBJECT)
+                    .setText("Please!")
+                    .build())
+                .build();
+
+            mailet.service(mail);
+
+            Collection<PerRecipientHeaders.Header> headersForRecipient1 = mail.getPerRecipientSpecificHeaders()
+                .getHeadersForRecipient(new MailAddress("user1@exemple.com"));
+            assertThat(headersForRecipient1.stream()
+                .filter(header -> header.getName().equals(RspamdScanner.FLAG_MAIL.asString()))
+                .filter(header -> header.getValue().startsWith("NO"))
+                .findAny())
+                .isPresent();
+
+            Collection<PerRecipientHeaders.Header> headersForRecipient2 = mail.getPerRecipientSpecificHeaders()
+                .getHeadersForRecipient(new MailAddress("user2@exemple.com"));
+            assertThat(headersForRecipient2.stream()
+                .filter(header -> header.getName().equals(RspamdScanner.FLAG_MAIL.asString()))
+                .filter(header -> header.getValue().startsWith("YES"))
+                .findAny())
+                .isPresent();
+        }
+
+        @Test
+        void shouldPerformPartialRejects() throws Exception {
+            RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user1@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user2@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.REJECT)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+
+            mailet = new RspamdScanner(rspamdHttpClient);
+
+            FakeMailContext mailetContext = FakeMailContext.defaultContext();
+            mailet.init(FakeMailetConfig.builder()
+                .setProperty("perUserScans", "true")
+                .setProperty("virusProcessor", "virus")
+                .setProperty("rejectSpamProcessor", "spam")
+                .mailetContext(mailetContext)
+                .build());
+
+            Mail mail = FakeMail.builder()
+                .name("name")
+                .recipients("user1@exemple.com", "user2@exemple.com")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient("user1@exemple.com")
+                    .addFrom("sender@exemple.com")
+                    .setSubject(INIT_SUBJECT)
+                    .setText("Please!")
+                    .build())
+                .build();
+
+            mailet.service(mail);
+
+            assertThat(mail.getRecipients())
+                .containsOnly(new MailAddress("user1@exemple.com"));
+
+            assertThat(mailetContext.getSentMails().get(0).getState()).isEqualTo("spam");
+            assertThat(mailetContext.getSentMails().get(0).getRecipients()).containsOnly(new MailAddress("user2@exemple.com"));
+        }
+
+        @Test
+        void shouldPerformPartialVirus() throws Exception {
+            RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user1@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user2@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .hasVirus(true)
+                    .build()));
+
+            mailet = new RspamdScanner(rspamdHttpClient);
+
+            FakeMailContext mailetContext = FakeMailContext.defaultContext();
+            mailet.init(FakeMailetConfig.builder()
+                .setProperty("perUserScans", "true")
+                .setProperty("virusProcessor", "virus")
+                .setProperty("rejectSpamProcessor", "spam")
+                .mailetContext(mailetContext)
+                .build());
+
+            Mail mail = FakeMail.builder()
+                .name("name")
+                .recipients("user1@exemple.com", "user2@exemple.com")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient("user1@exemple.com")
+                    .addFrom("sender@exemple.com")
+                    .setSubject(INIT_SUBJECT)
+                    .setText("Please!")
+                    .build())
+                .build();
+
+            mailet.service(mail);
+
+            assertThat(mail.getRecipients())
+                .containsOnly(new MailAddress("user1@exemple.com"));
+
+            assertThat(mailetContext.getSentMails().get(0).getState()).isEqualTo("virus");
+            assertThat(mailetContext.getSentMails().get(0).getRecipients()).containsOnly(new MailAddress("user2@exemple.com"));
+        }
     }
 }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
@@ -104,7 +104,7 @@ public class FeedHamToRspamdTaskTest {
         }
 
         @Override
-        public Mono<Void> reportAsHam(Publisher<ByteBuffer> content) {
+        public Mono<Void> reportAsHam(Publisher<ByteBuffer> content, Options options) {
             return Mono.from(content)
                 .doOnNext(e -> hitCounter.incrementAndGet())
                 .then();

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskTest.java
@@ -103,7 +103,7 @@ public class FeedSpamToRspamdTaskTest {
         }
 
         @Override
-        public Mono<Void> reportAsSpam(Publisher<ByteBuffer> content) {
+        public Mono<Void> reportAsSpam(Publisher<ByteBuffer> content, Options options) {
             return Mono.from(content)
                 .doOnNext(e -> hitCounter.incrementAndGet())
                 .then();

--- a/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
+++ b/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
@@ -1,0 +1,37 @@
+classifier "bayes" {
+  tokenizer {
+    name = "osb";
+  }
+  cache {
+  }
+  new_schema = true; # Always use new schema
+  store_tokens = true; # Redefine if storing of tokens is desired
+  signatures = true; # Store learn signatures
+  per_user = true; # Enable per user classifier
+  users_enabled = true;
+  min_tokens = 10;
+  backend = "redis";
+  min_learns = 0;
+
+  statfile {
+    symbol = "BAYES_HAM_USER";
+    spam = false;
+  }
+  statfile {
+    symbol = "BAYES_SPAM_USER";
+    spam = true;
+  }
+
+  learn_condition = 'return require("lua_bayes_learn").can_learn';
+
+  # Autolearn sample
+  # autolearn {
+  #  spam_threshold = 6.0; # When to learn spam (score >= threshold)
+  #  ham_threshold = -0.5; # When to learn ham (score <= threshold)
+  #  check_balance = true; # Check spam and ham balance
+  #  min_balance = 0.9; # Keep diff for spam/ham learns for at least this value
+  #}
+
+  .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/classifier-bayes.conf"
+  .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/classifier-bayes.conf"
+}

--- a/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
+++ b/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
@@ -5,20 +5,20 @@ classifier "bayes" {
   cache {
   }
   new_schema = true; # Always use new schema
-  store_tokens = true; # Redefine if storing of tokens is desired
-  signatures = true; # Store learn signatures
+  store_tokens = false; # Redefine if storing of tokens is desired
+  signatures = false; # Store learn signatures
   per_user = true; # Enable per user classifier
   users_enabled = true;
-  min_tokens = 10;
+  min_tokens = 11;
   backend = "redis";
-  min_learns = 0;
+  min_learns = 2;
 
   statfile {
-    symbol = "BAYES_HAM_USER";
+    symbol = "BAYES_HAM";
     spam = false;
   }
   statfile {
-    symbol = "BAYES_SPAM_USER";
+    symbol = "BAYES_SPAM";
     spam = true;
   }
 


### PR DESCRIPTION
Ref: https://rspamd.com/doc/architecture/protocol.html#http-headers
By add "Deliver-To" header when request to rspamd.
```
Defines actual delivery recipient of message. Can be used for personalized statistics and for user specific options.
```