### PR TITLE
[STABILITY] Limit number of threads in parallel when creating cassand…

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
@@ -52,7 +52,7 @@ public class CassandraTableManager {
         KeyspaceMetadata keyspaceMetadata = session.getMetadata().getKeyspaces().get(session.getKeyspace().get());
 
         return Flux.fromIterable(module.moduleTables())
-            .flatMap(table -> table.initialize(keyspaceMetadata, session, typesProvider))
+            .flatMap(table -> table.initialize(keyspaceMetadata, session, typesProvider), DEFAULT_CONCURRENCY)
             .reduce(InitializationStatus::reduce)
             .switchIfEmpty(Mono.just(InitializationStatus.ALREADY_DONE))
             .block();


### PR DESCRIPTION
…ra tables

I encountered some issues when trying to run James with a Cassandra not initialized yet. I could observe sometimes James starting to create the tables on Cassandra and then stopping on a driver timeout exception. 

We likely try to create too many tables in parallel at the same time. Limiting the concurrency seems to help greatly. It might help with the build stability too.