### PR TITLE
JAMES-3820 implement DNSRBLHandler as a MailHook instead of RcptHook …

### DIFF
--- a/examples/custom-smtp-command/README.md
+++ b/examples/custom-smtp-command/README.md
@@ -67,7 +67,7 @@ public class MyCmdHandlerLoader implements HandlersPackage {
             MailSizeEsmtpExtension.class,
             UsersRepositoryAuthHook.class,
             AuthRequiredToRelayRcptHook.class,
-            SenderAuthIdentifyVerificationRcptHook.class,
+            SenderAuthIdentifyVerificationHook.class,
             PostmasterAbuseRcptHook.class,
             ReceivedDataLineFilter.class,
             DataLineJamesMessageHookHandler.class,

--- a/examples/custom-smtp-command/src/main/java/org/apache/james/examples/MyCmdHandlerLoader.java
+++ b/examples/custom-smtp-command/src/main/java/org/apache/james/examples/MyCmdHandlerLoader.java
@@ -49,7 +49,7 @@ import org.apache.james.smtpserver.JamesMailCmdHandler;
 import org.apache.james.smtpserver.JamesRcptCmdHandler;
 import org.apache.james.smtpserver.JamesWelcomeMessageHandler;
 import org.apache.james.smtpserver.SendMailHandler;
-import org.apache.james.smtpserver.SenderAuthIdentifyVerificationRcptHook;
+import org.apache.james.smtpserver.SenderAuthIdentifyVerificationHook;
 import org.apache.james.smtpserver.UsersRepositoryAuthHook;
 
 /**
@@ -78,7 +78,7 @@ public class MyCmdHandlerLoader implements HandlersPackage {
             MailSizeEsmtpExtension.class,
             UsersRepositoryAuthHook.class,
             AuthRequiredToRelayRcptHook.class,
-            SenderAuthIdentifyVerificationRcptHook.class,
+            SenderAuthIdentifyVerificationHook.class,
             PostmasterAbuseRcptHook.class,
             ReceivedDataLineFilter.class,
             DataLineJamesMessageHookHandler.class,

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationHook.java
@@ -27,14 +27,14 @@ import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
-import org.apache.james.protocols.smtp.hook.RcptHook;
+import org.apache.james.protocols.smtp.hook.MailHook;
 
 import com.google.common.base.Preconditions;
 
 /**
  * Handler which check if the authenticated user is the same as the one used as MAIL FROM
  */
-public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements RcptHook {  
+public abstract class AbstractSenderAuthIdentifyVerificationHook implements MailHook {
     private static final HookResult INVALID_AUTH = HookResult.builder()
         .hookReturnCode(HookReturnCode.deny())
         .smtpReturnCode(SMTPRetCode.BAD_SEQUENCE)
@@ -49,7 +49,7 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
         .build();
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
+    public HookResult doMail(SMTPSession session, MaybeSender sender) {
         if (session.getUsername() != null) {
             // Check if the sender address is the same as the user which was used to authenticate.
             // Its important to ignore case here to fix JAMES-837. This is save to do because if the handler is called

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
@@ -22,7 +22,6 @@ package org.apache.james.protocols.smtp.core.fastfail;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.api.ProtocolSession.State;
@@ -32,13 +31,13 @@ import org.apache.james.protocols.smtp.dsn.DSNStatus;
 import org.apache.james.protocols.smtp.hook.HeloHook;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
-import org.apache.james.protocols.smtp.hook.RcptHook;
+import org.apache.james.protocols.smtp.hook.MailHook;
 
 
 /**
  * This CommandHandler can be used to reject not resolvable EHLO/HELO
  */
-public class ResolvableEhloHeloHandler implements RcptHook, HeloHook {
+public class ResolvableEhloHeloHandler implements MailHook, HeloHook {
 
     public static final ProtocolSession.AttachmentKey<Boolean> BAD_EHLO_HELO = ProtocolSession.AttachmentKey.of("BAD_EHLO_HELO", Boolean.class);
 
@@ -78,7 +77,7 @@ public class ResolvableEhloHeloHandler implements RcptHook, HeloHook {
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
+    public HookResult doMail(SMTPSession session, MaybeSender sender) {
         if (check(session)) {
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.deny())

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
@@ -22,6 +22,7 @@ package org.apache.james.protocols.smtp.core.fastfail;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.api.ProtocolSession.State;
@@ -32,12 +33,13 @@ import org.apache.james.protocols.smtp.hook.HeloHook;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.hook.MailHook;
+import org.apache.james.protocols.smtp.hook.RcptHook;
 
 
 /**
  * This CommandHandler can be used to reject not resolvable EHLO/HELO
  */
-public class ResolvableEhloHeloHandler implements MailHook, HeloHook {
+public class ResolvableEhloHeloHandler implements HeloHook, MailHook, RcptHook {
 
     public static final ProtocolSession.AttachmentKey<Boolean> BAD_EHLO_HELO = ProtocolSession.AttachmentKey.of("BAD_EHLO_HELO", Boolean.class);
 
@@ -71,14 +73,8 @@ public class ResolvableEhloHeloHandler implements MailHook, HeloHook {
         
     }
 
-    protected boolean check(SMTPSession session) {
-        // not reject it
-        return session.getAttachment(BAD_EHLO_HELO, State.Transaction).isPresent();
-    }
-
-    @Override
-    public HookResult doMail(SMTPSession session, MaybeSender sender) {
-        if (check(session)) {
+    protected HookResult doCheck(SMTPSession session) {
+        if (session.getAttachment(BAD_EHLO_HELO, State.Transaction).isPresent()) {
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.deny())
                 .smtpReturnCode(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS)
@@ -88,6 +84,16 @@ public class ResolvableEhloHeloHandler implements MailHook, HeloHook {
         } else {
             return HookResult.DECLINED;
         }
+    }
+
+    @Override
+    public HookResult doMail(SMTPSession session, MaybeSender sender) {
+        return doCheck(session);
+    }
+
+    @Override
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
+        return doCheck(session);
     }
 
     @Override

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
@@ -21,8 +21,8 @@
 package org.apache.james.protocols.smtp.core.fastfail;
 
 import static org.apache.james.protocols.api.ProtocolSession.State.Connection;
-import static org.apache.james.protocols.smtp.core.fastfail.DNSRBLHandler.RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME;
-import static org.apache.james.protocols.smtp.core.fastfail.DNSRBLHandler.RBL_DETAIL_MAIL_ATTRIBUTE_NAME;
+import static org.apache.james.protocols.smtp.core.fastfail.DNSRBLHandler.RBL_BLOCKLISTED;
+import static org.apache.james.protocols.smtp.core.fastfail.DNSRBLHandler.RBL_DETAIL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.InetSocketAddress;
@@ -192,8 +192,8 @@ public class DNSRBLHandlerTest {
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
         rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
-        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, State.Connection)).describedAs("Details").contains("Blocked - see http://www.spamcop.net/bl.shtml?127.0.0.2");
-        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isPresent();
+        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL, State.Connection)).describedAs("Details").contains("Blocked - see http://www.spamcop.net/bl.shtml?127.0.0.2");
+        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED, Connection)).withFailMessage("Blocked").isPresent();
     }
 
     // ip is blacklisted and has txt details but we don'T want to retrieve the txt record
@@ -205,8 +205,8 @@ public class DNSRBLHandlerTest {
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(false);
         rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
-        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isEmpty();
-        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isPresent();
+        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL, Connection)).withFailMessage("No details").isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED, Connection)).withFailMessage("Blocked").isPresent();
     }
 
     // ip is allowed to relay
@@ -219,8 +219,8 @@ public class DNSRBLHandlerTest {
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
         rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
-        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isEmpty();
-        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL, Connection)).withFailMessage("No details").isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED, Connection)).withFailMessage("Not blocked").isEmpty();
     }
 
     // ip not on blacklist
@@ -234,8 +234,8 @@ public class DNSRBLHandlerTest {
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
         rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
-        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isEmpty();
-        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL, Connection)).withFailMessage("No details").isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED, Connection)).withFailMessage("Not blocked").isEmpty();
     }
 
     // ip on blacklist without txt details
@@ -249,8 +249,8 @@ public class DNSRBLHandlerTest {
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
         rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
-        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isEmpty();
-        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isPresent();
+        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL, Connection)).isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED, Connection)).withFailMessage("Blocked").isPresent();
     }
 
     // ip on whitelist
@@ -264,8 +264,8 @@ public class DNSRBLHandlerTest {
         rbl.setWhitelist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
         rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
-        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isEmpty();
-        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL, Connection)).isEmpty();
+        assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED, Connection)).withFailMessage("Not blocked").isEmpty();
     }
    
 

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
@@ -191,7 +191,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
+        rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, State.Connection)).describedAs("Details").contains("Blocked - see http://www.spamcop.net/bl.shtml?127.0.0.2");
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isPresent();
     }
@@ -204,7 +204,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(false);
-        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
+        rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isEmpty();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isPresent();
     }
@@ -218,7 +218,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
+        rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isEmpty();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isEmpty();
     }
@@ -233,7 +233,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
+        rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isEmpty();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isEmpty();
     }
@@ -248,7 +248,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
+        rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isEmpty();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isPresent();
     }
@@ -263,7 +263,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setWhitelist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
+        rbl.doMail(mockedSMTPSession, MaybeSender.nullSender());
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isEmpty();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isEmpty();
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.core.Username;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -47,7 +46,7 @@ public class ResolvableEhloHeloHandlerTest {
 
 
     private SMTPSession setupMockSession(String argument,
-             final boolean relaying, final boolean authRequired, final Username username, MailAddress recipient) {
+             final boolean relaying, final boolean authRequired, final Username username) {
 
         return new BaseFakeSMTPSession() {
 
@@ -130,35 +129,32 @@ public class ResolvableEhloHeloHandlerTest {
     
     @Test
     void testRejectInvalidHelo() throws Exception {
-        MailAddress mailAddress = new MailAddress("test@localhost");
-        SMTPSession session = setupMockSession(INVALID_HOST, false, false, null, mailAddress);
+        SMTPSession session = setupMockSession(INVALID_HOST, false, false, null);
         ResolvableEhloHeloHandler handler = createHandler();
         
         handler.doHelo(session, INVALID_HOST);
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Invalid HELO").isPresent();
 
-        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
+        HookReturnCode result = handler.doMail(session, MaybeSender.nullSender()).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
     
     @Test
     void testNotRejectValidHelo() throws Exception {
-        MailAddress mailAddress = new MailAddress("test@localhost");
-        SMTPSession session = setupMockSession(VALID_HOST, false, false, null, mailAddress);
+        SMTPSession session = setupMockSession(VALID_HOST, false, false, null);
         ResolvableEhloHeloHandler handler = createHandler();
 
   
         handler.doHelo(session, VALID_HOST);
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Valid HELO").isEmpty();
 
-        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
+        HookReturnCode result = handler.doMail(session, MaybeSender.nullSender()).getResult();
         assertThat(HookReturnCode.declined()).describedAs("Not reject").isEqualTo(result);
     }
    
     @Test
     void testRejectInvalidHeloAuthUser() throws Exception {
-        MailAddress mailAddress = new MailAddress("test@localhost");
-        SMTPSession session = setupMockSession(INVALID_HOST, false, true, Username.of("valid@user"), mailAddress);
+        SMTPSession session = setupMockSession(INVALID_HOST, false, true, Username.of("valid@user"));
         ResolvableEhloHeloHandler handler = createHandler();
 
 
@@ -166,15 +162,14 @@ public class ResolvableEhloHeloHandlerTest {
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Value stored").isPresent();
 
 
-        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
+        HookReturnCode result = handler.doMail(session, MaybeSender.nullSender()).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
     
    
     @Test
     void testRejectRelay() throws Exception {
-        MailAddress mailAddress = new MailAddress("test@localhost");
-        SMTPSession session = setupMockSession(INVALID_HOST, true, false, null, mailAddress);
+        SMTPSession session = setupMockSession(INVALID_HOST, true, false, null);
         ResolvableEhloHeloHandler handler = createHandler();
 
 
@@ -182,7 +177,7 @@ public class ResolvableEhloHeloHandlerTest {
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Value stored").isPresent();
 
 
-        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
+        HookReturnCode result = handler.doMail(session, MaybeSender.nullSender()).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
 }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpIdentityVerificationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpIdentityVerificationTest.java
@@ -100,7 +100,7 @@ class SmtpIdentityVerificationTest {
             messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
                 .authenticate(USER, PASSWORD)
                 .sendMessageNoSender(USER))
-            .isEqualTo(new SMTPSendingException(SmtpSendingStep.RCPT, "503 5.7.1 Incorrect Authentication for Specified Email Address\n"));
+            .isEqualTo(new SMTPSendingException(SmtpSendingStep.Sender, "503 5.7.1 Incorrect Authentication for Specified Email Address\n"));
     }
 
     @Test
@@ -124,7 +124,7 @@ class SmtpIdentityVerificationTest {
         assertThatThrownBy(() ->
             messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
                 .sendMessage(USER, USER))
-            .isEqualTo(new SMTPSendingException(SmtpSendingStep.RCPT, "530 5.7.1 Authentication Required\n"));
+            .isEqualTo(new SMTPSendingException(SmtpSendingStep.Sender, "530 5.7.1 Authentication Required\n"));
     }
 
     @Test
@@ -148,6 +148,6 @@ class SmtpIdentityVerificationTest {
             messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
                 .authenticate(ATTACKER, ATTACKER_PASSWORD)
                 .sendMessage(USER, USER))
-            .isEqualTo(new SMTPSendingException(SmtpSendingStep.RCPT, "503 5.7.1 Incorrect Authentication for Specified Email Address\n"));
+            .isEqualTo(new SMTPSendingException(SmtpSendingStep.Sender, "503 5.7.1 Incorrect Authentication for Specified Email Address\n"));
     }
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/CoreCmdHandlerLoader.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/CoreCmdHandlerLoader.java
@@ -69,7 +69,7 @@ public class CoreCmdHandlerLoader implements HandlersPackage {
             MailSizeEsmtpExtension.class,
             UsersRepositoryAuthHook.class,
             AuthRequiredToRelayRcptHook.class,
-            SenderAuthIdentifyVerificationRcptHook.class,
+            SenderAuthIdentifyVerificationHook.class,
             PostmasterAbuseRcptHook.class,
             ReceivedDataLineFilter.class,
             DataLineJamesMessageHookHandler.class,

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationHook.java
@@ -27,7 +27,7 @@ import org.apache.james.core.Username;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.api.DomainListException;
 import org.apache.james.protocols.smtp.SMTPSession;
-import org.apache.james.protocols.smtp.core.AbstractSenderAuthIdentifyVerificationRcptHook;
+import org.apache.james.protocols.smtp.core.AbstractSenderAuthIdentifyVerificationHook;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.user.api.UsersRepository;
@@ -38,25 +38,25 @@ import org.slf4j.LoggerFactory;
 /**
  * Handler which check if the authenticated user is incorrect
  */
-public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthIdentifyVerificationRcptHook {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SenderAuthIdentifyVerificationRcptHook.class);
+public class SenderAuthIdentifyVerificationHook extends AbstractSenderAuthIdentifyVerificationHook {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SenderAuthIdentifyVerificationHook.class);
 
     private final DomainList domains;
     private final UsersRepository users;
     private final CanSendFrom canSendFrom;
 
     @Inject
-    public SenderAuthIdentifyVerificationRcptHook(DomainList domains, UsersRepository users, CanSendFrom canSendFrom) {
+    public SenderAuthIdentifyVerificationHook(DomainList domains, UsersRepository users, CanSendFrom canSendFrom) {
         this.domains = domains;
         this.users = users;
         this.canSendFrom = canSendFrom;
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
+    public HookResult doMail(SMTPSession session, MaybeSender sender) {
         ExtendedSMTPSession nSession = (ExtendedSMTPSession) session;
         if (nSession.verifyIdentity()) {
-            return super.doRcpt(session, sender, rcpt);
+            return super.doMail(session, sender);
         } else {
             return HookResult.DECLINED;
         }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationHook.java
@@ -53,10 +53,10 @@ public class SenderAuthIdentifyVerificationHook extends AbstractSenderAuthIdenti
     }
 
     @Override
-    public HookResult doMail(SMTPSession session, MaybeSender sender) {
+    public HookResult doCheck(SMTPSession session, MaybeSender sender) {
         ExtendedSMTPSession nSession = (ExtendedSMTPSession) session;
         if (nSession.verifyIdentity()) {
-            return super.doMail(session, sender);
+            return super.doCheck(session, sender);
         } else {
             return HookResult.DECLINED;
         }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
@@ -49,7 +49,7 @@ import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, ProtocolHandler {
+public class SPFHandler implements JamesMessageHook, MailHook, ProtocolHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SPFHandler.class);
 
@@ -155,8 +155,10 @@ public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, Protoco
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
+    public HookResult doMail(SMTPSession session, MaybeSender sender) {
         if (!session.isRelayingAllowed()) {
+            doSPFCheck(session, sender);
+
             // Check if session is blocklisted
             if (session.getAttachment(SPF_BLOCKLISTED, State.Transaction).isPresent()) {
 
@@ -172,12 +174,6 @@ public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, Protoco
                     .build();
             }
         }
-        return HookResult.DECLINED;
-    }
-
-    @Override
-    public HookResult doMail(SMTPSession session, MaybeSender sender) {
-        doSPFCheck(session, sender);
         return HookResult.DECLINED;
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.jspf.core.DNSService;
 import org.apache.james.jspf.core.exceptions.SPFErrorConstants;
@@ -40,7 +39,6 @@ import org.apache.james.protocols.smtp.dsn.DSNStatus;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.hook.MailHook;
-import org.apache.james.protocols.smtp.hook.RcptHook;
 import org.apache.james.smtpserver.JamesMessageHook;
 import org.apache.mailet.Attribute;
 import org.apache.mailet.AttributeName;

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -803,7 +803,6 @@ public class SMTPServerTest {
 
         smtpProtocol.sendCommand(heloCommand, fictionalDomain);
         smtpProtocol.setSender(mail);
-        smtpProtocol.addRecipient(rcpt);
 
         // this should give a 501 code cause the helo/ehlo could not resolved
         assertThat(smtpProtocol.getReplyCode())
@@ -875,7 +874,6 @@ public class SMTPServerTest {
 
             smtpProtocol1.sendCommand("helo", helo1);
             smtpProtocol1.setSender(mail);
-            smtpProtocol1.addRecipient(rcpt);
 
             // this should give a 501 code cause the helo not equal reverse of
             // ip
@@ -1153,7 +1151,6 @@ public class SMTPServerTest {
 
             smtpProtocol1.sendCommand("ehlo", ehlo1);
             smtpProtocol1.setSender(mail);
-            smtpProtocol1.addRecipient(rcpt);
 
             // this should give a 501 code cause the ehlo not equals reverse of
             // ip
@@ -1295,7 +1292,6 @@ public class SMTPServerTest {
 
         smtpProtocol.setSender(sender);
 
-        smtpProtocol.addRecipient("mail@sample.com");
         assertThat(smtpProtocol.getReplyCode())
             .as("expected 530 error")
             .isEqualTo(530);
@@ -1324,6 +1320,8 @@ public class SMTPServerTest {
         assertThat(smtpProtocol.getReplyCode())
             .as("authenticated")
             .isEqualTo(235);
+
+        smtpProtocol.setSender(sender);
 
         smtpProtocol.sendCommand("AUTH PLAIN");
         assertThat(smtpProtocol.getReplyCode())
@@ -1744,7 +1742,7 @@ public class SMTPServerTest {
         String userName = USER_LOCALHOST;
         String sender = USER_LOCALHOST;
 
-        smtpProtocol.setSender(sender);
+        //smtpProtocol.setSender(sender);
 
         usersRepository.addUser(Username.of(userName), "pwd");
 
@@ -1753,6 +1751,11 @@ public class SMTPServerTest {
         assertThat(smtpProtocol.getReplyCode())
             .as("authenticated")
             .isEqualTo(235);
+
+        smtpProtocol.setSender(sender);
+        assertThat(smtpProtocol.getReplyCode())
+            .as("authenticated.. not reject")
+            .isEqualTo(250);
 
         smtpProtocol.addRecipient("mail@sample.com");
         assertThat(smtpProtocol.getReplyCode())
@@ -1786,8 +1789,6 @@ public class SMTPServerTest {
         String sender = USER_LOCALHOST;
 
         smtpProtocol.setSender(sender);
-
-        smtpProtocol.addRecipient("mail@sample.com");
         assertThat(smtpProtocol.getReplyCode())
             .as("reject")
             .isEqualTo(554);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
@@ -183,47 +183,39 @@ public class SPFHandlerTest {
     @Test
     public void testSPFpass() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf1.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf1.james.apache.org");
         SPFHandler spf = new SPFHandler();
 
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFfail() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf2.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf2.james.apache.org");
         SPFHandler spf = new SPFHandler();
 
         spf.setDNSService(mockedDnsService);
 
-        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFsoftFail() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf3.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf3.james.apache.org");
         SPFHandler spf = new SPFHandler();
 
         spf.setDNSService(mockedDnsService);
 
-        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFsoftFailRejectEnabled() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf3.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
-
         setupMockedSMTPSession("192.168.100.1", "spf3.james.apache.org");
         SPFHandler spf = new SPFHandler();
 
@@ -231,15 +223,12 @@ public class SPFHandlerTest {
 
         spf.setBlockSoftFail(true);
 
-        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFpermError() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf4.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
-
         setupMockedSMTPSession("192.168.100.1", "spf4.james.apache.org");
         SPFHandler spf = new SPFHandler();
 
@@ -247,14 +236,12 @@ public class SPFHandlerTest {
 
         spf.setBlockSoftFail(true);
 
-        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFtempError() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf5.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf5.james.apache.org");
 
@@ -262,14 +249,12 @@ public class SPFHandlerTest {
 
         spf.setDNSService(mockedDnsService);
 
-        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
+        assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
     }
 
     @Test
     public void testSPFNoRecord() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf6.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf6.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -277,13 +262,11 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFpermErrorRejectDisabled() throws Exception {
         MaybeSender sender = MaybeSender.of(new MailAddress("test@spf4.james.apache.org"));
-        MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf4.james.apache.org");
         SPFHandler spf = new SPFHandler();
 
@@ -292,6 +275,5 @@ public class SPFHandlerTest {
         spf.setBlockPermError(false);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 }

--- a/src/homepage/howTo/custom-smtp-commands.html
+++ b/src/homepage/howTo/custom-smtp-commands.html
@@ -100,7 +100,7 @@ public class MyCmdHandlerLoader implements HandlersPackage {
             MailSizeEsmtpExtension.class,
             UsersRepositoryAuthHook.class,
             AuthRequiredToRelayRcptHook.class,
-            SenderAuthIdentifyVerificationRcptHook.class,
+            SenderAuthIdentifyVerificationHook.class,
             PostmasterAbuseRcptHook.class,
             ReceivedDataLineFilter.class,
             DataLineJamesMessageHookHandler.class,


### PR DESCRIPTION
…to call it as soon as possible after SMTP authentication.

At the moment the DNSRBL handler is implemented as a RcptHook. Thus, for every RCPT TO call this handler will be called and a blocklist lookup will be issued.

One can argue It makes sense to implement the handler as a ConnectHandler, so the blocklist check is done as early as possible. However, if SMTP AUTH is successful then we should allow the connecting client anyway.

Therefore it makes sense to implement the DNSRBL handler at MAIL FROM stage that is MailHook. One caveat: According to [RFC 4954](https://datatracker.ietf.org/doc/html/rfc4954#section-5), authentication information can optionally provided as ESMTP AUTH parameter with a single value in the 'MAIL FROM:' command.