### PR TITLE
JAMES-3827 Improve indexing of email address domains

### DIFF
--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/MailboxMappingFactory.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/MailboxMappingFactory.java
@@ -45,6 +45,7 @@ import org.opensearch.common.xcontent.XContentBuilder;
 
 public class MailboxMappingFactory {
     private static final String STANDARD = "standard";
+    private static final String SIMPLE = "simple";
     private static final String STORE = "store";
 
     public static XContentBuilder getMappingContent() {
@@ -135,6 +136,11 @@ public class MailboxMappingFactory {
                                     .field(TYPE, JsonMessageConstants.TEXT)
                                     .field(ANALYZER, KEEP_MAIL_AND_URL)
                                 .endObject()
+                                .startObject(JsonMessageConstants.EMailer.DOMAIN)
+                                    .field(TYPE, JsonMessageConstants.TEXT)
+                                    .field(ANALYZER, SIMPLE)
+                                    .field(SEARCH_ANALYZER, KEYWORD)
+                                .endObject()
                                 .startObject(JsonMessageConstants.EMailer.ADDRESS)
                                     .field(TYPE, JsonMessageConstants.TEXT)
                                     .field(ANALYZER, STANDARD)
@@ -179,6 +185,11 @@ public class MailboxMappingFactory {
                                     .field(TYPE, JsonMessageConstants.TEXT)
                                     .field(ANALYZER, KEEP_MAIL_AND_URL)
                                 .endObject()
+                                .startObject(JsonMessageConstants.EMailer.DOMAIN)
+                                    .field(TYPE, JsonMessageConstants.TEXT)
+                                    .field(ANALYZER, SIMPLE)
+                                    .field(SEARCH_ANALYZER, KEYWORD)
+                                .endObject()
                                 .startObject(JsonMessageConstants.EMailer.ADDRESS)
                                     .field(TYPE, JsonMessageConstants.TEXT)
                                     .field(ANALYZER, STANDARD)
@@ -199,6 +210,11 @@ public class MailboxMappingFactory {
                                     .field(TYPE, JsonMessageConstants.TEXT)
                                     .field(ANALYZER, KEEP_MAIL_AND_URL)
                                 .endObject()
+                                .startObject(JsonMessageConstants.EMailer.DOMAIN)
+                                    .field(TYPE, JsonMessageConstants.TEXT)
+                                    .field(ANALYZER, SIMPLE)
+                                    .field(SEARCH_ANALYZER, KEYWORD)
+                                .endObject()
                                 .startObject(JsonMessageConstants.EMailer.ADDRESS)
                                     .field(TYPE, JsonMessageConstants.TEXT)
                                     .field(ANALYZER, STANDARD)
@@ -218,6 +234,11 @@ public class MailboxMappingFactory {
                                 .startObject(JsonMessageConstants.EMailer.NAME)
                                     .field(TYPE, JsonMessageConstants.TEXT)
                                     .field(ANALYZER, KEEP_MAIL_AND_URL)
+                                .endObject()
+                                .startObject(JsonMessageConstants.EMailer.DOMAIN)
+                                    .field(TYPE, JsonMessageConstants.TEXT)
+                                    .field(ANALYZER, SIMPLE)
+                                    .field(SEARCH_ANALYZER, KEYWORD)
                                 .endObject()
                                 .startObject(JsonMessageConstants.EMailer.ADDRESS)
                                     .field(TYPE, JsonMessageConstants.TEXT)

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/EMailer.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/EMailer.java
@@ -30,10 +30,19 @@ public class EMailer implements SerializableMessage {
 
     private final Optional<String> name;
     private final String address;
+    private final String domain;
 
-    public EMailer(Optional<String> name, String address) {
+    public EMailer(Optional<String> name, String address, String domain) {
         this.name = name;
         this.address = address;
+        this.domain = la(domain);
+    }
+
+    String la(String s) {
+        if (s.contains(".")) {
+            return s.substring(0, s.lastIndexOf('.'));
+        }
+        return s;
     }
 
     @JsonProperty(JsonMessageConstants.EMailer.NAME)
@@ -46,6 +55,11 @@ public class EMailer implements SerializableMessage {
         return address;
     }
 
+    @JsonProperty(JsonMessageConstants.EMailer.DOMAIN)
+    public String getDomain() {
+        return domain;
+    }
+
     @Override
     public String serialize() {
         return Joiner.on(" ").join(name.orElse(" "), address);
@@ -56,14 +70,15 @@ public class EMailer implements SerializableMessage {
         if (o instanceof EMailer) {
             EMailer otherEMailer = (EMailer) o;
             return Objects.equals(name, otherEMailer.name)
-                && Objects.equals(address, otherEMailer.address);
+                && Objects.equals(address, otherEMailer.address)
+                && Objects.equals(domain, otherEMailer.domain);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(name, address);
+        return Objects.hash(name, address, domain);
     }
 
     @Override
@@ -71,6 +86,7 @@ public class EMailer implements SerializableMessage {
         return MoreObjects.toStringHelper(this)
             .add("name", name)
             .add("address", address)
+            .add("domain", domain)
             .toString();
     }
 }

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/EMailer.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/EMailer.java
@@ -35,10 +35,10 @@ public class EMailer implements SerializableMessage {
     public EMailer(Optional<String> name, String address, String domain) {
         this.name = name;
         this.address = address;
-        this.domain = la(domain);
+        this.domain = removeTopDomain(domain);
     }
 
-    String la(String s) {
+    String removeTopDomain(String s) {
         if (s.contains(".")) {
             return s.substring(0, s.lastIndexOf('.'));
         }

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/HeaderCollection.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/HeaderCollection.java
@@ -150,7 +150,7 @@ public class HeaderCollection {
                 .parseAddressList(rawHeaderValue)
                 .flatten()
                 .stream()
-                .map(mailbox -> new EMailer(Optional.ofNullable(mailbox.getName()), mailbox.getAddress()))
+                .map(mailbox -> new EMailer(Optional.ofNullable(mailbox.getName()), mailbox.getAddress(), mailbox.getDomain()))
                 .forEach(addressSet::add);
         }
 

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/JsonMessageConstants.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/JsonMessageConstants.java
@@ -58,6 +58,7 @@ public interface JsonMessageConstants {
     interface EMailer {
         String NAME = "name";
         String ADDRESS = "address";
+        String DOMAIN = "domain";
     }
 
     interface HEADER {

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/CriterionConverter.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/CriterionConverter.java
@@ -93,7 +93,6 @@ public class CriterionConverter {
     }
     
     private void registerHeaderOperatorConverters() {
-
         registerHeaderOperatorConverter(
             SearchQuery.ExistsOperator.class,
             (headerName, operator) ->
@@ -276,6 +275,7 @@ public class CriterionConverter {
         return boolQuery()
             .should(matchQuery(getFieldNameFromHeaderName(headerName) + "." + JsonMessageConstants.EMailer.NAME, value))
             .should(matchQuery(getFieldNameFromHeaderName(headerName) + "." + JsonMessageConstants.EMailer.ADDRESS, value))
+            .should(matchQuery(getFieldNameFromHeaderName(headerName) + "." + JsonMessageConstants.EMailer.DOMAIN, value))
             .should(matchQuery(getFieldNameFromHeaderName(headerName) + "." + JsonMessageConstants.EMailer.ADDRESS + "." + RAW, value));
     }
 

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/EMailersTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/EMailersTest.java
@@ -47,7 +47,7 @@ class EMailersTest {
 
     @Test
     void serializeShouldNotJoinWhenOneElement() {
-        EMailer emailer = new EMailer(Optional.of("name"), "address");
+        EMailer emailer = new EMailer(Optional.of("name"), "address@domain.tld", "domain.tld");
         EMailers eMailers = EMailers.from(ImmutableSet.of(emailer));
 
         assertThat(eMailers.serialize()).isEqualTo(emailer.serialize());
@@ -55,9 +55,9 @@ class EMailersTest {
 
     @Test
     void serializeShouldJoinWhenMultipleElements() {
-        EMailer emailer = new EMailer(Optional.of("name"), "address");
-        EMailer emailer2 = new EMailer(Optional.of("name2"), "address2");
-        EMailer emailer3 = new EMailer(Optional.of("name3"), "address3");
+        EMailer emailer = new EMailer(Optional.of("name"), "address@domain.tld", "domain.tld");
+        EMailer emailer2 = new EMailer(Optional.of("name2"), "address2@domain.tld", "domain.tld");
+        EMailer emailer3 = new EMailer(Optional.of("name3"), "address3@domain.tld", "domain.tld");
 
         String expected = Joiner.on(" ").join(emailer.serialize(), emailer2.serialize(), emailer3.serialize());
 

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/HeaderCollectionTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/HeaderCollectionTest.java
@@ -56,7 +56,7 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getToAddressSet())
-            .containsOnly(new EMailer(Optional.empty(), "ben.tellier@linagora.com"));
+            .containsOnly(new EMailer(Optional.empty(), "ben.tellier@linagora.com", "linagora.com"));
     }
 
     @Test
@@ -67,8 +67,8 @@ class HeaderCollectionTest {
 
         assertThat(headerCollection.getToAddressSet())
             .containsOnly(
-                new EMailer(Optional.empty(), "ben.tellier@linagora.com"),
-                new EMailer(Optional.empty(), "btellier@minet.net"));
+                new EMailer(Optional.empty(), "ben.tellier@linagora.com", "linagora.com"),
+                new EMailer(Optional.empty(), "btellier@minet.net", "minet.net"));
     }
 
     @Test
@@ -80,8 +80,8 @@ class HeaderCollectionTest {
 
         assertThat(headerCollection.getToAddressSet())
             .containsOnly(
-                new EMailer(Optional.empty(), "ben.tellier@linagora.com"),
-                new EMailer(Optional.empty(), "btellier@minet.net"));
+                new EMailer(Optional.empty(), "ben.tellier@linagora.com", "linagora.com"),
+                new EMailer(Optional.empty(), "btellier@minet.net", "minet.net"));
     }
 
     @Test
@@ -91,7 +91,7 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getToAddressSet())
-            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com"));
+            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com", "linagora.com"));
     }
 
     @ParameterizedTest
@@ -134,8 +134,8 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getFromAddressSet())
-            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com"),
-                new EMailer(Optional.of("Graham CROSMARIE"), "grah.crosmarie@linagora.com"));
+            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com", "linagora.com"),
+                new EMailer(Optional.of("Graham CROSMARIE"), "grah.crosmarie@linagora.com", "linagora.com"));
     }
 
     @Test
@@ -146,8 +146,8 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getFromAddressSet())
-            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com"),
-                new EMailer(Optional.of("Graham CROSMARIE"), "grah.crosmarie@linagora.com"));
+            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com", "linagora.com"),
+                new EMailer(Optional.of("Graham CROSMARIE"), "grah.crosmarie@linagora.com", "linagora.com"));
     }
 
     @Test
@@ -170,8 +170,8 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getToAddressSet())
-            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com"),
-                new EMailer(Optional.empty(), "grah.crosmarie@linagora.com"));
+            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com", "linagora.com"),
+                new EMailer(Optional.empty(), "grah.crosmarie@linagora.com", "linagora.com"));
     }
 
     @Test
@@ -181,7 +181,7 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getCcAddressSet())
-            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com"));
+            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com", "linagora.com"));
     }
 
     @Test
@@ -191,7 +191,7 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getReplyToAddressSet())
-            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com"));
+            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com", "linagora.com"));
     }
 
     @Test
@@ -201,7 +201,7 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getBccAddressSet())
-            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com"));
+            .containsOnly(new EMailer(Optional.of("Christophe Hamerling"), "chri.hamerling@linagora.com", "linagora.com"));
     }
 
     @Test
@@ -211,7 +211,7 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getBccAddressSet())
-            .containsOnly(new EMailer(Optional.of("Mickey"), "tricky@mouse.com"));
+            .containsOnly(new EMailer(Optional.of("Mickey"), "tricky@mouse.com", "mouse.com"));
     }
 
     @Test
@@ -221,8 +221,8 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getBccAddressSet())
-            .containsOnly(new EMailer(Optional.of("Mickey"), "tricky@mouse.com"),
-                new EMailer(Optional.of("Miny"), "hello@polo.com"));
+            .containsOnly(new EMailer(Optional.of("Mickey"), "tricky@mouse.com", "mouse.com"),
+                new EMailer(Optional.of("Miny"), "hello@polo.com", "polo.com"));
     }
 
     @Test
@@ -232,8 +232,8 @@ class HeaderCollectionTest {
             .build();
 
         assertThat(headerCollection.getBccAddressSet())
-            .containsOnly(new EMailer(Optional.of("Mickey"), "tricky@mouse.com"),
-                new EMailer(Optional.of("Miny"), "hello@polo.com"));
+            .containsOnly(new EMailer(Optional.of("Mickey"), "tricky@mouse.com", "mouse.com"),
+                new EMailer(Optional.of("Miny"), "hello@polo.com", "polo.com"));
     }
 
     @Test

--- a/mailbox/opensearch/src/test/resources/eml/inlined-mixed.json
+++ b/mailbox/opensearch/src/test/resources/eml/inlined-mixed.json
@@ -21,7 +21,8 @@
     "date": "2015-06-07T00:00:00+0200",
     "from": [{
         "name": "Bob",
-        "address": "bob@domain.tld"
+        "address": "bob@domain.tld",
+        "domain":"domain"
     }],
     "hasAttachment": false,
     "headers": [{
@@ -63,7 +64,8 @@
     "subtype": "text",
     "to": [{
         "name": "Alice",
-        "address": "alice@domain.tld"
+        "address": "alice@domain.tld",
+        "domain":"domain"
     }],
     "uid": 25,
     "userFlags": [],

--- a/mailbox/store/src/test/resources/eml/emailWithNonIndexableAttachmentWithoutAttachment.json
+++ b/mailbox/store/src/test/resources/eml/emailWithNonIndexableAttachmentWithoutAttachment.json
@@ -23,7 +23,8 @@
    "from" : [
       {
          "address" : "laura.ro@linagora.com",
-         "name" : "Laura ROYET"
+         "name" : "Laura ROYET",
+         "domain":"linagora"
       }
    ],
    "isUnread" : false,
@@ -69,7 +70,8 @@
    "to" : [
       {
          "address" : "laura.ro@linagora.com",
-         "name" : "Laura ROYET"
+         "name" : "Laura ROYET",
+         "domain":"linagora"
       }
    ]
 }

--- a/mailbox/store/src/test/resources/eml/htmlMail.json
+++ b/mailbox/store/src/test/resources/eml/htmlMail.json
@@ -101,13 +101,15 @@
   "from":[
     {
       "name":"Airbnb",
-      "address":"discover@airbnb.com"
+      "address":"discover@airbnb.com",
+      "domain":"airbnb"
     }
   ],
   "to":[
     {
       "name":null,
-      "address":"mister@james.org"
+      "address":"mister@james.org",
+      "domain":"james"
     }
   ],
   "cc":[],

--- a/mailbox/store/src/test/resources/eml/invalidCharset.json
+++ b/mailbox/store/src/test/resources/eml/invalidCharset.json
@@ -5,7 +5,11 @@
   "textBody":"This is an inline attachment: Cheers!",
   "cc":[],
   "date":"2015-06-07T00:00:00+0200",
-  "from":[{"name":"Antoine DUPRAT","address":"xyz@linagora.com"}],
+  "from":[{
+    "name":"Antoine DUPRAT",
+    "address":"xyz@linagora.com",
+    "domain":"linagora"
+  }],
   "hasAttachment":false,
   "headers":[
     {"name":"to","value":"Antoine DUPRAT <xyz@linagora.com>"},
@@ -26,7 +30,11 @@
   "size":25,
   "subject":["Inline attachment"],
   "subtype":"text",
-  "to":[{"name":"Antoine DUPRAT","address":"xyz@linagora.com"}],
+  "to":[{
+    "name":"Antoine DUPRAT",
+    "address":"xyz@linagora.com",
+    "domain":"linagora"
+  }],
   "uid":25,
   "userFlags":[],
   "mimeMessageID":"<26d91590-b995-8d45-f66a-0433c65745bb@linagora.com>",

--- a/mailbox/store/src/test/resources/eml/mail.json
+++ b/mailbox/store/src/test/resources/eml/mail.json
@@ -143,17 +143,20 @@
  "from": [
   {
    "name": "Murari",
-   "address": "murari.ksr@gmail.com"
+   "address": "murari.ksr@gmail.com",
+    "domain":"gmail"
   }
  ],
  "to": [
   {
    "name": "General Discussion about Arch Linux",
-   "address": "arch-general@archlinux.org"
+   "address": "arch-general@archlinux.org",
+    "domain":"archlinux"
   },
   {
    "name": "Üsteliğhan Maşrapa",
-   "address": "ustelighanmasrapa@domain.tld"
+   "address": "ustelighanmasrapa@domain.tld",
+    "domain":"domain"
   }
  ],
  "cc": [],

--- a/mailbox/store/src/test/resources/eml/nonTextual.json
+++ b/mailbox/store/src/test/resources/eml/nonTextual.json
@@ -13,7 +13,11 @@
   "textBody":"This mail have a non textual attachment !\r\n",
   "cc":[],
   "date":"2015-06-07T00:00:00+0200",
-  "from":[{"name":"Benoit Tellier","address":"btellier@linagora.com"}],
+  "from":[{
+    "name":"Benoit Tellier",
+    "address":"btellier@linagora.com",
+    "domain":"linagora"
+  }],
   "hasAttachment":false,
   "headers": [{
     "name": "return-path",
@@ -61,7 +65,11 @@
   "size":25,
   "subject":["Test message"],
   "subtype":"text",
-  "to":[{"name":null,"address":"btellier@linagora.com"}],
+  "to":[{
+    "name":null,
+    "address":"btellier@linagora.com",
+    "domain":"linagora"
+  }],
   "uid":25,
   "userFlags":[],
   "mimeMessageID":"<5582A0CE.4020801@linagora.com>",

--- a/mailbox/store/src/test/resources/eml/pgpSignedMail.json
+++ b/mailbox/store/src/test/resources/eml/pgpSignedMail.json
@@ -146,13 +146,15 @@
   "from": [
 	{
 	  "name": "Markus Koschany",
-	  "address": "apo@gambaru.de"
+	  "address": "apo@gambaru.de",
+	  "domain": "gambaru"
 	}
   ],
   "to": [
 	{
 	  "name": null,
-	  "address": "debian-security-announce@lists.debian.org"
+	  "address": "debian-security-announce@lists.debian.org",
+	  "domain": "lists.debian"
 	}
   ],
   "cc": [],

--- a/mailbox/store/src/test/resources/eml/recursiveMail.json
+++ b/mailbox/store/src/test/resources/eml/recursiveMail.json
@@ -62,13 +62,15 @@
   "from": [
     {
       "name": "Matthieu Baechler",
-      "address": "mbaechler@linagora.com"
+      "address": "mbaechler@linagora.com",
+      "domain": "linagora"
     }
   ],
   "to": [
     {
       "name": null,
-      "address": "btellier@linagora.com"
+      "address": "btellier@linagora.com",
+      "domain": "linagora"
     }
   ],
   "cc": [],

--- a/mailbox/store/src/test/resources/eml/recursiveMailWithoutAttachments.json
+++ b/mailbox/store/src/test/resources/eml/recursiveMailWithoutAttachments.json
@@ -62,13 +62,15 @@
   "from": [
     {
       "name": "Matthieu Baechler",
-      "address": "mbaechler@linagora.com"
+      "address": "mbaechler@linagora.com",
+      "domain": "linagora"
     }
   ],
   "to": [
     {
       "name": null,
-      "address": "btellier@linagora.com"
+      "address": "btellier@linagora.com",
+      "domain":"linagora"
     }
   ],
   "cc": [],

--- a/mailbox/store/src/test/resources/eml/spamMail.json
+++ b/mailbox/store/src/test/resources/eml/spamMail.json
@@ -101,13 +101,15 @@
   "from": [
 	{
 	  "name": "Content-filter at spam.minet.net",
-	  "address": "postmaster@minet.net"
+	  "address": "postmaster@minet.net",
+	  "domain": "minet"
 	}
   ],
   "to": [
 	{
 	  "name": null,
-	  "address": "root@listes.minet.net"
+	  "address": "root@listes.minet.net",
+      "domain": "listes.minet"
 	}
   ],
   "cc": [],


### PR DESCRIPTION
Given an email with `bob@domain.tld`

-> `bob@domain.tld` matches
-> `bob` (localpart) matches
-> `domain.tld` (domain) matches
-> `domain` (part of the domain) do not match. (and it should).

I think we could easily propose a better 'search experience' by improving indexing and searches for domains.

Traps to avoid:

Given `bob@domain.tld` search we should not return results of other addresses of `domain.tld` domain.

Given `domain.tld` search we should not return unrelated search results from the `tld` top-domain.

migration strategy will be aturaly covered upon the OpenSearch migration.