### PR TITLE
JAMES-3828 Rework AttibuteValue duplication; reject invalid values early

### DIFF
--- a/mailet/amqp/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
+++ b/mailet/amqp/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
@@ -228,7 +228,8 @@ public class AmqpForwardAttribute extends GenericMailet {
     @SuppressWarnings("unchecked")
     private Optional<Stream<byte[]>> extractAttributeValueContent(Object attributeContent) {
         if (attributeContent instanceof Map) {
-            return Optional.of(((Map<String, byte[]>) attributeContent).values().stream());
+            return Optional.of(((Map<String, AttributeValue<byte[]>>) attributeContent).values().stream()
+                .map(AttributeValue::getValue));
         }
         if (attributeContent instanceof List) {
             return Optional.of(((List<AttributeValue<byte[]>>) attributeContent).stream().map(AttributeValue::value));

--- a/mailet/amqp/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttributeTest.java
+++ b/mailet/amqp/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttributeTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import javax.mail.MessagingException;
@@ -46,17 +45,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
-import com.google.common.collect.ImmutableMap;
-
 class AmqpForwardAttributeTest {
 
     private static final AttributeName MAIL_ATTRIBUTE = AttributeName.of("ampq.attachments");
     private static final String EXCHANGE_NAME = "exchangeName";
     private static final String ROUTING_KEY = "routingKey";
     private static final String AMQP_URI = "amqp://host";
-    private static final byte[] ATTACHMENT_CONTENT = "Attachment content".getBytes(StandardCharsets.UTF_8);
-    private static final ImmutableMap<String, byte[]> ATTRIBUTE_VALUE = ImmutableMap.of("attachment1.txt", ATTACHMENT_CONTENT);
-    private static final Optional<Attribute> ATTRIBUTE_CONTENT = Optional.of(new Attribute(MAIL_ATTRIBUTE, AttributeValue.ofAny(ATTRIBUTE_VALUE)));
 
     private AmqpForwardAttribute mailet;
     private MailetContext mailetContext;

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -60,6 +60,11 @@ public class AttributeValue<T> {
         return new AttributeValue<>(value, Serializer.STRING_SERIALIZER);
     }
 
+    public static AttributeValue<byte[]> of(byte[] value) {
+        Preconditions.checkNotNull(value, "value should not be null");
+        return new AttributeValue<>(value, Serializer.BYTES_SERIALIZER);
+    }
+
     public static AttributeValue<Integer> of(Integer value) {
         Preconditions.checkNotNull(value, "value should not be null");
         return new AttributeValue<>(value, Serializer.INT_SERIALIZER);
@@ -136,6 +141,9 @@ public class AttributeValue<T> {
         }
         if (value instanceof String) {
             return of((String) value);
+        }
+        if (value instanceof byte[]) {
+            return of((byte[]) value);
         }
         if (value instanceof Integer) {
             return of((Integer) value);

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -244,10 +244,8 @@ public class AttributeValue<T> {
         }
     }
 
-    //FIXME : poor performance
-    @SuppressWarnings("unchecked")
     public AttributeValue<T> duplicate() {
-        return (AttributeValue<T>) fromJson(toJson());
+        return new AttributeValue<>(serializer.duplicate(value), serializer);
     }
 
     public JsonNode toJson() {

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -189,15 +189,6 @@ public class AttributeValue<T> {
         return fromJson(tree);
     }
 
-    public static Optional<AttributeValue<?>> optionalFromJsonString(String json) {
-        try {
-            return Optional.of(fromJsonString(json));
-        } catch (IOException e) {
-            LOGGER.error("Error while deserializing '" + json + "'", e);
-            return Optional.empty();
-        }
-    }
-
     public static AttributeValue<?> fromJson(JsonNode input) {
         return Optional.ofNullable(input)
                 .filter(ObjectNode.class::isInstance)

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -102,18 +102,24 @@ public class AttributeValue<T> {
 
     public static <T> AttributeValue<Optional<AttributeValue<T>>> of(Optional<AttributeValue<T>> value) {
         Preconditions.checkNotNull(value, "value should not be null");
+        Preconditions.checkArgument(value.map(v -> v instanceof AttributeValue).orElse(true),
+            "value should be of type Optional<AttributeValue<T>> and was not");
         return new AttributeValue<>(value, new Serializer.OptionalSerializer<>());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static AttributeValue<Collection<AttributeValue<?>>> of(Collection<AttributeValue<?>> value) {
         Preconditions.checkNotNull(value, "value should not be null");
+        Preconditions.checkArgument(value.stream().allMatch(entry -> entry instanceof AttributeValue),
+            "Expecting Collection<AttributeValue<?>: invalid typing.");
         return new AttributeValue<>(value, new Serializer.CollectionSerializer());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static AttributeValue<Map<String, AttributeValue<?>>> of(Map<String, AttributeValue<?>> value) {
         Preconditions.checkNotNull(value, "value should not be null");
+        Preconditions.checkArgument(value.entrySet().stream().allMatch(entry -> (entry.getKey() instanceof String) && (entry.getValue() instanceof AttributeValue)),
+            "Expecting Map<String, AttributeValue<?>>: invalid typing.");
         return new AttributeValue<>(value, new Serializer.MapSerializer());
     }
 

--- a/mailet/api/src/main/java/org/apache/mailet/Serializer.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Serializer.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.mailbox.model.MessageIdDto;
 import org.apache.james.util.streams.Iterators;
 import org.nustaq.serialization.FSTConfiguration;
@@ -70,6 +71,8 @@ public interface Serializer<T> {
     Optional<T> deserialize(JsonNode json);
 
     String getName();
+
+    T duplicate(T value);
 
     class Registry {
 
@@ -116,6 +119,11 @@ public interface Serializer<T> {
         }
 
         @Override
+        public Boolean duplicate(Boolean value) {
+            return value;
+        }
+
+        @Override
         public String getName() {
             return "BooleanSerializer";
         }
@@ -149,6 +157,11 @@ public interface Serializer<T> {
         }
 
         @Override
+        public String duplicate(String value) {
+            return value;
+        }
+
+        @Override
         public String getName() {
             return "StringSerializer";
         }
@@ -179,6 +192,11 @@ public interface Serializer<T> {
             } else {
                 return Optional.empty();
             }
+        }
+
+        @Override
+        public Integer duplicate(Integer value) {
+            return value;
         }
 
         @Override
@@ -217,6 +235,11 @@ public interface Serializer<T> {
         }
 
         @Override
+        public Long duplicate(Long value) {
+            return value;
+        }
+
+        @Override
         public String getName() {
             return "LongSerializer";
         }
@@ -252,6 +275,11 @@ public interface Serializer<T> {
         }
 
         @Override
+        public Float duplicate(Float value) {
+            return value;
+        }
+
+        @Override
         public String getName() {
             return "FloatSerializer";
         }
@@ -282,6 +310,11 @@ public interface Serializer<T> {
             } else {
                 return Optional.empty();
             }
+        }
+
+        @Override
+        public Double duplicate(Double value) {
+            return value;
         }
 
         @Override
@@ -320,6 +353,11 @@ public interface Serializer<T> {
         }
 
         @Override
+        public ZonedDateTime duplicate(ZonedDateTime value) {
+            return ZonedDateTime.ofInstant(value.toInstant(), value.getZone());
+        }
+
+        @Override
         public String getName() {
             return "DateSerializer";
         }
@@ -350,6 +388,11 @@ public interface Serializer<T> {
             return STRING_SERIALIZER
                     .deserialize(json)
                     .map(MessageIdDto::new);
+        }
+
+        @Override
+        public MessageIdDto duplicate(MessageIdDto value) {
+            return value;
         }
 
         @Override
@@ -426,6 +469,11 @@ public interface Serializer<T> {
         public int hashCode() {
             return Objects.hash(getClass());
         }
+
+        @Override
+        public T duplicate(T value) {
+            return deserialize(serialize(value)).get();
+        }
     }
 
     class UrlSerializer implements Serializer<URL> {
@@ -459,6 +507,11 @@ public interface Serializer<T> {
         public int hashCode() {
             return Objects.hash(getClass());
         }
+
+        @Override
+        public URL duplicate(URL value) {
+            return value;
+        }
     }
 
     Serializer<URL> URL_SERIALIZER = new UrlSerializer();
@@ -482,6 +535,13 @@ public interface Serializer<T> {
             } else {
                 return Optional.empty();
             }
+        }
+
+        @Override
+        public Collection<AttributeValue<U>> duplicate(Collection<AttributeValue<U>> value) {
+            return value.stream()
+                .map(AttributeValue::duplicate)
+                .collect(ImmutableList.toImmutableList());
         }
 
         @Override
@@ -523,6 +583,14 @@ public interface Serializer<T> {
         }
 
         @Override
+        public Map<String, AttributeValue<U>> duplicate(Map<String, AttributeValue<U>> value) {
+            return value.entrySet()
+                .stream()
+                .map(entry -> Pair.of(entry.getKey(), entry.getValue().duplicate()))
+                .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+        }
+
+        @Override
         public String getName() {
             return "MapSerializer";
         }
@@ -556,6 +624,11 @@ public interface Serializer<T> {
             } else {
                 return Optional.empty();
             }
+        }
+
+        @Override
+        public Optional<AttributeValue<U>> duplicate(Optional<AttributeValue<U>> value) {
+            return value.map(AttributeValue::duplicate);
         }
 
         @Override
@@ -594,6 +667,11 @@ public interface Serializer<T> {
             } catch (JsonProcessingException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+
+        @Override
+        public Serializable duplicate(Serializable value) {
+            return deserialize(serialize(value)).get();
         }
 
         @Override

--- a/mailet/api/src/main/java/org/apache/mailet/Serializer.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Serializer.java
@@ -27,6 +27,7 @@ import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZonedDateTime;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +90,7 @@ public interface Serializer<T> {
                     DOUBLE_SERIALIZER,
                     DATE_SERIALIZER,
                     MESSAGE_ID_DTO_SERIALIZER,
+                    BYTES_SERIALIZER,
                     new Serializer.ArbitrarySerializableSerializer<>(),
                     URL_SERIALIZER,
                     new CollectionSerializer<>(),
@@ -677,6 +679,42 @@ public interface Serializer<T> {
         @Override
         public String getName() {
             return "FSTSerializer";
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getClass());
+        }
+    }
+
+    Serializer<byte[]> BYTES_SERIALIZER = new BytesSerializer();
+
+    class BytesSerializer implements Serializer<byte[]> {
+
+        @Override
+        public JsonNode serialize(byte[] object) {
+            return STRING_SERIALIZER.serialize(Base64.getEncoder().encodeToString(object));
+        }
+
+        @Override
+        public Optional<byte[]> deserialize(JsonNode json) {
+            return STRING_SERIALIZER.deserialize(json).map(Base64.getDecoder()::decode);
+        }
+
+        @Override
+        public String getName() {
+            return "BytesSerializer";
+        }
+
+        @Override
+        public byte[] duplicate(byte[] value) {
+            // Assume byte arrays never to be mutated
+            return value;
         }
 
         @Override

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
@@ -518,6 +518,14 @@ class AttributeValueTest {
             assertThatIllegalStateException()
                 .isThrownBy(() -> AttributeValue.fromJsonString("{\"serializer\":\"CollectionSerializer\",\"value\": {}}"));
         }
+
+        @Test
+        void ofShouldRejectIllegalTypes() {
+            ImmutableList invalidList = ImmutableList.of("b");
+
+            assertThatThrownBy(() -> AttributeValue.of(invalidList))
+                .isInstanceOf(ClassCastException.class);
+        }
     }
 
     @Nested
@@ -573,6 +581,14 @@ class AttributeValueTest {
             assertThatIllegalStateException()
                 .isThrownBy(() -> AttributeValue.fromJsonString("{\"serializer\":\"MapSerializer\",\"value\": []}"));
         }
+
+        @Test
+        void ofShouldRejectIllegalTypes() {
+            ImmutableMap invalid = ImmutableMap.of("b", "c");
+
+            assertThatThrownBy(() -> AttributeValue.of(invalid))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Nested
@@ -625,6 +641,14 @@ class AttributeValueTest {
         void fromJsonStringShouldThrowOnMalformedFormattedJson() {
             assertThatIllegalStateException()
                 .isThrownBy(() -> AttributeValue.fromJsonString("{\"serializer\":\"OptionalSerializer\",\"value\": []}"));
+        }
+
+        @Test
+        void ofShouldRejectIllegalTypes() {
+            Optional invalid = Optional.of("b");
+
+            assertThatThrownBy(() -> AttributeValue.of(invalid))
+                .isInstanceOf(ClassCastException.class);
         }
     }
 

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMECheckSignature.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMECheckSignature.java
@@ -206,12 +206,12 @@ public class SMIMECheckSignature extends GenericMailet {
         // If at least one mail signer is found 
         // the mail attributes are set.
         if (signers != null) {
-            ArrayList<X509Certificate> signerinfolist = new ArrayList<>();
+            ArrayList<AttributeValue<?>> signerinfolist = new ArrayList<>();
 
             for (SMIMESignerInfo info : signers) {
                 if (info.isSignValid()
                         && (!onlyTrusted || info.getCertPath() != null)) {
-                    signerinfolist.add(info.getSignerCertificate());
+                    signerinfolist.add(AttributeValue.ofSerializable(info.getSignerCertificate()));
                 }
             }
 

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMECheckSignature.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMECheckSignature.java
@@ -22,7 +22,6 @@
 package org.apache.james.transport.mailets;
 
 import java.io.IOException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -216,7 +215,7 @@ public class SMIMECheckSignature extends GenericMailet {
             }
 
             if (signerinfolist.size() > 0) {
-                mail.setAttribute(new Attribute(mailAttribute, AttributeValue.ofAny(signerinfolist)));
+                mail.setAttribute(new Attribute(mailAttribute, AttributeValue.of(signerinfolist)));
             } else {
                 // if no valid signers are found the message is not modified.
                 strippedMessage = null;

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMEDecrypt.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMEDecrypt.java
@@ -162,9 +162,9 @@ public class SMIMEDecrypt extends GenericMailet {
             // behavior of the SMIMEVerifySignature mailet. In that way
             // it is possible to reuse the same matchers to analyze
             // the result of the operation.
-            ArrayList<X509Certificate> list = new ArrayList<>(1);
-            list.add(keyHolder.getCertificate());
-            mail.setAttribute(new Attribute(mailAttribute, AttributeValue.ofAny(list)));
+            ArrayList<AttributeValue<?>> list = new ArrayList<>(1);
+            list.add(AttributeValue.ofSerializable(keyHolder.getCertificate()));
+            mail.setAttribute(new Attribute(mailAttribute, AttributeValue.of(list)));
 
             // I start the message stripping.
             try {

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToHeader.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToHeader.java
@@ -26,6 +26,7 @@ import javax.mail.internet.MimeMessage;
 
 import org.apache.mailet.AttributeName;
 import org.apache.mailet.AttributeUtils;
+import org.apache.mailet.AttributeValue;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 import org.slf4j.Logger;
@@ -62,7 +63,7 @@ import net.fortuna.ical4j.model.component.VEvent;
 public class ICALToHeader extends GenericMailet {
     private static final Logger LOGGER = LoggerFactory.getLogger(ICALToHeader.class);
     @SuppressWarnings("unchecked")
-    private static final Class<Map<String, Calendar>> MAP_STRING_CALENDAR = (Class<Map<String, Calendar>>) (Object) Map.class;
+    private static final Class<Map<String, AttributeValue<?>>> MAP_STRING_CALENDAR = (Class<Map<String, AttributeValue<?>>>) (Object) Map.class;
 
     public static final String ATTRIBUTE_PROPERTY = "attribute";
     public static final String ATTRIBUTE_DEFAULT_NAME = "icalendar";
@@ -105,11 +106,14 @@ public class ICALToHeader extends GenericMailet {
         }
     }
 
-    private void processCalendars(Map<String, Calendar> calendarMap, Mail mail) {
+    private void processCalendars(Map<String, AttributeValue<?>> calendarMap, Mail mail) {
         calendarMap
             .values()
             .stream()
             .findAny()
+            .map(AttributeValue::getValue)
+            .filter(Calendar.class::isInstance)
+            .map(Calendar.class::cast)
             .ifPresent(Throwing.<Calendar>consumer(calendar -> writeToHeaders(calendar, mail))
                     .sneakyThrow());
     }

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICalendarParser.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICalendarParser.java
@@ -69,7 +69,7 @@ import net.fortuna.ical4j.model.Calendar;
 public class ICalendarParser extends GenericMailet {
     private static final Logger LOGGER = LoggerFactory.getLogger(ICalendarParser.class);
     @SuppressWarnings("unchecked")
-    private static final Class<Map<String, byte[]>> MAP_STRING_BYTES_CLASS = (Class<Map<String, byte[]>>) (Object) Map.class;
+    private static final Class<Map<String, AttributeValue<byte[]>>> MAP_STRING_BYTES_CLASS = (Class<Map<String, AttributeValue<byte[]>>>) (Object) Map.class;
 
     public static final String SOURCE_ATTRIBUTE_PARAMETER_NAME = "sourceAttribute";
     public static final String DESTINATION_ATTRIBUTE_PARAMETER_NAME = "destinationAttribute";
@@ -116,13 +116,13 @@ public class ICalendarParser extends GenericMailet {
             .ifPresent(icsAttachments -> addCalendarsToAttribute(mail, icsAttachments));
     }
 
-    private void addCalendarsToAttribute(Mail mail, Map<String, byte[]> icsAttachments) {
-        Map<String, Calendar> calendars = icsAttachments.entrySet()
+    private void addCalendarsToAttribute(Mail mail, Map<String, AttributeValue<byte[]>> icsAttachments) {
+        Map<String, AttributeValue<?>> calendars = icsAttachments.entrySet()
             .stream()
-            .flatMap(entry -> createCalendar(entry.getKey(), entry.getValue()))
-            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+            .flatMap(entry -> createCalendar(entry.getKey(), entry.getValue().getValue()))
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, pair -> AttributeValue.ofSerializable(pair.getValue())));
 
-        mail.setAttribute(new Attribute(destinationAttributeName, AttributeValue.ofAny(calendars)));
+        mail.setAttribute(new Attribute(destinationAttributeName, AttributeValue.of(calendars)));
     }
 
     @Override

--- a/mailet/icalendar/src/test/java/org/apache/james/transport/mailets/ICALToHeadersTest.java
+++ b/mailet/icalendar/src/test/java/org/apache/james/transport/mailets/ICALToHeadersTest.java
@@ -22,6 +22,8 @@ package org.apache.james.transport.mailets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Map;
+
 import javax.mail.MessagingException;
 
 import org.apache.james.util.MimeMessageUtil;
@@ -102,7 +104,7 @@ class ICALToHeadersTest {
         Mail mail = FakeMail.builder()
             .name("mail")
             .mimeMessage(MimeMessageUtil.defaultMimeMessage())
-            .attribute(makeAttribute("This is the wrong type"))
+            .attribute(new Attribute(ICALToHeader.ATTRIBUTE_DEFAULT, AttributeValue.of("This is the wrong type")))
             .build();
 
         testee.service(mail);
@@ -112,8 +114,8 @@ class ICALToHeadersTest {
 
     @Test
     void serviceShouldNotFailOnMailsWithWrongParametrizedAttribute() throws Exception {
-        ImmutableMap<String, String> wrongParametrizedMap = ImmutableMap.<String, String>builder()
-            .put("key", "value")
+        ImmutableMap<String, AttributeValue<?>> wrongParametrizedMap = ImmutableMap.<String, AttributeValue<?>>builder()
+            .put("key", AttributeValue.of("value"))
             .build();
 
         testee.init(FakeMailetConfig.builder().build());
@@ -131,8 +133,8 @@ class ICALToHeadersTest {
     @Test
     void serviceShouldWriteSingleICalendarToHeaders() throws Exception {
         Calendar calendar = new CalendarBuilder().build(ClassLoader.getSystemResourceAsStream("ics/meeting.ics"));
-        ImmutableMap<String, Calendar> icals = ImmutableMap.<String, Calendar>builder()
-            .put("key", calendar)
+        Map<String, AttributeValue<?>> icals = ImmutableMap.<String, AttributeValue<?>>builder()
+            .put("key", AttributeValue.ofSerializable(calendar))
             .build();
 
         testee.init(FakeMailetConfig.builder().build());
@@ -158,8 +160,8 @@ class ICALToHeadersTest {
     @Test
     void serviceShouldNotWriteHeaderWhenPropertyIsAbsent() throws Exception {
         Calendar calendar = new CalendarBuilder().build(ClassLoader.getSystemResourceAsStream("ics/meeting_without_dtstamp.ics"));
-        ImmutableMap<String, Calendar> icals = ImmutableMap.<String, Calendar>builder()
-            .put("key", calendar)
+        Map<String, AttributeValue<?>> icals = ImmutableMap.<String, AttributeValue<?>>builder()
+            .put("key", AttributeValue.ofSerializable(calendar))
             .build();
 
         testee.init(FakeMailetConfig.builder().build());
@@ -185,9 +187,9 @@ class ICALToHeadersTest {
     void serviceShouldWriteOnlyOneICalendarToHeaders() throws Exception {
         Calendar calendar = new CalendarBuilder().build(ClassLoader.getSystemResourceAsStream("ics/meeting.ics"));
         Calendar calendar2 = new CalendarBuilder().build(ClassLoader.getSystemResourceAsStream("ics/meeting_2.ics"));
-        ImmutableMap<String, Calendar> icals = ImmutableMap.<String, Calendar>builder()
-            .put("key", calendar)
-            .put("key2", calendar2)
+        Map<String, AttributeValue<?>> icals = ImmutableMap.<String, AttributeValue<?>>builder()
+            .put("key", AttributeValue.ofSerializable(calendar))
+            .put("key2", AttributeValue.ofSerializable(calendar2))
             .build();
 
         testee.init(FakeMailetConfig.builder().build());
@@ -204,7 +206,7 @@ class ICALToHeadersTest {
 
     @Test
     void serviceShouldNotFailOnEmptyMaps() throws Exception {
-        ImmutableMap<String, Calendar> icals = ImmutableMap.<String, Calendar>builder()
+        Map<String, AttributeValue<?>> icals = ImmutableMap.<String, AttributeValue<?>>builder()
             .build();
 
         testee.init(FakeMailetConfig.builder().build());
@@ -219,7 +221,7 @@ class ICALToHeadersTest {
         assertThat(mail.getMessage().getHeader(ICALToHeader.X_MEETING_UID_HEADER)).isNull();
     }
 
-    private Attribute makeAttribute(Object icals) {
-        return new Attribute(ICALToHeader.ATTRIBUTE_DEFAULT, AttributeValue.ofAny(icals));
+    private Attribute makeAttribute(Map<String, AttributeValue<?>> icals) {
+        return new Attribute(ICALToHeader.ATTRIBUTE_DEFAULT, AttributeValue.of(icals));
     }
 }

--- a/mailet/icalendar/src/test/java/org/apache/james/transport/mailets/ICalendarParserTest.java
+++ b/mailet/icalendar/src/test/java/org/apache/james/transport/mailets/ICalendarParserTest.java
@@ -56,7 +56,7 @@ class ICalendarParserTest {
 
     static final String WRONG_ICAL_VALUE = "anyValue";
     @SuppressWarnings("unchecked")
-    static final Class<Map<String, Calendar>> MAP_STRING_CALENDAR_CLASS = (Class<Map<String, Calendar>>) (Object) Map.class;
+    static final Class<Map<String, AttributeValue<Serializable>>> MAP_STRING_CALENDAR_CLASS = (Class<Map<String, AttributeValue<Serializable>>>) (Object) Map.class;
 
     ICalendarParser mailet = new ICalendarParser();
 
@@ -189,8 +189,8 @@ class ICalendarParserTest {
 
         mailet.init(mailetConfiguration);
 
-        Map<String, byte[]> attachments = ImmutableMap.<String, byte[]>builder()
-            .put("key", RIGHT_ICAL_VALUE.getBytes())
+        Map<String, AttributeValue<byte[]>> attachments = ImmutableMap.<String, AttributeValue<byte[]>>builder()
+            .put("key", AttributeValue.of(RIGHT_ICAL_VALUE.getBytes()))
             .build();
 
         Mail mail = FakeMail.builder()
@@ -218,9 +218,9 @@ class ICalendarParserTest {
 
         mailet.init(mailetConfiguration);
 
-        Map<String, byte[]> attachments = ImmutableMap.<String, byte[]>builder()
-            .put("key1", WRONG_ICAL_VALUE.getBytes())
-            .put("key2", RIGHT_ICAL_VALUE.getBytes())
+        Map<String, AttributeValue<byte[]>> attachments = ImmutableMap.<String, AttributeValue<byte[]>>builder()
+            .put("key1", AttributeValue.of(WRONG_ICAL_VALUE.getBytes()))
+            .put("key2", AttributeValue.of(RIGHT_ICAL_VALUE.getBytes()))
             .build();
         Mail mail = FakeMail.builder()
             .name("mail")
@@ -229,8 +229,8 @@ class ICalendarParserTest {
 
         mailet.service(mail);
 
-        Optional<Map<String, Calendar>> expectedCalendars = AttributeUtils.getValueAndCastFromMail(mail, DESTINATION_CUSTOM_ATTRIBUTE_NAME, MAP_STRING_CALENDAR_CLASS);
-        Map.Entry<String, Calendar> expectedCalendar = Maps.immutableEntry("key2", new Calendar());
+        Optional<Map<String, AttributeValue<Serializable>>> expectedCalendars = AttributeUtils.getValueAndCastFromMail(mail, DESTINATION_CUSTOM_ATTRIBUTE_NAME, MAP_STRING_CALENDAR_CLASS);
+        Map.Entry<String, AttributeValue<Serializable>> expectedCalendar = Maps.immutableEntry("key2", AttributeValue.ofSerializable(new Calendar()));
 
         assertThat(expectedCalendars).hasValueSatisfying(calendars ->
             assertThat(calendars)
@@ -253,8 +253,8 @@ class ICalendarParserTest {
 
         mailet.init(mailetConfiguration);
 
-        Map<String, byte[]> attachments = ImmutableMap.<String, byte[]>builder()
-            .put("key", ClassLoaderUtils.getSystemResourceAsByteArray("ics/ics_with_error.ics"))
+        Map<String, AttributeValue<byte[]>> attachments = ImmutableMap.<String, AttributeValue<byte[]>>builder()
+            .put("key", AttributeValue.of(ClassLoaderUtils.getSystemResourceAsByteArray("ics/ics_with_error.ics")))
             .build();
 
         Mail mail = FakeMail.builder()
@@ -264,7 +264,7 @@ class ICalendarParserTest {
 
         mailet.service(mail);
 
-        Optional<Map<String, Calendar>> expectedCalendars = AttributeUtils.getValueAndCastFromMail(mail, DESTINATION_CUSTOM_ATTRIBUTE_NAME, MAP_STRING_CALENDAR_CLASS);
+        Optional<Map<String, AttributeValue<Serializable>>> expectedCalendars = AttributeUtils.getValueAndCastFromMail(mail, DESTINATION_CUSTOM_ATTRIBUTE_NAME, MAP_STRING_CALENDAR_CLASS);
         assertThat(expectedCalendars).hasValueSatisfying(calendars ->
                 assertThat(calendars)
                         .hasSize(1));

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/MailAttributesListToMimeHeaders.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/MailAttributesListToMimeHeaders.java
@@ -19,17 +19,16 @@
 
 package org.apache.james.transport.mailets;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.mailet.AttributeName;
 import org.apache.mailet.AttributeUtils;
+import org.apache.mailet.AttributeValue;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 import org.slf4j.Logger;
@@ -85,18 +84,13 @@ public class MailAttributesListToMimeHeaders extends GenericMailet {
             .ifPresent(attribute -> {
                 if (attribute instanceof Collection) {
                     @SuppressWarnings("unchecked")
-                    Optional<Collection<Serializable>> values = Optional.of((Collection<Serializable>) attribute);
-                    addCollectionToHeader(message, entry.getValue(), values);
+                    Collection<AttributeValue<?>> values = (Collection<AttributeValue<?>>) attribute;
+                    values.forEach(
+                        value -> addValueToHeader(message, entry.getValue(), value.getValue()));
                 } else {
                     LOGGER.warn("Can not add {} to headers. Expecting class Collection but got {}.", attribute, attribute.getClass());
                 }
             });
-    }
-
-    private void addCollectionToHeader(MimeMessage message, String headerName, Optional<Collection<Serializable>> values) {
-        values.ifPresent(collection ->
-            collection.forEach(
-                value -> addValueToHeader(message, headerName, value)));
     }
 
     private void addValueToHeader(MimeMessage message, String headerName, Object value) {

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/MimeDecodingMailetTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/MimeDecodingMailetTest.java
@@ -37,7 +37,6 @@ import org.apache.mailet.MailetException;
 import org.apache.mailet.base.test.FakeMail;
 import org.apache.mailet.base.test.FakeMailContext;
 import org.apache.mailet.base.test.FakeMailetConfig;
-import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -49,7 +48,7 @@ class MimeDecodingMailetTest {
 
     private static final AttributeName MAIL_ATTRIBUTE = AttributeName.of("mime.attachments");
     @SuppressWarnings("unchecked")
-    private static final Class<Map<String, byte[]>> MAP_STRING_BYTES_CLASS = (Class<Map<String, byte[]>>) (Object) Map.class;
+    private static final Class<Map<String, AttributeValue<byte[]>>> MAP_STRING_BYTES_CLASS = (Class<Map<String, AttributeValue<byte[]>>>) (Object) Map.class;
 
     private MailetContext mailetContext;
     private MimeDecodingMailet testee;
@@ -145,15 +144,15 @@ class MimeDecodingMailetTest {
                 + "Content-Type: application/octet-stream; charset=utf-8\r\n\r\n"
                 + text;
         String expectedKey = "mimePart1";
-        AttributeValue<?> value = AttributeValue.ofAny(ImmutableMap.of(expectedKey, content.getBytes(StandardCharsets.UTF_8)));
+        AttributeValue<?> value = AttributeValue.of(ImmutableMap.of(expectedKey, AttributeValue.of(content.getBytes(StandardCharsets.UTF_8))));
         mail.setAttribute(new Attribute(MAIL_ATTRIBUTE, value));
 
-        byte[] expectedValue = text.getBytes(StandardCharsets.UTF_8);
+        AttributeValue<byte[]> expectedValue = AttributeValue.of(text.getBytes(StandardCharsets.UTF_8));
         testee.service(mail);
 
-        Optional<Map<String, byte[]>> processedAttribute = AttributeUtils.getValueAndCastFromMail(mail, MAIL_ATTRIBUTE, MAP_STRING_BYTES_CLASS);
+        Optional<Map<String, AttributeValue<byte[]>>> processedAttribute = AttributeUtils.getValueAndCastFromMail(mail, MAIL_ATTRIBUTE, MAP_STRING_BYTES_CLASS);
         assertThat(processedAttribute).hasValueSatisfying(map ->
-            assertThat(map)
-                .containsExactly(MapEntry.entry(expectedKey, expectedValue)));
+            assertThat(map.values().stream().findFirst().get().getValue())
+                .contains(expectedValue.value()));
     }
 }

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
@@ -65,7 +65,7 @@ class StripAttachmentTest {
     @SuppressWarnings("unchecked")
     private static Class<Collection<AttributeValue<String>>> COLLECTION_STRING_CLASS = (Class<Collection<AttributeValue<String>>>) (Object) Collection.class;
     @SuppressWarnings("unchecked")
-    private static Class<Map<String, byte[]>> MAP_STRING_BYTES_CLASS = (Class<Map<String, byte[]>>) (Object) Map.class;
+    private static Class<Map<String, AttributeValue<?>>> MAP_STRING_BYTES_CLASS = (Class<Map<String, AttributeValue<?>>>) (Object) Map.class;
 
     private static final String EXPECTED_ATTACHMENT_CONTENT = "#¤ãàé";
     private static final Optional<String> ABSENT_MIME_TYPE = Optional.empty();
@@ -283,13 +283,13 @@ class StripAttachmentTest {
 
         mailet.service(mail);
 
-        Optional<Map<String, byte[]>> savedValue = AttributeUtils.getValueAndCastFromMail(mail, AttributeName.of(customAttribute), MAP_STRING_BYTES_CLASS);
-        ConsumerChainer<Map<String, byte[]>> assertValue = Throwing.consumer(saved -> {
+        Optional<Map<String, AttributeValue<?>>> savedValue = AttributeUtils.getValueAndCastFromMail(mail, AttributeName.of(customAttribute), MAP_STRING_BYTES_CLASS);
+        ConsumerChainer<Map<String, AttributeValue<?>>> assertValue = Throwing.consumer(saved -> {
             assertThat(saved)
                     .hasSize(1)
                     .containsKeys(expectedKey);
 
-            MimeBodyPart savedBodyPart = new MimeBodyPart(new ByteArrayInputStream(saved.get(expectedKey)));
+            MimeBodyPart savedBodyPart = new MimeBodyPart(new ByteArrayInputStream((byte[]) saved.get(expectedKey).getValue()));
             String content = IOUtils.toString(savedBodyPart.getInputStream(), StandardCharsets.UTF_8);
             assertThat(content).isEqualTo(EXPECTED_ATTACHMENT_CONTENT);
         });
@@ -321,13 +321,13 @@ class StripAttachmentTest {
 
         mailet.service(mail);
 
-        Optional<Map<String, byte[]>> savedValue = AttributeUtils.getValueAndCastFromMail(mail, AttributeName.of(customAttribute), MAP_STRING_BYTES_CLASS);
-        ConsumerChainer<Map<String, byte[]>> assertValue = Throwing.consumer(saved -> {
+        Optional<Map<String, AttributeValue<?>>> savedValue = AttributeUtils.getValueAndCastFromMail(mail, AttributeName.of(customAttribute), MAP_STRING_BYTES_CLASS);
+        ConsumerChainer<Map<String, AttributeValue<?>>> assertValue = Throwing.consumer(saved -> {
             assertThat(saved)
                     .hasSize(1)
                     .containsKeys(expectedKey);
 
-            MimeBodyPart savedBodyPart = new MimeBodyPart(new ByteArrayInputStream(saved.get(expectedKey)));
+            MimeBodyPart savedBodyPart = new MimeBodyPart(new ByteArrayInputStream((byte[]) saved.get(expectedKey).getValue()));
             String content = IOUtils.toString(savedBodyPart.getInputStream(), StandardCharsets.UTF_8);
             assertThat(content).isEqualTo(EXPECTED_ATTACHMENT_CONTENT);
         });
@@ -655,7 +655,7 @@ class StripAttachmentTest {
         
         //Then
         assertThat(actual).isTrue();
-        Optional<Map<String, byte[]>> savedValue = AttributeUtils.getValueAndCastFromMail(mail, AttributeName.of(customAttribute), MAP_STRING_BYTES_CLASS);
+        Optional<Map<String,  AttributeValue<?>>> savedValue = AttributeUtils.getValueAndCastFromMail(mail, AttributeName.of(customAttribute), MAP_STRING_BYTES_CLASS);
         assertThat(savedValue)
                 .isPresent()
                 .hasValueSatisfying(saved ->


### PR DESCRIPTION
Prevent:

```
exception	java.lang.ClassCastException: class [B cannot be cast to class org.apache.mailet.AttributeValue ([B is in module java.base of loader 'bootstrap'; org.apache.mailet.AttributeValue is in unnamed module of loader 'app')
 at org.apache.mailet.Serializer$MapSerializer.lambda$serialize$0(Serializer.java:507)
  at com.google.common.collect.CollectCollectors.lambda$toImmutableMap$6(CollectCollectors.java:185)
   at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(Unknown Source)
    at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)
     at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
      at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
       at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
         at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source)
          at org.apache.mailet.Serializer$MapSerializer.serialize(Serializer.java:507)
           at org.apache.mailet.Serializer$MapSerializer.serialize(Serializer.java:503)
            at org.apache.mailet.AttributeValue.toJson(AttributeValue.java:256)
             at org.apache.mailet.AttributeValue.duplicate(AttributeValue.java:250)
              at org.apache.mailet.Attribute.duplicate(Attribute.java:62)
               at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
                at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(Unknown Source)
                 at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
                  at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
                   at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
                    at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
                     at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source)
                      at org.apache.james.server.core.MailImpl.duplicateAttributes(MailImpl.java:117)
                       at org.apache.james.server.core.MailImpl.duplicateWithoutMessage(MailImpl.java:111)
                        at org.apache.james.server.core.MailImpl.duplicate(MailImpl.java:97)
                         at org.apache.james.mailetcontainer.impl.MatcherSplitter.split(MatcherSplitter.java:149)
                          at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$executeProcessingStep$3(MailetProcessorImpl.java:158)
```