### PR TITLE
[BUILD] Tag Pulsar related work as unstable

### DIFF
--- a/mpt/impl/smtp/cassandra-pulsar/src/test/java/org/apache/james/mpt/smtp/CassandraPulsarForwardSmtpTest.java
+++ b/mpt/impl/smtp/cassandra-pulsar/src/test/java/org/apache/james/mpt/smtp/CassandraPulsarForwardSmtpTest.java
@@ -27,9 +27,12 @@ import org.apache.james.JamesServerExtension;
 import org.apache.james.Main;
 import org.apache.james.PulsarExtension;
 import org.apache.james.TestingSmtpRelayJamesServerBuilder;
+import org.apache.james.junit.categories.Unstable;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@Tag(Unstable.TAG)
 public class CassandraPulsarForwardSmtpTest implements ForwardSmtpTest {
 
     @Order(1)

--- a/mpt/impl/smtp/cassandra-pulsar/src/test/java/org/apache/james/mpt/smtp/CassandraPulsarSmtpStarttlsCommandTest.java
+++ b/mpt/impl/smtp/cassandra-pulsar/src/test/java/org/apache/james/mpt/smtp/CassandraPulsarSmtpStarttlsCommandTest.java
@@ -27,9 +27,12 @@ import org.apache.james.JamesServerExtension;
 import org.apache.james.Main;
 import org.apache.james.PulsarExtension;
 import org.apache.james.TestingSmtpRelayJamesServerBuilder;
+import org.apache.james.junit.categories.Unstable;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@Tag(Unstable.TAG)
 public class CassandraPulsarSmtpStarttlsCommandTest extends SmtpStarttlsCommandTest {
 
     @Order(1)

--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueFactoryTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueFactoryTest.java
@@ -33,6 +33,7 @@ import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.apache.james.junit.categories.Unstable;
 import org.apache.james.queue.api.MailQueueFactory;
 import org.apache.james.queue.api.MailQueueFactoryContract;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
@@ -44,9 +45,11 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+@Tag(Unstable.TAG)
 @ExtendWith(MailQueueMetricExtension.class)
 @ExtendWith(DockerPulsarExtension.class)
 class PulsarMailQueueFactoryTest implements MailQueueFactoryContract<PulsarMailQueue>, ManageableMailQueueFactoryContract<PulsarMailQueue> {

--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
@@ -39,6 +39,7 @@ import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.apache.james.junit.categories.Unstable;
 import org.apache.james.queue.api.DelayedMailQueueContract;
 import org.apache.james.queue.api.DelayedManageableMailQueueContract;
 import org.apache.james.queue.api.MailQueue;
@@ -57,6 +58,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -68,6 +70,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import scala.jdk.javaapi.OptionConverters;
 
+@Tag(Unstable.TAG)
 @ExtendWith(DockerPulsarExtension.class)
 public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricContract, ManageableMailQueueContract, DelayedMailQueueContract, DelayedManageableMailQueueContract {
 


### PR DESCRIPTION
Failed in 4 builds out of 7.

```
com.github.fge.lambdas.ThrownByLambdaException: org.apache.pulsar.client.admin.PulsarAdminException$NotFoundException: Tenant does not exist
Caused by: org.apache.pulsar.client.admin.PulsarAdminException$NotFoundException: Tenant does not exist
Caused by: org.apache.pulsar.shade.javax.ws.rs.NotFoundException: HTTP 404 Tenant does not exist
```