### PR TITLE
[DEPRECATION] Deprecate JDBCMailRepository

### DIFF
--- a/server/data/data-jdbc/pom.xml
+++ b/server/data/data-jdbc/pom.xml
@@ -31,6 +31,7 @@
     <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data :: JDBC Persistence</name>
+    <description>Deprecated Will be dropped in 3.9.0. See https://www.mail-archive.com/server-dev@james.apache.org/msg72460.html</description>
 
     <dependencies>
         <dependency>

--- a/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
@@ -76,7 +76,9 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * Implementation of a MailRepository on a database.
+ * @Deprecated Will be dropped in 3.9.0. See https://www.mail-archive.com/server-dev@james.apache.org/msg72460.html
  */
+@Deprecated
 public class JDBCMailRepository implements MailRepository, Configurable, Initializable {
     private static final Logger LOGGER = LoggerFactory.getLogger(JDBCMailRepository.class);
 

--- a/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/MessageInputStream.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/MessageInputStream.java
@@ -43,7 +43,9 @@ import org.apache.mailet.Mail;
  * 
  * <strong>Note</strong>: Javamail (or the Activation Framework) already uses a
  * worker thread when asked for an inputstream.
+ * @Deprecated Will be dropped in 3.9.0. See https://www.mail-archive.com/server-dev@james.apache.org/msg72460.html
  */
+@Deprecated
 final class MessageInputStream extends InputStream {
 
     /**

--- a/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/MimeMessageJDBCSource.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/MimeMessageJDBCSource.java
@@ -38,7 +38,9 @@ import org.apache.james.util.sql.JDBCUtil;
  * This class points to a specific message in a repository. This will return an
  * InputStream to the JDBC field/record, possibly sequenced with the file
  * stream.
+ * @Deprecated Will be dropped in 3.9.0. See https://www.mail-archive.com/server-dev@james.apache.org/msg72460.html
  */
+@Deprecated
 public class MimeMessageJDBCSource implements MimeMessageSource {
 
     /**

--- a/server/data/data-jdbc/src/test/java/org/apache/james/mailrepository/jdbc/JDBCMailRepositoryTest.java
+++ b/server/data/data-jdbc/src/test/java/org/apache/james/mailrepository/jdbc/JDBCMailRepositoryTest.java
@@ -37,7 +37,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
+/**
+ * @Deprecated Will be dropped in 3.9.0. See https://www.mail-archive.com/server-dev@james.apache.org/msg72460.html
+ */
+@Deprecated
 public class JDBCMailRepositoryTest implements MailRepositoryContract {
 
     private JDBCMailRepository mailRepository;


### PR DESCRIPTION
Will be dropped in 3.9.0.

See https://www.mail-archive.com/server-dev@james.apache.org/msg72460.html