### PR TITLE
[JAMES-3805] fixes more flaky pulsar tests

### DIFF
--- a/server/apps/scaling-pulsar-smtp/src/test/java/org/apache/james/PulsarExtension.java
+++ b/server/apps/scaling-pulsar-smtp/src/test/java/org/apache/james/PulsarExtension.java
@@ -21,6 +21,7 @@ package org.apache.james;
 
 import org.apache.james.backends.pulsar.DockerPulsarExtension;
 import org.apache.james.backends.pulsar.PulsarConfiguration;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -36,7 +37,7 @@ public class PulsarExtension implements GuiceModuleTestExtension {
     }
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) throws PulsarClientException {
+    public void beforeAll(ExtensionContext extensionContext) throws PulsarClientException, PulsarAdminException {
         pulsar.beforeAll(extensionContext);
     }
 


### PR DESCRIPTION
supercedes https://github.com/apache/james-project/pull/1236

without this patch repeat run of pulsar mailqueue sometimes fails within a dozen runs with a missing `public` tenant. With the patch I couldn't make the run fail on my laptop (stopped a bit over 40 runs)