### PR TITLE
JAMES-3775 Ensure ignoring error of the RspamdScanner mailet

### DIFF
--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -42,6 +42,7 @@ might not even be desirable.
         <rewriteSubject>true</rewriteSubject>
         <virusProcessor>virus</virusProcessor>
         <rejectSpamProcessor>spam</rejectSpamProcessor>
+        <onMailetException>ignore</onMailetException>
     </mailet>
     <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
         <targetFolderName>Spam</targetFolderName>

--- a/third-party/rspamd/sample-configuration/mailetcontainer_distributed.xml
+++ b/third-party/rspamd/sample-configuration/mailetcontainer_distributed.xml
@@ -90,6 +90,7 @@
             <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
                 <rewriteSubject>true</rewriteSubject>
                 <virusProcessor>virus</virusProcessor>
+                <onMailetException>ignore</onMailetException>
             </mailet>
             <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
                 <targetFolderName>Spam</targetFolderName>

--- a/third-party/rspamd/sample-configuration/mailetcontainer_memory.xml
+++ b/third-party/rspamd/sample-configuration/mailetcontainer_memory.xml
@@ -90,6 +90,7 @@
             <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
                 <rewriteSubject>true</rewriteSubject>
                 <virusProcessor>virus</virusProcessor>
+                <onMailetException>ignore</onMailetException>
             </mailet>
             <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
                 <targetFolderName>Spam</targetFolderName>


### PR DESCRIPTION
`RspamdScanner` mailet depends on third-party service which could fail when they are unavailable. We should ignore errors of the `RspamdScanner`.