### PR TITLE
JAMES-3775 Rspamd per user reporting

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
@@ -42,6 +42,12 @@ The Rspamd extension (optional) requires an extra configuration file `rspamd.pro
 
 | rSpamdPassword
 | Password for pass authentication when request to Rspamd's server. Eg: admin
+
+| rspamdTimeout
+| Integer. Timeout for http requests to Rspamd. Default to 15 seconds.
+
+| perUserBayes
+| Boolean. Whether to scan/learn mails using per-user Bayes. Default to false.
 |===
 
 `RspamdScanner` supports the following options:
@@ -55,19 +61,15 @@ might not even be desirable.
 
 * The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.
 
-* The `perUserScans` allows to specify if scans should be done on a per user basis, enabling per user scan results based on
-their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
-will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
-If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
-Defaults to false.
-
+This mailet can scan mails against per-user Bayes by configure `perUserBayes` in `rspamd.properties`. This is achieved
+through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
+If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies. Default to false.
 
 Here is an example of mailet pipeline conducting out RspamdScanner execution:
 
 ....
 <processor state="local-delivery" enableJmx="true">
     <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
-        <perUserScans>false</perUserScans>
         <rewriteSubject>true</rewriteSubject>
         <virusProcessor>virus</virusProcessor>
         <rejectSpamProcessor>spam</rejectSpamProcessor>
@@ -104,7 +106,8 @@ Here is an example of mailet pipeline conducting out RspamdScanner execution:
 ....
 
 ==== Feedback for Rspamd
-If enabled, the `RspamdListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to Rspamd
+If enabled, the `RspamdListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to Rspamd.
+This listener can report mails to per-user Bayes by configure `perUserBayes` in `rspamd.properties`.
 The Rspamd listener needs to explicitly be registered with xref:configure/listeners.adoc[listeners.xml].
 
 Example:

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/spam.adoc
@@ -29,6 +29,99 @@ with a configurable score threshold. Usually a message will only be
 considered as spam if it matches multiple criteria; matching just a single test
 will not usually be enough to reach the threshold. Note that this mailet is executed on a per-user basis.
 
+=== Rspamd
+
+The Rspamd extension (optional) requires an extra configuration file `rspamd.properties` to configure RSpamd connection
+
+.rspamd.properties content
+|===
+| Property name | explanation
+
+| rSpamdUrl
+| URL defining the Rspamd's server. Eg: http://rspamd:11334
+
+| rSpamdPassword
+| Password for pass authentication when request to Rspamd's server. Eg: admin
+|===
+
+`RspamdScanner` supports the following options:
+
+* You can specify the `virusProcessor` if you want to enable virus scanning for mail. Upon configurable `virusProcessor`
+you can specify how James process mail virus. We provide a sample Rspamd mailet and `virusProcessor` configuration:
+
+* You can specify the `rejectSpamProcessor`. Emails marked as `rejected` by Rspamd will be redirected to this
+processor. This corresponds to emails with the highest spam score, thus delivering them to users as marked as spam
+might not even be desirable.
+
+* The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.
+
+* The `perUserScans` allows to specify if scans should be done on a per user basis, enabling per user scan results based on
+their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
+will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
+If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
+Defaults to false.
+
+
+Here is an example of mailet pipeline conducting out RspamdScanner execution:
+
+....
+<processor state="local-delivery" enableJmx="true">
+    <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
+        <perUserScans>false</perUserScans>
+        <rewriteSubject>true</rewriteSubject>
+        <virusProcessor>virus</virusProcessor>
+        <rejectSpamProcessor>spam</rejectSpamProcessor>
+    </mailet>
+    <mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
+        <targetFolderName>Spam</targetFolderName>
+    </mailet>
+    <mailet match="All" class="LocalDelivery"/>
+</processor>
+<!--Choose one between these two following virus processor, or configure a custom one if you want-->
+<!--Hard reject virus mail-->
+<processor state="virus" enableJmx="false">
+    <mailet match="All" class="ToRepository">
+        <repositoryPath>file://var/mail/virus/</repositoryPath>
+    </mailet>
+</processor>
+<!--Soft reject virus mail-->
+<processor state="virus" enableJmx="false">
+    <mailet match="All" class="StripAttachment">
+        <remove>all</remove>
+        <pattern>.*</pattern>
+    </mailet>
+    <mailet match="All" class="AddSubjectPrefix">
+        <subjectPrefix>[VIRUS]</subjectPrefix>
+    </mailet>
+    <mailet match="All" class="LocalDelivery"/>
+</processor>
+<!--Store rejected spam emails (with a very high score) -->
+<processor state="virus" enableJmx="false">
+    <mailet match="All" class="ToRepository">
+        <repositoryPath>cassandra://var/mail/spam</repositoryPath>
+    </mailet>
+</processor>
+....
+
+==== Feedback for Rspamd
+If enabled, the `RspamdListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to Rspamd
+The Rspamd listener needs to explicitly be registered with xref:configure/listeners.adoc[listeners.xml].
+
+Example:
+
+....
+<listeners>
+    <listener>
+        <class>org.apache.james.rspamd.RspamdListener</class>
+    </listener>
+</listeners>
+....
+
+For more detail about how to use Rspamd's extension: `third-party/rspamd/index.md`
+
+Alternatively, batch reports can be triggered on user mailbox content via webAdmin. link:https://github.com/apache/james-project/tree/master/third-party/rspamd#additional-webadmin-endpoints[Read more].
+
+
 === SpamAssassin
 Here is an example of mailet pipeline conducting out SpamAssassin execution:
 
@@ -59,7 +152,7 @@ the table. Also, the correct approach is to send the original spam or non-spam
 as an attachment to another message sent to the feeder in order to avoid bias from the
 current sender's email header.
 
-=== Feedback for SpamAssassin
+==== Feedback for SpamAssassin
 
 If enabled, the `SpamAssassinListener` will asynchronously report users mails moved to the `Spam` mailbox as Spam,
 and other mails as `Ham`, effectively populating the user database for per user spam detection. This enables a per-user
@@ -92,45 +185,3 @@ Example:
   </listener>
 </listeners>
 ....
-
-== Rspamd
-
-The Rspamd extension (optional) requires an extra configuration file `rspamd.properties` to configure RSpamd connection
-
-.rspamd.properties content
-|===
-| Property name | explanation
-
-| rSpamdUrl
-| URL defining the Rspamd's server. Eg: http://rspamd:11334
-
-| rSpamdPassword
-| Password for pass authentication when request to Rspamd's server. Eg: admin
-|===
-
-
-Here is an example of mailet pipeline conducting out RspamdScanner execution:
-
-....
-<mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
-</mailet>
-<mailet match="IsMarkedAsSpam=org.apache.james.rspamd.status" class="WithStorageDirective">
-    <targetFolderName>Spam</targetFolderName>
-</mailet>
-....
-
-=== Feedback for Rspamd
-If enabled, the `RspamdListener` will base on the Mailbox event to detect the message is a spam or not, then James will send report `spam` or `ham` to Rspamd
-The Rspamd listener needs to explicitly be registered with xref:configure/listeners.adoc[listeners.xml].
-
-Example:
-
-....
-<listeners>
-    <listener>
-        <class>org.apache.james.rspamd.RspamdListener</class>
-    </listener>
-</listeners>
-....
-
-For more detail about how to use Rspamd's extension: `third-party/rspamd/index.md`

--- a/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/DockerRedis.java
+++ b/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/DockerRedis.java
@@ -46,6 +46,7 @@ public class DockerRedis {
         this.container = new GenericContainer<>(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG))
             .withExposedPorts(DEFAULT_PORT)
             .withNetwork(network)
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("james-redis-test"))
             .withNetworkAliases("redis");
     }
 

--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -40,7 +40,8 @@ might not even be desirable.
   their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
   will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
   If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
-  Defaults to false.
+  Please pay attention that per-user Bayes is only activated when we feed enough (min_learns) spam as well as (min_learns) 
+  ham messages to Rspamd. Defaults to false.
 
 ```xml
 <processor state="local-delivery" enableJmx="true">

--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -9,6 +9,8 @@ and [ClamAV](https://www.clamav.net/) (the antivirus engine).
 Configuration parameters:
     - `rSpamdUrl` : URL defining the Rspamd's server. Eg: http://rspamd:11334
     - `rSpamdPassword` : Password for pass authentication when request to Rspamd's server. Eg: admin
+    - `rspamdTimeout` : Timeout for HTTP requests called to Rspamd. Default to 15 seconds.
+    - `perUserBayes` : Use per-user Bayes for mail scanning/feedback. Default to false.
   
 - Declare the `extensions.properties` for this module.
 
@@ -25,6 +27,8 @@ guice.extension.task=org.apache.james.rspamd.module.RspamdTaskExtensionModule
 </listener>
 ```
 
+  This listener can report mails to per-user Bayes by configure `perUserBayes` in `rspamd.properties`.
+
 - Declare the Rspamd mailet for custom mail processing. 
 
   You can specify the `virusProcessor` if you want to enable virus scanning for mail. Upon configurable `virusProcessor`
@@ -36,17 +40,13 @@ might not even be desirable.
 
   The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.  
 
-  The `perUserScans` allows to specify if scans should be done on a per user basis, enabling per user scan results based on
-  their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
-  will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
-  If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
-  Please pay attention that per-user Bayes is only activated when we feed enough (min_learns) spam as well as (min_learns) 
-  ham messages to Rspamd. Defaults to false.
+  This mailet can scan mails against per-user Bayes by configure `perUserBayes` in `rspamd.properties`. This is achieved 
+through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
+If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies. Default to false.
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
     <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
-        <perUserScans>false</perUserScans>
         <rewriteSubject>true</rewriteSubject>
         <virusProcessor>virus</virusProcessor>
         <rejectSpamProcessor>spam</rejectSpamProcessor>
@@ -108,6 +108,7 @@ then run it: `docker-compose up`
 
 ### Report spam messages to Rspamd
 One can use this route to schedule a task that reports spam messages to Rspamd for its spam classify learning.
+This task can be configured to report spam messages to per-user Bayes via `perUserBayes` in `rspamd.properties`.
 
 ```bash
 curl -XPOST 'http://ip:port/rspamd?action=reportSpam
@@ -157,6 +158,7 @@ The scheduled task will have the following type `FeedSpamToRspamdTask` and the f
 
 ### Report ham messages to Rspamd
 One can use this route to schedule a task that reports ham messages to Rspamd for its spam classify learning.
+This task can be configured to report ham messages to per-user Bayes via `perUserBayes` in `rspamd.properties`.
 
 ```bash
 curl -XPOST 'http://ip:port/rspamd?action=reportHam

--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -34,11 +34,18 @@ you can specify how James process mail virus. We provide a sample Rspamd mailet 
 processor. This corresponds to emails with the highest spam score, thus delivering them to users as marked as spam 
 might not even be desirable.
 
-  The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.
-  
+  The `rewriteSubject` option allows to rewritte subjects when asked by Rspamd.  
+
+  The `perUserScans` allows to specify if scans should be done on a per user basis, enabling per user scan results based on
+  their own per-user bayes database. This is achieved through the use of Rspamd `Deliver-To` HTTP header. If true, Rspamd
+  will be called for each recipient of the mail, which comes at a performance cost. If true, subjects are not rewritten.
+  If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the cost of email copies.
+  Defaults to false.
+
 ```xml
 <processor state="local-delivery" enableJmx="true">
     <mailet match="All" class="org.apache.james.rspamd.RspamdScanner">
+        <perUserScans>false</perUserScans>
         <rewriteSubject>true</rewriteSubject>
         <virusProcessor>virus</virusProcessor>
         <rejectSpamProcessor>spam</rejectSpamProcessor>
@@ -67,6 +74,7 @@ might not even be desirable.
     <mailet match="All" class="AddSubjectPrefix">
         <subjectPrefix>[VIRUS]</subjectPrefix>
     </mailet>
+    <mailet match="All" class="LocalDelivery"/>
 </processor>
 
 <!--Store rejected spam emails (with a very high score) -->

--- a/third-party/rspamd/docker-compose-distributed.yml
+++ b/third-party/rspamd/docker-compose-distributed.yml
@@ -78,5 +78,6 @@ services:
       - PASSWORD=admin
     volumes:
       - $PWD/sample-configuration/antivirus.conf:/etc/rspamd/override.d/antivirus.conf
+      - $PWD/sample-configuration/statistic.conf:/etc/rspamd/statistic.conf
     ports:
       - 11334:11334

--- a/third-party/rspamd/docker-compose.yml
+++ b/third-party/rspamd/docker-compose.yml
@@ -44,5 +44,6 @@ services:
       - PASSWORD=admin
     volumes:
       - $PWD/sample-configuration/antivirus.conf:/etc/rspamd/override.d/antivirus.conf
+      - $PWD/sample-configuration/statistic.conf:/etc/rspamd/statistic.conf
     ports:
       - 11334:11334

--- a/third-party/rspamd/pom.xml
+++ b/third-party/rspamd/pom.xml
@@ -179,11 +179,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/third-party/rspamd/sample-configuration/rspamd.properties
+++ b/third-party/rspamd/sample-configuration/rspamd.properties
@@ -1,2 +1,4 @@
 rspamdUrl=http://rspamd:11334
 rspamdPassword=admin
+# Whether to scan/learn mails using per-user Bayes. Default to false.
+perUserBayes=false

--- a/third-party/rspamd/sample-configuration/statistic.conf
+++ b/third-party/rspamd/sample-configuration/statistic.conf
@@ -5,20 +5,20 @@ classifier "bayes" {
   cache {
   }
   new_schema = true; # Always use new schema
-  store_tokens = true; # Redefine if storing of tokens is desired
-  signatures = true; # Store learn signatures
+  store_tokens = false; # Redefine if storing of tokens is desired
+  signatures = false; # Store learn signatures
   per_user = true; # Enable per user classifier
   users_enabled = true;
-  min_tokens = 10;
+  min_tokens = 11;
   backend = "redis";
-  min_learns = 0;
+  min_learns = 50; // Should not be bias by too small learning set
 
   statfile {
-    symbol = "BAYES_HAM_USER";
+    symbol = "BAYES_HAM";
     spam = false;
   }
   statfile {
-    symbol = "BAYES_SPAM_USER";
+    symbol = "BAYES_SPAM";
     spam = true;
   }
 

--- a/third-party/rspamd/sample-configuration/statistic.conf
+++ b/third-party/rspamd/sample-configuration/statistic.conf
@@ -1,0 +1,37 @@
+classifier "bayes" {
+  tokenizer {
+    name = "osb";
+  }
+  cache {
+  }
+  new_schema = true; # Always use new schema
+  store_tokens = true; # Redefine if storing of tokens is desired
+  signatures = true; # Store learn signatures
+  per_user = true; # Enable per user classifier
+  users_enabled = true;
+  min_tokens = 10;
+  backend = "redis";
+  min_learns = 0;
+
+  statfile {
+    symbol = "BAYES_HAM_USER";
+    spam = false;
+  }
+  statfile {
+    symbol = "BAYES_SPAM_USER";
+    spam = true;
+  }
+
+  learn_condition = 'return require("lua_bayes_learn").can_learn';
+
+  # Autolearn sample
+  # autolearn {
+  #  spam_threshold = 6.0; # When to learn spam (score >= threshold)
+  #  ham_threshold = -0.5; # When to learn ham (score <= threshold)
+  #  check_balance = true; # Check spam and ham balance
+  #  min_balance = 0.9; # Keep diff for spam/ham learns for at least this value
+  #}
+
+  .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/classifier-bayes.conf"
+  .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/classifier-bayes.conf"
+}

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/RspamdListener.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/RspamdListener.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.event.SpamEventListener;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.rspamd.client.RspamdClientConfiguration;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.util.FunctionalUtils;
 import org.apache.james.util.ReactorUtils;
@@ -64,13 +65,16 @@ public class RspamdListener implements SpamEventListener, EventListener.Reactive
     private static final Group GROUP = new RspamdListenerGroup();
 
     private final RspamdHttpClient rspamdHttpClient;
+    private final RspamdClientConfiguration configuration;
     private final MailboxManager mailboxManager;
     private final MailboxSessionMapperFactory mapperFactory;
     private final SystemMailboxesProvider systemMailboxesProvider;
 
     @Inject
-    public RspamdListener(RspamdHttpClient rspamdHttpClient, MailboxManager mailboxManager, MailboxSessionMapperFactory mapperFactory, SystemMailboxesProvider systemMailboxesProvider) {
+    public RspamdListener(RspamdHttpClient rspamdHttpClient, MailboxManager mailboxManager, MailboxSessionMapperFactory mapperFactory, 
+                          SystemMailboxesProvider systemMailboxesProvider, RspamdClientConfiguration configuration) {
         this.rspamdHttpClient = rspamdHttpClient;
+        this.configuration = configuration;
         this.mailboxManager = mailboxManager;
         this.mapperFactory = mapperFactory;
         this.systemMailboxesProvider = systemMailboxesProvider;
@@ -114,7 +118,7 @@ public class RspamdListener implements SpamEventListener, EventListener.Reactive
             .flatMapMany(pair -> Flux.fromIterable(MessageRange.toRanges(addedEvent.getUids()))
                 .flatMap(range -> pair.getRight().findInMailboxReactive(pair.getLeft(), range, MessageMapper.FetchType.FULL, LIMIT)))
             .map(MailboxMessage::getFullContentReactive)
-            .flatMap(content -> rspamdHttpClient.reportAsHam(content, RspamdHttpClient.Options.forUser(addedEvent.getUsername())), ReactorUtils.DEFAULT_CONCURRENCY)
+            .flatMap(content -> reportHam(content, addedEvent), ReactorUtils.DEFAULT_CONCURRENCY)
             .then();
     }
 
@@ -133,14 +137,30 @@ public class RspamdListener implements SpamEventListener, EventListener.Reactive
             .flatMap(isSpam -> {
                 if (isSpam) {
                     LOGGER.debug("Spam event detected, EventId = {}", messageMoveEvent.getEventId().getId());
-                    return rspamdHttpClient.reportAsSpam(mailboxMessagesPublisher, RspamdHttpClient.Options.forUser(messageMoveEvent.getUsername()))
+                    return reportSpam(mailboxMessagesPublisher, messageMoveEvent)
                         .then();
                 } else {
                     return reportHamIfNotSpamDetected
-                        .flatMapMany(isHam -> rspamdHttpClient.reportAsHam(mailboxMessagesPublisher, RspamdHttpClient.Options.forUser(messageMoveEvent.getUsername())))
+                        .flatMapMany(isHam -> reportHam(mailboxMessagesPublisher, messageMoveEvent))
                         .then();
                 }
             });
+    }
+
+    private Mono<Void> reportHam(Publisher<ByteBuffer> content, Event messageMoveEvent) {
+        if (configuration.usePerUserBayes()) {
+            return rspamdHttpClient.reportAsHam(content, RspamdHttpClient.Options.forUser(messageMoveEvent.getUsername()));
+        } else {
+            return rspamdHttpClient.reportAsHam(content);
+        }
+    }
+
+    private Mono<Void> reportSpam(Flux<ByteBuffer> mailboxMessagesPublisher, MessageMoveEvent messageMoveEvent) {
+        if (configuration.usePerUserBayes()) {
+            return rspamdHttpClient.reportAsSpam(mailboxMessagesPublisher, RspamdHttpClient.Options.forUser(messageMoveEvent.getUsername()));
+        } else {
+            return rspamdHttpClient.reportAsSpam(mailboxMessagesPublisher);
+        }
     }
 
     @VisibleForTesting

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdClientConfiguration.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdClientConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.apache.commons.configuration2.Configuration;
 
 import com.github.fge.lambdas.Throwing;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class RspamdClientConfiguration {
@@ -43,17 +44,28 @@ public class RspamdClientConfiguration {
             });
 
         String rspamdPassword = config.getString("rspamdPassword", "");
-        return new RspamdClientConfiguration(rspamdUrl, rspamdPassword, rspamdTimeoutConfigure);
+        boolean perUserBayes = config.getBoolean("perUserBayes", false);
+        return new RspamdClientConfiguration(rspamdUrl, rspamdPassword, rspamdTimeoutConfigure, perUserBayes);
     }
 
     private final URL url;
     private final String password;
     private final Optional<Integer> timeout;
+    private final boolean perUserBayes;
 
+    @VisibleForTesting
     public RspamdClientConfiguration(URL url, String password, Optional<Integer> timeout) {
         this.url = url;
         this.password = password;
         this.timeout = timeout;
+        this.perUserBayes = false;
+    }
+
+    public RspamdClientConfiguration(URL url, String password, Optional<Integer> timeout, boolean perUserBayes) {
+        this.url = url;
+        this.password = password;
+        this.timeout = timeout;
+        this.perUserBayes = perUserBayes;
     }
 
     public URL getUrl() {
@@ -66,5 +78,9 @@ public class RspamdClientConfiguration {
 
     public Optional<Integer> getTimeout() {
         return timeout;
+    }
+
+    public boolean usePerUserBayes() {
+        return perUserBayes;
     }
 }

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/module/RspamdTaskExtensionModule.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/module/RspamdTaskExtensionModule.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
+import org.apache.james.rspamd.client.RspamdClientConfiguration;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.rspamd.task.FeedHamToRspamdTask;
 import org.apache.james.rspamd.task.FeedHamToRspamdTaskAdditionalInformationDTO;
@@ -54,9 +55,10 @@ public class RspamdTaskExtensionModule implements TaskExtensionModule {
                                      MessageIdManager messageIdManager,
                                      MailboxSessionMapperFactory mapperFactory,
                                      RspamdHttpClient rspamdHttpClient,
-                                     Clock clock) {
-        this.feedSpamTaskDTOModule = FeedSpamToRspamdTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, clock);
-        this.feedHamTaskDTOModule = FeedHamToRspamdTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, clock);
+                                     Clock clock,
+                                     RspamdClientConfiguration rspamdConfiguration) {
+        this.feedSpamTaskDTOModule = FeedSpamToRspamdTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, clock, rspamdConfiguration);
+        this.feedHamTaskDTOModule = FeedHamToRspamdTaskDTO.module(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, clock, rspamdConfiguration);
     }
 
     @Override

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskDTO.java
@@ -26,6 +26,7 @@ import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
+import org.apache.james.rspamd.client.RspamdClientConfiguration;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.server.task.json.dto.TaskDTO;
 import org.apache.james.server.task.json.dto.TaskDTOModule;
@@ -39,7 +40,8 @@ public class FeedHamToRspamdTaskDTO implements TaskDTO {
                                                                                     MessageIdManager messageIdManager,
                                                                                     MailboxSessionMapperFactory mapperFactory,
                                                                                     RspamdHttpClient rspamdHttpClient,
-                                                                                    Clock clock) {
+                                                                                    Clock clock,
+                                                                                    RspamdClientConfiguration rspamdConfiguration) {
         return DTOModule.forDomainObject(FeedHamToRspamdTask.class)
             .convertToDTO(FeedHamToRspamdTaskDTO.class)
             .toDomainObjectConverter(dto -> new FeedHamToRspamdTask(mailboxManager,
@@ -51,7 +53,8 @@ public class FeedHamToRspamdTaskDTO implements TaskDTO {
                     dto.getMessagesPerSecond(),
                     dto.getSamplingProbability(),
                     dto.getClassifiedAsSpam()),
-                clock))
+                clock,
+                rspamdConfiguration))
             .toDTOConverter((domain, type) -> new FeedHamToRspamdTaskDTO(type,
                 domain.getRunningOptions().getPeriodInSecond().orElse(null),
                 domain.getRunningOptions().getMessagesPerSecond(),

--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskDTO.java
@@ -26,6 +26,7 @@ import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
+import org.apache.james.rspamd.client.RspamdClientConfiguration;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.server.task.json.dto.TaskDTO;
 import org.apache.james.server.task.json.dto.TaskDTOModule;
@@ -39,7 +40,8 @@ public class FeedSpamToRspamdTaskDTO implements TaskDTO {
                                                                                       MessageIdManager messageIdManager,
                                                                                       MailboxSessionMapperFactory mapperFactory,
                                                                                       RspamdHttpClient rspamdHttpClient,
-                                                                                      Clock clock) {
+                                                                                      Clock clock,
+                                                                                      RspamdClientConfiguration rspamdConfiguration) {
         return DTOModule.forDomainObject(FeedSpamToRspamdTask.class)
             .convertToDTO(FeedSpamToRspamdTaskDTO.class)
             .toDomainObjectConverter(dto -> new FeedSpamToRspamdTask(mailboxManager,
@@ -51,7 +53,8 @@ public class FeedSpamToRspamdTaskDTO implements TaskDTO {
                     dto.getMessagesPerSecond(),
                     dto.getSamplingProbability(),
                     dto.getClassifiedAsSpam()),
-                clock))
+                clock,
+                rspamdConfiguration))
             .toDTOConverter((domain, type) -> new FeedSpamToRspamdTaskDTO(
                 type,
                 domain.getRunningOptions().getPeriodInSecond().orElse(null),

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerClamAV.java
@@ -36,6 +36,7 @@ public class DockerClamAV {
             .withEnv("CLAMAV_NO_FRESHCLAMD", "true")
             .withEnv("CLAMAV_NO_MILTERD", "true")
             .withNetwork(network)
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("james-clamav-test"))
             .withNetworkAliases("clamav");
     }
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamd.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/DockerRspamd.java
@@ -42,14 +42,14 @@ public class DockerRspamd {
         this.network = Network.newNetwork();
         this.dockerRedis = new DockerRedis(network);
         this.dockerClamAV = new DockerClamAV(network);
-        this.container = createRspamD();
+        this.container = createRspamd();
     }
 
     public boolean isRunning() {
         return container.isRunning();
     }
 
-    private GenericContainer<?> createRspamD() {
+    private GenericContainer<?> createRspamd() {
         return new GenericContainer<>(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG))
             .withExposedPorts(DEFAULT_PORT)
             .withEnv("REDIS", "redis")
@@ -57,6 +57,8 @@ public class DockerRspamd {
             .withEnv("PASSWORD", PASSWORD)
             .withCopyFileToContainer(MountableFile.forClasspathResource("rspamd-config/antivirus.conf"), "/etc/rspamd/override.d/")
             .withCopyFileToContainer(MountableFile.forClasspathResource("rspamd-config/actions.conf"), "/etc/rspamd/")
+            .withCopyFileToContainer(MountableFile.forClasspathResource("rspamd-config/statistic.conf"), "/etc/rspamd/")
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("james-rspamd-test"))
             .withNetwork(network);
     }
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdListenerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdListenerTest.java
@@ -88,8 +88,8 @@ public class RspamdListenerTest {
     void setup() {
         rspamdHttpClient = mock(RspamdHttpClient.class);
 
-        when(rspamdHttpClient.reportAsHam(any())).thenReturn(Mono.empty());
-        when(rspamdHttpClient.reportAsSpam(any())).thenReturn(Mono.empty());
+        when(rspamdHttpClient.reportAsHam(any(), any())).thenReturn(Mono.empty());
+        when(rspamdHttpClient.reportAsSpam(any(), any())).thenReturn(Mono.empty());
 
         StoreMailboxManager mailboxManager = spy(InMemoryIntegrationResources.defaultResources().getMailboxManager());
         SystemMailboxesProviderImpl systemMailboxesProvider = new SystemMailboxesProviderImpl(mailboxManager);
@@ -228,7 +228,7 @@ public class RspamdListenerTest {
 
         listener.event(messageMoveEvent);
 
-        verify(rspamdHttpClient).reportAsSpam(any());
+        verify(rspamdHttpClient).reportAsSpam(any(), any());
     }
 
     @Test
@@ -246,7 +246,7 @@ public class RspamdListenerTest {
 
         listener.event(messageMoveEvent);
 
-        verify(rspamdHttpClient).reportAsHam(any());
+        verify(rspamdHttpClient).reportAsHam(any(), any());
     }
 
     @Test
@@ -262,7 +262,7 @@ public class RspamdListenerTest {
 
         listener.event(addedEvent);
 
-        verify(rspamdHttpClient).reportAsHam(any());
+        verify(rspamdHttpClient).reportAsHam(any(), any());
     }
 
     @Test
@@ -279,6 +279,7 @@ public class RspamdListenerTest {
         listener.event(addedEvent);
 
         verify(rspamdHttpClient, never()).reportAsHam(any());
+        verify(rspamdHttpClient, never()).reportAsHam(any(), any());
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox) throws MailboxException {

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
@@ -21,18 +21,18 @@ package org.apache.james.rspamd;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collection;
-import java.util.Optional;
 
+import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.Username;
 import org.apache.james.core.builder.MimeMessageBuilder;
-import org.apache.james.junit.categories.Unstable;
-import org.apache.james.rspamd.client.RspamdClientConfiguration;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.rspamd.model.AnalysisResult;
 import org.apache.james.util.MimeMessageUtil;
@@ -42,32 +42,34 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
 import org.apache.mailet.ProcessingState;
 import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMailContext;
 import org.apache.mailet.base.test.FakeMailetConfig;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 
-@Tag(Unstable.TAG)
 class RspamdScannerTest {
-    @RegisterExtension
-    static DockerRspamdExtension rspamdExtension = new DockerRspamdExtension();
-    static final String rspamdPassword = "admin";
     static final String INIT_SUBJECT = "initial subject";
     static final String REWRITE_SUBJECT = "rewrite subject";
 
     private RspamdScanner mailet;
+    private RspamdHttpClient rspamdHttpClient;
 
     @BeforeEach
-    void setup() {
-        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), rspamdPassword, Optional.empty());
-        RspamdHttpClient client = new RspamdHttpClient(configuration);
-        mailet = new RspamdScanner(client);
+    void setup() throws MessagingException {
+        rspamdHttpClient = mock(RspamdHttpClient.class);
+        when(rspamdHttpClient.checkV2(any(Mail.class)))
+            .thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.NO_ACTION)
+                .score(12.1F)
+                .requiredScore(14F)
+                .build()));
+        mailet = new RspamdScanner(rspamdHttpClient);
     }
 
     @Test
@@ -179,6 +181,13 @@ class RspamdScannerTest {
             .recipient("user1@exemple.com")
             .mimeMessage(mimeMessage)
             .build();
+
+        when(rspamdHttpClient.checkV2(any(Mail.class)))
+            .thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.REJECT)
+                .score(15F)
+                .requiredScore(14F)
+                .build()));
 
         mailet.init(FakeMailetConfig.builder()
             .setProperty("rewriteSubject", "true")
@@ -438,6 +447,14 @@ class RspamdScannerTest {
             .mimeMessage(mimeMessage)
             .build();
 
+        when(rspamdHttpClient.checkV2(any(Mail.class)))
+            .thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.REJECT)
+                .score(15F)
+                .requiredScore(14F)
+                .hasVirus(true)
+                .build()));
+
         mailet.init(mailetConfig);
         mailet.service(mail);
 
@@ -481,5 +498,155 @@ class RspamdScannerTest {
         mailet.service(mail);
 
         assertThat(mail.getState()).isNull();
+    }
+
+    @Nested
+    class PerUser {
+        @Test
+        void shouldPositionPerUserHeaders() throws Exception {
+            RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user1@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(1.1F)
+                    .requiredScore(14F)
+                    .build()));
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user2@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.ADD_HEADER)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+
+            mailet = new RspamdScanner(rspamdHttpClient);
+
+            mailet.init(FakeMailetConfig.builder()
+                .setProperty("perUserScans", "true")
+                .setProperty("virusProcessor", "virus")
+                .setProperty("rejectSpamProcessor", "spam")
+                .build());
+
+            Mail mail = FakeMail.builder()
+                .name("name")
+                .recipients("user1@exemple.com", "user2@exemple.com")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient("user1@exemple.com")
+                    .addFrom("sender@exemple.com")
+                    .setSubject(INIT_SUBJECT)
+                    .setText("Please!")
+                    .build())
+                .build();
+
+            mailet.service(mail);
+
+            Collection<PerRecipientHeaders.Header> headersForRecipient1 = mail.getPerRecipientSpecificHeaders()
+                .getHeadersForRecipient(new MailAddress("user1@exemple.com"));
+            assertThat(headersForRecipient1.stream()
+                .filter(header -> header.getName().equals(RspamdScanner.FLAG_MAIL.asString()))
+                .filter(header -> header.getValue().startsWith("NO"))
+                .findAny())
+                .isPresent();
+
+            Collection<PerRecipientHeaders.Header> headersForRecipient2 = mail.getPerRecipientSpecificHeaders()
+                .getHeadersForRecipient(new MailAddress("user2@exemple.com"));
+            assertThat(headersForRecipient2.stream()
+                .filter(header -> header.getName().equals(RspamdScanner.FLAG_MAIL.asString()))
+                .filter(header -> header.getValue().startsWith("YES"))
+                .findAny())
+                .isPresent();
+        }
+
+        @Test
+        void shouldPerformPartialRejects() throws Exception {
+            RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user1@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user2@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.REJECT)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+
+            mailet = new RspamdScanner(rspamdHttpClient);
+
+            FakeMailContext mailetContext = FakeMailContext.defaultContext();
+            mailet.init(FakeMailetConfig.builder()
+                .setProperty("perUserScans", "true")
+                .setProperty("virusProcessor", "virus")
+                .setProperty("rejectSpamProcessor", "spam")
+                .mailetContext(mailetContext)
+                .build());
+
+            Mail mail = FakeMail.builder()
+                .name("name")
+                .recipients("user1@exemple.com", "user2@exemple.com")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient("user1@exemple.com")
+                    .addFrom("sender@exemple.com")
+                    .setSubject(INIT_SUBJECT)
+                    .setText("Please!")
+                    .build())
+                .build();
+
+            mailet.service(mail);
+
+            assertThat(mail.getRecipients())
+                .containsOnly(new MailAddress("user1@exemple.com"));
+
+            assertThat(mailetContext.getSentMails().get(0).getState()).isEqualTo("spam");
+            assertThat(mailetContext.getSentMails().get(0).getRecipients()).containsOnly(new MailAddress("user2@exemple.com"));
+        }
+
+        @Test
+        void shouldPerformPartialVirus() throws Exception {
+            RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user1@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .build()));
+            when(rspamdHttpClient.checkV2(any(Mail.class), eq(RspamdHttpClient.Options.forUser(Username.of("user2@exemple.com")))))
+                .thenReturn(Mono.just(AnalysisResult.builder()
+                    .action(AnalysisResult.Action.NO_ACTION)
+                    .score(12.1F)
+                    .requiredScore(14F)
+                    .hasVirus(true)
+                    .build()));
+
+            mailet = new RspamdScanner(rspamdHttpClient);
+
+            FakeMailContext mailetContext = FakeMailContext.defaultContext();
+            mailet.init(FakeMailetConfig.builder()
+                .setProperty("perUserScans", "true")
+                .setProperty("virusProcessor", "virus")
+                .setProperty("rejectSpamProcessor", "spam")
+                .mailetContext(mailetContext)
+                .build());
+
+            Mail mail = FakeMail.builder()
+                .name("name")
+                .recipients("user1@exemple.com", "user2@exemple.com")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient("user1@exemple.com")
+                    .addFrom("sender@exemple.com")
+                    .setSubject(INIT_SUBJECT)
+                    .setText("Please!")
+                    .build())
+                .build();
+
+            mailet.service(mail);
+
+            assertThat(mail.getRecipients())
+                .containsOnly(new MailAddress("user1@exemple.com"));
+
+            assertThat(mailetContext.getSentMails().get(0).getState()).isEqualTo("virus");
+            assertThat(mailetContext.getSentMails().get(0).getRecipients()).containsOnly(new MailAddress("user2@exemple.com"));
+        }
     }
 }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/route/FeedMessageRouteTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/route/FeedMessageRouteTest.java
@@ -121,14 +121,15 @@ public class FeedMessageRouteTest {
         taskManager = new MemoryTaskManager(new Hostname("foo"));
         UpdatableTickingClock clock = new UpdatableTickingClock(NOW);
         JsonTransformer jsonTransformer = new JsonTransformer();
-        RspamdHttpClient client = new RspamdHttpClient(new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty()));
+        RspamdClientConfiguration rspamdConfiguration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(rspamdConfiguration);
         MessageIdManager messageIdManager = inMemoryIntegrationResources.getMessageIdManager();
         MailboxSessionMapperFactory mapperFactory = mailboxManager.getMapperFactory();
 
         TasksRoutes tasksRoutes = new TasksRoutes(taskManager, jsonTransformer, DTOConverter.of(FeedSpamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE,
             FeedHamToRspamdTaskAdditionalInformationDTO.SERIALIZATION_MODULE));
         FeedMessageRoute feedMessageRoute = new FeedMessageRoute(taskManager, mailboxManager, usersRepository, client, jsonTransformer, clock,
-            messageIdManager, mapperFactory);
+            messageIdManager, mapperFactory, rspamdConfiguration);
 
         webAdminServer = WebAdminUtils.createWebAdminServer(feedMessageRoute, tasksRoutes).start();
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
@@ -104,7 +104,7 @@ public class FeedHamToRspamdTaskTest {
         }
 
         @Override
-        public Mono<Void> reportAsHam(Publisher<ByteBuffer> content) {
+        public Mono<Void> reportAsHam(Publisher<ByteBuffer> content, Options options) {
             return Mono.from(content)
                 .doOnNext(e -> hitCounter.incrementAndGet())
                 .then();

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedHamToRspamdTaskTest.java
@@ -121,6 +121,7 @@ public class FeedHamToRspamdTaskTest {
     private UsersRepository usersRepository;
     private Clock clock;
     private RspamdHttpClient client;
+    private RspamdClientConfiguration configuration;
     private FeedHamToRspamdTask task;
 
     @BeforeEach
@@ -139,10 +140,11 @@ public class FeedHamToRspamdTaskTest {
         mailboxManager.createMailbox(ALICE_INBOX_MAILBOX, mailboxManager.createSystemSession(ALICE));
 
         clock = new UpdatableTickingClock(NOW);
-        client = new RspamdHttpClient(new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty()));
+        configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty(), true);
+        client = new RspamdHttpClient(configuration);
         messageIdManager = inMemoryIntegrationResources.getMessageIdManager();
         mapperFactory = mailboxManager.getMapperFactory();
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, RunningOptions.DEFAULT, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, RunningOptions.DEFAULT, clock, configuration);
     }
 
     @AfterEach
@@ -186,9 +188,11 @@ public class FeedHamToRspamdTaskTest {
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW));
         appendHamMessage(ALICE_INBOX_MAILBOX, Date.from(NOW));
 
-        TestRspamdHttpClient rspamdHttpClient = new TestRspamdHttpClient(new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty()));
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty(), true);
+        TestRspamdHttpClient rspamdHttpClient = new TestRspamdHttpClient(configuration);
 
-        FeedHamToRspamdTask feedHamToRspamdTask = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, rspamdHttpClient, RunningOptions.DEFAULT, clock);
+        FeedHamToRspamdTask feedHamToRspamdTask = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory,
+            rspamdHttpClient, RunningOptions.DEFAULT, clock, configuration);
 
 
         Task.Result result = feedHamToRspamdTask.run();
@@ -201,7 +205,7 @@ public class FeedHamToRspamdTaskTest {
     void taskShouldReportHamMessageInPeriod() throws MailboxException {
         RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY, ALL_MESSAGES);
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)));
 
@@ -220,7 +224,7 @@ public class FeedHamToRspamdTaskTest {
     void taskShouldNotReportHamMessageNotInPeriod() throws MailboxException {
         RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY, ALL_MESSAGES);
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(THREE_DAYS_IN_SECOND)));
 
@@ -239,7 +243,7 @@ public class FeedHamToRspamdTaskTest {
     void mixedInternalDateCase() throws MailboxException {
         RunningOptions runningOptions = new RunningOptions(Optional.of(TWO_DAYS_IN_SECOND),
             DEFAULT_MESSAGES_PER_SECOND, DEFAULT_SAMPLING_PROBABILITY, ALL_MESSAGES);
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(THREE_DAYS_IN_SECOND)));
         appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)));
@@ -259,7 +263,7 @@ public class FeedHamToRspamdTaskTest {
     void taskWithSamplingProbabilityIsZeroShouldReportNonHamMessage() {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0, ALL_MESSAGES);
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         IntStream.range(0, 10)
             .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -295,7 +299,7 @@ public class FeedHamToRspamdTaskTest {
     void taskWithVeryLowSamplingProbabilityShouldReportNotAllHamMessages() {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.01, ALL_MESSAGES);
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         IntStream.range(0, 10)
                 .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -314,7 +318,7 @@ public class FeedHamToRspamdTaskTest {
     void taskWithVeryHighSamplingProbabilityShouldReportMoreThanZeroMessage() {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.99, ALL_MESSAGES);
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         IntStream.range(0, 10)
             .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -333,7 +337,7 @@ public class FeedHamToRspamdTaskTest {
     void taskWithAverageSamplingProbabilityShouldReportSomeMessages() {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 0.5, ALL_MESSAGES);
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         IntStream.range(0, 10)
             .forEach(Throwing.intConsumer(any -> appendHamMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)))));
@@ -352,7 +356,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldReportUnclassifiedWhenClassifiedAsSpamIsTrue() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.of(true));
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "Unrelated: at all");
 
@@ -370,7 +374,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldNotReportHamWhenClassifiedAsSpamIsTrue() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.of(true));
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "org.apache.james.rspamd.flag: NO");
 
@@ -388,7 +392,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldReportSpamWhenClassifiedAsSpamIsTrue() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.of(true));
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "org.apache.james.rspamd.flag: YES");
 
@@ -406,7 +410,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldReportUnclassifiedWhenClassifiedAsSpamIsOmited() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.empty());
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "Unrelated: at all");
 
@@ -424,7 +428,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldReportHamWhenClassifiedAsSpamIsOmited() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.empty());
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "org.apache.james.rspamd.flag: NO");
 
@@ -442,7 +446,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldNotReportSpamWhenClassifiedAsSpamIsOmited() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.empty());
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "org.apache.james.rspamd.flag: YES");
 
@@ -460,7 +464,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldReportUnclassifiedWhenClassifiedAsSpamIsFalse() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.of(false));
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "Unrelated: at all");
 
@@ -478,7 +482,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldReportHamWhenClassifiedAsSpamIsFalse() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.of(false));
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "org.apache.james.rspamd.flag: NO");
 
@@ -496,7 +500,7 @@ public class FeedHamToRspamdTaskTest {
     void shouldNotReportSpamWhenClassifiedAsSpamIsFalse() throws Exception {
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.of(false));
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, client, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "org.apache.james.rspamd.flag: YES");
 
@@ -573,7 +577,7 @@ public class FeedHamToRspamdTaskTest {
 
         RunningOptions runningOptions = new RunningOptions(Optional.empty(),
             DEFAULT_MESSAGES_PER_SECOND, 1.0, Optional.of(false));
-        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, httpClient, runningOptions, clock);
+        task = new FeedHamToRspamdTask(mailboxManager, usersRepository, messageIdManager, mapperFactory, httpClient, runningOptions, clock, configuration);
 
         appendMessage(BOB_INBOX_MAILBOX, Date.from(NOW.minusSeconds(ONE_DAY_IN_SECOND)), "org.apache.james.rspamd.flag: NO");
 

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/task/FeedSpamToRspamdTaskTest.java
@@ -103,7 +103,7 @@ public class FeedSpamToRspamdTaskTest {
         }
 
         @Override
-        public Mono<Void> reportAsSpam(Publisher<ByteBuffer> content) {
+        public Mono<Void> reportAsSpam(Publisher<ByteBuffer> content, Options options) {
             return Mono.from(content)
                 .doOnNext(e -> hitCounter.incrementAndGet())
                 .then();

--- a/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
+++ b/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
@@ -1,0 +1,37 @@
+classifier "bayes" {
+  tokenizer {
+    name = "osb";
+  }
+  cache {
+  }
+  new_schema = true; # Always use new schema
+  store_tokens = true; # Redefine if storing of tokens is desired
+  signatures = true; # Store learn signatures
+  per_user = true; # Enable per user classifier
+  users_enabled = true;
+  min_tokens = 10;
+  backend = "redis";
+  min_learns = 0;
+
+  statfile {
+    symbol = "BAYES_HAM_USER";
+    spam = false;
+  }
+  statfile {
+    symbol = "BAYES_SPAM_USER";
+    spam = true;
+  }
+
+  learn_condition = 'return require("lua_bayes_learn").can_learn';
+
+  # Autolearn sample
+  # autolearn {
+  #  spam_threshold = 6.0; # When to learn spam (score >= threshold)
+  #  ham_threshold = -0.5; # When to learn ham (score <= threshold)
+  #  check_balance = true; # Check spam and ham balance
+  #  min_balance = 0.9; # Keep diff for spam/ham learns for at least this value
+  #}
+
+  .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/classifier-bayes.conf"
+  .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/classifier-bayes.conf"
+}

--- a/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
+++ b/third-party/rspamd/src/test/resources/rspamd-config/statistic.conf
@@ -5,20 +5,20 @@ classifier "bayes" {
   cache {
   }
   new_schema = true; # Always use new schema
-  store_tokens = true; # Redefine if storing of tokens is desired
-  signatures = true; # Store learn signatures
+  store_tokens = false; # Redefine if storing of tokens is desired
+  signatures = false; # Store learn signatures
   per_user = true; # Enable per user classifier
   users_enabled = true;
-  min_tokens = 10;
+  min_tokens = 11;
   backend = "redis";
-  min_learns = 0;
+  min_learns = 2;
 
   statfile {
-    symbol = "BAYES_HAM_USER";
+    symbol = "BAYES_HAM";
     spam = false;
   }
   statfile {
-    symbol = "BAYES_SPAM_USER";
+    symbol = "BAYES_SPAM";
     spam = true;
   }
 


### PR DESCRIPTION
Rebase on master, contribute my work on fixup commits.
Not a code or Rspamd issue, just a Bayes configuration issue.
Result:
```java
  Bob spam score before: 20.825
  Alice spam score before: 20.825
  Bob spam score after: 25.925
  Alice spam score after: 20.825

  Bob ham score before: 0.99
  Alice ham score before: 0.99
  Bob ham score after: 0.374475
  Alice ham score after: 0.99
```

We have the option to enable per-user in Rspamd mailet but not for listener and tasks (always call use per-user bayes). Maybe we should have a configuration option for them?
