### PR TITLE
JAMES-3827 Support From fields without domain parts in the email address

### DIFF
--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/EMailer.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/EMailer.java
@@ -39,6 +39,9 @@ public class EMailer implements SerializableMessage {
     }
 
     String removeTopDomain(String s) {
+        if (s == null) {
+            return null;
+        }
         if (s.contains(".")) {
             return s.substring(0, s.lastIndexOf('.'));
         }

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/EMailerTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/EMailerTest.java
@@ -19,6 +19,10 @@
 
 package org.apache.james.mailbox.opensearch.json;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -28,5 +32,11 @@ class EMailerTest {
     void eMailerShouldRespectBeanContract() {
         EqualsVerifier.forClass(EMailer.class)
             .verify();
+    }
+
+    @Test
+    void shouldSupportNullDomain() {
+        assertThatCode(() -> new EMailer(Optional.empty(), "localPart", null))
+            .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "s" is nul
  at org.apache.james.mailbox.elasticsearch.json.EMailer.removeTopDomain(EMailer.java:42)
  at org.apache.james.mailbox.elasticsearch.json.EMailer.<init>(EMailer.java:38)
  at org.apache.james.mailbox.elasticsearch.json.HeaderCollection$Builder.lambda$manageAddressField$0(HeaderCollection.java:145)
```