### PR TITLE
Fix release year for 3.7.0

### DIFF
--- a/src/site/xdoc/server/release-notes.xml
+++ b/src/site/xdoc/server/release-notes.xml
@@ -48,7 +48,7 @@
             <p><a href="https://james.apache.org/james/update/2022/08/26/james-3.7.1.html">Read the release announce</a>. </p>
         </section>
         <section name="Version 3.7.0">
-            <p>Released March 2021</p>
+            <p>Released March 2022</p>
             <p><a href="https://james.apache.org/james/update/2022/03/21/james-3.7.0.html">Read the release announce</a>. </p>
         </section>
         <section name="Version 3.6.1">


### PR DESCRIPTION
For 3.7.0 it should read "Released March 202**2**" rather than "Released March 2021".