### PR TITLE
JAMES-3842 Access SSLSession from Hooks and Handlers

### DIFF
--- a/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSession.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSession.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.net.ssl.SSLSession;
+
 import org.apache.james.core.Username;
 import org.apache.james.protocols.api.handler.LineHandler;
 
@@ -218,6 +220,11 @@ public interface ProtocolSession extends CommandDetectionSession {
      * Return true if the starttls was started
      */
     boolean isTLSStarted();
+    
+    /**
+     * Return the {@link SSLSession} of this protocol session. Empty if it does not use SSL/TLS. 
+     */
+    Optional<SSLSession> getSSLSession();
     
     /**
      * Return the {@link ProtocolConfiguration}

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.net.ssl.SSLSession;
+
 import org.apache.james.core.Username;
 import org.apache.james.protocols.api.handler.LineHandler;
 
@@ -118,6 +120,11 @@ public class ProtocolSessionImpl implements ProtocolSession {
     @Override
     public boolean isTLSStarted() {
         return transport.isTLSStarted();
+    }
+
+    @Override
+    public Optional<SSLSession> getSSLSession() {
+        return transport.getSSLSession();
     }
 
     @Override

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolTransport.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolTransport.java
@@ -20,6 +20,9 @@
 package org.apache.james.protocols.api;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
+
+import javax.net.ssl.SSLSession;
 
 import org.apache.james.protocols.api.handler.LineHandler;
 
@@ -57,6 +60,11 @@ public interface ProtocolTransport {
      * Return <code>true</code> if <code>STARTTLS</code> is supported by this {@link ProtocolTransport}
      */
     boolean isStartTLSSupported();
+
+    /*
+     * Return the {@link SSLSession} of this transport. Empty if it does not use SSL/TLS. 
+     */
+    Optional<SSLSession> getSSLSession();
 
     /**
      * Return <code>true</code> if <code>PROXY</code> is required by this {@link ProtocolTransport}

--- a/protocols/api/src/test/java/org/apache/james/protocols/api/AbstractProtocolTransportTest.java
+++ b/protocols/api/src/test/java/org/apache/james/protocols/api/AbstractProtocolTransportTest.java
@@ -27,9 +27,12 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.IntStream;
+
+import javax.net.ssl.SSLSession;
 
 import org.apache.james.protocols.api.handler.LineHandler;
 import org.junit.jupiter.api.Test;
@@ -81,6 +84,11 @@ public class AbstractProtocolTransportTest {
                 throw new UnsupportedOperationException();
             }
             
+            @Override
+            public Optional<SSLSession> getSSLSession() {
+                throw new UnsupportedOperationException();
+            }
+
             @Override
             public boolean isReadable() {
                 throw new UnsupportedOperationException();

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
@@ -23,6 +23,8 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.net.ssl.SSLSession;
+
 import org.apache.commons.text.RandomStringGenerator;
 import org.apache.james.core.Username;
 import org.apache.james.imap.api.ImapSessionState;
@@ -179,6 +181,13 @@ public interface ImapSession extends CommandDetectionSession {
      */
     boolean supportStartTLS();
 
+    /**
+     * Return the {@link SSLSession} of this protocol session. Empty if it does not use SSL/TLS.
+     * 
+     * @return SSLSession
+     */
+    Optional<SSLSession> getSSLSession();
+    
     /**
      * Return true if compression is active
      * 

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/FakeImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/FakeImapSession.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLSession;
+
 import org.apache.james.imap.api.ImapSessionState;
 import org.apache.james.imap.api.process.ImapLineHandler;
 import org.apache.james.imap.api.process.ImapSession;
@@ -137,6 +139,11 @@ public class FakeImapSession implements ImapSession {
     @Override
     public boolean supportStartTLS() {
         return false;
+    }
+
+    @Override
+    public Optional<SSLSession> getSSLSession() {
+        return Optional.empty();
     }
 
     @Override

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyProtocolTransport.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyProtocolTransport.java
@@ -24,6 +24,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.channels.FileChannel;
+import java.util.Optional;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 
 import org.apache.james.protocols.api.AbstractProtocolTransport;
 import org.apache.james.protocols.api.ProtocolSession;
@@ -70,6 +74,13 @@ public class NettyProtocolTransport extends AbstractProtocolTransport {
     @Override
     public boolean isStartTLSSupported() {
         return encryption != null && encryption.isStartTLS();
+    }
+
+    @Override
+    public Optional<SSLSession> getSSLSession() {
+        return Optional.ofNullable(channel.pipeline().get(SslHandler.class))
+            .map(SslHandler::engine)
+            .map(SSLEngine::getSession);
     }
 
     @Override

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/BaseFakeSMTPSession.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/BaseFakeSMTPSession.java
@@ -33,6 +33,8 @@ import org.apache.james.protocols.api.handler.LineHandler;
 import org.apache.james.protocols.smtp.SMTPConfiguration;
 import org.apache.james.protocols.smtp.SMTPSession;
 
+import javax.net.ssl.SSLSession;
+
 /**
  * Abstract class to simplify the mocks
  */
@@ -124,6 +126,11 @@ public class BaseFakeSMTPSession implements SMTPSession {
 
     @Override
     public boolean isTLSStarted() {
+        throw new UnsupportedOperationException("Unimplemented Stub Method");
+    }
+
+    @Override
+    public Optional<SSLSession> getSSLSession() {
         throw new UnsupportedOperationException("Unimplemented Stub Method");
     }
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.imap.api.ImapSessionState;
 import org.apache.james.imap.api.process.ImapLineHandler;
@@ -43,6 +46,7 @@ import io.netty.handler.codec.compression.JZlibEncoder;
 import io.netty.handler.codec.compression.ZlibDecoder;
 import io.netty.handler.codec.compression.ZlibEncoder;
 import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.ssl.SslHandler;
 import reactor.core.publisher.Mono;
 
 public class NettyImapSession implements ImapSession, NettyConstants {
@@ -277,6 +281,14 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     @Override
     public boolean isTLSActive() {
         return channel.pipeline().get(SSL_HANDLER) != null;
+    }
+
+    @Override
+    public Optional<SSLSession> getSSLSession() {
+        return Optional.ofNullable(channel.pipeline().get(SSL_HANDLER))
+            .map(SslHandler.class::cast)
+            .map(SslHandler::engine)
+            .map(SSLEngine::getSession);
     }
 
     @Override


### PR DESCRIPTION
James supports SMTPS and StartTLS, but currently has no way to programmatically access the resulting SSLSession from SMTP Hooks, POP3 Command Handlers etc. I propose to make the SSLSession accessible through the ProtocolSession.

This way, hooks/handlers can examine the SSL/TLS parameters negotiated with the currently connected client. They can check e.g. TLS version and selected cipher suite to evaluate the security level of the connection. With certificate based client authentication enabled, they can get the provided client certificate, e.g. to check against a permission list. Or a JamesMessageHook could attach it to the Mail object, so this information becomes even available to Mailets after spooling.
