### PR TITLE
JAMES-3843 VacationMailet should use null sender

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/VacationMailet.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/VacationMailet.java
@@ -46,12 +46,15 @@ import reactor.core.publisher.Mono;
 
 public class VacationMailet extends GenericMailet {
 
+    public static final String EXPLICIT_SENDER_PROPERTY = "james.vacation.sender.explicit";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(VacationMailet.class);
 
     private final VacationService vacationService;
     private final ZonedDateTimeProvider zonedDateTimeProvider;
     private final AutomaticallySentMailDetector automaticallySentMailDetector;
     private final MimeMessageBodyGenerator mimeMessageBodyGenerator;
+    private final boolean explicitSender;
 
     @Inject
     public VacationMailet(VacationService vacationService, ZonedDateTimeProvider zonedDateTimeProvider,
@@ -61,6 +64,7 @@ public class VacationMailet extends GenericMailet {
         this.zonedDateTimeProvider = zonedDateTimeProvider;
         this.automaticallySentMailDetector = automaticallySentMailDetector;
         this.mimeMessageBodyGenerator = mimeMessageBodyGenerator;
+        this.explicitSender = Boolean.parseBoolean(System.getProperty(EXPLICIT_SENDER_PROPERTY, "false"));
     }
 
     @Override
@@ -139,7 +143,7 @@ public class VacationMailet extends GenericMailet {
     }
 
     private void sendNotification(VacationReply vacationReply) throws MessagingException {
-        getMailetContext().sendMail(vacationReply.getSender(),
+        getMailetContext().sendMail(explicitSender ? vacationReply.getSender() : MailAddress.nullSender(),
             vacationReply.getRecipients(),
             vacationReply.getMimeMessage());
     }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/VacationMailetTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/VacationMailetTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -122,7 +123,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verify(vacationService).retrieveVacation(AccountId.fromString(USERNAME));
         verify(vacationService).isNotificationRegistered(ACCOUNT_ID, recipientId);
         verify(vacationService).registerNotification(ACCOUNT_ID, recipientId, Optional.of(DATE_TIME_2018));
@@ -152,7 +153,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verifyNoMoreInteractions(mailetContext);
     }
 
@@ -206,8 +207,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
-        verify(mailetContext).sendMail(eq(secondRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext, times(2)).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verifyNoMoreInteractions(mailetContext);
     }
 
@@ -288,7 +288,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verifyNoMoreInteractions(mailetContext);
     }
 

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.net.smtp.SMTPClient;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.dnsservice.api.InMemoryDNSService;
 import org.apache.james.jmap.api.model.AccountId;
+import org.apache.james.transport.mailets.VacationMailet;
 import org.apache.james.vacation.api.VacationPatch;
 import org.apache.james.jmap.draft.JmapGuiceProbe;
 import org.apache.james.junit.categories.BasicFeature;
@@ -70,6 +71,7 @@ public abstract class VacationRelayIntegrationTest {
         getInMemoryDns()
             .registerMxRecord("yopmail.com", fakeSmtp.getContainer().getContainerIp());
 
+        System.setProperty(VacationMailet.EXPLICIT_SENDER_PROPERTY, "true");
         guiceJamesServer = getJmapServer();
         guiceJamesServer.start();
 
@@ -87,6 +89,7 @@ public abstract class VacationRelayIntegrationTest {
     public void teardown() {
         fakeSmtp.clean();
         guiceJamesServer.stop();
+        System.clearProperty(VacationMailet.EXPLICIT_SENDER_PROPERTY);
     }
 
     @Category(BasicFeature.class)


### PR DESCRIPTION
When the VacationMailet sends a vacation message, it uses the original recipient as envelope sender. However, RFC 5230 states
"5.1. SMTP MAIL FROM Address
The SMTP MAIL FROM address of the message envelope SHOULD be set to <>."
While we are technically OK because of the SHOULD, I do not see any real requirement to deviate from the recommendation. In fact, using the null sender can help prevent mail loops. So I propose we change the VacationMailet accordingly.