### PR TITLE
[Changes] updated docker-compose.yml files

### DIFF
--- a/server/apps/cassandra-app/docker-compose.yml
+++ b/server/apps/cassandra-app/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   james:
     depends_on:
-      - elasticsearch
+      - opensearch
       - cassandra
       - tika
     image: apache/james:cassandra-latest

--- a/server/apps/distributed-app/docker-compose.yml
+++ b/server/apps/distributed-app/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   james:
     depends_on:
-      - elasticsearch
+      - opensearch
       - cassandra
       - tika
       - rabbitmq

--- a/server/apps/distributed-pop3-app/docker-compose.yml
+++ b/server/apps/distributed-pop3-app/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   james:
     depends_on:
-      - elasticsearch
+      - opensearch
       - cassandra
       - tika
       - rabbitmq
@@ -22,10 +22,20 @@ services:
       - "993:993"
       - "8000:8000"
 
+  opensearch:
+    image: opensearchproject/opensearch:2.1.0
+    environment:
+      - discovery.type=single-node
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - DISABLE_SECURITY_PLUGIN=true
+
   cassandra:
     image: cassandra:3.11.10
     ports:
       - "9042:9042"
+
+  tika:
+    image: apache/tika:1.28.2
 
   rabbitmq:
     image: rabbitmq:3.9.18-management
@@ -42,4 +52,3 @@ services:
       - S3BACKEND=mem
       - LOG_LEVEL=trace
       - REMOTE_MANAGEMENT_DISABLE=1
-

--- a/third-party/clamav/docker-compose.yml
+++ b/third-party/clamav/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   james:
     depends_on:
-      - elasticsearch
+      - opensearch
       - cassandra
       - tika
       - rabbitmq


### PR DESCRIPTION
Updated docker-compose.yml files based on the jira ticket [JAMES-3844](https://issues.apache.org/jira/browse/JAMES-3844).

Issues Fixed: docker-compose up is able to pull images and start the services for 

server/apps/cassandra-app/docker-compose.yml
server/apps/distributed-app/docker-compose.yml
third-party/clamav/docker-compose.yml

Issues unresolved: 
docker image tag referred in the below docker-compose isn't available in docker hub, so it doesn't start without performing a local build to james server
server/apps/distributed-pop3-app/docker-compose.yml

These issues should get resolved once a proper build is pushed to docker-compose