### PR TITLE
JAMES-3843 VacationMailet should use null sender

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/VacationMailet.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/VacationMailet.java
@@ -46,12 +46,15 @@ import reactor.core.publisher.Mono;
 
 public class VacationMailet extends GenericMailet {
 
+    public static final String EXPLICIT_SENDER_PROPERTY = "james.vacation.sender.explicit";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(VacationMailet.class);
 
     private final VacationService vacationService;
     private final ZonedDateTimeProvider zonedDateTimeProvider;
     private final AutomaticallySentMailDetector automaticallySentMailDetector;
     private final MimeMessageBodyGenerator mimeMessageBodyGenerator;
+    private final boolean explicitSender;
 
     @Inject
     public VacationMailet(VacationService vacationService, ZonedDateTimeProvider zonedDateTimeProvider,
@@ -61,6 +64,7 @@ public class VacationMailet extends GenericMailet {
         this.zonedDateTimeProvider = zonedDateTimeProvider;
         this.automaticallySentMailDetector = automaticallySentMailDetector;
         this.mimeMessageBodyGenerator = mimeMessageBodyGenerator;
+        this.explicitSender = Boolean.parseBoolean(System.getProperty(EXPLICIT_SENDER_PROPERTY, "false"));
     }
 
     @Override
@@ -139,7 +143,7 @@ public class VacationMailet extends GenericMailet {
     }
 
     private void sendNotification(VacationReply vacationReply) throws MessagingException {
-        getMailetContext().sendMail(vacationReply.getSender(),
+        getMailetContext().sendMail(explicitSender ? vacationReply.getSender() : MailAddress.nullSender(),
             vacationReply.getRecipients(),
             vacationReply.getMimeMessage());
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/VacationMailet.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/VacationMailet.java
@@ -46,15 +46,12 @@ import reactor.core.publisher.Mono;
 
 public class VacationMailet extends GenericMailet {
 
-    public static final String EXPLICIT_SENDER_PROPERTY = "james.vacation.sender.explicit";
-
     private static final Logger LOGGER = LoggerFactory.getLogger(VacationMailet.class);
 
     private final VacationService vacationService;
     private final ZonedDateTimeProvider zonedDateTimeProvider;
     private final AutomaticallySentMailDetector automaticallySentMailDetector;
     private final MimeMessageBodyGenerator mimeMessageBodyGenerator;
-    private final boolean explicitSender;
 
     @Inject
     public VacationMailet(VacationService vacationService, ZonedDateTimeProvider zonedDateTimeProvider,
@@ -64,7 +61,6 @@ public class VacationMailet extends GenericMailet {
         this.zonedDateTimeProvider = zonedDateTimeProvider;
         this.automaticallySentMailDetector = automaticallySentMailDetector;
         this.mimeMessageBodyGenerator = mimeMessageBodyGenerator;
-        this.explicitSender = Boolean.parseBoolean(System.getProperty(EXPLICIT_SENDER_PROPERTY, "false"));
     }
 
     @Override
@@ -143,7 +139,7 @@ public class VacationMailet extends GenericMailet {
     }
 
     private void sendNotification(VacationReply vacationReply) throws MessagingException {
-        getMailetContext().sendMail(explicitSender ? vacationReply.getSender() : MailAddress.nullSender(),
+        getMailetContext().sendMail(MailAddress.nullSender(),
             vacationReply.getRecipients(),
             vacationReply.getMimeMessage());
     }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/VacationMailetTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/VacationMailetTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -122,7 +123,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verify(vacationService).retrieveVacation(AccountId.fromString(USERNAME));
         verify(vacationService).isNotificationRegistered(ACCOUNT_ID, recipientId);
         verify(vacationService).registerNotification(ACCOUNT_ID, recipientId, Optional.of(DATE_TIME_2018));
@@ -152,7 +153,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verifyNoMoreInteractions(mailetContext);
     }
 
@@ -206,8 +207,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
-        verify(mailetContext).sendMail(eq(secondRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext, times(2)).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verifyNoMoreInteractions(mailetContext);
     }
 
@@ -288,7 +288,7 @@ public class VacationMailetTest {
 
         testee.service(mail);
 
-        verify(mailetContext).sendMail(eq(originalRecipient), eq(ImmutableList.of(originalSender)), any());
+        verify(mailetContext).sendMail(eq(MailAddress.nullSender()), eq(ImmutableList.of(originalSender)), any());
         verifyNoMoreInteractions(mailetContext);
     }
 

--- a/server/mailet/mock-smtp-server/pom.xml
+++ b/server/mailet/mock-smtp-server/pom.xml
@@ -129,7 +129,7 @@
                     <to>
                         <image>linagora/mock-smtp-server</image>
                         <tags>
-                            <tag>0.5</tag>
+                            <tag>0.6</tag>
                         </tags>
                     </to>
                     <container>

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/MockMessageHandler.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/MockMessageHandler.java
@@ -187,6 +187,9 @@ public class MockMessageHandler implements MessageHandler {
     }
 
     private MailAddress parse(String mailAddress) {
+        if (mailAddress.isEmpty()) {
+            return MailAddress.nullSender();
+        }
         try {
             return new MailAddress(mailAddress);
         } catch (AddressException e) {

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Mail.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Mail.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import javax.mail.internet.AddressException;
+
 import org.apache.james.core.MailAddress;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -228,6 +230,19 @@ public class Mail {
 
             public Builder from(MailAddress from) {
                 this.from = from;
+                return this;
+            }
+
+            public Builder from(String from) {
+                if (from.equals("<>")) {
+                    this.from = MailAddress.nullSender();
+                } else {
+                    try {
+                        this.from = new MailAddress(from);
+                    } catch (AddressException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
                 return this;
             }
 

--- a/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/ConfigurationClientTest.java
+++ b/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/ConfigurationClientTest.java
@@ -22,7 +22,9 @@ package org.apache.james.mock.smtp.server;
 import static org.apache.james.mock.smtp.server.Fixture.BEHAVIOR_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.james.core.MailAddress;
 import org.apache.james.mock.smtp.server.Fixture.MailsFixutre;
+import org.apache.james.mock.smtp.server.model.Mail;
 import org.apache.james.mock.smtp.server.model.SMTPExtension;
 import org.apache.james.mock.smtp.server.model.SMTPExtensions;
 import org.junit.jupiter.api.AfterEach;
@@ -131,6 +133,35 @@ class ConfigurationClientTest {
 
         assertThat(testee.listMails())
             .containsExactly(MailsFixutre.MAIL_1, MailsFixutre.MAIL_2);
+    }
+
+    @Test
+    void listMailsShouldReturnMailWithNullSender() throws Exception {
+        final Mail mail = new Mail(
+            Mail.Envelope.builder()
+                .from(MailAddress.nullSender())
+                .addRecipientMailAddress(new MailAddress(Fixture.ALICE))
+                .addRecipient(Mail.Recipient.builder()
+                    .address(new MailAddress(Fixture.JACK))
+                    .addParameter(Mail.Parameter.builder()
+                        .name("param1")
+                        .value("value1")
+                        .build())
+                    .addParameter(Mail.Parameter.builder()
+                        .name("param2")
+                        .value("value2")
+                        .build())
+                    .build())
+                .addMailParameter(Mail.Parameter.builder()
+                    .name("param3")
+                    .value("value3")
+                    .build())
+                .build(),
+            "bob to alice and jack");
+        mailRepository.store(mail);
+
+        assertThat(testee.listMails())
+            .containsExactly(mail);
     }
 
     @Test

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/pom.xml
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/pom.xml
@@ -103,6 +103,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>mock-smtp-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
         </dependency>

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/MockSmtpTestRule.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/MockSmtpTestRule.java
@@ -1,0 +1,74 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap;
+
+import java.util.UUID;
+
+import org.apache.james.mock.smtp.server.ConfigurationClient;
+import org.apache.james.util.Host;
+import org.apache.james.util.docker.DockerContainer;
+import org.apache.james.util.docker.Images;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class MockSmtpTestRule implements TestRule {
+    public static class DockerMockSmtp {
+        private static final Logger LOGGER = LoggerFactory.getLogger(DockerMockSmtp.class);
+
+        private final DockerContainer mockSmtpServer;
+
+        DockerMockSmtp() {
+            mockSmtpServer = DockerContainer.fromName(Images.MOCK_SMTP_SERVER)
+                .withLogConsumer(outputFrame -> LOGGER.debug("MockSMTP: " + outputFrame.getUtf8String()))
+                .withExposedPorts(25, 8000)
+                .waitingFor(Wait.forLogMessage(".*Mock SMTP server started.*", 1))
+                .withName("james-testing-mock-smtp-server-" + UUID.randomUUID());
+        }
+
+        public ConfigurationClient getConfigurationClient() {
+            return ConfigurationClient.from(Host.from(
+                mockSmtpServer.getHostIp(),
+                mockSmtpServer.getMappedPort(8000)));
+        }
+
+        public String getIPAddress() {
+            return mockSmtpServer.getContainerIp();
+        }
+    }
+
+    private final DockerMockSmtp dockerMockSmtp;
+
+    public MockSmtpTestRule() {
+        this.dockerMockSmtp = new DockerMockSmtp();
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return dockerMockSmtp.mockSmtpServer.apply(statement, description);
+    }
+
+    public DockerMockSmtp getDockerMockSmtp() {
+        return dockerMockSmtp;
+    }
+}

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.net.smtp.SMTPClient;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.dnsservice.api.InMemoryDNSService;
 import org.apache.james.jmap.api.model.AccountId;
+import org.apache.james.transport.mailets.VacationMailet;
 import org.apache.james.vacation.api.VacationPatch;
 import org.apache.james.jmap.draft.JmapGuiceProbe;
 import org.apache.james.junit.categories.BasicFeature;
@@ -70,6 +71,7 @@ public abstract class VacationRelayIntegrationTest {
         getInMemoryDns()
             .registerMxRecord("yopmail.com", fakeSmtp.getContainer().getContainerIp());
 
+        System.setProperty(VacationMailet.EXPLICIT_SENDER_PROPERTY, "true");
         guiceJamesServer = getJmapServer();
         guiceJamesServer.start();
 
@@ -87,6 +89,7 @@ public abstract class VacationRelayIntegrationTest {
     public void teardown() {
         fakeSmtp.clean();
         guiceJamesServer.stop();
+        System.clearProperty(VacationMailet.EXPLICIT_SENDER_PROPERTY);
     }
 
     @Category(BasicFeature.class)

--- a/server/testing/src/main/java/org/apache/james/util/docker/Images.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/Images.java
@@ -27,5 +27,5 @@ public interface Images {
     String ELASTICSEARCH_7 = "docker.elastic.co/elasticsearch/elasticsearch:7.10.2";
     String OPENSEARCH = "opensearchproject/opensearch:2.1.0";
     String TIKA = "apache/tika:1.28.2";
-    String MOCK_SMTP_SERVER = "linagora/mock-smtp-server:0.4";
+    String MOCK_SMTP_SERVER = "linagora/mock-smtp-server:0.6";
 }


### PR DESCRIPTION
https://github.com/apache/james-project/pull/1278 without the custom config hack to turn off the nullSender, and without turning off the integration tests.

CC @ottoka