### PR TITLE
JAMES-3846 Improve vacation notice appearance

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/util/MimeMessageBodyGenerator.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/util/MimeMessageBodyGenerator.java
@@ -38,7 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class MimeMessageBodyGenerator {
-    public static final String MIXED = "mixed";
+    public static final String ALTERNATIVE = "alternative";
     public static final String EMPTY_TEXT = "";
 
     private final HtmlTextExtractor htmlTextExtractor;
@@ -63,7 +63,7 @@ public class MimeMessageBodyGenerator {
 
     private Multipart generateMultipart(String htmlText, Optional<String> plainText) throws MessagingException {
         try {
-            Multipart multipart = new MimeMultipart(MIXED);
+            Multipart multipart = new MimeMultipart(ALTERNATIVE);
             addTextPart(multipart, htmlText, "text/html");
             addTextPart(multipart, retrievePlainTextMessage(plainText, htmlText), ContentTypeField.TYPE_TEXT_PLAIN);
             return multipart;
@@ -84,7 +84,7 @@ public class MimeMessageBodyGenerator {
     }
 
     private String retrievePlainTextMessage(Optional<String> plainText, String htmlText) {
-        return plainText.orElseGet(() -> htmlTextExtractor.toPlainText(htmlText));
+        return plainText.filter(text -> !text.isBlank()).orElseGet(() -> htmlTextExtractor.toPlainText(htmlText));
     }
 
 }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/util/MimeMessageBodyGeneratorTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/util/MimeMessageBodyGeneratorTest.java
@@ -91,6 +91,22 @@ public class MimeMessageBodyGeneratorTest {
     }
 
     @Test
+    public void fromShouldProvideAPlainTextVersionWhenHtmlAndEmptyText() throws Exception {
+        String htmlText = "<p>HTML text</p>";
+        String plainText = "Plain text";
+        when(htmlTextExtractor.toPlainText(htmlText)).thenReturn(plainText);
+
+        String rowContent = IOUtils.toString(
+            mimeMessageBodyGenerator.from(original,
+                    Optional.of(""),
+                    Optional.of(htmlText))
+                .getInputStream(), StandardCharsets.UTF_8);
+
+        assertThat(rowContent).containsSequence(htmlText);
+        assertThat(rowContent).containsSequence(plainText);
+    }
+
+    @Test
     public void fromShouldCombinePlainTextAndHtml() throws Exception {
         String htmlText = "<p>HTML text</p>";
         String plainText = "Plain text";


### PR DESCRIPTION
I noticed that vacation notices generated by James look somewhat strange in Thunderbird, and probably other mail clients as well: It shows both the HTML and plain text variant of the message (see attached screenshot). This is likely caused by the Content-Type of multipart/mixed.

I suggest we change this to multipart/alternative instead, so a HTML capable client will only show the HTML part, while a text-only client will show the text part instead.

I also noticed that, after setting an HTML message and an empty text message by accident, the generated text part is naturally empty. This is OK for HTML-capable clients, but in the worst case a text-only client would show just an empty mail, even though there is content in the HTML part.

I suggest we make the vacation notice generation more robust, and also generate a text message from HTML in this case, which will be more useful to the recipients.