### PR TITLE
[FIX] Prevent stack overflow in FETCH command

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/FetchPartPathDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/FetchPartPathDecoder.java
@@ -331,23 +331,23 @@ public class FetchPartPathDecoder {
     }
 
     private void readHeaderNames(int at, int lastWordStart, CharSequence sectionSpecification) throws DecodingException {
-        if (at < sectionSpecification.length()) {
+        while (at < sectionSpecification.length()) {
             final char next = sectionSpecification.charAt(at);
             switch (next) {
-            case ' ':
-                readName(lastWordStart, at, sectionSpecification);
-                int nextWord = skipSpaces(at, sectionSpecification);
-                readHeaderNames(nextWord, nextWord, sectionSpecification);
-                break;
-            case ')':
-                readName(lastWordStart, at, sectionSpecification);
-                break;
-            default:
-                readHeaderNames(at + 1, lastWordStart, sectionSpecification);
+                case ' ':
+                    readName(lastWordStart, at, sectionSpecification);
+                    int nextWord = skipSpaces(at, sectionSpecification);
+                    at = nextWord;
+                    lastWordStart = nextWord;
+                    break;
+                case ')':
+                    readName(lastWordStart, at, sectionSpecification);
+                    return;
+                default:
+                    at = at + 1;
             }
-        } else {
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Closing parenthesis missing.");
         }
+        throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Closing parenthesis missing.");
     }
 
     private void readName(int wordStart, int wordFinish, CharSequence sectionSpecification) {

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/FetchPartPathDecoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/FetchPartPathDecoderTest.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Fail.fail;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.james.imap.api.message.SectionType;
 import org.junit.jupiter.api.BeforeEach;
@@ -179,6 +181,14 @@ class FetchPartPathDecoderTest {
     @Test
     void testShouldReadManyFieldNotNames() throws Exception {
         String[] names = { "ONE", "TWO", "THREE", "FOUR", "FIVE", "345345" };
+        checkReadNames("1.8.HEADER.FIELDS.NOT", names);
+    }
+
+    @Test
+    void manyHeadersShouldNotLeadToStackOverFlow() throws Exception {
+        String[] names = IntStream.range(0, 3000)
+            .mapToObj(Integer::toString)
+            .toArray(String[]::new);
         checkReadNames("1.8.HEADER.FIELDS.NOT", names);
     }
 


### PR DESCRIPTION
Kill recursion when dealing with header names.