### PR TITLE
JAMES-3788 Fix PROXY protocol support with TLS

### DIFF
--- a/examples/proxy-smtp/README.md
+++ b/examples/proxy-smtp/README.md
@@ -33,6 +33,12 @@ docker-compose up helo
 
 If you expose HAProxy's port 25 you can also send a HELO using telnet.
 
+Similarly, one can test a setup mixing SSL and SMTP (with James responsible for SSL termination):
+
+```
+openssl s_client -host 127.0.0.1 -port 465
+```
+
 ## IMAP
 
 This docker example uses HAProxy exposes port 143 (SMTP)
@@ -48,6 +54,12 @@ Will generate the following logs:
 ```
 james      | 02:30:48.927 [INFO ] o.a.j.i.n.ImapChannelUpstreamHandler - Connection established from 192.168.208.3
 james      | 02:30:48.963 [INFO ] o.a.j.i.n.HAProxyMessageHandler - Connection from 192.168.208.1 runs through 192.168.208.3 proxy
+```
+
+Similarly, one can test a setup mixing SSL and IMAP (with James responsible for SSL termination):
+
+```
+openssl s_client -host 127.0.0.1 -port 993
 ```
 
 ## Limitations

--- a/examples/proxy-smtp/docker-compose.yml
+++ b/examples/proxy-smtp/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - 25:25
       - 143:143
+      - 993:993
+      - 465:465
     depends_on:
       - james
 

--- a/examples/proxy-smtp/haproxy.cfg
+++ b/examples/proxy-smtp/haproxy.cfg
@@ -3,9 +3,9 @@ global
 
 defaults
   mode tcp
-  timeout client 10s
+  timeout client 1800s
   timeout connect 5s
-  timeout server 10s
+  timeout server 1800s
   log global
   option tcplog
 
@@ -13,12 +13,26 @@ frontend smtp-frontend
   bind :25
   default_backend james-servers
 
+frontend smtps-frontend
+  bind :465
+  default_backend smtps-servers
+
 backend james-servers
   server james1 james:2525 send-proxy
+
+backend smtps-servers
+  server james1 james:465 send-proxy
 
 frontend imap-frontend
   bind :143
   default_backend james-servers-imap
 
+frontend imaps-frontend
+  bind :993
+  default_backend james-servers-imaps
+
 backend james-servers-imap
   server james1 james:143 send-proxy
+
+backend james-servers-imaps
+  server james1 james:993 send-proxy

--- a/examples/proxy-smtp/imapserver.xml
+++ b/examples/proxy-smtp/imapserver.xml
@@ -53,4 +53,34 @@ under the License.
         </auth>
         <proxyRequired>true</proxyRequired>
     </imapserver>
+    <imapserver enabled="true">
+        <jmxName>imapsserver</jmxName>
+        <bind>0.0.0.0:993</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="true" startTLS="false">
+            <!-- To create a new keystore execute:
+              keytool -genkey -alias james -keyalg RSA -storetype PKCS12 -keystore /path/to/james/conf/keystore
+             -->
+            <keystore>file://conf/keystore</keystore>
+            <keystoreType>PKCS12</keystoreType>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+
+            <!-- Alternatively TLS keys can be supplied via PEM files -->
+            <!-- <privateKey>file://conf/private.key</privateKey> -->
+            <!-- <certificates>file://conf/certs.self-signed.csr</certificates> -->
+            <!-- An optional secret might be specified for the private key -->
+            <!-- <secret>james72laBalle</secret> -->
+        </tls>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <idleTimeInterval>120</idleTimeInterval>
+        <idleTimeIntervalUnit>SECONDS</idleTimeIntervalUnit>
+        <enableIdle>true</enableIdle>
+        <plainAuthDisallowed>true</plainAuthDisallowed>
+        <auth>
+            <plainAuthEnabled>true</plainAuthEnabled>
+        </auth>
+        <proxyRequired>true</proxyRequired>
+    </imapserver>
 </imapservers>

--- a/examples/proxy-smtp/smtpserver.xml
+++ b/examples/proxy-smtp/smtpserver.xml
@@ -48,6 +48,34 @@
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
     </smtpserver>
+    <smtpserver enabled="true">
+        <jmxName>smtpsserver-global</jmxName>
+        <bind>0.0.0.0:465</bind>
+        <connectionBacklog>200</connectionBacklog>
+        <tls socketTLS="true" startTLS="false">
+            <keystore>file://conf/keystore</keystore>
+            <keystoreType>PKCS12</keystoreType>
+            <secret>james72laBalle</secret>
+            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+        </tls>
+        <connectiontimeout>360</connectiontimeout>
+        <connectionLimit>0</connectionLimit>
+        <connectionLimitPerIP>0</connectionLimitPerIP>
+        <auth>
+            <announce>never</announce>
+            <requireSSL>false</requireSSL>
+        </auth>
+        <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
+        <verifyIdentity>false</verifyIdentity>
+        <proxyRequired>true</proxyRequired>
+        <maxmessagesize>0</maxmessagesize>
+        <addressBracketsEnforcement>true</addressBracketsEnforcement>
+        <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+        <handlerchain>
+            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
+            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
+        </handlerchain>
+    </smtpserver>
 </smtpservers>
 
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -255,7 +255,11 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
                
                 Encryption secure = getEncryption();
                 if (secure != null && !secure.isStartTLS()) {
-                    pipeline.addFirst(SSL_HANDLER, secure.sslHandler());
+                    if (proxyRequired) {
+                        channel.pipeline().addAfter("proxyInformationHandler", SSL_HANDLER, secure.sslHandler());
+                    } else {
+                        channel.pipeline().addFirst(SSL_HANDLER, secure.sslHandler());
+                    }
                 }
 
                 pipeline.addLast(CHUNK_WRITE_HANDLER, new ChunkedWriteHandler());


### PR DESCRIPTION
Given James is responsible of TLS termination, PROXY protocol should be handled first, before SSL.

Add examples for TLS + PROXY support.

Cc @ouvtam 