### PR TITLE
JAMES-3851 TLS host name verification should handle trailing dot

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
@@ -252,11 +252,20 @@ public class MailDelivrerToHost {
 
     private void connect(HostAddress outgoingMailServer, SMTPTransport transport) throws MessagingException {
         if (configuration.getAuthUser() != null) {
-            transport.connect(outgoingMailServer.getHostName(), configuration.getAuthUser(), configuration.getAuthPass());
+            transport.connect(getHostName(outgoingMailServer), configuration.getAuthUser(), configuration.getAuthPass());
         } else if (configuration.isConnectByHostname()) {
-            transport.connect(outgoingMailServer.getHostName(), null, null);
+            transport.connect(getHostName(outgoingMailServer), null, null);
         } else {
             transport.connect(); // connect via IP address instead of host name
+        }
+    }
+
+    private String getHostName(HostAddress outgoingMailServer) {
+        String host = outgoingMailServer.getHostName();
+        if (host.length() > 0 && host.charAt(host.length() - 1) == '.') {
+            return host.substring(0, host.length() - 1);
+        } else {
+            return host;
         }
     }
 


### PR DESCRIPTION
I noticed that sometimes RemoteDelivery opens a connection using a fully qualified hostname that ends with a trailing dot, like "mail.example.org." I believe James may get that from MX resolving, since afaik DNS servers may do this to indicate an absolute FQDN vs. a relative one. This is not an issue when establishing a connection, but will break TLS hostname verification, since the CN and SubjectAltNames in server certificates never use trailing dots.

Consequently, RemoteDelivery should strip a trailing dot from the hostname before connecting.

Note that this is the minimal fix for the verification issue; log messages related to remote delivery will still show the hostname with a trailing dot. I am not sure if this is intended behavior, i.e. to see exactly what James got from DNS resolution. Otherwise, an alternative would be to fix this early in MXHostAddressIterator. Let me know if you prefer the latter.