### PR TITLE
JAMES-3856 RFC-9208 Implement IMAP QUOTA revision

### DIFF
--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/QuotaTest.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/QuotaTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public abstract class QuotaTest implements ImapTestConstants {
 
-    private static final QuotaCountLimit MAX_MESSAGE_QUOTA = QuotaCountLimit.count(4096);
+    private static final QuotaCountLimit MAX_MESSAGE_QUOTA = QuotaCountLimit.count(7);
     private static final QuotaSizeLimit MAX_STORAGE_QUOTA = QuotaSizeLimit.size(5 * 1024L * 1024L * 1024L);
 
     protected abstract ImapHostSystem createImapHostSystem();

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Quota.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Quota.test
@@ -63,6 +63,19 @@ S: \* 2 EXISTS
 S: \* 2 RECENT
 S: A004 OK (\[.+\] )?APPEND completed.
 
+C: A006 GETQUOTAROOT #private.imapuser.test
+S: \* QUOTAROOT "#private\.imapuser\.test" #private&imapuser
+S: \* QUOTA #private&imapuser \(MESSAGE 6 7\)
+S: \* QUOTA #private&imapuser \(STORAGE 1 5242880\)
+S: A006 OK GETQUOTAROOT completed.
+
+C: A007 GETQUOTA #private&imapuser
+# seven because of pre inserted messages for imapuser
+S: \* QUOTA #private&imapuser \(MESSAGE 6 7\)
+# 1 = 1KB : 254 * 4 + 3 * 310 = 1946 so shrinked to 1KB
+S: \* QUOTA #private&imapuser \(STORAGE 1 5242880\)
+S: A007 OK GETQUOTA completed.
+
 C: A005 APPEND #private.imapuser.test (\Seen \Draft) "09-Apr-2008 15:17:51 +0200" {310+}
 C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
 C: From: Fred Foobar <foobar@Blurdybloop.COM>
@@ -84,16 +97,29 @@ AWAIT
 
 C: A006 GETQUOTAROOT #private.imapuser.test
 S: \* QUOTAROOT "#private\.imapuser\.test" #private&imapuser
-S: \* QUOTA #private&imapuser \(MESSAGE 7 4096\)
+S: \* QUOTA #private&imapuser \(MESSAGE 7 7\)
 S: \* QUOTA #private&imapuser \(STORAGE 1 5242880\)
 S: A006 OK GETQUOTAROOT completed.
 
 C: A007 GETQUOTA #private&imapuser
 # seven because of pre inserted messages for imapuser
-S: \* QUOTA #private&imapuser \(MESSAGE 7 4096\)
+S: \* QUOTA #private&imapuser \(MESSAGE 7 7\)
 # 1 = 1KB : 254 * 4 + 3 * 310 = 1946 so shrinked to 1KB
 S: \* QUOTA #private&imapuser \(STORAGE 1 5242880\)
 S: A007 OK GETQUOTA completed.
 
 C: A007 SETQUOTA #private&imapuser (MESSAGE 4096) (STORAGE 5242880)
 S: A007 NO SETQUOTA You need the Full admin rights right to perform command SETQUOTA on mailbox Can not perform SETQUOTA commands.
+
+C: A005 APPEND #private.imapuser.test (\Seen \Draft) "09-Apr-2008 15:17:51 +0200" {310+}
+C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
+C: From: Fred Foobar <foobar@Blurdybloop.COM>
+C: Subject: afternoon meeting 2
+C: To: mooch@owatagu.siam.edu
+C: Message-Id: <B27397-0100000@Blurdybloop.COM>
+C: MIME-Version: 1.0
+C: Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
+C:
+C: Hello Joe, could we change that to 4:00pm tomorrow?
+C:
+S: A005 NO \[OVERQUOTA\] APPEND failed. Over quota.

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Status.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Status.test
@@ -62,6 +62,65 @@ C: a008 STATUS statustest (UNSEEN SIZE MESSAGES )
 S: \* STATUS \"statustest\" \(MESSAGES 1 SIZE 254 UNSEEN 1\)
 S: a008 OK STATUS completed.
 
+C: A009 APPEND statustest {254+}
+C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
+C: From: Fred Foobar <foobar@Blurdybloop.COM>
+C: Subject: Test 01
+C: To: mooch@owatagu.siam.edu
+C: Message-Id: <B27397-0100000@Blurdybloop.COM>
+C: MIME-Version: 1.0
+C: Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
+C:
+C: Test 01
+C:
+S: A009 OK (\[.+\] )?APPEND completed.
+
+C: A010 APPEND statustest {254+}
+C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
+C: From: Fred Foobar <foobar@Blurdybloop.COM>
+C: Subject: Test 01
+C: To: mooch@owatagu.siam.edu
+C: Message-Id: <B27397-0100000@Blurdybloop.COM>
+C: MIME-Version: 1.0
+C: Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
+C:
+C: Test 01
+C:
+S: A010 OK (\[.+\] )?APPEND completed.
+
+C: A011 APPEND statustest {254+}
+C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
+C: From: Fred Foobar <foobar@Blurdybloop.COM>
+C: Subject: Test 01
+C: To: mooch@owatagu.siam.edu
+C: Message-Id: <B27397-0100000@Blurdybloop.COM>
+C: MIME-Version: 1.0
+C: Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
+C:
+C: Test 01
+C:
+S: A011 OK (\[.+\] )?APPEND completed.
+
+C: 10 SELECT statustest
+S: \* FLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\Seen\)
+S: \* 4 EXISTS
+S: \* 4 RECENT
+S: \* OK \[UIDVALIDITY \d+\].*
+S: \* OK \[UNSEEN 1\] .*
+S: \* OK \[PERMANENTFLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\\Seen( \\\*)?\)\].*
+S: \* OK \[HIGHESTMODSEQ \d+\].*
+S: \* OK \[UIDNEXT 5\].*
+S: 10 OK \[READ-WRITE\] SELECT completed.
+
+C: A012 STORE 1:2 FLAGS (\Deleted)
+S: \* 1 FETCH \(FLAGS \(\\Deleted \\Recent\)\)
+S: \* 2 FETCH \(FLAGS \(\\Deleted \\Recent\)\)
+S: A012 OK STORE completed.
+
+C: A013 STATUS statustest (UNSEEN SIZE MESSAGES DELETED DELETED-STORAGE)
+S: \* STATUS \"statustest\" \(MESSAGES 4 SIZE 1016 DELETED 2 DELETED-STORAGE 508 UNSEEN 4\)
+S: A013 OK STATUS completed.
+
 # Cleanup
 C: a1 DELETE statustest
 S: a1 OK DELETE completed.

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConstants.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConstants.java
@@ -92,6 +92,8 @@ public interface ImapConstants {
     Capability SUPPORTS_ACL = Capability.of("ACL");
 
     Capability SUPPORTS_QUOTA = Capability.of("QUOTA");
+    Capability SUPPORTS_QUOTA_RES_STORAGE = Capability.of("QUOTA=RES-STORAGE");
+    Capability SUPPORTS_QUOTA_RES_MESSAGE = Capability.of("QUOTA=RES-MESSAGE");
 
     Capability SUPPORTS_MOVE = Capability.of("MOVE");
 
@@ -151,6 +153,10 @@ public interface ImapConstants {
     String STATUS_MESSAGES = "MESSAGES";
 
     String STATUS_SIZE = "SIZE";
+
+    String STATUS_DELETED = "DELETED";
+
+    String STATUS_DELETED_STORAGE = "DELETED-STORAGE";
 
     String STATUS_HIGHESTMODSEQ = "HIGHESTMODSEQ";
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
@@ -84,6 +84,8 @@ public class HumanReadableText {
 
     public static final HumanReadableText FAILURE_NO_SUCH_MAILBOX = new HumanReadableText("org.apache.james.imap.FAILURE_NO_SUCH_MAILBOX", "failed. No such mailbox.");
 
+    public static final HumanReadableText FAILURE_OVERQUOTA = new HumanReadableText("org.apache.james.imap.OVERQUOTA", "failed. Over quota.");
+
     public static final HumanReadableText FAILURE_NO_QUOTA_RESOURCE = new HumanReadableText("org.apache.james.imap.FAILURE_NO_SUCH_QUOTA_RESOURCE", "failed. No such quota resource.");
 
     public static final HumanReadableText START_TRANSACTION_FAILED = new HumanReadableText("org.apache.james.imap.START_TRANSACTION_FAILED", "failed. Cannot start transaction.");

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/StatusDataItems.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/StatusDataItems.java
@@ -30,10 +30,15 @@ public class StatusDataItems {
         MESSAGES,
         RECENT,
         UID_NEXT,
-        SIZE,
         UID_VALIDITY,
         UNSEEN,
-        HIGHEST_MODSEQ
+        HIGHEST_MODSEQ,
+        // See https://www.iana.org/go/rfc8438
+        SIZE,
+        // See https://www.rfc-editor.org/rfc/rfc9208.html
+        DELETED,
+        // See https://www.rfc-editor.org/rfc/rfc9208.html
+        DELETED_STORAGE
     }
 
     private final EnumSet<StatusItem> statusItems;
@@ -68,6 +73,14 @@ public class StatusDataItems {
 
     public boolean isSize() {
         return statusItems.contains(StatusItem.SIZE);
+    }
+
+    public boolean isDeleted() {
+        return statusItems.contains(StatusItem.DELETED);
+    }
+
+    public boolean isDeletedStorage() {
+        return statusItems.contains(StatusItem.DELETED_STORAGE);
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/response/StatusResponse.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/response/StatusResponse.java
@@ -153,6 +153,7 @@ public interface StatusResponse extends ImapResponseMessage {
 
         /** RFC2060 <code>TRYCREATE</code> response code */
         private static final ResponseCode TRYCREATE = new ResponseCode("TRYCREATE");
+        private static final ResponseCode OVERQUOTA = new ResponseCode("OVERQUOTA");
 
         /** RFC5162 <code>CLOSED</code> response code */
         private static final ResponseCode CLOSED = new ResponseCode("CLOSED");
@@ -287,6 +288,10 @@ public interface StatusResponse extends ImapResponseMessage {
          */
         public static ResponseCode tryCreate() {
             return TRYCREATE;
+        }
+
+        public static ResponseCode overQuota() {
+            return OVERQUOTA;
         }
 
         /**

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/StatusCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/StatusCommandParser.java
@@ -75,6 +75,9 @@ public class StatusCommandParser extends AbstractImapCommandParser {
         if (c == 'm' || c == 'M') {
             return readMessages(request);
         }
+        if (c == 'd' || c == 'D') {
+            return readDeleted(request);
+        }
         if (c == 'r' || c == 'R') {
             return readRecent(request);
         }
@@ -180,6 +183,29 @@ public class StatusCommandParser extends AbstractImapCommandParser {
         assertChar(request, 'e', 'E');
         assertChar(request, 's', 'S');
         return StatusDataItems.StatusItem.MESSAGES;
+    }
+
+    private StatusDataItems.StatusItem readDeleted(ImapRequestLineReader request) throws DecodingException {
+        assertChar(request, 'd', 'D');
+        assertChar(request, 'e', 'E');
+        assertChar(request, 'l', 'L');
+        assertChar(request, 'e', 'E');
+        assertChar(request, 't', 'T');
+        assertChar(request, 'e', 'E');
+        assertChar(request, 'd', 'D');
+        char c = request.nextWordChar();
+        if (c == '-') {
+            assertChar(request, '-', '-');
+            assertChar(request, 's', 'S');
+            assertChar(request, 't', 'T');
+            assertChar(request, 'o', 'O');
+            assertChar(request, 'r', 'R');
+            assertChar(request, 'a', 'A');
+            assertChar(request, 'g', 'G');
+            assertChar(request, 'e', 'E');
+            return StatusDataItems.StatusItem.DELETED_STORAGE;
+        }
+        return StatusDataItems.StatusItem.DELETED;
     }
 
     private void assertChar(ImapRequestLineReader reader, char low, char up) throws DecodingException {

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/MailboxStatusResponseEncoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/MailboxStatusResponseEncoder.java
@@ -41,6 +41,8 @@ public class MailboxStatusResponseEncoder implements ImapConstants, ImapResponse
         Long messages = response.getMessages();
         Long recent = response.getRecent();
         Long size = response.getSize();
+        Long deleted = response.getDeleted();
+        Long deletedStorage = response.getDeletedStorage();
         MessageUid uidNext = response.getUidNext();
         ModSeq highestModSeq = response.getHighestModSeq();
         UidValidity uidValidity = response.getUidValidity();
@@ -60,6 +62,16 @@ public class MailboxStatusResponseEncoder implements ImapConstants, ImapResponse
         if (size != null) {
             composer.message(STATUS_SIZE);
             composer.message(size);
+        }
+
+        if (deleted != null) {
+            composer.message(STATUS_DELETED);
+            composer.message(deleted);
+        }
+
+        if (deletedStorage != null) {
+            composer.message(STATUS_DELETED_STORAGE);
+            composer.message(deletedStorage);
         }
 
         if (recent != null) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/response/MailboxStatusResponse.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/response/MailboxStatusResponse.java
@@ -29,6 +29,8 @@ import org.apache.james.mailbox.model.UidValidity;
  */
 public class MailboxStatusResponse implements ImapResponseMessage {
     private final Long size;
+    private final Long deleted;
+    private final Long deletedStorage;
     private final Long messages;
     private final Long recent;
     private final MessageUid uidNext;
@@ -37,8 +39,10 @@ public class MailboxStatusResponse implements ImapResponseMessage {
     private final String mailbox;
     private final ModSeq highestModSeq;
 
-    public MailboxStatusResponse(Long size, Long messages, Long recent, MessageUid uidNext, ModSeq highestModSeq, UidValidity uidValidity, Long unseen, String mailbox) {
+    public MailboxStatusResponse(Long size, Long deleted, Long deletedStorage, Long messages, Long recent, MessageUid uidNext, ModSeq highestModSeq, UidValidity uidValidity, Long unseen, String mailbox) {
         this.size = size;
+        this.deleted = deleted;
+        this.deletedStorage = deletedStorage;
         this.messages = messages;
         this.recent = recent;
         this.uidNext = uidNext;
@@ -50,6 +54,14 @@ public class MailboxStatusResponse implements ImapResponseMessage {
 
     public Long getSize() {
         return size;
+    }
+
+    public Long getDeleted() {
+        return deleted;
+    }
+
+    public Long getDeletedStorage() {
+        return deletedStorage;
     }
 
     /**

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaRootProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaRootProcessor.java
@@ -54,8 +54,8 @@ import reactor.core.publisher.Mono;
  * GETQUOTAROOT Processor
  */
 public class GetQuotaRootProcessor extends AbstractMailboxProcessor<GetQuotaRootRequest> implements CapabilityImplementingProcessor {
+    private static final List<Capability> CAPABILITIES = ImmutableList.of(ImapConstants.SUPPORTS_QUOTA, ImapConstants.SUPPORTS_QUOTA_RES_MESSAGE, ImapConstants.SUPPORTS_QUOTA_RES_STORAGE);
 
-    private static final List<Capability> CAPABILITIES = ImmutableList.of(ImapConstants.SUPPORTS_QUOTA);
     private final QuotaRootResolver quotaRootResolver;
     private final QuotaManager quotaManager;
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/MailboxStatusResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/MailboxStatusResponseEncoderTest.java
@@ -53,10 +53,13 @@ class MailboxStatusResponseEncoderTest  {
         final MessageUid uidNext = MessageUid.of(5);
         final UidValidity uidValidity = UidValidity.of(7L);
         final Long unseen = 11L;
+        final Long size = 42L;
+        final Long deleted = 23L;
+        final Long deletedStorage = 13L;
         final String mailbox = "A mailbox named desire";
 
-        encoder.encode(new MailboxStatusResponse(null, messages, recent, uidNext,
+        encoder.encode(new MailboxStatusResponse(null, null, deletedStorage, messages, recent, uidNext,
                 null, uidValidity, unseen, mailbox), composer);
-        assertThat(writer.getString()).isEqualTo("* STATUS \"A mailbox named desire\" (MESSAGES 2 RECENT 3 UIDNEXT 5 UIDVALIDITY 7 UNSEEN 11)\r\n");
+        assertThat(writer.getString()).isEqualTo("* STATUS \"A mailbox named desire\" (MESSAGES 2 DELETED_STORAGE 13 RECENT 3 UIDNEXT 5 UIDVALIDITY 7 UNSEEN 11)\r\n");
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/MailboxStatusResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/MailboxStatusResponseEncoderTest.java
@@ -60,6 +60,6 @@ class MailboxStatusResponseEncoderTest  {
 
         encoder.encode(new MailboxStatusResponse(null, null, deletedStorage, messages, recent, uidNext,
                 null, uidValidity, unseen, mailbox), composer);
-        assertThat(writer.getString()).isEqualTo("* STATUS \"A mailbox named desire\" (MESSAGES 2 DELETED_STORAGE 13 RECENT 3 UIDNEXT 5 UIDVALIDITY 7 UNSEEN 11)\r\n");
+        assertThat(writer.getString()).isEqualTo("* STATUS \"A mailbox named desire\" (MESSAGES 2 DELETED-STORAGE 13 RECENT 3 UIDNEXT 5 UIDVALIDITY 7 UNSEEN 11)\r\n");
     }
 }

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/architecture/implemented-standards.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/architecture/implemented-standards.adoc
@@ -50,7 +50,7 @@ The following IMAP specifications are implemented:
 
  - link:https://datatracker.ietf.org/doc/html/rfc3501.html[RFC-3501] INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4rev1
  - link:https://datatracker.ietf.org/doc/html/rfc2177.html[RFC-2177] IMAP IDLE (mailbox scoped push notifications)
- - link:https://datatracker.ietf.org/doc/html/rfc2087.html[RFC-2087] IMAP Quota
+ - link:https://www.rfc-editor.org/rfc/rfc9208.html[RFC-9208] IMAP QUOTA Extension
  - link:https://datatracker.ietf.org/doc/html/rfc2342.html[RFC-2342] IMAP namespace
  - link:https://datatracker.ietf.org/doc/html/rfc2088.html[RFC-2088] IMAP non synchronized literals
  - link:https://datatracker.ietf.org/doc/html/rfc4315.html[RFC-4315] IMAP UIDPLUS

--- a/src/site/xdoc/protocols/imap4.xml
+++ b/src/site/xdoc/protocols/imap4.xml
@@ -59,6 +59,7 @@
        <li>MOVE (RFC 6851 https://tools.ietf.org/html/rfc6851 on master). This is enabled only if you use a MailboxManager exposing the Move capability</li>
        <li>METADATA Extension (RFC 5464 http://www.ietf.org/rfc/rfc5464.txt on master). This is enabled only if you use a MailboxManager exposing the Annotation capability</li>
        <li>IMAP Extension for STATUS=SIZE (https://www.rfc-editor.org/rfc/rfc8438.html)</li>
+       <li>IMAP QUOTA (https://www.rfc-editor.org/rfc/rfc9208.html)</li>
      </ul>
      <p>We follow RFC2683 recommendations for our implementations:</p>
      <ul>


### PR DESCRIPTION
 - Adds QUOTA=RES-MESSAGE and QUOTA=RES-STORAGE capabilities
 - Adds support for DELETED status item (also mandated by RFC-9051 IMAP4Rev2)
 - Adds support for DELETED_STORAGE status item
 - Adds the optional OVERQUOTA response code for append commands
 - Document support for this specification