### PR TITLE
MAILBOX-270 Fix IMAP ANNOTATION capability

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConstants.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConstants.java
@@ -97,7 +97,7 @@ public interface ImapConstants {
 
     Capability SUPPORTS_UIDPLUS = Capability.of("UIDPLUS");
 
-    Capability SUPPORTS_ANNOTATION = Capability.of("ANNOTATION");
+    Capability SUPPORTS_ANNOTATION = Capability.of("ANNOTATE-EXPERIMENT-1");
     
     String INBOX_NAME = "INBOX";
 


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc5257.html#section-6.4 states:

This document registers "ANNOTATE-EXPERIMENT-1" as an IMAPEXT capability.

Clearly we have a typo here...