### PR TITLE
Backport a few more bugs [3.7.x]

### DIFF
--- a/server/apps/memory-app/src/test/java/org/apache/james/StartSequenceTest.java
+++ b/server/apps/memory-app/src/test/java/org/apache/james/StartSequenceTest.java
@@ -1,0 +1,189 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.james.lifecycle.api.Startable;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.ProvidesIntoSet;
+
+class StartSequenceTest {
+    static class A implements Startable {
+        public boolean started = false;
+
+        public void start() {
+            started = true;
+        }
+    }
+    static class D implements Startable {
+        public boolean started = false;
+
+        public void start() {
+            started = true;
+        }
+    }
+    static class F implements Startable {
+        public boolean started = false;
+
+        public void start() {
+            started = true;
+        }
+    }
+
+    static class B implements Startable {
+        private final A a;
+
+        @Inject
+        B(A a) {
+            this.a = a;
+        }
+
+        public void start() {
+            assert a.started;
+        }
+    }
+
+    static class C implements Startable {
+        private final D d;
+
+        @Inject
+        C(D d) {
+            this.d = d;
+        }
+
+        public void start() {
+            assert d.started;
+        }
+    }
+
+    static class E implements Startable {
+        private final F f;
+        private final A a;
+
+        @Inject
+        E(F f, A a) {
+            this.f = f;
+            this.a = a;
+        }
+
+        public void start() {
+            assert f.started;
+            assert a.started;
+        }
+    }
+
+    static class ConfigurableTestModule extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            bind(B.class).in(Scopes.SINGLETON);
+            bind(C.class).in(Scopes.SINGLETON);
+            bind(D.class).in(Scopes.SINGLETON);
+            bind(F.class).in(Scopes.SINGLETON);
+        }
+
+        @Provides
+        @Singleton
+        E e(F f, A a) {
+            return new E(f, a);
+        }
+
+        @Provides
+        @Singleton
+        A a() {
+            return new A();
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation initA(A a) {
+            return InitilizationOperationBuilder
+                .forClass(A.class)
+                .init(a::start);
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation initB(B b) {
+            return InitilizationOperationBuilder
+                .forClass(B.class)
+                .init(b::start);
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation initC(C c) {
+            return InitilizationOperationBuilder
+                .forClass(C.class)
+                .init(c::start);
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation initD(D d) {
+            return InitilizationOperationBuilder
+                .forClass(D.class)
+                .init(d::start);
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation initD(E e) {
+            return InitilizationOperationBuilder
+                .forClass(E.class)
+                .init(e::start)
+                .requires(ImmutableList.of(A.class, F.class));
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation initD(F f) {
+            return InitilizationOperationBuilder
+                .forClass(F.class)
+                .init(f::start);
+        }
+    }
+
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryJamesConfiguration>(tmpDir ->
+        MemoryJamesConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .usersRepository(DEFAULT)
+            .build())
+        .server(configuration -> MemoryJamesServerMain.createServer(configuration)
+            .overrideWith(new TestJMAPServerModule())
+            .overrideWith(new ConfigurableTestModule()))
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+        .disableAutoStart()
+        .build();
+
+    @Test
+    void providesShouldBeTakenIntoAccountByTheStartSequence(GuiceJamesServer server) {
+        assertThatCode(server::start).doesNotThrowAnyException();
+    }
+}

--- a/server/container/guice/common/src/main/java/org/apache/james/utils/InitializationOperations.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/InitializationOperations.java
@@ -31,31 +31,31 @@ import com.google.inject.Inject;
 public class InitializationOperations {
 
     private final Set<InitializationOperation> initializationOperations;
-    private final Startables configurables;
+    private final Startables startables;
 
     @Inject
-    public InitializationOperations(Set<InitializationOperation> initializationOperations, Startables configurables) {
+    public InitializationOperations(Set<InitializationOperation> initializationOperations, Startables startables) {
         this.initializationOperations = initializationOperations;
-        this.configurables = configurables;
+        this.startables = startables;
     }
 
     public void initModules() {
-        Set<InitializationOperation> processed = processConfigurables();
+        Set<InitializationOperation> processed = processStartables();
         
         processOthers(processed);
     }
 
-    private Set<InitializationOperation> processConfigurables() {
-        return configurables.get().stream()
+    private Set<InitializationOperation> processStartables() {
+        return startables.get().stream()
             .flatMap(this::configurationPerformerFor)
             .distinct()
             .peek(Throwing.consumer(InitializationOperation::initModule).sneakyThrow())
             .collect(Collectors.toSet());
     }
 
-    private Stream<InitializationOperation> configurationPerformerFor(Class<? extends Startable> configurable) {
+    private Stream<InitializationOperation> configurationPerformerFor(Class<? extends Startable> startable) {
         return initializationOperations.stream()
-                .filter(x -> x.forClass().equals(configurable));
+                .filter(x -> x.forClass().equals(startable));
     }
 
     private void processOthers(Set<InitializationOperation> processed) {

--- a/server/container/guice/common/src/main/java/org/apache/james/utils/Startables.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/Startables.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 public class Startables {
-
     private final Set<Class<? extends Startable>> startables;
 
     public Startables() {

--- a/server/container/guice/common/src/test/java/org/apache/james/modules/InitializationOperationsTest.java
+++ b/server/container/guice/common/src/test/java/org/apache/james/modules/InitializationOperationsTest.java
@@ -30,12 +30,14 @@ import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitializationOperations;
+import org.apache.james.utils.InitilizationOperationBuilder;
 import org.junit.jupiter.api.Test;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.ProvidesIntoSet;
 
 class InitializationOperationsTest {
     @Test
@@ -56,55 +58,21 @@ class InitializationOperationsTest {
             bind(B.class).in(Scopes.SINGLETON);
             bind(A.class).in(Scopes.SINGLETON);
             bind(C.class).in(Scopes.SINGLETON);
-    
-            Multibinder.newSetBinder(binder(), InitializationOperation.class).addBinding().to(BInitializationOperation.class);
-            Multibinder.newSetBinder(binder(), InitializationOperation.class).addBinding().to(AInitializationOperation.class);
-        }
-    }
-
-    private static class AInitializationOperation implements InitializationOperation {
-        private final A a;
-
-        @Inject
-        private AInitializationOperation(A a) {
-            this.a = a;
         }
 
-        @Override
-        public void initModule() {
-            try {
-                a.configure(null);
-            } catch (ConfigurationException e) {
-                throw new RuntimeException(e);
-            }
+        @ProvidesIntoSet
+        InitializationOperation initA(A a) {
+            return InitilizationOperationBuilder
+                .forClass(A.class)
+                .init(() -> a.configure(null));
         }
 
-        @Override
-        public Class<? extends Startable> forClass() {
-            return A.class;
-        }
-    }
 
-    private static class BInitializationOperation implements InitializationOperation {
-        private final B b;
-
-        @Inject
-        private BInitializationOperation(B b) {
-            this.b = b;
-        }
-
-        @Override
-        public void initModule() {
-            try {
-                b.configure(null);
-            } catch (ConfigurationException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        @Override
-        public Class<? extends Startable> forClass() {
-            return B.class;
+        @ProvidesIntoSet
+        InitializationOperation initB(B b) {
+            return InitilizationOperationBuilder
+                .forClass(B.class)
+                .init(() -> b.configure(null));
         }
     }
 

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/InitializationOperation.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/InitializationOperation.java
@@ -19,7 +19,11 @@
 
 package org.apache.james.utils;
 
+import java.util.List;
+
 import org.apache.james.lifecycle.api.Startable;
+
+import com.google.common.collect.ImmutableList;
 
 public interface InitializationOperation {
 
@@ -33,4 +37,8 @@ public interface InitializationOperation {
      * @return the Class that this object will initialize.
      */
     Class<? extends Startable> forClass();
+
+    default List<Class<?>> requires() {
+        return ImmutableList.of();
+    }
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderFolder.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderFolder.java
@@ -84,7 +84,7 @@ public class ToSenderFolder extends GenericMailet {
             MailAddress sender = mail.getMaybeSender().get();
             Username username = retrieveUser(sender);
 
-            mailboxAppender.append(mail.getMessage(), username, folder);
+            mailboxAppender.append(mail.getMessage(), username, folder).block();
 
             LOGGER.error("Local delivery with ToSenderFolder mailet for mail {} with sender {} in folder {}", mail.getName(), sender, folder);
         }


### PR DESCRIPTION
 - ToSenderFolder should call `.block`
 - Correct the start sequence for provisionned guice resources.