### PR TITLE
[REFACTORING] More flexible fetch groups for Mailbox metadata

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -25,6 +25,7 @@ import static org.apache.james.mailbox.MessageManager.MailboxMetaData.RecentMode
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -55,7 +56,6 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageManager.MailboxMetaData;
-import org.apache.james.mailbox.MessageManager.MailboxMetaData.FetchGroup;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -398,7 +398,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
         return Mono.from(mailboxManager.getMailboxReactive(mailboxPath, mailboxSession))
             .flatMap(Throwing.function(mailbox -> selectMailbox(session, responder, mailbox, currentMailbox)
                 .flatMap(Throwing.function(sessionMailbox ->
-                    mailbox.getMetaDataReactive(recentMode(!openReadOnly), mailboxSession, FetchGroup.FIRST_UNSEEN)
+                    mailbox.getMetaDataReactive(recentMode(!openReadOnly), mailboxSession, EnumSet.of(MailboxMetaData.Item.FirstUnseen, MailboxMetaData.Item.HighestModSeq, MailboxMetaData.Item.NextUid, MailboxMetaData.Item.MailboxCounters))
                         .doOnNext(next -> addRecent(next, sessionMailbox))))));
     }
 
@@ -460,7 +460,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
                     boolean send = true;
                     return getSelectedMailboxReactive(session,
                             Mono.error(() -> new EnableException("Unable to enable " + capability.asString(), new MailboxException("Session not in SELECTED state"))))
-                        .flatMap(Throwing.function(mailbox -> mailbox.getMetaDataReactive(IGNORE, session.getMailboxSession(), FetchGroup.NO_COUNT)))
+                        .flatMap(Throwing.function(mailbox -> mailbox.getMetaDataReactive(IGNORE, session.getMailboxSession(), EnumSet.of(MailboxMetaData.Item.HighestModSeq))))
                         .doOnNext(metaData -> condstoreEnablingCommand(session, responder, metaData, send))
                         .then();
                 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
@@ -22,6 +22,7 @@ package org.apache.james.imap.processor;
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_UIDPLUS;
 import static org.apache.james.mailbox.MessageManager.MailboxMetaData.RecentMode.IGNORE;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -36,7 +37,6 @@ import org.apache.james.imap.message.request.ExpungeRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
-import org.apache.james.mailbox.MessageManager.MailboxMetaData.FetchGroup;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MessageRangeException;
 import org.apache.james.mailbox.model.MailboxACL;
@@ -106,7 +106,7 @@ public class ExpungeProcessor extends AbstractMailboxProcessor<ExpungeRequest> i
         //
         // See RFC5162 3.3 EXPUNGE Command 3.5. UID EXPUNGE Command
         if (EnableProcessor.getEnabledCapabilities(session).contains(ImapConstants.SUPPORTS_QRESYNC)  && expunged > 0) {
-            return mailbox.getMetaDataReactive(IGNORE, mailboxSession, FetchGroup.NO_COUNT)
+            return mailbox.getMetaDataReactive(IGNORE, mailboxSession, EnumSet.of(MessageManager.MailboxMetaData.Item.HighestModSeq))
                 .doOnNext(metaData -> okComplete(request, ResponseCode.highestModSeq(metaData.getHighestModSeq()), responder))
                 .then();
         } else {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetACLProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetACLProcessor.java
@@ -21,6 +21,7 @@ package org.apache.james.imap.processor;
 
 import static org.apache.james.mailbox.MessageManager.MailboxMetaData.RecentMode.IGNORE;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -33,7 +34,7 @@ import org.apache.james.imap.message.request.GetACLRequest;
 import org.apache.james.imap.message.response.ACLResponse;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MessageManager.MailboxMetaData.FetchGroup;
+import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.model.MailboxACL;
@@ -97,7 +98,7 @@ public class GetACLProcessor extends AbstractMailboxProcessor<GetACLRequest> imp
                     no(request, responder, text);
                     return Mono.empty();
                 } else {
-                    return mailbox.getMetaDataReactive(IGNORE, mailboxSession, FetchGroup.NO_COUNT)
+                    return mailbox.getMetaDataReactive(IGNORE, mailboxSession, EnumSet.noneOf(MessageManager.MailboxMetaData.Item.class))
                         .doOnNext(metaData -> {
                             ACLResponse aclResponse = new ACLResponse(mailboxName, metaData.getACL());
                             responder.respond(aclResponse);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -133,7 +134,7 @@ public class SearchProcessor extends AbstractMailboxProcessor<SearchRequest> imp
         // See RFC4551: 3.4. MODSEQ Search Criterion in SEARCH
         if (session.getAttribute(SEARCH_MODSEQ) != null) {
             try {
-                return mailbox.getMetaDataReactive(IGNORE, msession, MailboxMetaData.FetchGroup.NO_COUNT)
+                return mailbox.getMetaDataReactive(IGNORE, msession, EnumSet.of(MailboxMetaData.Item.HighestModSeq))
                     .flatMap(metaData -> {
                         // Enable CONDSTORE as this is a CONDSTORE enabling command
                         condstoreEnablingCommand(session, responder,  metaData, true);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
@@ -23,6 +23,7 @@ import static org.apache.james.mailbox.MessageManager.MailboxMetaData.RecentMode
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -233,7 +234,7 @@ public class StoreProcessor extends AbstractMailboxProcessor<StoreRequest> {
 
                     if (unchangedSince != -1) {
                         // Enable CONDSTORE as this is a CONDSTORE enabling command
-                        return mailbox.getMetaDataReactive(IGNORE, mailboxSession, MailboxMetaData.FetchGroup.NO_COUNT)
+                        return mailbox.getMetaDataReactive(IGNORE, mailboxSession, EnumSet.of(MailboxMetaData.Item.HighestModSeq))
                             .doOnNext(metaData -> condstoreEnablingCommand(session, responder,  metaData, true));
                     }
                     return Mono.empty();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -23,6 +23,7 @@ import static org.apache.james.mailbox.MessageManager.MailboxMetaData.RecentMode
 import static org.apache.james.util.ReactorUtils.logOnError;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -95,7 +96,7 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
                 Set<Capability> enabled = EnableProcessor.getEnabledCapabilities(session);
                 if (constoreCommand && !enabled.contains(ImapConstants.SUPPORTS_CONDSTORE)) {
                     // Enable CONDSTORE as this is a CONDSTORE enabling command
-                    return mailbox.getMetaDataReactive(IGNORE, mailboxSession, MailboxMetaData.FetchGroup.NO_COUNT)
+                    return mailbox.getMetaDataReactive(IGNORE, mailboxSession, EnumSet.of(MailboxMetaData.Item.HighestModSeq))
                         .doOnNext(metaData -> condstoreEnablingCommand(session, responder, metaData, true))
                         .flatMap(Throwing.<MailboxMetaData, Mono<Void>>function(
                             any -> doFetch(selected, request, responder, fetch, mailboxSession, mailbox, session))

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetACLProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetACLProcessorTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
+
 import org.apache.james.core.Username;
 import org.apache.james.imap.api.ImapConstants;
 import org.apache.james.imap.api.message.response.ImapResponseMessage;
@@ -91,7 +93,7 @@ class GetACLProcessorTest {
 
         imapSession.authenticated();
         imapSession.setMailboxSession(mailboxSession);
-        when(messageManager.getMetaDataReactive(any(MailboxMetaData.RecentMode.class), any(MailboxSession.class), any(MailboxMetaData.FetchGroup.class)))
+        when(messageManager.getMetaDataReactive(any(MailboxMetaData.RecentMode.class), any(MailboxSession.class), any(EnumSet.class)))
             .thenReturn(Mono.just(metaData));
         when(mailboxManager.getMailboxReactive(any(MailboxPath.class), any(MailboxSession.class)))
             .thenReturn(Mono.just(messageManager));

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/ListRightsProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/ListRightsProcessorTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import org.apache.james.core.Username;
@@ -99,7 +100,7 @@ class ListRightsProcessorTest {
 
         imapSession.authenticated();
         imapSession.setMailboxSession(mailboxSession);
-        when(messageManager.getMetaDataReactive(any(MailboxMetaData.RecentMode.class), any(MailboxSession.class), any(MailboxMetaData.FetchGroup.class)))
+        when(messageManager.getMetaDataReactive(any(MailboxMetaData.RecentMode.class), any(MailboxSession.class), any(EnumSet.class)))
             .thenReturn(Mono.just(metaData));
         when(mailboxManager.getMailboxReactive(any(MailboxPath.class), any(MailboxSession.class)))
             .thenReturn(Mono.just(messageManager));


### PR DESCRIPTION
 - Simpler code
 - Allows saving on some uneeded Cassandra queries, especially for STATUS