### PR TITLE
JAMES-3864 Refactor vhost management

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -788,7 +788,16 @@ public class RabbitMQConfiguration {
     }
 
     public Optional<String> getVhost() {
-        return vhost;
+        return vhost.or(this::getVhostFromPath);
+    }
+
+    private Optional<String> getVhostFromPath() {
+        String vhostPath = uri.getPath();
+        if (vhostPath.startsWith("/")) {
+            return Optional.of(vhostPath.substring(1))
+                .filter(value -> !value.isEmpty());
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQConfigurationTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQConfigurationTest.java
@@ -485,6 +485,36 @@ class RabbitMQConfigurationTest {
             .isEqualTo(Optional.of("test"));
     }
 
+    @Test
+    void fromShouldReturnVhostValueWhenDeclaredInURI() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        String amqpUri = "amqp://james:james@rabbitmqhost:5672/test";
+        configuration.addProperty("uri", amqpUri);
+        String managementUri = "http://james:james@rabbitmqhost:15672/api/";
+        configuration.addProperty("management.uri", managementUri);
+        configuration.addProperty("management.user", DEFAULT_USER);
+        configuration.addProperty("management.password", DEFAULT_PASSWORD_STRING);
+
+        assertThat(RabbitMQConfiguration.from(configuration).getVhost())
+            .isEqualTo(Optional.of("test"));
+    }
+
+    @Test
+    void fromShouldReturnVhostValueWhenGivenAndNotUriOne() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        String amqpUri = "amqp://james:james@rabbitmqhost:5672/test";
+        configuration.addProperty("uri", amqpUri);
+        String managementUri = "http://james:james@rabbitmqhost:15672/api/";
+        configuration.addProperty("management.uri", managementUri);
+        configuration.addProperty("management.user", DEFAULT_USER);
+        configuration.addProperty("management.password", DEFAULT_PASSWORD_STRING);
+
+        configuration.addProperty("vhost", "vhosttest");
+
+        assertThat(RabbitMQConfiguration.from(configuration).getVhost())
+            .isEqualTo(Optional.of("vhosttest"));
+    }
+
     @Nested
     class ManagementCredentialsTest {
         @Test

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/rabbitmq.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/rabbitmq.adoc
@@ -13,7 +13,8 @@ to get some examples and hints.
 | Property name | explanation
 
 | uri
-| the amqp URI pointing to RabbitMQ server. Details about amqp URI format is in https://www.rabbitmq.com/uri-spec.html[RabbitMQ URI Specification]
+| the amqp URI pointing to RabbitMQ server. If you use a vhost, specify it as well at the end of the URI.
+Details about amqp URI format is in https://www.rabbitmq.com/uri-spec.html[RabbitMQ URI Specification]
 
 | management.uri
 | the URI pointing to RabbitMQ Management Service. James need to retrieve some information about listing queues
@@ -101,8 +102,8 @@ A coma separated list of hosts, example: hosts=ip1:5672,ip2:5672
 | Whether or not the queue backing notifications should be durable. Optional boolean, defaults to true.
 
 | vhost
-| Optional string. The virtual host used by James to create queues and exchanges on Rabbitmq.
-If omitted, it will use the default Rabbitmq one "/".
+| Optional string. This parameter is only a workaround to support invalid URIs containing character like '_'.
+You still need to specify the vhost in the uri parameter.
 
 |===
 

--- a/server/apps/distributed-app/sample-configuration/rabbitmq.properties
+++ b/server/apps/distributed-app/sample-configuration/rabbitmq.properties
@@ -3,10 +3,11 @@
 # Read https://james.apache.org/server/config-rabbitmq.html for further details
 
 # Mandatory
-uri=amqp://rabbitmq:5672
+# If you use a vhost, specify it as well at the end of the URI
+uri=amqp://rabbitmq:5672/vhost
 
 # Vhost to use for creating queues and exchanges
-# Optional, will default to default rabbitmq vhost "/" if not declared
+# Optional, only use this if you have invalid URIs containing characters like '_'
 # vhost=vhost1
 
 # Optional, default to the host specified as part of the URI.

--- a/server/apps/distributed-pop3-app/sample-configuration/rabbitmq.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/rabbitmq.properties
@@ -3,10 +3,11 @@
 # Read https://james.apache.org/server/config-rabbitmq.html for further details
 
 # Mandatory
-uri=amqp://rabbitmq:5672
+# If you use a vhost, specify it as well at the end of the URI
+uri=amqp://rabbitmq:5672/vhost
 
 # Vhost to use for creating queues and exchanges
-# Optional, will default to default rabbitmq vhost "/" if not declared
+# Optional, only use this if you have invalid URIs containing characters like '_'
 # vhost=vhost1
 
 # Optional, default to the host specified as part of the URI.

--- a/src/site/xdoc/server/config-rabbitmq.xml
+++ b/src/site/xdoc/server/config-rabbitmq.xml
@@ -43,7 +43,8 @@
       <dl>
           <dt><strong>uri</strong></dt>
           <dd>
-              the amqp URI pointing to RabbitMQ server. Details about amqp URI format is in <a href="https://www.rabbitmq.com/uri-spec.html">RabbitMQ URI Specification</a>
+              the amqp URI pointing to RabbitMQ server. If you use a vhost, specify it as well at the end of the URI.
+              Details about amqp URI format is in <a href="https://www.rabbitmq.com/uri-spec.html">RabbitMQ URI Specification</a>
           </dd>
 
           <dt><strong>management.uri</strong></dt>
@@ -140,8 +141,8 @@
 
           <dt><strong>vhost</strong></dt>
           <dd>Optional string.
-              The virtual host used by James to create queues and exchanges on Rabbitmq.
-              If omitted, it will use the default Rabbitmq one "/".
+              This parameter is only a workaround to support invalid URIs containing character like '_'.
+              You still need to specify the vhost in the uri parameter.
           </dd>
       </dl>
   </section>


### PR DESCRIPTION
vhost parameter should only be used in special cases with bad formatted URIs (like with '_' characters) as a workaround. For most of the time, adding the vhost in the uri is enough!