### PR TITLE
[FIX] Avoid clearing the schemaVersion

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
@@ -22,6 +22,8 @@ package org.apache.james.backends.cassandra.init;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
+import java.util.function.Predicate;
+
 import javax.inject.Inject;
 
 import org.apache.james.backends.cassandra.components.CassandraModule;
@@ -58,9 +60,10 @@ public class CassandraTableManager {
             .block();
     }
 
-    public void clearAllTables() {
+    public void clearTables(Predicate<CassandraTable> condition) {
         CassandraAsyncExecutor executor = new CassandraAsyncExecutor(session);
         Flux.fromIterable(module.moduleTables())
+                .filter(condition)
                 .publishOn(Schedulers.boundedElastic())
                 .map(CassandraTable::getName)
                 .flatMap(name -> truncate(executor, name), DEFAULT_CONCURRENCY)

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
@@ -27,6 +27,7 @@ import org.apache.james.backends.cassandra.init.ClusterFactory;
 import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFactory;
 import org.apache.james.backends.cassandra.init.configuration.ClusterConfiguration;
 import org.apache.james.backends.cassandra.init.configuration.KeyspaceConfiguration;
+import org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable;
 import org.apache.james.util.Host;
 
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -95,6 +96,7 @@ public final class CassandraCluster implements AutoCloseable {
     }
 
     void clearTables() {
-        new CassandraTableManager(module, nonPrivilegedSession).clearAllTables();
+        new CassandraTableManager(module, nonPrivilegedSession)
+            .clearTables(table -> !table.getName().equals(CassandraSchemaVersionTable.TABLE_NAME));
     }
 }

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
@@ -58,6 +58,7 @@ class TestingSessionTest {
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
         dao = new CassandraSchemaVersionDAO(cassandra.getConf());
+        dao.truncateVersion().block();
     }
 
     @Test

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/SessionWithInitializedTablesFactoryTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/SessionWithInitializedTablesFactoryTest.java
@@ -98,7 +98,7 @@ class SessionWithInitializedTablesFactoryTest {
         assertThat(versionManager(session).computeVersion().block())
                 .isEqualTo(MAX_VERSION);
 
-        new CassandraTableManager(MODULE, session).clearAllTables();
+        new CassandraTableManager(MODULE, session).clearTables(t -> true);
         versionManagerDAO(session).updateVersion(MIN_VERSION);
         assertThat(versionManager(session).computeVersion().block())
                 .isEqualTo(MIN_VERSION);
@@ -113,7 +113,7 @@ class SessionWithInitializedTablesFactoryTest {
         assertThat(versionManager(session).computeVersion().block())
                 .isEqualTo(MAX_VERSION);
 
-        new CassandraTableManager(MODULE, session).clearAllTables();
+        new CassandraTableManager(MODULE, session).clearTables(t -> true);
         versionManagerDAO(session).updateVersion(MIN_VERSION);
         assertThat(versionManager(session).computeVersion().block())
                 .isEqualTo(MIN_VERSION);

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
@@ -36,6 +36,7 @@ class CassandraSchemaVersionDAOTest {
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
         testee = new CassandraSchemaVersionDAO(cassandra.getConf());
+        testee.truncateVersion().block();
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerSideEffectTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerSideEffectTest.java
@@ -62,7 +62,7 @@ class CassandraMessageIdManagerSideEffectTest extends AbstractMessageIdManagerSi
                 StatementRecorder.Selector.preparedStatement("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id")))
                 .hasSize(3); // an extra read is still performed
             softly.assertThat(statementRecorder.listExecutedStatements(
-                StatementRecorder.Selector.preparedStatement("SELECT acl,version FROM acl WHERE id=:id")))
+                StatementRecorder.Selector.preparedStatement("SELECT * FROM aclv2 WHERE id=:id")))
                 .hasSize(2);
         });
     }

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/server/CassandraTruncateTableTask.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/server/CassandraTruncateTableTask.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import org.apache.james.CleanupTasksPerformer;
 import org.apache.james.backends.cassandra.init.CassandraTableManager;
+import org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable;
 
 public class CassandraTruncateTableTask implements CleanupTasksPerformer.CleanupTask {
     private final CassandraTableManager tableManager;
@@ -34,7 +35,8 @@ public class CassandraTruncateTableTask implements CleanupTasksPerformer.Cleanup
 
     @Override
     public Result run() {
-        tableManager.clearAllTables();
+        tableManager
+            .clearTables(table -> !table.getName().equals(CassandraSchemaVersionTable.TABLE_NAME));
         return Result.COMPLETED;
     }
 }

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerIntegrationTest.java
@@ -87,7 +87,7 @@ class RabbitMQWebAdminServerIntegrationTest extends WebAdminServerIntegrationTes
         .then()
             .statusCode(HttpStatus.OK_200)
             .contentType(JSON_CONTENT_TYPE)
-            .body(is("{\"version\":null}"));
+            .body(is("{\"version\":12}"));
     }
 
     @Test


### PR DESCRIPTION
Apart from the first test that did create the table, follow up tests have no way to know the actual version ad thus choose the lowest. Avoiding clearing this table avoids this.