### PR TITLE
JAMES-3754 Date searching should align IMAP4rev2 specifications

### DIFF
--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/CriterionConverter.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/CriterionConverter.java
@@ -304,11 +304,11 @@ public class CriterionConverter {
     private QueryBuilder convertDateOperator(String field, SearchQuery.DateComparator dateComparator, String lowDateString, String upDateString) {
         switch (dateComparator) {
         case BEFORE:
-            return rangeQuery(field).lte(upDateString);
+            return rangeQuery(field).lt(lowDateString); // less than start of the current day
         case AFTER:
-            return rangeQuery(field).gt(lowDateString);
+            return rangeQuery(field).gte(upDateString); // start of next day + greater than that
         case ON:
-            return rangeQuery(field).lte(upDateString).gte(lowDateString);
+            return rangeQuery(field).lt(upDateString).gte(lowDateString);
         }
         throw new RuntimeException("Unknown date operator");
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -856,7 +856,7 @@ public abstract class AbstractMessageSearchIndexTest {
         // Date : 2014/07/02 00:00:00.000 ( Paris time zone )
 
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery).toStream())
-            .containsOnly(m7.getUid(), m8.getUid(), m9.getUid());
+            .containsOnly(m8.getUid(), m9.getUid());
     }
 
     @Test
@@ -867,7 +867,7 @@ public abstract class AbstractMessageSearchIndexTest {
         // Date : 2014/02/02 00:00:00.000 ( Paris time zone )
 
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery).toStream())
-            .containsOnly(m1.getUid(), m2.getUid());
+            .containsOnly(m1.getUid());
     }
 
     @Test
@@ -889,7 +889,7 @@ public abstract class AbstractMessageSearchIndexTest {
         // Date : 2014/07/02 00:00:00.000 ( Paris time zone )
 
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery).toStream())
-            .containsOnly(m7.getUid(), m8.getUid(), m9.getUid());
+            .containsOnly(m8.getUid(), m9.getUid());
     }
 
     @Test
@@ -900,7 +900,7 @@ public abstract class AbstractMessageSearchIndexTest {
         // Date : 2014/02/02 00:00:00.000 ( Paris time zone )
 
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery).toStream())
-            .containsOnly(m1.getUid(), m2.getUid());
+            .containsOnly(m1.getUid());
     }
 
     @Test


### PR DESCRIPTION
We did not align the specs for BEFORE, ON, SINCE ... commands for a few edge cases.
https://www.rfc-editor.org/rfc/rfc9051.html#name-search-command

With this change, this is how our internal API for date searching should work (Opensearch/Elasticsearch):
![image](https://user-images.githubusercontent.com/55171818/207566297-a4856039-cd87-469f-b371-f769b0de1cc8.png)

e.g User searches `SINCE <date>`, we union ON and AFTER parts at IMAP layer => align the spec `Messages whose internal date (disregarding time and timezone) is within or later than the specified date.`

The same alignment is for other search date commands.
