### PR TITLE
[BUILD] Fix unstable cassandra mapper tests

### DIFF
--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperRelaxedConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperRelaxedConsistencyTest.java
@@ -33,15 +33,16 @@ class CassandraMessageIdMapperRelaxedConsistencyTest {
 
     @Nested
     class WeakReadConsistency extends MessageIdMapperTest {
-        private final CassandraMapperProvider mapperProvider = new CassandraMapperProvider(
-            cassandraCluster.getCassandraCluster(),
-            CassandraConfiguration.builder()
-                .messageReadStrongConsistency(false)
-                .messageWriteStrongConsistency(true)
-                .build());
+        private CassandraMapperProvider mapperProvider;
 
         @Override
         protected CassandraMapperProvider provideMapper() {
+            mapperProvider = new CassandraMapperProvider(
+                cassandraCluster.getCassandraCluster(),
+                CassandraConfiguration.builder()
+                    .messageReadStrongConsistency(false)
+                    .messageWriteStrongConsistency(true)
+                    .build());
             return mapperProvider;
         }
 
@@ -53,15 +54,16 @@ class CassandraMessageIdMapperRelaxedConsistencyTest {
 
     @Nested
     class WeakWriteConsistency extends MessageIdMapperTest {
-        private final CassandraMapperProvider mapperProvider = new CassandraMapperProvider(
-            cassandraCluster.getCassandraCluster(),
-            CassandraConfiguration.builder()
-                .messageReadStrongConsistency(false)
-                .messageWriteStrongConsistency(false)
-                .build());
+        private CassandraMapperProvider mapperProvider;
 
         @Override
         protected CassandraMapperProvider provideMapper() {
+            mapperProvider = new CassandraMapperProvider(
+                cassandraCluster.getCassandraCluster(),
+                CassandraConfiguration.builder()
+                    .messageReadStrongConsistency(false)
+                    .messageWriteStrongConsistency(false)
+                    .build());
             return mapperProvider;
         }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -63,12 +63,13 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MailboxAggregateModule.MODULE);
 
-    private final CassandraMapperProvider mapperProvider = new CassandraMapperProvider(
-        cassandraCluster.getCassandraCluster(),
-        CassandraConfiguration.DEFAULT_CONFIGURATION);
+    private CassandraMapperProvider mapperProvider;
 
     @Override
     protected CassandraMapperProvider provideMapper() {
+        mapperProvider = new CassandraMapperProvider(
+            cassandraCluster.getCassandraCluster(),
+            CassandraConfiguration.DEFAULT_CONFIGURATION);
         return mapperProvider;
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperRelaxedConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperRelaxedConsistencyTest.java
@@ -34,15 +34,16 @@ class CassandraMessageMapperRelaxedConsistencyTest {
 
     @Nested
     class WeakReadConsistency extends MessageMapperTest {
-        private final CassandraMapperProvider cassandraMapperProvider = new CassandraMapperProvider(
-            cassandraCluster.getCassandraCluster(),
-            CassandraConfiguration.builder()
-                .messageReadStrongConsistency(false)
-                .messageWriteStrongConsistency(true)
-                .build());
+        private CassandraMapperProvider cassandraMapperProvider;
 
         @Override
         protected MapperProvider createMapperProvider() {
+            cassandraMapperProvider = new CassandraMapperProvider(
+                cassandraCluster.getCassandraCluster(),
+                CassandraConfiguration.builder()
+                    .messageReadStrongConsistency(false)
+                    .messageWriteStrongConsistency(true)
+                    .build());
             return cassandraMapperProvider;
         }
 
@@ -54,15 +55,16 @@ class CassandraMessageMapperRelaxedConsistencyTest {
 
     @Nested
     class WeakWriteConsistency extends MessageMapperTest {
-        private final CassandraMapperProvider cassandraMapperProvider = new CassandraMapperProvider(
-            cassandraCluster.getCassandraCluster(),
-            CassandraConfiguration.builder()
-                .messageReadStrongConsistency(false)
-                .messageWriteStrongConsistency(false)
-                .build());
+        private CassandraMapperProvider cassandraMapperProvider;
 
         @Override
         protected MapperProvider createMapperProvider() {
+            cassandraMapperProvider = new CassandraMapperProvider(
+                cassandraCluster.getCassandraCluster(),
+                CassandraConfiguration.builder()
+                    .messageReadStrongConsistency(false)
+                    .messageWriteStrongConsistency(false)
+                    .build());
             return cassandraMapperProvider;
         }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -60,12 +60,13 @@ class CassandraMessageMapperTest extends MessageMapperTest {
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MailboxAggregateModule.MODULE);
 
-    private final CassandraMapperProvider cassandraMapperProvider = new CassandraMapperProvider(
-        cassandraCluster.getCassandraCluster(),
-        CassandraConfiguration.DEFAULT_CONFIGURATION);
+    private CassandraMapperProvider cassandraMapperProvider;
 
     @Override
     protected MapperProvider createMapperProvider() {
+        cassandraMapperProvider = new CassandraMapperProvider(
+            cassandraCluster.getCassandraCluster(),
+            CassandraConfiguration.DEFAULT_CONFIGURATION);
         return cassandraMapperProvider;
     }
 


### PR DESCRIPTION
## Why
Recently, sometime we observed `java.lang.IllegalStateException: Session is closed` for Cassandra mapper tests in CI failed builds.

Git bisect issued commit: https://github.com/apache/james-project/commit/746ca874aecfb5ea77679a081a32999471bbbce7

Currently, for each test, `mapperProvider` is created before BeforeEachCallBack and BeforeEach lead to it sometime points to a closed CqlSession (when max tests e.g 500 played then Cassandra container restart -> close the old session and opens a new session). 

Current flow for each mapper test: 
create new final `mapperProvider` (refer to to-be-closed session) -> BeforeEachCallback (restarting Cassandra leads to closing the old session and creating a new session) -> BeforeEach (return the `mapperProvider`refers to closed session).

## How
We need to let `mapperProvider` be created in BeforeEach to avoid referring to a closed session.

Now the flow: 
create a null `mapperProvider` -> BeforeEachCallback (restarting Cassandra leads to closing the old session and creating a new session) -> BeforeEach (set a new `mapperProvider` which always refers to the new session)

## DoD
Builds after this should not throw `java.lang.IllegalStateException: Session is closed`.