### PR TITLE
JAMES-3870 Group IMAP response line within TCP packets

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
@@ -263,4 +263,8 @@ public interface ImapSession extends CommandDetectionSession {
     }
 
     void schedule(Runnable runnable, Duration waitDelay);
+
+    default void flush() {
+
+    }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -97,7 +97,6 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
             if (sm != null) {
                 sm.unregisterIdle();
             }
-            session1.popLineHandler();
             if (!DONE.equals(line.toUpperCase(Locale.US))) {
                 String message = String.format("Continuation for IMAP IDLE was not understood. Expected 'DONE', got '%s'.", line);
                 StatusResponse response = getStatusResponseFactory()
@@ -109,6 +108,7 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
             } else {
                 okComplete(request, responder);
             }
+            session1.popLineHandler();
             idleActive.set(false);
         });
 
@@ -167,7 +167,8 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
 
         @Override
         public Publisher<Void> reactiveEvent(Event event) {
-            return unsolicitedResponses(session, responder, false);
+            return unsolicitedResponses(session, responder, false)
+                .then(Mono.fromRunnable(session::flush));
         }
 
         @Override

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
@@ -57,7 +57,7 @@ public class ChannelImapResponseWriter implements ImapResponseWriter {
     @Override
     public void write(byte[] buffer) throws IOException {
         if (channel.isActive()) {
-            channel.writeAndFlush(Unpooled.wrappedBuffer(buffer));
+            channel.write(Unpooled.wrappedBuffer(buffer));
         }
     }
 
@@ -72,16 +72,18 @@ public class ChannelImapResponseWriter implements ImapResponseWriter {
                 // See JAMES-1305 and JAMES-1306
                 ChannelPipeline cp = channel.pipeline();
                 if (zeroCopy && cp.get(SslHandler.class) == null && cp.get(ZlibEncoder.class) == null) {
-                    channel.writeAndFlush(new DefaultFileRegion(fc, fc.position(), literal.size()));
+                    channel.write(new DefaultFileRegion(fc, fc.position(), literal.size()));
                 } else {
-                    channel.writeAndFlush(new ChunkedNioFile(fc, 8192));
+                    channel.write(new ChunkedNioFile(fc, 8192));
                 }
             } else {
-                channel.writeAndFlush(new ChunkedStream(in));
+                channel.write(new ChunkedStream(in));
             }
         }
     }
     
-    
+    public void flush() {
+        channel.flush();
+    }
 
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapLineHandlerAdapter.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapLineHandlerAdapter.java
@@ -49,6 +49,7 @@ public class ImapLineHandlerAdapter extends ChannelInboundHandlerAdapter {
         byte[] data = new byte[buf.readableBytes()];
         buf.readBytes(data);
         lineHandler.onLine(session, data);
+        ctx.channel().flush();
     }
 
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -183,6 +183,7 @@ public class NettyImapSession implements ImapSession, NettyConstants {
         }
         executeSafely(() -> {
             runnable.run();
+            channel.flush();
             channel.pipeline().addFirst(SSL_HANDLER, secure.sslHandler());
             stopDetectingCommandInjection();
         });
@@ -229,6 +230,7 @@ public class NettyImapSession implements ImapSession, NettyConstants {
 
         executeSafely(() -> {
             runnable.run();
+            channel.flush();
             ZlibDecoder decoder = new JZlibDecoder(ZlibWrapper.NONE);
             ZlibEncoder encoder = new JZlibEncoder(ZlibWrapper.NONE, 5);
 
@@ -252,12 +254,14 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     public void pushLineHandler(ImapLineHandler lineHandler) {
         LineHandlerAware handler = (LineHandlerAware) channel.pipeline().get(REQUEST_DECODER);
         handler.pushLineHandler(new ImapLineHandlerAdapter(this, lineHandler));
+        channel.flush();
     }
 
     @Override
     public void popLineHandler() {
         LineHandlerAware handler = (LineHandlerAware) channel.pipeline().get(REQUEST_DECODER);
         handler.popLineHandler();
+        channel.flush();
     }
 
     @Override
@@ -306,5 +310,10 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     @Override
     public void schedule(Runnable runnable, Duration waitDelay) {
         channel.eventLoop().schedule(runnable, waitDelay.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void flush() {
+        channel.flush();
     }
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -254,14 +254,12 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     public void pushLineHandler(ImapLineHandler lineHandler) {
         LineHandlerAware handler = (LineHandlerAware) channel.pipeline().get(REQUEST_DECODER);
         handler.pushLineHandler(new ImapLineHandlerAdapter(this, lineHandler));
-        channel.flush();
     }
 
     @Override
     public void popLineHandler() {
         LineHandlerAware handler = (LineHandlerAware) channel.pipeline().get(REQUEST_DECODER);
         handler.popLineHandler();
-        channel.flush();
     }
 
     @Override


### PR DESCRIPTION
Today each Imap response line is transmitted in a
distinct TCP packet.

This causes a lot of network overhead as
=> TCP headers are added for each response line.
   To give an idea a LIST response line is 35 bytes
   long but result in a 101 bytes TCP frame so a 188%
   overcost....
=> TCP ack are conducted for each line independently.
   An ACK is 66 bytes

This is especially problematic for LIST, FETCH commands that actually result in many (100, 1000, maybe millions) response lines.

![master-list-responses-with-flush](https://user-images.githubusercontent.com/6928740/209788251-965ab8c9-a303-4de2-82d7-48e380fd5b38.png)

We should try to limit the calls to "flush" with Netty, and force the flush only once per IMAP command (at the end of processing). Netty is free to transmit some data earlier if it's buffer states requires it.

The entire mailbox list take 1 packet to transmit (1420 bytes total for 41 mailboxes so ~35 bytes per mailbox) and a single ACK (66 bytes).

![pr-list-responses-without-flush](https://user-images.githubusercontent.com/6928740/209788275-60aa8ba9-bd02-4484-8a01-6f49e3b5727d.png)
