### PR TITLE
JAMES-3872 Add another read level to get attachment metadata without reading the email body

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/FetchGroup.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/FetchGroup.java
@@ -36,6 +36,7 @@ public class FetchGroup extends Profiles<FetchGroup> {
     public enum Profile {
         MIME_DESCRIPTOR,
         HEADERS,
+        HEADERS_WITH_ATTACHMENTS_METADATA,
         FULL_CONTENT,
         BODY_CONTENT,
         MIME_HEADERS,
@@ -48,6 +49,7 @@ public class FetchGroup extends Profiles<FetchGroup> {
      */
     public static final FetchGroup MINIMAL = new FetchGroup(EnumSet.noneOf(Profile.class));
     public static final FetchGroup HEADERS = new FetchGroup(EnumSet.of(Profile.HEADERS));
+    public static final FetchGroup HEADERS_WITH_ATTACHMENTS_METADATA = new FetchGroup(EnumSet.of(Profile.HEADERS_WITH_ATTACHMENTS_METADATA));
     public static final FetchGroup FULL_CONTENT = new FetchGroup(EnumSet.of(Profile.FULL_CONTENT));
     public static final FetchGroup BODY_CONTENT = new FetchGroup(EnumSet.of(Profile.BODY_CONTENT));
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
@@ -53,7 +53,7 @@ public class AttachmentLoader {
     }
 
     private Mono<List<MessageAttachmentMetadata>> loadAttachments(Stream<MessageAttachmentRepresentation> messageAttachmentRepresentations, MessageMapper.FetchType fetchType) {
-        if (fetchType == MessageMapper.FetchType.FULL) {
+        if (fetchType == MessageMapper.FetchType.FULL || fetchType == MessageMapper.FetchType.ATTACHMENTS_METADATA) {
             return getAttachments(messageAttachmentRepresentations.collect(ImmutableList.toImmutableList()));
         } else {
             return Mono.just(ImmutableList.of());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -324,6 +324,7 @@ public class CassandraMessageDAO {
         switch (fetchType) {
             case FULL:
                 return getFullContent(headerId, bodyId);
+            case ATTACHMENTS_METADATA:
             case HEADERS:
                 return getContent(headerId, SIZE_BASED);
             case METADATA:

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
@@ -397,6 +397,7 @@ public class CassandraMessageDAOV3 {
         switch (fetchType) {
             case FULL:
                 return getFullContent(headerId, bodyId);
+            case ATTACHMENTS_METADATA:
             case HEADERS:
                 return getContent(headerId, SIZE_BASED)
                     .map(ByteContent::new);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -51,6 +51,7 @@ import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.ParsedAttachment;
 import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.FlagsUpdateCalculator;
+import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
@@ -445,6 +446,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
 
     @Test
     void messagesRetrievedUsingFetchTypeAttachmentsMetadataShouldHaveAttachmentsMetadataLoaded() throws MailboxException {
+        AttachmentMapper attachmentMapper = mapperProvider.createAttachmentMapper();
         MessageId messageId = mapperProvider.generateMessageId();
         String content = "Subject: Test1 \n\nBody1\n.\n";
         ParsedAttachment attachment1 = ParsedAttachment.builder()

--- a/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndexTest.java
+++ b/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndexTest.java
@@ -239,7 +239,7 @@ class SimpleMessageSearchIndexTest extends AbstractMessageSearchIndexTest {
     
     @Test
     public void canCompareFetchTypes() {
-        assertThat(FetchType.values()).containsExactly(FetchType.METADATA, FetchType.HEADERS, FetchType.FULL);
+        assertThat(FetchType.values()).containsExactly(FetchType.METADATA, FetchType.HEADERS, FetchType.ATTACHMENTS_METADATA, FetchType.FULL);
         
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.METADATA, FetchType.METADATA)).isEqualTo(FetchType.METADATA);
         assertThat(SimpleMessageSearchIndex.maxFetchType(FetchType.METADATA, FetchType.HEADERS)).isEqualTo(FetchType.HEADERS);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/BatchSizes.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/BatchSizes.java
@@ -134,12 +134,13 @@ public class BatchSizes {
         switch (fetchType) {
             case METADATA:
                 return fetchMetadata;
+            case ATTACHMENTS_METADATA:
             case HEADERS:
                 return fetchHeaders;
             case FULL:
                 return fetchFull;
         }
-        throw new RuntimeException("Unknown fetchTpe: " + fetchType);
+        throw new RuntimeException("Unknown fetchType: " + fetchType);
     }
 
     public Optional<Integer> getCopyBatchSize() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/ResultUtils.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/ResultUtils.java
@@ -51,6 +51,7 @@ import com.google.common.annotations.VisibleForTesting;
 public class ResultUtils {
     private static final EnumSet<FetchGroup.Profile> SUPPORTED_GROUPS = EnumSet.of(
         FetchGroup.Profile.HEADERS,
+        FetchGroup.Profile.HEADERS_WITH_ATTACHMENTS_METADATA,
         FetchGroup.Profile.BODY_CONTENT,
         FetchGroup.Profile.FULL_CONTENT,
         FetchGroup.Profile.MIME_DESCRIPTOR);
@@ -205,7 +206,7 @@ public class ResultUtils {
         if (profiles.contains(FetchGroup.Profile.MIME_CONTENT)) {
             addMimeBodyContent(message, messageResult, mimePath);
         }
-        if (profiles.contains(FetchGroup.Profile.HEADERS)) {
+        if (profiles.contains(FetchGroup.Profile.HEADERS) || profiles.contains(FetchGroup.Profile.HEADERS_WITH_ATTACHMENTS_METADATA)) {
             addHeaders(message, messageResult, mimePath);
         }
         if (profiles.contains(FetchGroup.Profile.MIME_HEADERS)) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/FetchGroupConverter.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/FetchGroupConverter.java
@@ -51,12 +51,16 @@ public class FetchGroupConverter {
         return reduce(fetchTypes);
     }
 
-    public static MessageMapper.FetchType reduce(Collection<MessageMapper.FetchType> fetchTypes) {
+    private static MessageMapper.FetchType reduce(Collection<MessageMapper.FetchType> fetchTypes) {
         boolean full = fetchTypes.contains(MessageMapper.FetchType.FULL);
         boolean headers = fetchTypes.contains(MessageMapper.FetchType.HEADERS);
+        boolean headersWithAttachmentsMetadata = fetchTypes.contains(MessageMapper.FetchType.ATTACHMENTS_METADATA);
 
         if (full) {
             return MessageMapper.FetchType.FULL;
+        }
+        if (headersWithAttachmentsMetadata) {
+            return MessageMapper.FetchType.ATTACHMENTS_METADATA;
         }
         if (headers) {
             return MessageMapper.FetchType.HEADERS;
@@ -68,6 +72,8 @@ public class FetchGroupConverter {
         switch (profile) {
             case HEADERS:
                 return MessageMapper.FetchType.HEADERS;
+            case HEADERS_WITH_ATTACHMENTS_METADATA:
+                return MessageMapper.FetchType.ATTACHMENTS_METADATA;
             case BODY_CONTENT:
             case FULL_CONTENT:
             case MIME_CONTENT:

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -307,7 +307,14 @@ public interface MessageMapper extends Mapper {
          * </p>
          */
         HEADERS,
-        
+        /**
+         * Fetch the {@link #HEADERS}, {@link Property}'s and the {@link #ATTACHMENTS_METADATA}'s for the {@link MailboxMessage}. This includes:
+         *
+         * <p>
+         * {@link MailboxMessage#getAttachments()}
+         * </p>
+         */
+        ATTACHMENTS_METADATA,
         /**
          * Fetch the complete {@link MailboxMessage}
          * 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/FetchGroupConverterTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/FetchGroupConverterTest.java
@@ -39,6 +39,7 @@ class FetchGroupConverterTest {
         return Stream.of(
             Arguments.arguments(FetchGroup.MINIMAL, FetchType.METADATA),
             Arguments.arguments(FetchGroup.HEADERS, FetchType.HEADERS),
+            Arguments.arguments(FetchGroup.HEADERS_WITH_ATTACHMENTS_METADATA, FetchType.ATTACHMENTS_METADATA),
             Arguments.arguments(FetchGroup.BODY_CONTENT, FetchType.FULL),
             Arguments.arguments(FetchGroup.FULL_CONTENT, FetchType.FULL),
             Arguments.arguments(FetchGroup.BODY_CONTENT.with(Profile.HEADERS), FetchType.FULL),

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -53,7 +53,6 @@ import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.FlagsUpdateCalculator;
-import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
@@ -85,7 +84,6 @@ public abstract class MessageMapperTest {
     protected MapperProvider mapperProvider;
     protected MessageMapper messageMapper;
     private MailboxMapper mailboxMapper;
-    protected AttachmentMapper attachmentMapper;
 
     protected Mailbox benwaInboxMailbox;
     protected Mailbox benwaWorkMailbox;
@@ -109,7 +107,6 @@ public abstract class MessageMapperTest {
 
         this.messageMapper = mapperProvider.createMessageMapper();
         this.mailboxMapper = mapperProvider.createMailboxMapper();
-        this.attachmentMapper = mapperProvider.createAttachmentMapper();
 
         initData();
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -53,6 +53,7 @@ import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.FlagsUpdateCalculator;
+import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
@@ -81,9 +82,10 @@ public abstract class MessageMapperTest {
 
     protected static final String USER_FLAG = "userFlag";
 
-    private MapperProvider mapperProvider;
+    protected MapperProvider mapperProvider;
     protected MessageMapper messageMapper;
     private MailboxMapper mailboxMapper;
+    protected AttachmentMapper attachmentMapper;
 
     protected Mailbox benwaInboxMailbox;
     protected Mailbox benwaWorkMailbox;
@@ -107,6 +109,7 @@ public abstract class MessageMapperTest {
 
         this.messageMapper = mapperProvider.createMessageMapper();
         this.mailboxMapper = mapperProvider.createMailboxMapper();
+        this.attachmentMapper = mapperProvider.createAttachmentMapper();
 
         initData();
     }

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/resources/eml/inlined-single-attachment.eml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/resources/eml/inlined-single-attachment.eml
@@ -1,0 +1,30 @@
+Date: Wed, 26 Jan 2022 12:21:37 +0100
+From: Bob <bob@domain.tld>
+To: Alice <alice@domain.tld>
+Subject: My subject
+Message-ID: <20220126112137.wookj26xellphlam@W0248292>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="7f4cfz6rtfqdbqxn"
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+
+--7f4cfz6rtfqdbqxn
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+Main test message...
+
+--7f4cfz6rtfqdbqxn
+Content-Type: application/json; charset=us-ascii
+Content-Disposition: attachment; filename="yyy.txt"
+Content-Transfer-Encoding: quoted-printable
+
+[
+    {
+        "Id": "2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    }
+]
+
+--7f4cfz6rtfqdbqxn
+
+

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailGetSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailGetSerializer.scala
@@ -25,7 +25,7 @@ import org.apache.james.jmap.api.model.Size.Size
 import org.apache.james.jmap.api.model.{EmailAddress, EmailerName, Preview}
 import org.apache.james.jmap.core.Id.IdConstraint
 import org.apache.james.jmap.core.{Properties, UuidState}
-import org.apache.james.jmap.mail.{AddressesHeaderValue, BlobId, Charset, DateHeaderValue, Disposition, EmailAddressGroup, EmailBody, EmailBodyMetadata, EmailBodyPart, EmailBodyValue, EmailChangesRequest, EmailChangesResponse, EmailFastView, EmailFullView, EmailGetRequest, EmailGetResponse, EmailHeader, EmailHeaderName, EmailHeaderValue, EmailHeaderView, EmailHeaders, EmailIds, EmailMetadata, EmailMetadataView, EmailNotFound, EmailView, FetchAllBodyValues, FetchHTMLBodyValues, FetchTextBodyValues, GroupName, GroupedAddressesHeaderValue, HasAttachment, HeaderMessageId, HeaderURL, IsEncodingProblem, IsTruncated, Keyword, Keywords, Language, Languages, Location, MailboxIds, MessageIdsHeaderValue, Name, PartId, RawHeaderValue, Subject, TextHeaderValue, ThreadId, Type, URLsHeaderValue, UnparsedEmailId}
+import org.apache.james.jmap.mail._
 import org.apache.james.mailbox.model.{Cid, MailboxId, MessageId}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -152,12 +152,18 @@ object EmailGetSerializer {
 
   private implicit val emailMetadataWrites: OWrites[EmailMetadata] = Json.writes[EmailMetadata]
   private implicit val emailHeadersWrites: Writes[EmailHeaders] = Json.writes[EmailHeaders]
+  private implicit val attachmentsMetadataWrites: Writes[AttachmentsMetadata] = Json.writes[AttachmentsMetadata]
   private implicit val emailBodyMetadataWrites: Writes[EmailBodyMetadata] = Json.writes[EmailBodyMetadata]
 
   private val emailFastViewWrites: OWrites[EmailFastView] = (JsPath.write[EmailMetadata] and
     JsPath.write[EmailHeaders] and
     JsPath.write[EmailBodyMetadata] and
     JsPath.write[Map[String, Option[EmailHeaderValue]]]) (unlift(EmailFastView.unapply))
+  private val emailFastViewWithAttachmentsWrites: OWrites[EmailFastViewWithAttachments] = (JsPath.write[EmailMetadata] and
+    JsPath.write[EmailHeaders] and
+    JsPath.write[AttachmentsMetadata] and
+    JsPath.write[EmailBodyMetadata] and
+    JsPath.write[Map[String, Option[EmailHeaderValue]]]) (unlift(EmailFastViewWithAttachments.unapply))
   private val emailHeaderViewWrites: OWrites[EmailHeaderView] = (JsPath.write[EmailMetadata] and
     JsPath.write[EmailHeaders] and
     JsPath.write[Map[String, Option[EmailHeaderValue]]]) (unlift(EmailHeaderView.unapply))
@@ -172,6 +178,7 @@ object EmailGetSerializer {
     case view: EmailMetadataView => emailMetadataViewWrites.writes(view)
     case view: EmailHeaderView => emailHeaderViewWrites.writes(view)
     case view: EmailFastView => emailFastViewWrites.writes(view)
+    case view: EmailFastViewWithAttachments => emailFastViewWithAttachmentsWrites.writes(view)
     case view: EmailFullView => emailFullViewWrites.writes(view)
   }
 


### PR DESCRIPTION
### Why
The idea is to allow fastly retrieve preview of a mail with attachment metadata with JMAP. e.g with GMAIL:
![image](https://user-images.githubusercontent.com/55171818/209802473-d39559c2-a97c-4aa3-9c39-462040dbe579.png)

Nowadays, to fetch the `attachments` property, we use the FULL_CONTENT fetch type means fetching the body content while we don't need that in this case.

We should introduce a JMAP read level that retrieves the `attachments` property without fetching the body of the mail.

### Todo
- [x] Jira ticket
- [x] Debug the JMAP distributed test failing when returning empty `attachments` property
- [x] Write more tests making sure the new FetchType work as expected
- [ ] others...


