### PR TITLE
JAMES-3756 SessionTranslator should only ask 1 delegation source

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
@@ -110,6 +110,8 @@ public interface SessionProvider {
         return otherUserId -> loginAsOtherUser(givenUserid, otherUserId);
     }
 
+    MailboxSession loginAsOtherUserWithoutCheckingDelegation(Username givenUserid, Username otherUserId);
+
     /**
      * <p>
      * Logs the session out, freeing any resources. Clients who open session

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
@@ -96,6 +96,11 @@ public class SessionProviderImpl implements SessionProvider {
     }
 
     @Override
+    public MailboxSession loginAsOtherUserWithoutCheckingDelegation(Username givenUserid, Username otherUserId) {
+        return createSession(otherUserId, Optional.of(givenUserid), MailboxSession.SessionType.User);
+    }
+
+    @Override
     public void logout(MailboxSession session) {
         if (session != null) {
             session.close();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -269,6 +269,11 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     @Override
+    public MailboxSession loginAsOtherUserWithoutCheckingDelegation(Username givenUserid, Username otherUserId) {
+        return sessionProvider.loginAsOtherUserWithoutCheckingDelegation(givenUserid, otherUserId);
+    }
+
+    @Override
     public void logout(MailboxSession session) {
         sessionProvider.logout(session);
     }


### PR DESCRIPTION
Instead of two sources with the same truth (https://github.com/linagora/james-project/issues/4673).
(`sessionProvider.authenticate(session.getUser).as(targetUser)` called the 2nd source `authorized users`).