### PR TITLE
[REFACTOING] Improve SessionProvider API

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxSession.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxSession.java
@@ -106,7 +106,6 @@ public class MailboxSession {
     private final SessionId sessionId;
     private final Username userName;
     private final Optional<Username> loggedInUser;
-    private boolean open = true;
     private final List<Locale> localePreferences;
     private final Map<Object, Object> attributes;
     private final char pathSeparator;
@@ -148,22 +147,6 @@ public class MailboxSession {
      */
     public SessionId getSessionId() {
         return sessionId;
-    }
-
-    /**
-     * Is this session open?
-     * 
-     * @return true if the session is open, false otherwise
-     */
-    public boolean isOpen() {
-        return open;
-    }
-
-    /**
-     * Closes this session.
-     */
-    public void close() {
-        open = false;
     }
 
     /**
@@ -250,6 +233,6 @@ public class MailboxSession {
         String tab = " ";
 
         return "MailboxSession ( " + "sessionId = "
-            + this.sessionId + tab + "open = " + this.open + tab + " )";
+            + this.sessionId + " )";
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
@@ -30,13 +30,6 @@ public interface SessionProvider {
     }
 
     /**
-     * Return the delimiter to use for folders
-     *
-     * @return delimiter
-     */
-    char getDelimiter();
-
-    /**
      * Creates a new system session.<br>
      * A system session is intended to be used for programmatic access.<br>
      *

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
@@ -71,25 +71,4 @@ public interface SessionProvider {
      *             when the creation fails for other reasons
      */
     AuthorizationStep authenticate(Username givenUserid);
-
-    /**
-     * <p>
-     * Logs the session out, freeing any resources. Clients who open session
-     * should make best efforts to call this when the session is closed.
-     * </p>
-     * <p>
-     * Note that clients may not always be able to call logout (whether forced
-     * or not). Mailboxes that create sessions which are expensive to maintain
-     * <code>MUST</code> retain a reference and periodically check
-     * {@link MailboxSession#isOpen()}.
-     * </p>
-     * <p>
-     * Note that implementations much be aware that it is possible that this
-     * method may be called more than once with the same session.
-     * </p>
-     *
-     * @param session
-     *            not null
-     */
-    void logout(MailboxSession session);
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
@@ -23,8 +23,10 @@ import org.apache.james.core.Username;
 import org.apache.james.mailbox.exception.MailboxException;
 
 public interface SessionProvider {
-    interface DelegationLogin {
+    interface AuthorizationStep {
         MailboxSession as(Username other) throws MailboxException;
+
+        MailboxSession withoutDelegation() throws MailboxException;
     }
 
     /**
@@ -38,7 +40,7 @@ public interface SessionProvider {
      * Creates a new system session.<br>
      * A system session is intended to be used for programmatic access.<br>
      *
-     * Use {@link #login(Username, String)} when accessing this API from a
+     * Use {@link #authenticate(Username)} when accessing this API from a
      * protocol.
      *
      * @param userName
@@ -46,28 +48,6 @@ public interface SessionProvider {
      * @return <code>MailboxSession</code>, not null
      */
     MailboxSession createSystemSession(Username userName);
-
-    /**
-     * Creates a session for the given user.
-     *
-     * Use {@link #createSystemSession(Username)} for interactions not done by the user himself.
-     */
-    MailboxSession login(Username userName);
-
-    /**
-     * Autenticates the given user against the given password.<br>
-     * When authenticated and authorized, a session will be supplied
-     *
-     * @param userid
-     *            user name
-     * @param passwd
-     *            password supplied
-     * @return a <code>MailboxSession</code> when the user is authenticated and
-     *            authorized to access
-     * @throws MailboxException
-     *            when the creation fails for other reasons
-     */
-    MailboxSession login(Username userid, String passwd) throws MailboxException;
 
     /**
      * Authenticates the given user against the given password,
@@ -78,37 +58,26 @@ public interface SessionProvider {
      *            username of the given user, matching the credentials
      * @param passwd
      *            password supplied for the given user
-     * @param otherUserId
-     *            username of the real user
      * @return a <code>MailboxSession</code> for the real user
      *            when the given user is authenticated and authorized to access
      * @throws MailboxException
      *             when the creation fails for other reasons
      */
-    MailboxSession loginAsOtherUser(Username givenUserid, String passwd, Username otherUserId) throws MailboxException;
 
-    default DelegationLogin authenticate(Username givenUserid, String passwd) {
-        return otherUserId -> loginAsOtherUser(givenUserid, passwd, otherUserId);
-    }
+    AuthorizationStep authenticate(Username givenUserid, String passwd);
 
     /**
      * Checking given user can log in as another user
      * When delegated and authorized, a session for the other user will be supplied
      *
      * @param givenUserid
-     *            username of the given user, matching the credentials
-     * @param otherUserId
-     *            username of the real user
+     *            username of the given user
      * @return a <code>MailboxSession</code> for the real user
      *            when the given user is authenticated and authorized to access
      * @throws MailboxException
      *             when the creation fails for other reasons
      */
-    MailboxSession loginAsOtherUser(Username givenUserid, Username otherUserId) throws MailboxException;
-
-    default DelegationLogin authenticate(Username givenUserid) {
-        return otherUserId -> loginAsOtherUser(givenUserid, otherUserId);
-    }
+    AuthorizationStep authenticate(Username givenUserid);
 
     /**
      * <p>

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressContract.java
@@ -74,7 +74,6 @@ public interface MailboxManagerStressContract<T extends MailboxManager> {
             }, new MailboxIdRegistrationKey(mailboxId)))
             .block();
         getManager().endProcessingRequest(session);
-        getManager().logout(session);
 
         final AtomicBoolean fail = new AtomicBoolean(false);
         final ConcurrentHashMap<MessageUid, Object> uids = new ConcurrentHashMap<>();
@@ -102,7 +101,6 @@ public interface MailboxManagerStressContract<T extends MailboxManager> {
                         fail.set(true);
                     }
                     getManager().endProcessingRequest(mailboxSession);
-                    getManager().logout(mailboxSession);
                 } catch (Exception e) {
                     e.printStackTrace();
                     fail.set(true);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -161,7 +161,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
     @AfterEach
     void tearDown() {
-        mailboxManager.logout(session);
         mailboxManager.endProcessingRequest(session);
     }
 
@@ -2555,17 +2554,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             session = mailboxManager.createSystemSession(USER_1);
 
             assertThat(session.getUser()).isEqualTo(USER_1);
-        }
-
-        @Test
-        void closingSessionShouldWork() {
-            session = mailboxManager.createSystemSession(USER_1);
-            mailboxManager.startProcessingRequest(session);
-
-            mailboxManager.logout(session);
-            mailboxManager.endProcessingRequest(session);
-
-            assertThat(session.isOpen()).isFalse();
         }
     }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/manager/ManagerTestProvisionner.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/manager/ManagerTestProvisionner.java
@@ -58,7 +58,7 @@ public class ManagerTestProvisionner {
     public ManagerTestProvisionner(IntegrationResources<?> integrationResources) throws Exception {
         this.integrationResources = integrationResources;
 
-        session = integrationResources.getMailboxManager().login(USER, USER_PASS);
+        session = integrationResources.getMailboxManager().authenticate(USER, USER_PASS).withoutDelegation();
         subFolder = new MailboxPath(INBOX, "INBOX.SUB");
 
         MaxQuotaManager maxQuotaManager = integrationResources.getMaxQuotaManager();

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/mock/DataProvisioner.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/mock/DataProvisioner.java
@@ -94,7 +94,6 @@ public class DataProvisioner {
             .forEach(name ->  createSubSubMailboxes(mailboxManager, mailboxSession, name));
 
         mailboxManager.endProcessingRequest(mailboxSession);
-        mailboxManager.logout(mailboxSession);
     }
 
     private static void createSubSubMailboxes(MailboxManager mailboxManager,MailboxSession mailboxSession, String subFolderName) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
@@ -100,13 +100,6 @@ public class SessionProviderImpl implements SessionProvider {
         };
     }
 
-    @Override
-    public void logout(MailboxSession session) {
-        if (session != null) {
-            session.close();
-        }
-    }
-
     private MailboxSession createSession(Username userName, Optional<Username> loggedInUser, MailboxSession.SessionType type) {
         return new MailboxSession(newSessionId(), userName, loggedInUser, new ArrayList<>(), MailboxConstants.DEFAULT_DELIMITER, type);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
@@ -49,11 +49,6 @@ public class SessionProviderImpl implements SessionProvider {
     }
 
     @Override
-    public char getDelimiter() {
-        return MailboxConstants.DEFAULT_DELIMITER;
-    }
-
-    @Override
     public MailboxSession createSystemSession(Username userName) {
         return createSession(userName, Optional.empty(), MailboxSession.SessionType.System);
     }
@@ -113,7 +108,7 @@ public class SessionProviderImpl implements SessionProvider {
     }
 
     private MailboxSession createSession(Username userName, Optional<Username> loggedInUser, MailboxSession.SessionType type) {
-        return new MailboxSession(newSessionId(), userName, loggedInUser, new ArrayList<>(), getDelimiter(), type);
+        return new MailboxSession(newSessionId(), userName, loggedInUser, new ArrayList<>(), MailboxConstants.DEFAULT_DELIMITER, type);
     }
 
     private MailboxSession.SessionId newSessionId() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -249,23 +249,13 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     @Override
-    public MailboxSession login(Username userid, String passwd) throws MailboxException {
-        return sessionProvider.login(userid, passwd);
+    public AuthorizationStep authenticate(Username givenUserid, String passwd) {
+        return sessionProvider.authenticate(givenUserid, passwd);
     }
 
     @Override
-    public MailboxSession login(Username userid) {
-        return sessionProvider.login(userid);
-    }
-
-    @Override
-    public MailboxSession loginAsOtherUser(Username adminUserid, String passwd, Username otherUserId) throws MailboxException {
-        return sessionProvider.loginAsOtherUser(adminUserid, passwd, otherUserId);
-    }
-
-    @Override
-    public MailboxSession loginAsOtherUser(Username thisUserId, Username otherUserId) throws MailboxException {
-        return sessionProvider.loginAsOtherUser(thisUserId, otherUserId);
+    public AuthorizationStep authenticate(Username givenUserid) {
+        return sessionProvider.authenticate(givenUserid);
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -244,11 +244,6 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     @Override
-    public char getDelimiter() {
-        return sessionProvider.getDelimiter();
-    }
-
-    @Override
     public AuthorizationStep authenticate(Username givenUserid, String passwd) {
         return sessionProvider.authenticate(givenUserid, passwd);
     }
@@ -383,7 +378,7 @@ public class StoreMailboxManager implements MailboxManager {
         // Create parents first
         // If any creation fails then the mailbox will not be created
         // TODO: transaction
-        List<MailboxPath> intermediatePaths = sanitizedMailboxPath.getHierarchyLevels(getDelimiter());
+        List<MailboxPath> intermediatePaths = sanitizedMailboxPath.getHierarchyLevels(mailboxSession.getPathDelimiter());
         boolean isRootPath = intermediatePaths.size() == 1;
 
         return Flux.fromIterable(intermediatePaths)
@@ -638,7 +633,7 @@ public class StoreMailboxManager implements MailboxManager {
         // Find submailboxes
         MailboxQuery.UserBound query = MailboxQuery.builder()
             .userAndNamespaceFrom(from)
-            .expression(new PrefixedWildcard(from.getName() + getDelimiter()))
+            .expression(new PrefixedWildcard(from.getName() + session.getPathDelimiter()))
             .build()
             .asUserBound();
 
@@ -844,7 +839,7 @@ public class StoreMailboxManager implements MailboxManager {
     private MailboxMetaData toMailboxMetadata(MailboxSession session, Map<MailboxPath, Boolean> parentMap, Mailbox mailbox, MailboxCounters counters) throws UnsupportedRightException {
         return new MailboxMetaData(
             mailbox,
-            getDelimiter(),
+            session.getPathDelimiter(),
             computeChildren(parentMap, mailbox),
             Selectability.NONE,
             storeRightManager.getResolvedMailboxACL(mailbox, session),

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -253,11 +253,6 @@ public class StoreMailboxManager implements MailboxManager {
         return sessionProvider.authenticate(givenUserid);
     }
 
-    @Override
-    public void logout(MailboxSession session) {
-        sessionProvider.logout(session);
-    }
-
     /**
      * Create a {@link MailboxManager} for the given Mailbox. By default this will return a {@link StoreMessageManager}. If
      * your implementation needs something different, just override this method

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
@@ -168,63 +168,63 @@ class StoreMailboxManagerTest {
 
     @Test
     void loginShouldCreateSessionWhenGoodPassword() throws Exception {
-        MailboxSession expected = storeMailboxManager.login(CURRENT_USER, CURRENT_USER_PASSWORD);
+        MailboxSession expected = storeMailboxManager.authenticate(CURRENT_USER, CURRENT_USER_PASSWORD).withoutDelegation();
 
         assertThat(expected.getUser()).isEqualTo(CURRENT_USER);
     }
 
     @Test
     void loginShouldThrowWhenBadPassword() {
-        assertThatThrownBy(() -> storeMailboxManager.login(CURRENT_USER, BAD_PASSWORD))
+        assertThatThrownBy(() -> storeMailboxManager.authenticate(CURRENT_USER, BAD_PASSWORD).withoutDelegation())
             .isInstanceOf(BadCredentialsException.class);
     }
 
     @Test
     void loginAsOtherUserShouldNotCreateUserSessionWhenAdminWithBadPassword() {
-        assertThatThrownBy(() -> storeMailboxManager.loginAsOtherUser(ADMIN, BAD_PASSWORD, CURRENT_USER))
+        assertThatThrownBy(() -> storeMailboxManager.authenticate(ADMIN, BAD_PASSWORD).as(CURRENT_USER))
             .isInstanceOf(BadCredentialsException.class);
     }
 
     @Test
     void loginAsOtherUserShouldNotCreateUserSessionWhenNotAdmin() {
-        assertThatThrownBy(() -> storeMailboxManager.loginAsOtherUser(CURRENT_USER, CURRENT_USER_PASSWORD, UNKNOWN_USER))
+        assertThatThrownBy(() -> storeMailboxManager.authenticate(CURRENT_USER, CURRENT_USER_PASSWORD).as(UNKNOWN_USER))
             .isInstanceOf(ForbiddenDelegationException.class);
     }
 
     @Test
     void loginAsOtherUserShouldThrowBadCredentialWhenBadPasswordAndNotAdminUser() {
-        assertThatThrownBy(() -> storeMailboxManager.loginAsOtherUser(CURRENT_USER, BAD_PASSWORD, CURRENT_USER))
+        assertThatThrownBy(() -> storeMailboxManager.authenticate(CURRENT_USER, BAD_PASSWORD).as(CURRENT_USER))
             .isInstanceOf(BadCredentialsException.class);
     }
 
     @Test
     void loginAsOtherUserShouldThrowBadCredentialWhenBadPasswordNotAdminUserAndUnknownUser() {
-        assertThatThrownBy(() -> storeMailboxManager.loginAsOtherUser(CURRENT_USER, BAD_PASSWORD, UNKNOWN_USER))
+        assertThatThrownBy(() -> storeMailboxManager.authenticate(CURRENT_USER, BAD_PASSWORD).as(UNKNOWN_USER))
             .isInstanceOf(BadCredentialsException.class);
     }
 
     @Test
     void loginAsOtherUserShouldThrowBadCredentialsWhenBadPasswordAndUserDoesNotExists() {
-        assertThatThrownBy(() -> storeMailboxManager.loginAsOtherUser(ADMIN, BAD_PASSWORD, UNKNOWN_USER))
+        assertThatThrownBy(() -> storeMailboxManager.authenticate(ADMIN, BAD_PASSWORD).as(UNKNOWN_USER))
             .isInstanceOf(BadCredentialsException.class);
     }
 
     @Test
     void loginAsOtherUserShouldNotCreateUserSessionWhenDelegatedUserDoesNotExist() {
-        assertThatThrownBy(() -> storeMailboxManager.loginAsOtherUser(ADMIN, ADMIN_PASSWORD, UNKNOWN_USER))
+        assertThatThrownBy(() -> storeMailboxManager.authenticate(ADMIN, ADMIN_PASSWORD).as(UNKNOWN_USER))
             .isInstanceOf(UserDoesNotExistException.class);
     }
 
     @Test
     void loginAsOtherUserShouldCreateUserSessionWhenAdminWithGoodPassword() throws Exception {
-        MailboxSession expected = storeMailboxManager.loginAsOtherUser(ADMIN, ADMIN_PASSWORD, CURRENT_USER);
+        MailboxSession expected = storeMailboxManager.authenticate(ADMIN, ADMIN_PASSWORD).as(CURRENT_USER);
 
         assertThat(expected.getUser()).isEqualTo(CURRENT_USER);
     }
 
     @Test
     void loginAsOtherUserWithoutPasswordShouldCreateUserSession() throws MailboxException {
-        MailboxSession expected = storeMailboxManager.loginAsOtherUser(ADMIN, CURRENT_USER);
+        MailboxSession expected = storeMailboxManager.authenticate(ADMIN).as(CURRENT_USER);
 
         assertThat(expected.getUser()).isEqualTo(CURRENT_USER);
     }

--- a/mailbox/tools/copier/src/test/java/org/apache/james/mailbox/tools/copier/MailboxCopierTest.java
+++ b/mailbox/tools/copier/src/test/java/org/apache/james/mailbox/tools/copier/MailboxCopierTest.java
@@ -123,7 +123,6 @@ class MailboxCopierTest {
         }
 
         mailboxManager.endProcessingRequest(mailboxSession);
-        mailboxManager.logout(mailboxSession);
     }
 
     /**

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
@@ -104,7 +104,6 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
         MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
         mailboxManager.startProcessingRequest(mailboxSession);
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
-        mailboxManager.logout(mailboxSession);
         mailboxManager.endProcessingRequest(mailboxSession);
     }
 
@@ -119,7 +118,6 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
                 .rights(rights)
                 .asAddition()),
             mailboxSession);
-        mailboxManager.logout(mailboxSession);
         mailboxManager.endProcessingRequest(mailboxSession);
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -71,8 +71,9 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
             if (!authFailure) {
                 final MailboxManager mailboxManager = getMailboxManager();
                 try {
-                    final MailboxSession mailboxSession = mailboxManager.login(authenticationAttempt.getAuthenticationId(),
-                        authenticationAttempt.getPassword());
+                    final MailboxSession mailboxSession = mailboxManager.authenticate(authenticationAttempt.getAuthenticationId(),
+                        authenticationAttempt.getPassword())
+                        .withoutDelegation();
                     session.authenticated();
                     session.setMailboxSession(mailboxSession);
                     provisionInbox(session, mailboxManager, mailboxSession);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
@@ -41,7 +41,6 @@ public class LogoutProcessor extends AbstractMailboxProcessor<LogoutRequest> {
     @Override
     protected Mono<Void> processRequestReactive(LogoutRequest request, ImapSession session, Responder responder) {
         MailboxSession mailboxSession = session.getMailboxSession();
-        getMailboxManager().logout(mailboxSession);
         return session.logout()
             .then(Mono.fromRunnable(() -> {
                 bye(responder);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
@@ -69,9 +69,6 @@ public class SystemMessageProcessor extends AbstractProcessor<SystemMessage> {
         final MailboxSession session = imapSession.getMailboxSession();
         if (session == null) {
             LOGGER.trace("No mailbox session so no force logout needed");
-        } else {
-            session.close();
-            mailboxManager.logout(session);
         }
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -124,7 +124,6 @@ class MailboxEventAnalyserTest {
     private static final Username USER = Username.of("user");
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
     private static final MailboxSession OTHER_MAILBOX_SESSION = MailboxSessionUtil.create(USER);
-    private static final char PATH_DELIMITER = '.';
     private static final MailboxPath MAILBOX_PATH = new MailboxPath("namespace", USER, "name");
     private static final TestId MAILBOX_ID = TestId.of(36);
     private static final UidValidity UID_VALIDITY = UidValidity.of(1024);
@@ -148,7 +147,6 @@ class MailboxEventAnalyserTest {
 
         MailboxManager mailboxManager = mock(MailboxManager.class);
         MessageManager messageManager = mock(MessageManager.class);
-        when(mailboxManager.getDelimiter()).thenReturn(PATH_DELIMITER);
         when(mailboxManager.getMailbox(any(MailboxId.class), any(MailboxSession.class)))
             .thenReturn(messageManager);
         when(mailboxManager.getMailbox(any(MailboxPath.class), any(MailboxSession.class)))

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxProbeImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxProbeImpl.java
@@ -102,7 +102,6 @@ public class MailboxProbeImpl implements GuiceProbe, MailboxProbe {
     private void closeSession(MailboxSession session) {
         if (session != null) {
             mailboxManager.endProcessingRequest(session);
-            mailboxManager.logout(session);
         }
     }
 

--- a/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
+++ b/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
@@ -210,7 +210,6 @@ public class MailboxManagerManagement extends StandardMBean implements MailboxMa
     private void closeSession(MailboxSession session) {
         if (session != null) {
             mailboxManager.endProcessingRequest(session);
-            mailboxManager.logout(session);
         }
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailboxAppenderImpl.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailboxAppenderImpl.java
@@ -131,12 +131,7 @@ public class MailboxAppenderImpl implements MailboxAppender {
     }
 
     private void closeProcessing(MailboxSession session) {
-        session.close();
-        try {
-            mailboxManager.logout(session);
-        } finally {
-            mailboxManager.endProcessingRequest(session);
-        }
+        mailboxManager.endProcessingRequest(session);
     }
 
 }

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/AllowAuthenticationStrategy.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/AllowAuthenticationStrategy.java
@@ -44,7 +44,7 @@ public class AllowAuthenticationStrategy implements AuthenticationStrategy {
 
     @Override
     public Mono<MailboxSession> createMailboxSession(HttpServerRequest httpRequest) {
-        return Mono.fromCallable(() -> mailboxManager.login(BOB));
+        return Mono.fromCallable(() -> mailboxManager.authenticate(BOB).withoutDelegation());
     }
 
     @Override

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AccessTokenAuthenticationStrategy.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AccessTokenAuthenticationStrategy.java
@@ -28,6 +28,7 @@ import org.apache.james.jmap.exceptions.UnauthorizedException;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
@@ -51,7 +52,7 @@ public class AccessTokenAuthenticationStrategy implements AuthenticationStrategy
             .filter(tokenString -> !tokenString.startsWith("Bearer"))
             .map(AccessToken::fromString)
             .flatMap(item -> Mono.from(accessTokenManager.getUsernameFromToken(item)))
-            .map(mailboxManager::login)
+            .map(Throwing.function(user -> mailboxManager.authenticate(user).withoutDelegation()))
             .onErrorResume(InvalidAccessToken.class, error -> Mono.error(new UnauthorizedException("Invalid access token", error)))
             .onErrorResume(NotAnAccessTokenException.class, error -> Mono.error(new UnauthorizedException("Not an access token", error)));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/QueryParameterAccessTokenAuthenticationStrategy.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/QueryParameterAccessTokenAuthenticationStrategy.java
@@ -31,6 +31,7 @@ import org.apache.james.jmap.draft.model.AttachmentAccessToken;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
@@ -57,7 +58,7 @@ public class QueryParameterAccessTokenAuthenticationStrategy implements Authenti
             .filter(tokenManager::isValid)
             .map(AttachmentAccessToken::getUsername)
             .map(Username::of)
-            .map(mailboxManager::login);
+            .map(Throwing.function(user -> mailboxManager.authenticate(user).withoutDelegation()));
     }
 
     @Override

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/MailboxFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/MailboxFactoryTest.java
@@ -72,8 +72,8 @@ public class MailboxFactoryTest {
 
         user = ManagerTestProvisionner.USER;
         otherUser = OTHER_USER;
-        mailboxSession = mailboxManager.login(user, ManagerTestProvisionner.USER_PASS);
-        otherMailboxSession = mailboxManager.login(otherUser, ManagerTestProvisionner.OTHER_USER_PASS);
+        mailboxSession = mailboxManager.authenticate(user, ManagerTestProvisionner.USER_PASS).withoutDelegation();
+        otherMailboxSession = mailboxManager.authenticate(otherUser, ManagerTestProvisionner.OTHER_USER_PASS).withoutDelegation();
         sut = new MailboxFactory(mailboxManager, quotaManager, quotaRootResolver);
     }
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/AccessTokenAuthenticationStrategyTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/AccessTokenAuthenticationStrategyTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.core.Username;
 import org.apache.james.jmap.api.access.AccessToken;
 import org.apache.james.jmap.api.access.exceptions.InvalidAccessToken;
@@ -33,6 +34,8 @@ import org.apache.james.jmap.draft.crypto.AccessTokenManagerImpl;
 import org.apache.james.jmap.exceptions.UnauthorizedException;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.SessionProvider;
+import org.apache.james.mailbox.exception.MailboxException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -115,8 +118,18 @@ public class AccessTokenAuthenticationStrategyTest {
         Username username = Username.of("123456789");
         MailboxSession fakeMailboxSession = mock(MailboxSession.class);
 
-        when(mockedMailboxManager.login(eq(username)))
-            .thenReturn(fakeMailboxSession);
+        when(mockedMailboxManager.authenticate(eq(username)))
+            .thenReturn(new SessionProvider.AuthorizationStep() {
+                @Override
+                public MailboxSession as(Username other) {
+                    throw new NotImplementedException();
+                }
+
+                @Override
+                public MailboxSession withoutDelegation() {
+                    return fakeMailboxSession;
+                }
+            });
 
         UUID authHeader = UUID.randomUUID();
         AccessToken accessToken = AccessToken.fromString(authHeader.toString());

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/JWTAuthenticationStrategyTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/JWTAuthenticationStrategyTest.java
@@ -26,12 +26,15 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.core.Username;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.jmap.exceptions.UnauthorizedException;
 import org.apache.james.jwt.JwtTokenVerifier;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.SessionProvider;
+import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -122,8 +125,18 @@ public class JWTAuthenticationStrategyTest {
         MailboxSession fakeMailboxSession = mock(MailboxSession.class);
 
         when(stubTokenVerifier.verifyAndExtractLogin(validAuthHeader)).thenReturn(Optional.of(username));
-        when(mockedMailboxManager.login(eq(Username.of(username))))
-                .thenReturn(fakeMailboxSession);
+        when(mockedMailboxManager.authenticate(eq(Username.of(username))))
+            .thenReturn(new SessionProvider.AuthorizationStep() {
+                @Override
+                public MailboxSession as(Username other) throws MailboxException {
+                    throw new NotImplementedException();
+                }
+
+                @Override
+                public MailboxSession withoutDelegation() throws MailboxException {
+                    return fakeMailboxSession;
+                }
+            });
         when(mockedHeaders.get(AUTHORIZATION_HEADERS))
             .thenReturn(fakeAuthHeaderWithPrefix);
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/XUserAuthenticationStrategyTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/XUserAuthenticationStrategyTest.java
@@ -24,12 +24,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.core.Username;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.lib.DomainListConfiguration;
 import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.jmap.exceptions.UnauthorizedException;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.SessionProvider;
+import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,8 +61,18 @@ public class XUserAuthenticationStrategyTest {
         when(mockedMailboxManager.createSystemSession(any()))
             .thenReturn(fakeMailboxSession);
 
-        when(mockedMailboxManager.login(any()))
-            .thenReturn(fakeMailboxSession);
+        when(mockedMailboxManager.authenticate(any()))
+            .thenReturn(new SessionProvider.AuthorizationStep() {
+                @Override
+                public MailboxSession as(Username other) {
+                    throw new NotImplementedException();
+                }
+
+                @Override
+                public MailboxSession withoutDelegation() {
+                    return fakeMailboxSession;
+                }
+            });
 
         when(mockedRequest.requestHeaders())
             .thenReturn(mockedHeaders);

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/custom/authentication/strategy/AllowAuthenticationStrategy.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/custom/authentication/strategy/AllowAuthenticationStrategy.scala
@@ -30,7 +30,7 @@ import reactor.netty.http.server.HttpServerRequest
 
 case class AllowAuthenticationStrategy @Inject() (mailboxManager: MailboxManager) extends AuthenticationStrategy {
   override def createMailboxSession(httpRequest: HttpServerRequest): Mono[MailboxSession] =
-    SMono.fromCallable(() => mailboxManager.login(Fixture.BOB))
+    SMono.fromCallable(() => mailboxManager.authenticate(Fixture.BOB).withoutDelegation())
       .asJava()
 
   override def correspondingChallenge(): AuthenticationChallenge =

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/BasicAuthenticationStrategy.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/http/BasicAuthenticationStrategy.scala
@@ -118,7 +118,7 @@ class BasicAuthenticationStrategy @Inject()(val usersRepository: UsersRepository
       .handle(publishNext)
       .filterWhen(isValid)
       .map(_.username)
-      .map(mailboxManager.login)
+      .map(mailboxManager.authenticate(_).withoutDelegation())
       .asJava()
 
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/JWTAuthenticationStrategy.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/JWTAuthenticationStrategy.java
@@ -30,6 +30,7 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.util.ReactorUtils;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
@@ -71,7 +72,7 @@ public class JWTAuthenticationStrategy implements AuthenticationStrategy {
 
                 return username;
             }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER))
-            .map(mailboxManager::login);
+            .map(Throwing.function(user -> mailboxManager.authenticate(user).withoutDelegation()));
     }
 
     @Override

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/XUserAuthenticationStrategy.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/http/XUserAuthenticationStrategy.java
@@ -68,7 +68,7 @@ public class XUserAuthenticationStrategy implements AuthenticationStrategy {
             } catch (UsersRepositoryException e) {
                 throw new UnauthorizedException("Invalid username", e);
             }
-            return mailboxManager.login(username);
+            return mailboxManager.authenticate(username).withoutDelegation();
         }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
     }
 

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
@@ -151,10 +151,6 @@ public class DistributedMailboxAdapter implements Mailbox {
 
     @Override
     public void close() {
-        try {
-            mailboxManager.logout(session);
-        } finally {
-            mailboxManager.endProcessingRequest(session);
-        }
+        mailboxManager.endProcessingRequest(session);
     }
 }

--- a/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/core/PassCmdHandler.java
+++ b/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/core/PassCmdHandler.java
@@ -87,7 +87,7 @@ public class PassCmdHandler extends AbstractPassCmdHandler  {
     private Mailbox auth(POP3Session session, String password) throws IOException {
         MailboxSession mSession = null;
         try {
-            mSession = manager.login(session.getUsername(), password);
+            mSession = manager.authenticate(session.getUsername(), password).withoutDelegation();
             session.stopDetectingCommandInjection();
             manager.startProcessingRequest(mSession);
             MailboxPath inbox = MailboxPath.inbox(mSession);

--- a/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
+++ b/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
@@ -128,10 +128,6 @@ public class MailboxAdapter implements Mailbox {
 
     @Override
     public void close() throws IOException {
-        try {
-            mailboxManager.logout(session);
-        } finally {
-            mailboxManager.endProcessingRequest(session);
-        }
+        mailboxManager.endProcessingRequest(session);
     }
 }

--- a/server/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
+++ b/server/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
@@ -272,7 +272,7 @@ public class POP3ServerTest {
 
         pop3Client.disconnect();
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar");
+        MailboxSession session = mailboxManager.authenticate(username, "bar").withoutDelegation();
         if (!mailboxManager.mailboxExists(mailboxPath, session).block()) {
             mailboxManager.createMailbox(mailboxPath, session);
         }
@@ -352,7 +352,7 @@ public class POP3ServerTest {
         Username username = Username.of("foo2");
         usersRepository.addUser(username, "bar2");
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar2");
+        MailboxSession session = mailboxManager.authenticate(username, "bar2").withoutDelegation();
         mailboxManager.createMailbox(mailboxPath, session);
         byte[] content = ("Return-path: return@test.com\r\n"
             + "Content-Transfer-Encoding: plain\r\n"
@@ -389,7 +389,7 @@ public class POP3ServerTest {
         Username username = Username.of("foo2");
         usersRepository.addUser(username, "bar2");
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar2");
+        MailboxSession session = mailboxManager.authenticate(username, "bar2").withoutDelegation();
         mailboxManager.createMailbox(mailboxPath, session);
         byte[] content = ("Return-path: return@test.com\r\n"
             + "Content-Transfer-Encoding: plain\r\n"
@@ -426,7 +426,7 @@ public class POP3ServerTest {
         Username username = Username.of("foo2");
         usersRepository.addUser(username, "bar2");
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar2");
+        MailboxSession session = mailboxManager.authenticate(username, "bar2").withoutDelegation();
         mailboxManager.createMailbox(mailboxPath, session);
         byte[] content = ("Return-path: return@test.com\r\n"
             + "Content-Transfer-Encoding: plain\r\n"
@@ -469,7 +469,7 @@ public class POP3ServerTest {
         usersRepository.addUser(username, "bar2");
 
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar2");
+        MailboxSession session = mailboxManager.authenticate(username, "bar2").withoutDelegation();
 
         if (!mailboxManager.mailboxExists(mailboxPath, session).block()) {
             mailboxManager.createMailbox(mailboxPath, session);
@@ -556,7 +556,7 @@ public class POP3ServerTest {
         usersRepository.addUser(username, "bar2");
 
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar2");
+        MailboxSession session = mailboxManager.authenticate(username, "bar2").withoutDelegation();
 
         if (!mailboxManager.mailboxExists(mailboxPath, session).block()) {
             mailboxManager.createMailbox(mailboxPath, session);
@@ -602,7 +602,7 @@ public class POP3ServerTest {
         usersRepository.addUser(username, "bar2");
 
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar2");
+        MailboxSession session = mailboxManager.authenticate(username, "bar2").withoutDelegation();
 
         if (!mailboxManager.mailboxExists(mailboxPath, session).block()) {
             mailboxManager.createMailbox(mailboxPath, session);
@@ -652,7 +652,7 @@ public class POP3ServerTest {
         usersRepository.addUser(username, "bar2");
 
         MailboxPath mailboxPath = MailboxPath.inbox(username);
-        MailboxSession session = mailboxManager.login(username, "bar2");
+        MailboxSession session = mailboxManager.authenticate(username, "bar2").withoutDelegation();
 
         if (!mailboxManager.mailboxExists(mailboxPath, session).block()) {
             mailboxManager.createMailbox(mailboxPath, session);
@@ -861,7 +861,7 @@ public class POP3ServerTest {
 
         Username username = Username.of("foo6");
         usersRepository.addUser(username, "bar6");
-        MailboxSession session = mailboxManager.login(username, "bar6");
+        MailboxSession session = mailboxManager.authenticate(username, "bar6").withoutDelegation();
 
         MailboxPath mailboxPath = MailboxPath.inbox(username);
 


### PR DESCRIPTION
 - Decrease method cardinality for login / delegation methods
 - Remove uneeded methods 
    - getPathDelimiter() - can be carried by the MailboxSession instead. No need to enforce the delimiter choice for a whole SessionProvider impl.
    - logout: isOpen is never used, this bit of logic can be strip away.