### PR TITLE
JAMES-3756 - Update Delegate/get, DelegatedAccount/get - return DelegationId in response

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/DelegateGetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/DelegateGetMethodContract.scala
@@ -28,6 +28,7 @@ import net.javacrumbs.jsonunit.core.internal.Options
 import org.apache.http.HttpStatus.SC_OK
 import org.apache.james.GuiceJamesServer
 import org.apache.james.jmap.core.ResponseObject.SESSION_STATE
+import org.apache.james.jmap.delegation.DelegationId
 import org.apache.james.jmap.http.UserCredential
 import org.apache.james.jmap.rfc8621.contract.DelegateGetMethodContract.BOB_ACCOUNT_ID
 import org.apache.james.jmap.rfc8621.contract.Fixture.{ACCEPT_RFC8621_VERSION_HEADER, ANDRE, ANDRE_ACCOUNT_ID, ANDRE_PASSWORD, BOB, BOB_PASSWORD, CEDRIC, DOMAIN, authScheme, baseRequestSpecBuilder}
@@ -134,7 +135,7 @@ trait DelegateGetMethodContract {
            |                "notFound": [],
            |                "list": [
            |                    {
-           |                        "id": "${Fixture.ANDRE_ACCOUNT_ID}",
+           |                        "id": "${DelegationId.from(BOB, ANDRE).serialize}",
            |                        "username": "${ANDRE.asString()}"
            |                    }
            |                ]
@@ -233,10 +234,10 @@ trait DelegateGetMethodContract {
   def delegateGetShouldReturnNotFoundAndListWhenMixCases(server: GuiceJamesServer): Unit = {
     val delegatedId = server.getProbe(classOf[DelegationProbe])
       .addAuthorizedUser(BOB, ANDRE)
-      .id.value
+      .serialize
     val delegatedId2 = server.getProbe(classOf[DelegationProbe])
       .addAuthorizedUser(BOB, CEDRIC)
-      .id.value
+      .serialize
 
     val response = `given`
       .body(
@@ -330,7 +331,7 @@ trait DelegateGetMethodContract {
   def delegateGetShouldNotReturnDelegateOfOtherUserWhenProvideIds(server: GuiceJamesServer): Unit = {
     val delegateId = server.getProbe(classOf[DelegationProbe])
       .addAuthorizedUser(ANDRE, BOB)
-      .id.value
+      .serialize
 
     val response = `given`
       .body(
@@ -373,10 +374,10 @@ trait DelegateGetMethodContract {
   def bobShouldNotGetDelegateListOfAliceEvenDelegated(server: GuiceJamesServer): Unit = {
     val delegateId1 = server.getProbe(classOf[DelegationProbe])
       .addAuthorizedUser(ANDRE, BOB)
-      .id.value
+      .serialize
     val delegateId2 =  server.getProbe(classOf[DelegationProbe])
       .addAuthorizedUser(ANDRE, CEDRIC)
-      .id.value
+      .serialize
 
     val response = `given`
       .body(
@@ -423,7 +424,7 @@ trait DelegateGetMethodContract {
   def delegateGetReturnIdWhenNoPropertiesRequested(server: GuiceJamesServer): Unit = {
     val delegateId = server.getProbe(classOf[DelegationProbe])
       .addAuthorizedUser(BOB, ANDRE)
-      .id.value
+      .serialize
 
     val response = `given`
       .body(

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/probe/DelegationProbe.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/probe/DelegationProbe.scala
@@ -23,7 +23,7 @@ import com.google.inject.AbstractModule
 import com.google.inject.multibindings.Multibinder
 import javax.inject.Inject
 import org.apache.james.core.Username
-import org.apache.james.jmap.core.AccountId
+import org.apache.james.jmap.delegation.DelegationId
 import org.apache.james.user.api.DelegationStore
 import org.apache.james.utils.GuiceProbe
 import reactor.core.scala.publisher.{SFlux, SMono}
@@ -46,8 +46,8 @@ class DelegationProbe @Inject()(delegationStore: DelegationStore) extends GuiceP
       .collectSeq()
       .block()
 
-  def addAuthorizedUser(baseUser: Username, userWithAccess: Username): AccountId =
+  def addAuthorizedUser(baseUser: Username, userWithAccess: Username): DelegationId =
     SMono.fromPublisher(delegationStore.addAuthorizedUser(baseUser, userWithAccess))
-      .`then`(SMono.just(AccountId.from(userWithAccess).toOption.get))
+      .`then`(SMono.just(DelegationId.from(baseUser, userWithAccess)))
       .block()
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/delegation/DelegateGet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/delegation/DelegateGet.scala
@@ -20,11 +20,10 @@
 package org.apache.james.jmap.delegation
 
 import java.util.UUID
-
 import eu.timepit.refined.auto._
 import org.apache.james.core.Username
 import org.apache.james.jmap.core.Id.Id
-import org.apache.james.jmap.core.{AccountId, Properties}
+import org.apache.james.jmap.core.{AccountId, Id, Properties}
 import org.apache.james.jmap.method.WithAccountId
 
 import scala.util.Try
@@ -51,19 +50,13 @@ case class DelegateIds(value: List[UnparsedDelegateId])
 case class DelegateGetRequest(accountId: AccountId,
                               ids: Option[DelegateIds],
                               properties: Option[Properties]) extends WithAccountId
-
-object Delegate {
-  def from(username: Username): Delegate =
-    AccountId.from(username)
-      .map(accountId => Delegate(accountId, username)) match {
-      case Right(value) => value
-      case Left(error) => throw error
-    }
-
+case class Delegate(id: DelegationId,
+                    username: Username) {
+  def delegationIdAsId(): Id = Id.validate(id.serialize) match {
+    case Right(value) => value
+    case Left(error) => throw error
+  }
 }
-
-case class Delegate(id: AccountId,
-                    username: Username)
 
 case class DelegateNotFound(value: Set[UnparsedDelegateId])
 
@@ -72,8 +65,8 @@ object DelegateGetResult {
     requestIds match {
       case None => DelegateGetResult(delegates)
       case Some(value) => DelegateGetResult(
-        list = delegates.filter(delegate => value.contains(delegate.id.id)),
-        notFound = DelegateNotFound(value.diff(delegates.map(_.id.id).toSet).map(UnparsedDelegateId)))
+        list = delegates.filter(delegate => value.contains(delegate.delegationIdAsId())),
+        notFound = DelegateNotFound(value.diff(delegates.map(_.delegationIdAsId()).toSet).map(UnparsedDelegateId)))
     }
 }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/delegation/DelegatedAccountGet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/delegation/DelegatedAccountGet.scala
@@ -42,8 +42,8 @@ object DelegatedAccountGetResult {
     requestIds match {
       case None => DelegatedAccountGetResult(delegates)
       case Some(value) => DelegatedAccountGetResult(
-        list = delegates.filter(delegate => value.contains(delegate.id.id)),
-        notFound = DelegatedAccountNotFound(value.diff(delegates.map(_.id.id).toSet).map(UnparsedDelegateId)))
+        list = delegates.filter(delegate => value.contains(delegate.delegationIdAsId())),
+        notFound = DelegatedAccountNotFound(value.diff(delegates.map(_.delegationIdAsId()).toSet).map(UnparsedDelegateId)))
     }
 }
 case class DelegatedAccountGetResult(list: Seq[Delegate],

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/DelegateGetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/DelegateGetMethod.scala
@@ -26,6 +26,7 @@ import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JA
 import org.apache.james.jmap.core.Invocation.{Arguments, MethodName}
 import org.apache.james.jmap.core.{ErrorCode, Invocation, Properties, SessionTranslator}
 import org.apache.james.jmap.delegation.{Delegate, DelegateGet, DelegateGetRequest, DelegateGetResult, ForbiddenAccountManagementException}
+import org.apache.james.jmap.delegation.{Delegate, DelegateGet, DelegateGetRequest, DelegateGetResult, DelegationId}
 import org.apache.james.jmap.json.{DelegationSerializer, ResponseSerializer}
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.mailbox.MailboxSession
@@ -73,7 +74,7 @@ class DelegateGetMethod @Inject()(val metricFactory: MetricFactory,
 
   private def getAuthorizedUser(baseUser: Username, request: DelegateGetRequest): SMono[DelegateGetResult] =
     SFlux(delegationStore.authorizedUsers(baseUser))
-      .map(Delegate.from)
+      .map(authorizedUser => Delegate(DelegationId.from(baseUser, authorizedUser), authorizedUser))
       .collectSeq()
       .map(delegates => DelegateGetResult.from(delegates, request.ids.map(_.value.map(_.id).toSet)))
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/DelegatedAccountGetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/DelegatedAccountGetMethod.scala
@@ -26,6 +26,7 @@ import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JA
 import org.apache.james.jmap.core.Invocation.{Arguments, MethodName}
 import org.apache.james.jmap.core.{ErrorCode, Invocation, Properties, SessionTranslator}
 import org.apache.james.jmap.delegation.{Delegate, DelegatedAccountGet, DelegatedAccountGetRequest, DelegatedAccountGetResult, ForbiddenAccountManagementException}
+import org.apache.james.jmap.delegation.{Delegate, DelegatedAccountGet, DelegatedAccountGetRequest, DelegatedAccountGetResult, DelegationId}
 import org.apache.james.jmap.json.{DelegationSerializer, ResponseSerializer}
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.mailbox.MailboxSession
@@ -73,7 +74,7 @@ class DelegatedAccountGetMethod @Inject()(val metricFactory: MetricFactory,
 
   private def getDelegatedUser(baseUser: Username, request: DelegatedAccountGetRequest): SMono[DelegatedAccountGetResult] =
     SFlux(delegationStore.delegatedUsers(baseUser))
-      .map(Delegate.from)
+      .map(delegatedUser => Delegate(DelegationId.from(delegatedUser, baseUser), delegatedUser))
       .collectSeq()
       .map(delegates => DelegatedAccountGetResult.from(delegates, request.ids.map(_.value.map(_.id).toSet)))
 


### PR DESCRIPTION
Currently, the get method returns AccountId as an id of delegation in response.
=> 
Update: use DelegationId, which is already (Same id as Delegate/Set method)