### PR TITLE
[JAMES-3877] enables configuration of jdbc pool max connections

### DIFF
--- a/server/apps/jpa-app/sample-configuration/james-database-mariadb.properties
+++ b/server/apps/jpa-app/sample-configuration/james-database-mariadb.properties
@@ -40,3 +40,5 @@ openjpa.streaming=false
 # datasource.validationQueryTimeoutSec=2
 # This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
 # datasource.validationQuery=select 1
+# The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
+# datasource.maxTotal=8

--- a/server/apps/jpa-app/sample-configuration/james-database.properties
+++ b/server/apps/jpa-app/sample-configuration/james-database.properties
@@ -44,3 +44,5 @@ openjpa.streaming=false
 # datasource.validationQueryTimeoutSec=2
 # This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
 # datasource.validationQuery=select 1
+# The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
+# datasource.maxTotal=8

--- a/server/apps/jpa-smtp-app/sample-configuration/james-database-mariadb.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/james-database-mariadb.properties
@@ -40,3 +40,5 @@ openjpa.streaming=false
 # datasource.validationQueryTimeoutSec=2
 # This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
 # datasource.validationQuery=select 1
+# The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
+# datasource.maxTotal=8

--- a/server/apps/jpa-smtp-app/sample-configuration/james-database.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/james-database.properties
@@ -44,3 +44,5 @@ openjpa.streaming=false
 # datasource.validationQueryTimeoutSec=2
 # This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
 # datasource.validationQuery=select 1
+# The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
+# datasource.maxTotal=8

--- a/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
+++ b/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
@@ -40,7 +40,7 @@ public class JPAEntityManagerModule extends AbstractModule {
     @Singleton
     public EntityManagerFactory provideEntityManagerFactory(JPAConfiguration jpaConfiguration) {
         HashMap<String, String> properties = new HashMap<>();
-        
+
         properties.put("openjpa.ConnectionDriverName", jpaConfiguration.getDriverName());
         properties.put("openjpa.ConnectionURL", jpaConfiguration.getDriverURL());
         jpaConfiguration.getCredential()
@@ -55,6 +55,9 @@ public class JPAEntityManagerModule extends AbstractModule {
             .ifPresent(timeoutSecond -> connectionFactoryProperties.add("ValidationTimeout=" + timeoutSecond * 1000));
         jpaConfiguration.getValidationQuery()
             .ifPresent(validationQuery -> connectionFactoryProperties.add("ValidationSQL='" + validationQuery + "'"));
+        jpaConfiguration.getMaxConnections().ifPresent(maxConnections ->
+                connectionFactoryProperties.add("MaxTotal=" + maxConnections)
+        );
 
         properties.put("openjpa.ConnectionFactoryProperties", Joiner.on(", ").join(connectionFactoryProperties));
 
@@ -71,6 +74,7 @@ public class JPAEntityManagerModule extends AbstractModule {
                 .testOnBorrow(dataSource.getBoolean("datasource.testOnBorrow", false))
                 .validationQueryTimeoutSec(dataSource.getInteger("datasource.validationQueryTimeoutSec", null))
                 .validationQuery(dataSource.getString("datasource.validationQuery", null))
+                .maxConnections(dataSource.getInteger("datasource.maxTotal",null))
                 .username(dataSource.getString("database.username"))
                 .password(dataSource.getString("database.password"))
                 .build();

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -56,7 +56,7 @@
 
                 <p>This configuration file is only relevant when using JPA, with Spring or Guice.</p>
 
-                <p>Consult <a href="https://github.com/apache/james-project/tree/master/server/apps/spring-app/src/main/resources/james-database.properties">james.properties</a> in GIT to get some examples and hints.</p>
+                <p>Consult <a href="https://github.com/apache/james-project/tree/master/server/apps/spring-app/src/main/resources/james-database.properties">james-database.properties</a> in GIT to get some examples and hints.</p>
 
                 <p>The database connection in database.properties</p>
 
@@ -72,10 +72,10 @@
                 <p>Also, since James will use JDBC to access the database, an appropriate JDBC driver must be
                     available for installation. You can place the JDBC driver jar in the conf/lib folder, it will
                     be automatically loaded.</p>
-
+                <p>Database configuration</p>
                 <dl>
                     <dt><strong>database.driverClassName</strong></dt>
-                    <dd>he class name of the database driver to be used.</dd>
+                    <dd>The class name of the database driver to be used.</dd>
                     <dt><strong>database.url</strong></dt>
                     <dd>The JDBC connection URL for your database/driver.</dd>
                     <dt><strong>database.username</strong></dt>
@@ -88,12 +88,19 @@
                     <dd>true or false - Use streaming for Blobs. This is only supported on a limited set of databases atm. You
                         should check if its supported by your DB before enable it. See <a href="http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html">http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html</a> (#7.11. LOB Streaming).</dd>
                 </dl>
+                <p>The JPA datasource handling is delegated to commons-dbcp, some of dbcp properties can be configured through james-database.properties. The corresponding definitions and default values can be found in the <a href="https://commons.apache.org/proper/commons-dbcp/configuration.html">dbcp documentation</a></p>
+                <ul>
+                    <li>datasource.testOnBorrow</li>
+                    <li>datasource.validationQueryTimeoutSec</li>
+                    <li>datasource.validationQuery</li>
+                    <li>datasource.maxTotal</li>
 
-                <p>Note for postgresql databases: Add standard_conforming_strings=off to your postgresql.xml, otherwise you
-                    will get ""Invalid escape string Hint: Escape string must be empty or one character. {prepstmnt 174928937
+                </ul>
+                <p>Note for postgresql databases: Add <code>standard_conforming_strings=off</code> to your postgresql.xml, otherwise you
+                    will get <code>""Invalid escape string Hint: Escape string must be empty or one character. {prepstmnt 174928937
                     SELECT t0.mailbox_id, t0.mailbox_highest_modseq, t0.mailbox_last_uid, t0.mailbox_name, t0.mailbox_namespace,
                     t0.mailbox_uid_validity, t0.user_name FROM public.james_mailbox t0 WHERE (t0.mailbox_name LIKE ?
-                    ESCAPE '\\' AND t0.user_name = ? AND t0.mailbox_namespace = ?) [params=?, ?, ?]} [code=0, state=22025]"</p>
+                        ESCAPE '\\' AND t0.user_name = ? AND t0.mailbox_namespace = ?) [params=?, ?, ?]} [code=0, state=22025]"</code></p>
 
             </subsection>
 


### PR DESCRIPTION
It all in the comment and the jira issue, not all the dbcp data source properties are exposed through james-database.properties. I need to add one to configure maxTotal connection