### PR TITLE
[boyscout] logs bound port when webmin server starts

### DIFF
--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
@@ -117,7 +117,7 @@ public class WebAdminServer implements Startable {
             });
             publicRoutes.forEach(routes -> routes.define(service));
             service.awaitInitialization();
-            LOGGER.info("Web admin server started");
+            LOGGER.info("Web admin server started on port {}", service.port());
         }
         return this;
     }


### PR DESCRIPTION
Logging bound port at startup helps make sure the ops setup is correct. The idea was lifted from `AbstractConfigurableAsyncServer` which is used for the SMTP server.