### PR TITLE
Improves logs for guice context and ssl contexts initialization errors

### DIFF
--- a/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
+++ b/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
@@ -118,7 +118,12 @@ public class Main implements JamesServerMain {
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration);
 
-        JamesServerMain.main(server);
+        try {
+            JamesServerMain.main(server);
+        } catch (Exception e) {
+            LOGGER.error("Failed to start", e);
+            throw e;
+        }
     }
 
     public static GuiceJamesServer createServer(SMTPRelayConfiguration configuration) {

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
@@ -32,7 +32,10 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509ExtendedKeyManager;
 
 import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.protocols.lib.netty.AbstractConfigurableAsyncServer;
 import org.apache.james.protocols.netty.Encryption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
 
@@ -41,6 +44,8 @@ import nl.altindag.ssl.trustmanager.TrustStoreTrustOptions;
 import nl.altindag.ssl.util.PemUtils;
 
 public class LegacyJavaEncryptionFactory implements Encryption.Factory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractConfigurableAsyncServer.class);
+
     private final FileSystem fileSystem;
     private final SslConfig sslConfig;
 
@@ -52,23 +57,24 @@ public class LegacyJavaEncryptionFactory implements Encryption.Factory {
     @Override
     public Encryption create() throws Exception {
         SSLFactory.Builder sslFactoryBuilder = SSLFactory.builder()
-            .withSslContextAlgorithm("TLS");
+                .withSslContextAlgorithm("TLS");
         if (sslConfig.getKeystore() != null) {
             char[] passwordAsCharArray = Optional.ofNullable(sslConfig.getSecret())
-                .orElse("")
-                .toCharArray();
+                    .orElse("")
+                    .toCharArray();
+            LOGGER.debug("Building SSL config for keystore({}) at {}", sslConfig.getKeystoreType(), fileSystem.getFile(sslConfig.getKeystore()).toPath().toAbsolutePath());
             sslFactoryBuilder.withIdentityMaterial(
-                fileSystem.getFile(sslConfig.getKeystore()).toPath(),
-                passwordAsCharArray,
-                passwordAsCharArray,
-                sslConfig.getKeystoreType());
+                    fileSystem.getFile(sslConfig.getKeystore()).toPath(),
+                    passwordAsCharArray,
+                    passwordAsCharArray,
+                    sslConfig.getKeystoreType());
         } else {
             X509ExtendedKeyManager keyManager = PemUtils.loadIdentityMaterial(
-                fileSystem.getResource(sslConfig.getCertificates()),
-                fileSystem.getResource(sslConfig.getPrivateKey()),
-                Optional.ofNullable(sslConfig.getSecret())
-                    .map(String::toCharArray)
-                    .orElse(null));
+                    fileSystem.getResource(sslConfig.getCertificates()),
+                    fileSystem.getResource(sslConfig.getPrivateKey()),
+                    Optional.ofNullable(sslConfig.getSecret())
+                            .map(String::toCharArray)
+                            .orElse(null));
 
             sslFactoryBuilder.withIdentityMaterial(keyManager);
         }
@@ -77,7 +83,7 @@ public class LegacyJavaEncryptionFactory implements Encryption.Factory {
             Optional<TrustStoreTrustOptions<? extends CertPathTrustManagerParameters>> maybeTrustOptions = clientAuthTrustOptions(sslConfig);
 
             maybeTrustOptions.ifPresentOrElse(Throwing.<TrustStoreTrustOptions<? extends CertPathTrustManagerParameters>>consumer(trustOptions ->
-                sslFactoryBuilder.withTrustMaterial(
+            sslFactoryBuilder.withTrustMaterial(
                     fileSystem.getFile(sslConfig.getTruststore()).toPath(),
                     sslConfig.getTruststoreSecret(),
                     sslConfig.getKeystoreType(),

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/SslConfig.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/SslConfig.java
@@ -60,7 +60,12 @@ public class SslConfig {
             String truststoreType = config.getString("tls.clientAuth.truststoreType", "JKS");
             char[] truststoreSecret = config.getString("tls.clientAuth.truststoreSecret", "").toCharArray();
             boolean enableOCSPCRLChecks = config.getBoolean("tls.enableOCSPCRLChecks", false);
-            LOGGER.info("TLS enabled with auth {} using truststore {}", clientAuth, truststore);
+
+            if (useSSL) {
+                LOGGER.info("SSL enabled with keystore({}) at {}, certificates {}", keystoreType, keystore, certificates);
+            } else {
+                LOGGER.info("TLS enabled with auth {} using truststore {}", clientAuth, truststore);
+            }
 
             return new SslConfig(useStartTLS, useSSL, clientAuth, keystore, keystoreType, privateKey, certificates, secret, truststore, truststoreType, enabledCipherSuites, enabledProtocols, truststoreSecret, enableOCSPCRLChecks);
         } else {


### PR DESCRIPTION
While doing the setup of our james instance, we had a hard time making sure that the right keystore and corresponding parameters were applied, and ti diagnose some invalid configuration leading to guice context configuration error.
These two commits helped us debug it.