### PR TITLE
Adds minimal pulsar authentication support to pulsar configuration

### DIFF
--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -31,6 +31,7 @@
     <name>Apache James :: Backends Common :: Pulsar</name>
     <properties>
         <pulsar-client.version>2.11.0</pulsar-client.version>
+        <clever-cloud.pulsar4s.version>2.9.0</clever-cloud.pulsar4s.version>
     </properties>
 
     <dependencies>
@@ -51,12 +52,36 @@
         <dependency>
             <groupId>com.clever-cloud.pulsar4s</groupId>
             <artifactId>pulsar4s-akka-streams_${scala.base}</artifactId>
-            <version>2.8.1</version>
+            <version>${clever-cloud.pulsar4s.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!--
+                    Using pulsar-client-all ensures that shaded dependencies are
+                    pulled only once reducing the overall bundle size
+                    This requires excluding the non-all dependencies from the
+                    scala wrapper
+                    -->
+                    <groupId>org.apache.pulsar</groupId>
+                    <artifactId>pulsar-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.clever-cloud.pulsar4s</groupId>
             <artifactId>pulsar4s-core_${scala.base}</artifactId>
-            <version>2.8.1</version>
+            <version>${clever-cloud.pulsar4s.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!--
+                    Using pulsar-client-all ensures that shaded dependencies are
+                    pulled only once reducing the overall bundle size
+                    This requires excluding the non-all dependencies from the
+                    scala wrapper
+                    -->
+                    <groupId>org.apache.pulsar</groupId>
+                    <artifactId>pulsar-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.dimafeng</groupId>
@@ -94,12 +119,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-client</artifactId>
-            <version>${pulsar-client.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-client-admin</artifactId>
+            <artifactId>pulsar-client-all</artifactId>
             <version>${pulsar-client.version}</version>
         </dependency>
         <dependency>

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -87,6 +87,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client</artifactId>
+            <version>2.9.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client-admin</artifactId>
             <version>2.9.3</version>
         </dependency>

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -85,6 +85,10 @@
             <version>2.6.20</version>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
         </dependency>

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -29,6 +29,9 @@
 
     <artifactId>apache-james-backends-pulsar</artifactId>
     <name>Apache James :: Backends Common :: Pulsar</name>
+    <properties>
+        <pulsar-client.version>2.11.0</pulsar-client.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -88,12 +91,12 @@
         <dependency>
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client</artifactId>
-            <version>2.9.3</version>
+            <version>${pulsar-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client-admin</artifactId>
-            <version>2.9.3</version>
+            <version>${pulsar-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/backends-common/pulsar/src/main/scala/org/apache/james/backends/pulsar/PulsarClients.scala
+++ b/backends-common/pulsar/src/main/scala/org/apache/james/backends/pulsar/PulsarClients.scala
@@ -1,0 +1,68 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.pulsar
+
+import com.sksamuel.pulsar4s.{PulsarAsyncClient, PulsarClient, PulsarClientConfig}
+import org.apache.commons.io.IOUtils
+import org.apache.pulsar.client.admin.PulsarAdmin
+import org.apache.pulsar.client.impl.auth.{AuthenticationBasic, AuthenticationDisabled, AuthenticationToken}
+
+import java.io.Closeable
+import javax.annotation.PreDestroy
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+object PulsarClients {
+  def create(configuration: PulsarConfiguration): PulsarClients = {
+    val pulsarAuth = configuration.auth match {
+      case Auth.NoAuth => new AuthenticationDisabled()
+      case Auth.Token(value) => new AuthenticationToken(value)
+      case Auth.Basic(userId, password) =>
+        val basic = new AuthenticationBasic()
+        basic.configure(Map("userId" -> userId, "password" -> password).asJava)
+        basic
+    }
+
+    val adminClient: PulsarAdmin =
+      PulsarAdmin.builder()
+        .serviceHttpUrl(configuration.adminUri)
+        .authentication(pulsarAuth)
+        .build()
+
+    val asyncClient: PulsarAsyncClient = {
+      PulsarClient(
+        PulsarClientConfig(
+          serviceUrl = configuration.brokerUri,
+          authentication = Some(pulsarAuth)
+        )
+      )
+    }
+
+    new PulsarClients(adminClient, asyncClient)
+  }
+}
+
+
+class PulsarClients(val adminClient: PulsarAdmin, val asyncClient: PulsarAsyncClient) {
+  @PreDestroy
+  def stop(): Unit = {
+    val closeableAsyncClient: Closeable = () => asyncClient.close()
+    IOUtils.closeQuietly(adminClient, closeableAsyncClient)
+  }
+}

--- a/backends-common/pulsar/src/main/scala/org/apache/james/backends/pulsar/PulsarConfiguration.scala
+++ b/backends-common/pulsar/src/main/scala/org/apache/james/backends/pulsar/PulsarConfiguration.scala
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
-
 package org.apache.james.backends.pulsar
 
 import java.net.{URI, URISyntaxException}
@@ -27,16 +26,45 @@ object PulsarConfiguration {
   val BROKER_URI_PROPERTY_NAME = "broker.uri"
   val ADMIN_URI_PROPERTY_NAME = "admin.uri"
   val NAMESPACE_PROPERTY_NAME = "namespace"
+  val AUTHENTICATION_TYPE_PROPERTY_NAME = "authentication.type"
+  val AUTHENTICATION_TYPE_NO_AUTH = "no-auth"
+  val AUTHENTICATION_TYPE_AUTH_TOKEN = "token"
+  val AUTHENTICATION_TYPE_AUTH_BASIC = "basic"
+  val AUTHENTICATION_TOKEN_PROPERTY_NAME = "authentication.token"
+  val AUTHENTICATION_BASIC_USERID_PROPERTY_NAME = "authentication.basic.userId"
+  val AUTHENTICATION_BASIC_PASSWORD_PROPERTY_NAME = "authentication.basic.password"
+
 
   def from(configuration: Configuration): PulsarConfiguration = {
     val brokerUri: String = extractUri(configuration, BROKER_URI_PROPERTY_NAME)
     val adminUri: String = extractUri(configuration, ADMIN_URI_PROPERTY_NAME)
+    val authTypeString: String = configuration.getString(AUTHENTICATION_TYPE_PROPERTY_NAME, AUTHENTICATION_TYPE_NO_AUTH);
+    val auth = authTypeString match {
+      case AUTHENTICATION_TYPE_NO_AUTH => Auth.NoAuth
 
+      case AUTHENTICATION_TYPE_AUTH_TOKEN =>
+        val token = configuration.getString(AUTHENTICATION_TOKEN_PROPERTY_NAME)
+        if (Strings.isNullOrEmpty(token))
+          throw new IllegalStateException(s"You need to specify a non-empty value for ${AUTHENTICATION_TOKEN_PROPERTY_NAME}")
+        Auth.Token(token)
+
+      case AUTHENTICATION_TYPE_AUTH_BASIC =>
+        val userId = configuration.getString(AUTHENTICATION_BASIC_USERID_PROPERTY_NAME)
+        if (Strings.isNullOrEmpty(userId))
+          throw new IllegalStateException(s"You need to specify a non-empty value for ${AUTHENTICATION_BASIC_USERID_PROPERTY_NAME}")
+        val password = configuration.getString(AUTHENTICATION_BASIC_PASSWORD_PROPERTY_NAME)
+        if (Strings.isNullOrEmpty(password))
+          throw new IllegalStateException(s"You need to specify a non-empty value for ${AUTHENTICATION_BASIC_PASSWORD_PROPERTY_NAME}")
+        Auth.Basic(userId, password)
+
+      case _ =>
+        throw new NotImplementedError(s"Authentication type $authTypeString is not implemented")
+    }
 
     val namespace = configuration.getString(NAMESPACE_PROPERTY_NAME)
     if (Strings.isNullOrEmpty(namespace))
       throw new IllegalStateException(s"You need to specify the pulsar namespace as ${NAMESPACE_PROPERTY_NAME}")
-    new PulsarConfiguration(brokerUri, adminUri, Namespace(namespace))
+    new PulsarConfiguration(brokerUri, adminUri, Namespace(namespace), auth)
   }
 
   private def extractUri(configuration: Configuration, uriPropertyName: String): String = {
@@ -55,4 +83,20 @@ object PulsarConfiguration {
 
 case class Namespace(asString: String)
 
-case class PulsarConfiguration(brokerUri: String, adminUri: String, namespace: Namespace)
+sealed trait Auth
+
+object Auth {
+  def noAuth() = NoAuth
+
+  case object NoAuth extends Auth
+
+  def token(value: String) = Token(value)
+
+  case class Token(value: String) extends Auth
+
+  def basic(userId: String, password: String) = Basic(userId, password)
+
+  case class Basic(userId: String, password: String) extends Auth
+}
+
+case class PulsarConfiguration(brokerUri: String, adminUri: String, namespace: Namespace, auth: Auth = Auth.NoAuth)

--- a/backends-common/pulsar/src/test/java/org/apache/james/backends/pulsar/DockerPulsarExtension.java
+++ b/backends-common/pulsar/src/test/java/org/apache/james/backends/pulsar/DockerPulsarExtension.java
@@ -70,7 +70,9 @@ public class DockerPulsarExtension implements
         return new PulsarConfiguration(
                 container.getPulsarBrokerUrl(),
                 container.getHttpServiceUrl(),
-                new Namespace("test/" + RandomStringUtils.randomAlphabetic(10)));
+                new Namespace("test/" + RandomStringUtils.randomAlphabetic(10)),
+                Auth.noAuth()
+        );
     }
 
     public PulsarConfiguration getConfiguration() {

--- a/server/container/guice/queue/pulsar/src/main/java/org/apache/james/queue/pulsar/module/PulsarQueueModule.java
+++ b/server/container/guice/queue/pulsar/src/main/java/org/apache/james/queue/pulsar/module/PulsarQueueModule.java
@@ -27,6 +27,7 @@ import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.backends.pulsar.PulsarClients;
 import org.apache.james.backends.pulsar.PulsarConfiguration;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.Store;
@@ -70,7 +71,14 @@ public class PulsarQueueModule extends AbstractModule {
 
     @Provides
     @Singleton
+    private PulsarClients pulsarClients(PulsarConfiguration configuration) {
+        return PulsarClients.create(configuration);
+    }
+
+    @Provides
+    @Singleton
     public MailQueueFactory<? extends ManageableMailQueue> mailQueue(PulsarConfiguration pulsarConfig,
+                                                                     PulsarClients pulsarClients,
                                                                      BlobId.Factory blobIdFactory,
                                                                      MimeMessageStore.Factory mimeFactory,
                                                                      MailQueueItemDecoratorFactory decoratorFactory,
@@ -79,6 +87,7 @@ public class PulsarQueueModule extends AbstractModule {
         Store<MimeMessage, MimeMessagePartsId> mimeMessageMimeMessagePartsIdStore = mimeFactory.mimeMessageStore();
         return new PulsarMailQueueFactory(
                 pulsarConfig,
+                pulsarClients,
                 blobIdFactory,
                 mimeMessageMimeMessagePartsIdStore,
                 decoratorFactory,

--- a/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/PulsarMailQueueFactory.scala
+++ b/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/PulsarMailQueueFactory.scala
@@ -20,7 +20,7 @@
 package org.apache.james.queue.pulsar
 
 import akka.actor.ActorSystem
-import org.apache.james.backends.pulsar.{Auth, PulsarConfiguration}
+import org.apache.james.backends.pulsar.{Auth, PulsarClients, PulsarConfiguration}
 import org.apache.james.blob.api.{BlobId, Store}
 import org.apache.james.blob.mail.MimeMessagePartsId
 import org.apache.james.metrics.api.{GaugeRegistry, MetricFactory}
@@ -39,6 +39,7 @@ import scala.jdk.OptionConverters._
 import scala.util.Try
 
 class PulsarMailQueueFactory @Inject()(pulsarConfiguration: PulsarConfiguration,
+  pulsarClients:PulsarClients,
   blobIdFactory: BlobId.Factory,
   mimeMessageStore: Store[MimeMessage, MimeMessagePartsId],
   mailQueueItemDecoratorFactory: MailQueueItemDecoratorFactory,
@@ -46,7 +47,7 @@ class PulsarMailQueueFactory @Inject()(pulsarConfiguration: PulsarConfiguration,
   gaugeRegistry: GaugeRegistry
 ) extends MailQueueFactory[PulsarMailQueue] {
   private val queues: AtomicReference[Map[MailQueueName, PulsarMailQueue]] = new AtomicReference(Map.empty)
-  private val admin = pulsarConfiguration.adminClient
+  private val admin = pulsarClients.adminClient
   private val system: ActorSystem = ActorSystem("pulsar-mailqueue")
 
   @PreDestroy
@@ -69,6 +70,7 @@ class PulsarMailQueueFactory @Inject()(pulsarConfiguration: PulsarConfiguration,
       val queue = map.get(name)
         .fold(new PulsarMailQueue(
           PulsarMailQueueConfiguration(name, pulsarConfiguration),
+          pulsarClients,
           blobIdFactory,
           mimeMessageStore,
           mailQueueItemDecoratorFactory,

--- a/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/PulsarMailQueueFactory.scala
+++ b/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/PulsarMailQueueFactory.scala
@@ -20,12 +20,13 @@
 package org.apache.james.queue.pulsar
 
 import akka.actor.ActorSystem
-import org.apache.james.backends.pulsar.PulsarConfiguration
+import org.apache.james.backends.pulsar.{Auth, PulsarConfiguration}
 import org.apache.james.blob.api.{BlobId, Store}
 import org.apache.james.blob.mail.MimeMessagePartsId
 import org.apache.james.metrics.api.{GaugeRegistry, MetricFactory}
 import org.apache.james.queue.api.{MailQueueFactory, MailQueueItemDecoratorFactory, MailQueueName}
 import org.apache.pulsar.client.admin.PulsarAdmin
+import org.apache.pulsar.client.impl.auth.{AuthenticationBasic, AuthenticationToken}
 
 import java.util
 import java.util.Optional
@@ -45,9 +46,7 @@ class PulsarMailQueueFactory @Inject()(pulsarConfiguration: PulsarConfiguration,
   gaugeRegistry: GaugeRegistry
 ) extends MailQueueFactory[PulsarMailQueue] {
   private val queues: AtomicReference[Map[MailQueueName, PulsarMailQueue]] = new AtomicReference(Map.empty)
-  private val admin =
-    PulsarAdmin.builder().serviceHttpUrl(pulsarConfiguration.adminUri).build()
-
+  private val admin = pulsarConfiguration.adminClient
   private val system: ActorSystem = ActorSystem("pulsar-mailqueue")
 
   @PreDestroy

--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueFactoryTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueFactoryTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.backends.pulsar.DockerPulsarExtension;
+import org.apache.james.backends.pulsar.PulsarClients;
 import org.apache.james.backends.pulsar.PulsarConfiguration;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.HashBlobId;
@@ -60,6 +61,7 @@ class PulsarMailQueueFactoryTest implements MailQueueFactoryContract<PulsarMailQ
     private MailQueueItemDecoratorFactory factory;
     private PulsarConfiguration config;
     private MailQueueMetricExtension.MailQueueMetricTestSystem metricTestSystem;
+    private PulsarClients pulsarClients;
 
     @BeforeEach
     void setUp(DockerPulsarExtension.DockerPulsar dockerPulsar, MailQueueMetricExtension.MailQueueMetricTestSystem metricTestSystem) throws PulsarClientException, PulsarAdminException {
@@ -73,17 +75,20 @@ class PulsarMailQueueFactoryTest implements MailQueueFactoryContract<PulsarMailQ
         mimeMessageStore = mimeMessageStoreFactory.mimeMessageStore();
         factory = new RawMailQueueItemDecoratorFactory();
         config = dockerPulsar.getConfiguration();
+        pulsarClients = PulsarClients.create(config);
         mailQueueFactory = newInstance();
     }
 
     @AfterEach
     void tearDown() {
         mailQueueFactory.stop();
+        pulsarClients.stop();
     }
 
     private PulsarMailQueueFactory newInstance() {
         return new PulsarMailQueueFactory(
                 config,
+                pulsarClients,
                 blobIdFactory,
                 mimeMessageStore,
                 factory,


### PR DESCRIPTION
The initial implementation only supported no auth, which doesn't work well in a prod environment. 

This PR adds support for 
- explicit no auth
- basic user/password auth
- token auth
