### PR TITLE
JAMES-3694 Refine RabbitMQ usage of x-expires queue feature

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -767,7 +767,6 @@ public class RabbitMQConfiguration {
         if (allowQuorum && useQuorumQueues) {
             builder.quorumQueue().replicationFactor(quorumQueueReplicationFactor);
         }
-        queueTTL.ifPresent(builder::queueTTL);
         return builder;
     }
 

--- a/server/task/task-api/src/test/java/org/apache/james/task/TaskManagerContract.java
+++ b/server/task/task-api/src/test/java/org/apache/james/task/TaskManagerContract.java
@@ -47,10 +47,10 @@ public interface TaskManagerContract {
     ConditionFactory awaitAtMostTwoSeconds = calmlyAwait.atMost(Duration.ofSeconds(2));
     java.time.Duration TIMEOUT = java.time.Duration.ofMinutes(15);
 
-    TaskManager taskManager();
+    TaskManager taskManager() throws Exception;
 
     @Test
-    default void submitShouldReturnATaskId() {
+    default void submitShouldReturnATaskId() throws Exception {
         TaskId taskId = taskManager().submit(new CompletedTask());
         assertThat(taskId).isNotNull();
     }
@@ -63,7 +63,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void getStatusShouldReturnWaitingWhenNotYetProcessed(CountDownLatch waitingForResultLatch) {
+    default void getStatusShouldReturnWaitingWhenNotYetProcessed(CountDownLatch waitingForResultLatch) throws Exception {
         TaskManager taskManager = taskManager();
         taskManager.submit(new MemoryReferenceTask(() -> {
             waitingForResultLatch.await();
@@ -77,7 +77,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void taskCodeAfterCancelIsNotRun(CountDownLatch waitingForResultLatch) throws InterruptedException {
+    default void taskCodeAfterCancelIsNotRun(CountDownLatch waitingForResultLatch) throws Exception {
         TaskManager taskManager = taskManager();
         CountDownLatch waitForTaskToBeLaunched = new CountDownLatch(1);
         AtomicInteger count = new AtomicInteger(0);
@@ -98,7 +98,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void completedTaskShouldNotBeCancelled() {
+    default void completedTaskShouldNotBeCancelled() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId id = taskManager.submit(new CompletedTask());
 
@@ -114,7 +114,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void failedTaskShouldNotBeCancelled() {
+    default void failedTaskShouldNotBeCancelled() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId id = taskManager.submit(new FailedTask());
 
@@ -130,7 +130,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void getStatusShouldBeCancelledWhenCancelled(CountDownLatch countDownLatch) {
+    default void getStatusShouldBeCancelledWhenCancelled(CountDownLatch countDownLatch) throws Exception {
         TaskManager taskManager = taskManager();
         TaskId id = taskManager.submit(new MemoryReferenceTask(() -> {
             countDownLatch.await();
@@ -152,7 +152,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void aWaitingTaskShouldBeCancelled(CountDownLatch countDownLatch) {
+    default void aWaitingTaskShouldBeCancelled(CountDownLatch countDownLatch) throws Exception {
         TaskManager taskManager = taskManager();
         TaskId id = taskManager.submit(new MemoryReferenceTask(() -> {
             countDownLatch.await();
@@ -176,7 +176,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void cancelShouldBeIdempotent(CountDownLatch waitingForResultLatch) {
+    default void cancelShouldBeIdempotent(CountDownLatch waitingForResultLatch) throws Exception {
         TaskManager taskManager = taskManager();
         TaskId id = taskManager.submit(new MemoryReferenceTask(() -> {
             waitingForResultLatch.await();
@@ -189,7 +189,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void getStatusShouldReturnInProgressWhenProcessingIsInProgress(CountDownLatch waitingForResultLatch) {
+    default void getStatusShouldReturnInProgressWhenProcessingIsInProgress(CountDownLatch waitingForResultLatch) throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(new MemoryReferenceTask(() -> {
             waitingForResultLatch.await();
@@ -201,7 +201,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void getStatusShouldReturnCompletedWhenRunSuccessfully() {
+    default void getStatusShouldReturnCompletedWhenRunSuccessfully() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(
             new CompletedTask());
@@ -212,7 +212,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void additionalInformationShouldBeUpdatedWhenRunSuccessfully() {
+    default void additionalInformationShouldBeUpdatedWhenRunSuccessfully() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(new MemoryReferenceWithCounterTask(counter -> {
             counter.incrementAndGet();
@@ -230,7 +230,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void additionalInformationShouldBeUpdatedWhenFailed() {
+    default void additionalInformationShouldBeUpdatedWhenFailed() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(new MemoryReferenceWithCounterTask(counter -> {
             counter.incrementAndGet();
@@ -248,7 +248,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void additionalInformationShouldBeUpdatedWhenCancelled(CountDownLatch countDownLatch) {
+    default void additionalInformationShouldBeUpdatedWhenCancelled(CountDownLatch countDownLatch) throws Exception {
         TaskManager taskManager = taskManager();
         TaskId id = taskManager.submit(new MemoryReferenceWithCounterTask((counter) -> {
             counter.incrementAndGet();
@@ -273,7 +273,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void additionalInformationShouldBeUpdatedDuringExecution(CountDownLatch countDownLatch) {
+    default void additionalInformationShouldBeUpdatedDuringExecution(CountDownLatch countDownLatch) throws Exception {
         TaskManager taskManager = taskManager();
         TaskId id = taskManager.submit(new MemoryReferenceWithCounterTask((counter) -> {
             counter.incrementAndGet();
@@ -288,7 +288,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void additionalInformationShouldBeAvailableOnAnyTaskManagerDuringExecution(CountDownLatch countDownLatch) {
+    default void additionalInformationShouldBeAvailableOnAnyTaskManagerDuringExecution(CountDownLatch countDownLatch) throws Exception {
         TaskManager taskManager = taskManager();
         TaskManager otherTaskManager = taskManager();
         TaskId id = taskManager.submit(new MemoryReferenceWithCounterTask((counter) -> {
@@ -312,7 +312,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void getStatusShouldReturnFailedWhenRunPartially() {
+    default void getStatusShouldReturnFailedWhenRunPartially() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(
             new FailedTask());
@@ -493,22 +493,22 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void listShouldBeEmptyWhenNoTasks() {
+    default void listShouldBeEmptyWhenNoTasks() throws Exception {
         assertThat(taskManager().list()).isEmpty();
     }
 
     @Test
-    default void listCancelledShouldBeEmptyWhenNoTasks() {
+    default void listCancelledShouldBeEmptyWhenNoTasks() throws Exception {
         assertThat(taskManager().list(TaskManager.Status.CANCELLED)).isEmpty();
     }
 
     @Test
-    default void listCancelRequestedShouldBeEmptyWhenNoTasks() {
+    default void listCancelRequestedShouldBeEmptyWhenNoTasks() throws Exception {
         assertThat(taskManager().list(TaskManager.Status.CANCEL_REQUESTED)).isEmpty();
     }
 
     @Test
-    default void awaitShouldNotThrowWhenCompletedTask() throws TaskManager.ReachedTimeoutException {
+    default void awaitShouldNotThrowWhenCompletedTask() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(new CompletedTask());
         taskManager.await(taskId, TIMEOUT);
@@ -516,7 +516,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void awaitShouldAwaitWaitingTask() throws TaskManager.ReachedTimeoutException, InterruptedException {
+    default void awaitShouldAwaitWaitingTask() throws Exception {
         TaskManager taskManager = taskManager();
         CountDownLatch latch = new CountDownLatch(1);
         taskManager.submit(new MemoryReferenceTask(
@@ -537,7 +537,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void awaitWithATooShortTimeoutShouldReturnATimeoutAwaitedTaskExecutionDetailsAndThrow() {
+    default void awaitWithATooShortTimeoutShouldReturnATimeoutAwaitedTaskExecutionDetailsAndThrow() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(new MemoryReferenceTask(
             () -> {
@@ -550,7 +550,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void submittedTaskShouldExecuteSequentially() {
+    default void submittedTaskShouldExecuteSequentially() throws Exception {
         TaskManager taskManager = taskManager();
         ConcurrentLinkedQueue<Integer> queue = new ConcurrentLinkedQueue<>();
 
@@ -580,7 +580,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void awaitShouldReturnFailedWhenExceptionThrown() {
+    default void awaitShouldReturnFailedWhenExceptionThrown() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(new ThrowingTask());
         awaitUntilTaskHasStatus(taskId, TaskManager.Status.FAILED, taskManager);
@@ -589,7 +589,7 @@ public interface TaskManagerContract {
     }
 
     @Test
-    default void getStatusShouldReturnFailedWhenExceptionThrown() {
+    default void getStatusShouldReturnFailedWhenExceptionThrown() throws Exception {
         TaskManager taskManager = taskManager();
         TaskId taskId = taskManager.submit(new ThrowingTask());
         awaitUntilTaskHasStatus(taskId, TaskManager.Status.FAILED, taskManager);

--- a/server/task/task-distributed/src/main/scala/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueSupplier.scala
+++ b/server/task/task-distributed/src/main/scala/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueSupplier.scala
@@ -22,7 +22,7 @@ import java.time.Duration
 
 import com.google.common.annotations.VisibleForTesting
 import javax.inject.Inject
-import org.apache.james.backends.rabbitmq.ReceiverProvider
+import org.apache.james.backends.rabbitmq.{RabbitMQConfiguration, ReceiverProvider}
 import org.apache.james.eventsourcing.EventSourcingSystem
 import org.apache.james.server.task.json.JsonTaskSerializer
 import org.apache.james.task.SerialTaskManagerWorker
@@ -33,7 +33,8 @@ class RabbitMQWorkQueueSupplier @Inject()(private val sender: Sender,
                                           private val receiverProvider: ReceiverProvider,
                                           private val jsonTaskSerializer: JsonTaskSerializer,
                                           private val cancelRequestName: CancelRequestQueueName,
-                                          private val configuration: RabbitMQWorkQueueConfiguration) extends WorkQueueSupplier {
+                                          private val configuration: RabbitMQWorkQueueConfiguration,
+                                          private val rabbitMQConfiguration: RabbitMQConfiguration) extends WorkQueueSupplier {
 
   val DEFAULT_ADDITIONAL_INFORMATION_POLLING_INTERVAL =  Duration.ofSeconds(30)
   override def apply(eventSourcingSystem: EventSourcingSystem): RabbitMQWorkQueue = {
@@ -44,7 +45,7 @@ class RabbitMQWorkQueueSupplier @Inject()(private val sender: Sender,
   def apply(eventSourcingSystem: EventSourcingSystem, additionalInformationPollingInterval: Duration): RabbitMQWorkQueue = {
     val listener = WorkerStatusListener(eventSourcingSystem)
     val worker = new SerialTaskManagerWorker(listener, additionalInformationPollingInterval)
-    val rabbitMQWorkQueue = new RabbitMQWorkQueue(worker, sender, receiverProvider, jsonTaskSerializer, configuration, cancelRequestName)
+    val rabbitMQWorkQueue = new RabbitMQWorkQueue(worker, sender, receiverProvider, jsonTaskSerializer, configuration, cancelRequestName, rabbitMQConfiguration)
     rabbitMQWorkQueue
   }
 }

--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriberTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriberTest.java
@@ -65,15 +65,15 @@ class RabbitMQTerminationSubscriberTest implements TerminationSubscriberContract
         .isolationPolicy(WEAK);
 
     @Override
-    public TerminationSubscriber subscriber() {
+    public TerminationSubscriber subscriber() throws Exception {
         RabbitMQTerminationSubscriber subscriber = new RabbitMQTerminationSubscriber(TerminationQueueName.generate(), rabbitMQExtension.getSender(),
-            rabbitMQExtension.getReceiverProvider(), SERIALIZER);
+            rabbitMQExtension.getReceiverProvider(), SERIALIZER, rabbitMQExtension.getRabbitMQ().getConfiguration());
         subscriber.start();
         return subscriber;
     }
 
     @Test
-    void givenTwoTerminationSubscribersWhenAnEventIsSentItShouldBeReceivedByBoth() {
+    void givenTwoTerminationSubscribersWhenAnEventIsSentItShouldBeReceivedByBoth() throws Exception {
         TerminationSubscriber subscriber1 = subscriber();
         TerminationSubscriber subscriber2 = subscriber();
 
@@ -94,7 +94,7 @@ class RabbitMQTerminationSubscriberTest implements TerminationSubscriberContract
     }
 
     @Test
-    void eventProcessingShouldNotCrashOnInvalidMessage() {
+    void eventProcessingShouldNotCrashOnInvalidMessage() throws Exception {
         TerminationSubscriber subscriber1 = subscriber();
         Flux<Event> firstListener = Flux.from(subscriber1.listenEvents());
 
@@ -113,7 +113,7 @@ class RabbitMQTerminationSubscriberTest implements TerminationSubscriberContract
     }
 
     @Test
-    void eventProcessingShouldNotCrashOnInvalidMessages() {
+    void eventProcessingShouldNotCrashOnInvalidMessages() throws Exception {
         TerminationSubscriber subscriber1 = subscriber();
         Flux<Event> firstListener = Flux.from(subscriber1.listenEvents());
 

--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueuePersistenceTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueuePersistenceTest.java
@@ -50,10 +50,10 @@ class RabbitMQWorkQueuePersistenceTest {
     private JsonTaskSerializer serializer;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         worker = spy(new ImmediateWorker());
         serializer = JsonTaskSerializer.of(TestTaskDTOModules.COMPLETED_TASK_MODULE, TestTaskDTOModules.MEMORY_REFERENCE_TASK_MODULE.apply(new MemoryReferenceTaskStore()));
-        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate());
+        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate(), rabbitMQExtension.getRabbitMQ().getConfiguration());
         //declare the queue but do not start consuming from it
         testee.declareQueue();
     }
@@ -90,9 +90,9 @@ class RabbitMQWorkQueuePersistenceTest {
         assertThat(worker.results).containsExactly(Task.Result.COMPLETED);
     }
 
-    private void startNewConsumingWorkqueue() {
+    private void startNewConsumingWorkqueue() throws Exception {
         worker = spy(new ImmediateWorker());
-        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate());
+        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate(), rabbitMQExtension.getRabbitMQ().getConfiguration());
         testee.start();
     }
 }

--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueTest.java
@@ -66,10 +66,10 @@ class RabbitMQWorkQueueTest {
 
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         worker = new ImmediateWorker();
         serializer = JsonTaskSerializer.of(TestTaskDTOModules.COMPLETED_TASK_MODULE, TestTaskDTOModules.MEMORY_REFERENCE_TASK_MODULE.apply(new MemoryReferenceTaskStore()));
-        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate());
+        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate(), rabbitMQExtension.getRabbitMQ().getConfiguration());
         testee.start();
     }
 
@@ -96,11 +96,11 @@ class RabbitMQWorkQueueTest {
     }
 
     @Test
-    void givenTwoWorkQueuesOnlyTheFirstOneIsConsumingTasks() {
+    void givenTwoWorkQueuesOnlyTheFirstOneIsConsumingTasks() throws Exception {
         testee.submit(TASK_WITH_ID);
 
         ImmediateWorker otherTaskManagerWorker = new ImmediateWorker();
-        try (RabbitMQWorkQueue otherWorkQueue = new RabbitMQWorkQueue(otherTaskManagerWorker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate())) {
+        try (RabbitMQWorkQueue otherWorkQueue = new RabbitMQWorkQueue(otherTaskManagerWorker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), serializer, RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate(), rabbitMQExtension.getRabbitMQ().getConfiguration())) {
             otherWorkQueue.start();
 
             IntStream.range(0, 9)
@@ -112,7 +112,7 @@ class RabbitMQWorkQueueTest {
     }
 
     @Test
-    void givenANonDeserializableTaskItShouldBeFlaggedAsFailedAndItDoesNotPreventFollowingTasks() throws InterruptedException {
+    void givenANonDeserializableTaskItShouldBeFlaggedAsFailedAndItDoesNotPreventFollowingTasks() throws Exception {
         Task task = new TestTask(42);
         TaskId taskId = TaskId.fromString("4bf6d081-aa30-11e9-bf6c-2d3b9e84aafd");
         TaskWithId taskWithId = new TaskWithId(taskId, task);
@@ -120,7 +120,7 @@ class RabbitMQWorkQueueTest {
         ImmediateWorker otherTaskManagerWorker = new ImmediateWorker();
         JsonTaskSerializer otherTaskSerializer = JsonTaskSerializer.of(TestTaskDTOModules.TEST_TYPE);
         try (RabbitMQWorkQueue otherWorkQueue = new RabbitMQWorkQueue(otherTaskManagerWorker, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(), otherTaskSerializer,
-            RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate())) {
+            RabbitMQWorkQueueConfiguration$.MODULE$.enabled(), CancelRequestQueueName.generate(), rabbitMQExtension.getRabbitMQ().getConfiguration())) {
             //wait to be sur that the first workqueue has subscribed as an exclusive consumer of the RabbitMQ queue.
             Thread.sleep(200);
             otherWorkQueue.start();

--- a/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/TerminationSubscriberContract.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/TerminationSubscriberContract.java
@@ -53,10 +53,10 @@ public interface TerminationSubscriberContract {
     Duration DELAY_BEFORE_PUBLISHING = Duration.ofMillis(50);
     ExecutorService EXECUTOR = Executors.newCachedThreadPool();
 
-    TerminationSubscriber subscriber();
+    TerminationSubscriber subscriber() throws Exception;
 
     @Test
-    default void handlingCompletedShouldBeListed() {
+    default void handlingCompletedShouldBeListed() throws Exception {
         TerminationSubscriber subscriber = subscriber();
 
         sendEvents(subscriber, COMPLETED_EVENT);
@@ -65,7 +65,7 @@ public interface TerminationSubscriberContract {
     }
 
     @Test
-    default void handlingFailedShouldBeListed() {
+    default void handlingFailedShouldBeListed() throws Exception {
         TerminationSubscriber subscriber = subscriber();
 
         sendEvents(subscriber, FAILED_EVENT);
@@ -74,7 +74,7 @@ public interface TerminationSubscriberContract {
     }
 
     @Test
-    default void handlingCancelledShouldBeListed() {
+    default void handlingCancelledShouldBeListed() throws Exception {
         TerminationSubscriber subscriber = subscriber();
 
         sendEvents(subscriber, CANCELLED_EVENT);
@@ -83,7 +83,7 @@ public interface TerminationSubscriberContract {
     }
 
     @Test
-    default void handlingNonTerminalEventShouldNotBeListed() {
+    default void handlingNonTerminalEventShouldNotBeListed() throws Exception {
         TerminationSubscriber subscriber = subscriber();
         TaskEvent event = new Started(new TaskAggregateId(TaskId.generateTaskId()), EventId.fromSerialized(42), new Hostname("foo"));
 
@@ -93,7 +93,7 @@ public interface TerminationSubscriberContract {
     }
 
     @Test
-    default void handlingMultipleEventsShouldBeListed() {
+    default void handlingMultipleEventsShouldBeListed() throws Exception {
         TerminationSubscriber subscriber = subscriber();
 
         sendEvents(subscriber, COMPLETED_EVENT, FAILED_EVENT, CANCELLED_EVENT);
@@ -102,7 +102,7 @@ public interface TerminationSubscriberContract {
     }
 
     @Test
-    default void multipleListeningEventsShouldShareEvents() {
+    default void multipleListeningEventsShouldShareEvents() throws Exception {
         TerminationSubscriber subscriber = subscriber();
 
         Flux<Event> firstListener = Flux.from(subscriber.listenEvents());
@@ -122,7 +122,7 @@ public interface TerminationSubscriberContract {
     }
 
     @Test
-    default void dynamicListeningEventsShouldGetOnlyNewEvents() {
+    default void dynamicListeningEventsShouldGetOnlyNewEvents() throws Exception {
         TerminationSubscriber subscriber = subscriber();
 
         sendEvents(subscriber, COMPLETED_EVENT, FAILED_EVENT, CANCELLED_EVENT);


### PR DESCRIPTION
 - Apply queue expiracy only for per-node queues

Those are temporary RPC-like response queues tied to a
specific James instance, needing cleanup. Other,
permanent queues should not be deleted.

 - Apply queue expiracy for the task manager

Safer than auto-deletes