### PR TITLE
JAMES-3740 Small improvments for UidMSNConverter

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -83,13 +83,7 @@ public class UidMsnConverter {
     private void addAllToEmptyLongStructure(List<MessageUid> addedUids) {
         uids.ensureCapacity(addedUids.size());
         for (MessageUid uid : addedUids) {
-            if (uid.asLong() > INTEGER_MAX_VALUE) {
-                uids.clear();
-                switchToLongs();
-                addAllUnSynchronized(addedUids);
-                return;
-            }
-            uids.add((int) uid.asLong());
+            uids.add(uid.asLong());
         }
         uids.sort(LongComparators.NATURAL_COMPARATOR);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -121,6 +121,8 @@ public class UidMsnConverter {
         for (int i = 0; i < uidsAsInts.size(); i++) {
             uids.add(uidsAsInts.getInt(i));
         }
+        uidsAsInts.clear();
+        uidsAsInts.trim();
     }
 
     public synchronized NullableMessageSequenceNumber getMsn(MessageUid uid) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -229,7 +229,7 @@ public class UidMsnConverter {
                 uidsAsInts.add((int) uid.asLong());
                 return;
             }
-            if (uidsAsInts.contains((int) uid.asLong())) {
+            if (contains(uid)) {
                 return;
             } else {
                 uidsAsInts.add((int) uid.asLong());
@@ -240,13 +240,17 @@ public class UidMsnConverter {
                 uids.add(uid.asLong());
                 return;
             }
-            if (uids.contains(uid.asLong())) {
+            if (contains(uid)) {
                 return;
             } else {
                 uids.add(uid.asLong());
                 uids.sort(LongComparators.NATURAL_COMPARATOR);
             }
         }
+    }
+
+    private boolean contains(MessageUid uid) {
+        return getMsnUnsynchronized(uid).foldSilent(() -> false, any -> true);
     }
 
     private boolean isLastUid(MessageUid uid) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -192,7 +192,7 @@ public class UidMsnConverter {
                 uidsAsInts.removeInt(index);
             }
         } else {
-            int index = Arrays.binarySearch(uids.elements(), 0, uids.size(), (int) uid.asLong());
+            int index = Arrays.binarySearch(uids.elements(), 0, uids.size(), uid.asLong());
             if (index >= 0) {
                 uids.removeLong(index);
             }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -20,7 +20,6 @@
 package org.apache.james.imap.processor.base;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -235,7 +234,6 @@ public class UidMsnConverter {
             } else {
                 uidsAsInts.add((int) uid.asLong());
                 uidsAsInts.sort(IntComparators.NATURAL_COMPARATOR);
-                Collections.sort(uids);
             }
         } else {
             if (isLastUid(uid)) {

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -424,6 +424,121 @@ class UidMsnConverterTest {
     }
 
     @Test
+    void addAllShouldSupportIntOverflowWhenNonEmpty() {
+        testee.addUid(MessageUid.of(17));
+        testee.addAll(ImmutableList.of(MessageUid.of(36),
+            MessageUid.of(Integer.MAX_VALUE + 1L),
+            MessageUid.of(Integer.MAX_VALUE + 2L),
+            MessageUid.of(13)));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(13),
+                2, MessageUid.of(17),
+                3, MessageUid.of(36),
+                4, MessageUid.of(Integer.MAX_VALUE + 1L),
+                5, MessageUid.of(Integer.MAX_VALUE + 2L)));
+    }
+
+    @Test
+    void addUidShouldNotCreateDuplicatesInLongMode() {
+        testee.addUid(MessageUid.of(17));
+        testee.addAll(ImmutableList.of(MessageUid.of(36),
+            MessageUid.of(Integer.MAX_VALUE + 1L),
+            MessageUid.of(Integer.MAX_VALUE + 2L),
+            MessageUid.of(13)));
+        testee.addUid(MessageUid.of(13));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(13),
+                2, MessageUid.of(17),
+                3, MessageUid.of(36),
+                4, MessageUid.of(Integer.MAX_VALUE + 1L),
+                5, MessageUid.of(Integer.MAX_VALUE + 2L)));
+    }
+
+    @Test
+    void removeLongShouldNotAlterIntStructure() {
+        testee.addUid(MessageUid.of(17));
+
+        testee.remove(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(17)));
+    }
+
+    @Test
+    void getMsnShouldReturnNoneWhenUsedForALongAgainstAnIntStructure() {
+        testee.addUid(MessageUid.of(17));
+
+        assertThat(testee.getMsn(MessageUid.of(Integer.MAX_VALUE + 1L)))
+            .isEqualTo(NullableMessageSequenceNumber.noMessage());
+    }
+
+    @Test
+    void getMsnShouldWorkForLongStructure() {
+        testee.addUid(MessageUid.of(17));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        assertThat(testee.getMsn(MessageUid.of(Integer.MAX_VALUE + 1L)))
+            .isEqualTo(NullableMessageSequenceNumber.of(2));
+    }
+
+    @Test
+    void getMsnShouldHandleNotFoundForLongStructure() {
+        testee.addUid(MessageUid.of(17));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        assertThat(testee.getMsn(MessageUid.of(Integer.MAX_VALUE + 2L)))
+            .isEqualTo(NullableMessageSequenceNumber.noMessage());
+    }
+
+    @Test
+    void removeShouldWorkForLong() {
+        testee.addUid(MessageUid.of(17));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        testee.remove(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(17)));
+    }
+
+    @Test
+    void removeShouldHandleNotFoundForLong() {
+        testee.addUid(MessageUid.of(17));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        testee.remove(MessageUid.of(Integer.MAX_VALUE + 2L));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(17),
+                2, MessageUid.of(Integer.MAX_VALUE + 1L)));
+    }
+
+    @Test
+    void getAndRemoveShouldWorkForLong() {
+        testee.addUid(MessageUid.of(17));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        testee.getAndRemove(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(17)));
+    }
+
+    @Test
+    void getAndRemoveShouldHandleNotFoundForLong() {
+        testee.addUid(MessageUid.of(17));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 1L));
+
+        testee.getAndRemove(MessageUid.of(Integer.MAX_VALUE + 2L));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(17),
+                2, MessageUid.of(Integer.MAX_VALUE + 1L)));
+    }
+
+    @Test
     void addAndRemoveShouldLeadToMonoticMSNToUIDConversionWhenMixed() throws Exception {
         int initialCount = 1000;
         for (int i = 1; i <= initialCount; i++) {

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -392,6 +392,38 @@ class UidMsnConverterTest {
     }
 
     @Test
+    void addUidShouldSupportIntOverflow() {
+        testee.addUid(MessageUid.of(36));
+        testee.addUid(MessageUid.of(17));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 1L));
+        testee.addUid(MessageUid.of(Integer.MAX_VALUE + 2L));
+        testee.addUid(MessageUid.of(13));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(13),
+                2, MessageUid.of(17),
+                3, MessageUid.of(36),
+                4, MessageUid.of(Integer.MAX_VALUE + 1L),
+                5, MessageUid.of(Integer.MAX_VALUE + 2L)));
+    }
+
+    @Test
+    void addAllShouldSupportIntOverflow() {
+        testee.addAll(ImmutableList.of(MessageUid.of(36),
+            MessageUid.of(17),
+            MessageUid.of(Integer.MAX_VALUE + 1L),
+            MessageUid.of(Integer.MAX_VALUE + 2L),
+            MessageUid.of(13)));
+
+        assertThat(mapTesteeInternalDataToMsnByUid())
+            .isEqualTo(ImmutableMap.of(1, MessageUid.of(13),
+                2, MessageUid.of(17),
+                3, MessageUid.of(36),
+                4, MessageUid.of(Integer.MAX_VALUE + 1L),
+                5, MessageUid.of(Integer.MAX_VALUE + 2L)));
+    }
+
+    @Test
     void addAndRemoveShouldLeadToMonoticMSNToUIDConversionWhenMixed() throws Exception {
         int initialCount = 1000;
         for (int i = 1; i <= initialCount; i++) {


### PR DESCRIPTION
 - contains calls can rely on binary search
 - remove duplicated collection.sort call
 - and fix a bug for adding longs in the structure.
 - fix long removal
 - deallocate int structure when switching to long
 - complete test coverage