### PR TITLE
[PERF] Use UnsynchronizedBufferedInputStream

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -24,7 +24,6 @@ import static org.apache.james.mailbox.extension.PreDeletionHook.DeleteOperation
 import static org.apache.james.mailbox.store.mail.AbstractMessageMapper.UNLIMITED;
 import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -108,6 +107,7 @@ import org.apache.james.mime4j.stream.MimeTokenStream;
 import org.apache.james.mime4j.stream.RecursionMode;
 import org.apache.james.util.io.BodyOffsetInputStream;
 import org.apache.james.util.io.InputStreamConsummer;
+import org.apache.james.util.io.UnsynchronizedBufferedInputStream;
 import org.apache.james.util.streams.Iterators;
 import org.reactivestreams.Publisher;
 
@@ -357,9 +357,9 @@ public class StoreMessageManager implements MessageManager {
             // source for the InputStream
             file = Files.createTempFile("imap", ".msg").toFile();
             try (FileOutputStream out = new FileOutputStream(file);
-                BufferedOutputStream bufferedOut = new BufferedOutputStream(out);
-                BufferedInputStream tmpMsgIn = new BufferedInputStream(new TeeInputStream(msgIn, bufferedOut));
-                BodyOffsetInputStream bIn = new BodyOffsetInputStream(tmpMsgIn)) {
+                 BufferedOutputStream bufferedOut = new BufferedOutputStream(out);
+                 UnsynchronizedBufferedInputStream tmpMsgIn = new UnsynchronizedBufferedInputStream(new TeeInputStream(msgIn, bufferedOut));
+                 BodyOffsetInputStream bIn = new BodyOffsetInputStream(tmpMsgIn)) {
                 Pair<PropertyBuilder, HeaderImpl> pair = parseProperties(bIn);
                 PropertyBuilder propertyBuilder = pair.getLeft();
                 HeaderImpl headers = pair.getRight();
@@ -405,7 +405,7 @@ public class StoreMessageManager implements MessageManager {
             }
 
             try (InputStream contentStream = msgIn.getInputStream();
-                    BufferedInputStream bufferedContentStream = new BufferedInputStream(contentStream);
+                 UnsynchronizedBufferedInputStream bufferedContentStream = new UnsynchronizedBufferedInputStream(contentStream);
                     BodyOffsetInputStream bIn = new BodyOffsetInputStream(bufferedContentStream)) {
                 Pair<PropertyBuilder, HeaderImpl> pair = parseProperties(bIn);
                 PropertyBuilder propertyBuilder = pair.getLeft();

--- a/mailet/crypto/src/main/java/org/apache/james/transport/KeyStoreHolder.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/KeyStoreHolder.java
@@ -21,7 +21,6 @@
 
 package org.apache.james.transport;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -47,6 +46,7 @@ import java.util.List;
 
 import javax.mail.MessagingException;
 
+import org.apache.james.util.io.UnsynchronizedBufferedInputStream;
 import org.bouncycastle.cert.jcajce.JcaCertStoreBuilder;
 import org.bouncycastle.cert.selector.X509CertificateHolderSelector;
 import org.bouncycastle.cert.selector.jcajce.JcaX509CertSelectorConverter;
@@ -101,7 +101,7 @@ public class KeyStoreHolder {
         }
         
         keyStore = KeyStore.getInstance(keyStoreType);        
-        keyStore.load(new BufferedInputStream(new FileInputStream(keyStoreFileName)), keyStorePassword.toCharArray());
+        keyStore.load(new UnsynchronizedBufferedInputStream(new FileInputStream(keyStoreFileName)), keyStorePassword.toCharArray());
         if (keyStore.size() == 0) {
             throw new KeyStoreException("The keystore must be not empty");
         }

--- a/mailet/crypto/src/main/java/org/apache/james/transport/SMIMEKeyHolder.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/SMIMEKeyHolder.java
@@ -21,7 +21,6 @@
 
 package org.apache.james.transport;
 
-import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -46,6 +45,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.apache.james.util.io.UnsynchronizedBufferedInputStream;
 import org.bouncycastle.cert.jcajce.JcaCertStore;
 import org.bouncycastle.cms.SignerInfoGenerator;
 import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoGeneratorBuilder;
@@ -128,7 +128,7 @@ public class SMIMEKeyHolder implements KeyHolder {
         }
         
         KeyStore keyStore = KeyStore.getInstance(keyStoreType);
-        keyStore.load(new BufferedInputStream(new FileInputStream(keyStoreFileName)), keyStorePassword.toCharArray());
+        keyStore.load(new UnsynchronizedBufferedInputStream(new FileInputStream(keyStoreFileName)), keyStorePassword.toCharArray());
         
         Enumeration<String> aliases = keyStore.aliases();
         if (keyAlias == null) {

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/RecoverAttachment.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/RecoverAttachment.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.transport.mailets;
 
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +30,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.apache.james.util.io.UnsynchronizedBufferedInputStream;
 import org.apache.mailet.AttributeName;
 import org.apache.mailet.AttributeUtils;
 import org.apache.mailet.AttributeValue;
@@ -119,7 +119,7 @@ public class RecoverAttachment extends GenericMailet {
                     continue;
                 }
                 byte[] bytes = (byte[]) i.next().getValue();
-                InputStream is = new BufferedInputStream(
+                InputStream is = new UnsynchronizedBufferedInputStream(
                         new ByteArrayInputStream(bytes));
                 MimeBodyPart p = new MimeBodyPart(is);
                 if (!(message.isMimeType("multipart/*") && (message

--- a/server/container/core/src/main/java/org/apache/james/server/core/MimeMessageInputStreamSource.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MimeMessageInputStreamSource.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.server.core;
 
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,6 +36,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.DeferredFileOutputStream;
 import org.apache.james.lifecycle.api.Disposable;
 import org.apache.james.util.SizeFormat;
+import org.apache.james.util.io.UnsynchronizedBufferedInputStream;
 
 /**
  * Takes an input stream and creates a repeatable input stream source for a
@@ -186,7 +186,7 @@ public class MimeMessageInputStreamSource extends Disposable.LeakAware<MimeMessa
         if (getResource().getOut().isInMemory()) {
             return new ByteArrayInputStream(getResource().getOut().getData());
         } else {
-            InputStream in = new BufferedInputStream(new FileInputStream(getResource().getOut().getFile()), 2048);
+            InputStream in = new UnsynchronizedBufferedInputStream(new FileInputStream(getResource().getOut().getFile()), 2048);
             getResource().streams.add(in);
             return in;
         }

--- a/server/container/util/src/main/java/org/apache/james/util/DataChunker.java
+++ b/server/container/util/src/main/java/org/apache/james/util/DataChunker.java
@@ -19,10 +19,11 @@
 
 package org.apache.james.util;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+
+import org.apache.james.util.io.UnsynchronizedBufferedInputStream;
 
 import com.google.common.base.Preconditions;
 
@@ -56,7 +57,7 @@ public class DataChunker {
     public static Flux<ByteBuffer> chunkStream(InputStream data, int chunkSize) {
         Preconditions.checkNotNull(data);
         Preconditions.checkArgument(chunkSize > 0, CHUNK_SIZE_MUST_BE_STRICTLY_POSITIVE);
-        BufferedInputStream bufferedInputStream = new BufferedInputStream(data);
+        UnsynchronizedBufferedInputStream bufferedInputStream = new UnsynchronizedBufferedInputStream(data);
         return Flux
             .<ByteBuffer>generate(sink -> {
                 try {

--- a/server/container/util/src/main/java/org/apache/james/util/io/UnsynchronizedBufferedInputStream.java
+++ b/server/container/util/src/main/java/org/apache/james/util/io/UnsynchronizedBufferedInputStream.java
@@ -1,0 +1,238 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.util.io;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Copied from {@link java.io.BufferedInputStream} with the following modifications:
+ *  - Removal of 'synchronized' keyword
+ *  - Removal of 'volatile' keyword
+ *  - Removal of Unsafe usages
+ *
+ *  See https://issues.apache.org/jira/projects/IO/issues/IO-786 for rationals
+ */
+public class UnsynchronizedBufferedInputStream extends FilterInputStream {
+    private static int DEFAULT_BUFFER_SIZE = 8192;
+    private static int MAX_BUFFER_SIZE = 2147483639;
+    protected byte[] buf;
+    protected int count;
+    protected int pos;
+    protected int markpos;
+    protected int marklimit;
+
+    private InputStream getInIfOpen() throws IOException {
+        InputStream input = this.in;
+        if (input == null) {
+            throw new IOException("Stream closed");
+        } else {
+            return input;
+        }
+    }
+
+    private byte[] getBufIfOpen() throws IOException {
+        byte[] buffer = this.buf;
+        if (buffer == null) {
+            throw new IOException("Stream closed");
+        } else {
+            return buffer;
+        }
+    }
+
+    public UnsynchronizedBufferedInputStream(InputStream in) {
+        this(in, DEFAULT_BUFFER_SIZE);
+    }
+
+    public UnsynchronizedBufferedInputStream(InputStream in, int size) {
+        super(in);
+        this.markpos = -1;
+        if (size <= 0) {
+            throw new IllegalArgumentException("Buffer size <= 0");
+        } else {
+            this.buf = new byte[size];
+        }
+    }
+
+    private void fill() throws IOException {
+        byte[] buffer = this.getBufIfOpen();
+        int nsz;
+        if (this.markpos < 0) {
+            this.pos = 0;
+        } else if (this.pos >= buffer.length) {
+            if (this.markpos > 0) {
+                nsz = this.pos - this.markpos;
+                System.arraycopy(buffer, this.markpos, buffer, 0, nsz);
+                this.pos = nsz;
+                this.markpos = 0;
+            } else if (buffer.length >= this.marklimit) {
+                this.markpos = -1;
+                this.pos = 0;
+            } else {
+                if (buffer.length >= MAX_BUFFER_SIZE) {
+                    throw new OutOfMemoryError("Required array size too large");
+                }
+
+                nsz = this.pos <= MAX_BUFFER_SIZE - this.pos ? this.pos * 2 : MAX_BUFFER_SIZE;
+                if (nsz > this.marklimit) {
+                    nsz = this.marklimit;
+                }
+
+                byte[] nbuf = new byte[nsz];
+                System.arraycopy(buffer, 0, nbuf, 0, this.pos);
+
+                buffer = nbuf;
+            }
+        }
+
+        this.count = this.pos;
+        nsz = this.getInIfOpen().read(buffer, this.pos, buffer.length - this.pos);
+        if (nsz > 0) {
+            this.count = nsz + this.pos;
+        }
+
+    }
+
+    public int read() throws IOException {
+        if (this.pos >= this.count) {
+            this.fill();
+            if (this.pos >= this.count) {
+                return -1;
+            }
+        }
+
+        return this.getBufIfOpen()[this.pos++] & 255;
+    }
+
+    private int read1(byte[] b, int off, int len) throws IOException {
+        int avail = this.count - this.pos;
+        if (avail <= 0) {
+            if (len >= this.getBufIfOpen().length && this.markpos < 0) {
+                return this.getInIfOpen().read(b, off, len);
+            }
+
+            this.fill();
+            avail = this.count - this.pos;
+            if (avail <= 0) {
+                return -1;
+            }
+        }
+
+        int cnt = avail < len ? avail : len;
+        System.arraycopy(this.getBufIfOpen(), this.pos, b, off, cnt);
+        this.pos += cnt;
+        return cnt;
+    }
+
+    public int read(byte[] b, int off, int len) throws IOException {
+        this.getBufIfOpen();
+        if ((off | len | off + len | b.length - (off + len)) < 0) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        } else {
+            int n = 0;
+
+            InputStream input;
+            do {
+                int nread = this.read1(b, off + n, len - n);
+                if (nread <= 0) {
+                    return n == 0 ? nread : n;
+                }
+
+                n += nread;
+                if (n >= len) {
+                    return n;
+                }
+
+                input = this.in;
+            } while (input == null || input.available() > 0);
+
+            return n;
+        }
+    }
+
+    public long skip(long n) throws IOException {
+        this.getBufIfOpen();
+        if (n <= 0L) {
+            return 0L;
+        } else {
+            long avail = (long)(this.count - this.pos);
+            if (avail <= 0L) {
+                if (this.markpos < 0) {
+                    return this.getInIfOpen().skip(n);
+                }
+
+                this.fill();
+                avail = (long)(this.count - this.pos);
+                if (avail <= 0L) {
+                    return 0L;
+                }
+            }
+
+            long skipped = avail < n ? avail : n;
+            this.pos = (int)((long)this.pos + skipped);
+            return skipped;
+        }
+    }
+
+    public int available() throws IOException {
+        int n = this.count - this.pos;
+        int avail = this.getInIfOpen().available();
+        return n > 2147483647 - avail ? 2147483647 : n + avail;
+    }
+
+    public void mark(int readlimit) {
+        this.marklimit = readlimit;
+        this.markpos = this.pos;
+    }
+
+    public void reset() throws IOException {
+        this.getBufIfOpen();
+        if (this.markpos < 0) {
+            throw new IOException("Resetting to invalid mark");
+        } else {
+            this.pos = this.markpos;
+        }
+    }
+
+    public boolean markSupported() {
+        return true;
+    }
+
+    public void close() throws IOException {
+        while (true) {
+            byte[] buffer;
+            if ((buffer = this.buf) != null) {
+
+                InputStream input = this.in;
+                this.in = null;
+                if (input != null) {
+                    input.close();
+                }
+
+                return;
+            }
+
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Synchronized methods becomes ore expensive with higher JRE versions (loom) making calling
`BufferedInputStream::read()` method for each byte prohibitive.

See https://issues.apache.org/jira/projects/IO/issues/IO-786

![Screenshot from 2023-01-30 09-06-03](https://user-images.githubusercontent.com/6928740/215441811-eb896d5c-8da1-451d-a8c4-34e5a84d3bbb.png)
