### PR TITLE
Fix a leak in TextExtractor

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/extractor/TextExtractor.java
@@ -21,8 +21,9 @@ package org.apache.james.mailbox.extractor;
 
 import java.io.InputStream;
 
-import com.github.fge.lambdas.Throwing;
 import org.apache.james.mailbox.model.ContentType;
+
+import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/TextExtractorContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/TextExtractorContract.java
@@ -1,0 +1,6 @@
+package org.apache.james.mailbox.extractor;
+
+import static org.junit.jupiter.api.Assertions.*;
+class TextExtractorContract {
+  
+}

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/TextExtractorContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/TextExtractorContract.java
@@ -1,6 +1,59 @@
 package org.apache.james.mailbox.extractor;
 
-import static org.junit.jupiter.api.Assertions.*;
-class TextExtractorContract {
-  
+import org.apache.james.mailbox.model.ContentType;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.Mockito.*;
+
+public interface TextExtractorContract {
+
+    TextExtractor testee();
+    ContentType supportedContentType();
+
+    byte[] supportedContent();
+
+    @Test
+    default void extractContentShouldCloseInputStreamOnSuccess() throws Exception {
+        InputStream stream = spy(new ByteArrayInputStream(supportedContent()));
+
+        testee().extractContent(stream, supportedContentType());
+
+        verify(stream).close();
+    }
+
+    @Test
+    default void extractContentShouldCloseInputStreamOnException() throws Exception {
+        InputStream stream = mock(InputStream.class);
+
+        when(stream.read(any(), anyInt(), anyInt())).thenThrow(new IOException(""));
+
+        catchException(() -> testee().extractContent(stream, supportedContentType()));
+
+        verify(stream).close();
+    }
+
+    @Test
+    default void extractContentReactiveShouldCloseInputStreamOnSuccess() throws Exception {
+        InputStream stream = spy(new ByteArrayInputStream(supportedContent()));
+
+        testee().extractContentReactive(stream, supportedContentType()).block();
+
+        verify(stream).close();
+    }
+
+    @Test
+    default void extractContentReactiveShouldCloseInputStreamOnException() throws Exception {
+        InputStream stream = mock(InputStream.class);
+
+        when(stream.read(any(), anyInt(), anyInt())).thenThrow(new IOException(""));
+
+        catchException(() -> testee().extractContentReactive(stream, supportedContentType()).block());
+
+        verify(stream).close();
+    }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/TextExtractorContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/TextExtractorContract.java
@@ -1,3 +1,21 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
 package org.apache.james.mailbox.extractor;
 
 import org.apache.james.mailbox.model.ContentType;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Optional;
 
+import com.github.fge.lambdas.Throwing;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
@@ -46,11 +47,13 @@ public class DefaultTextExtractor implements TextExtractor {
 
     @Override
     public ParsedContent extractContent(InputStream inputStream, ContentType contentType) throws Exception {
-        if (applicable(contentType)) {
-            Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
-            return new ParsedContent(Optional.ofNullable(IOUtils.toString(inputStream, charset)), new HashMap<>());
-        } else {
-            return new ParsedContent(Optional.empty(), new HashMap<>());
+        try (var input = inputStream) {
+            if (applicable(contentType)) {
+                Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
+                return new ParsedContent(Optional.ofNullable(IOUtils.toString(input, charset)), new HashMap<>());
+            } else {
+                return new ParsedContent(Optional.empty(), new HashMap<>());
+            }
         }
     }
 
@@ -58,8 +61,10 @@ public class DefaultTextExtractor implements TextExtractor {
     public Mono<ParsedContent> extractContentReactive(InputStream inputStream, ContentType contentType) {
         if (applicable(contentType)) {
             Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
-            return Mono.fromCallable(() -> new ParsedContent(Optional.ofNullable(IOUtils.toString(inputStream, charset)), new HashMap<>()))
-                .subscribeOn(Schedulers.boundedElastic());
+            return Mono.using(() -> inputStream,
+                    stream -> Mono.fromCallable(() -> new ParsedContent(Optional.ofNullable(IOUtils.toString(stream, charset)), new HashMap<>()))
+                            .subscribeOn(Schedulers.boundedElastic()),
+                    Throwing.consumer(InputStream::close).orDoNothing());
         } else {
             return Mono.just(new ParsedContent(Optional.empty(), new HashMap<>()));
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractor.java
@@ -25,11 +25,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Optional;
 
-import com.github.fge.lambdas.Throwing;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.model.ContentType;
+
+import com.github.fge.lambdas.Throwing;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/extractor/DefaultTextExtractorTest.java
@@ -22,14 +22,31 @@ package org.apache.james.mailbox.store.extractor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.james.mailbox.extractor.TextExtractor;
+import org.apache.james.mailbox.extractor.TextExtractorContract;
 import org.apache.james.mailbox.model.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class DefaultTextExtractorTest {
+class DefaultTextExtractorTest implements TextExtractorContract {
     TextExtractor textExtractor;
+
+    @Override
+    public TextExtractor testee() {
+        return textExtractor;
+    }
+
+    @Override
+    public ContentType supportedContentType() {
+        return ContentType.of("text/plain");
+    }
+
+    @Override
+    public byte[] supportedContent() {
+        return "foo".getBytes(StandardCharsets.UTF_8);
+    }
 
     @BeforeEach
     void setUp() {

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/CachingTextExtractor.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/CachingTextExtractor.java
@@ -37,7 +37,6 @@ import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Weigher;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
 
 import reactor.core.publisher.Mono;

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/CachingTextExtractor.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/CachingTextExtractor.java
@@ -132,15 +132,4 @@ public class CachingTextExtractor implements TextExtractor {
             .doOnNext(next -> weightMetric.add(computeWeight(next)));
     }
 
-    private Exception unwrap(Exception e) {
-        return Optional.ofNullable(e.getCause())
-            .filter(throwable -> throwable instanceof Exception)
-            .map(throwable -> (Exception) throwable)
-            .orElse(e);
-    }
-
-    @VisibleForTesting
-    long size() {
-        return cache.synchronous().estimatedSize();
-    }
 }


### PR DESCRIPTION
I propose a new contract to make sure `TextExtractor` implementations close the provided input streams.

I only made it to work with Default implementation but I'm sure it can be extended to other implementations.