### PR TITLE
[PERF] MimeDescriptorImpl: avoid counting lines for non text parts

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/UidRange.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/UidRange.java
@@ -138,7 +138,7 @@ public final class UidRange implements Iterable<MessageUid> {
         if (range.getUidFrom().equals(range.getUidTo())) {
             return String.valueOf(range.getUidFrom().asLong());
         } else {
-            return String.format("%d:%d", range.getUidFrom().asLong(), range.getUidTo().asLong());
+            return range.getUidFrom().asLong() + ":" + range.getUidTo().asLong();
         }
     }
 


### PR DESCRIPTION
This allows buffering parts reads, which is used to discover its size.

Local benchmark showed
 - A good 10x speed enhancement on 650KB email (2.9ms to 0.25 ms)
 - A decent 2x speed enhancement on 5KB email (40 us to 20 us)

Context: Line length is only needed for textual parts...