### PR TITLE
[FIX] JMAP urn:ietf:params:jmap:submission submissionExtensions shoul…

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
@@ -81,7 +81,7 @@ object CustomMethodContract {
       |  "capabilities" : {
       |    "urn:ietf:params:jmap:submission": {
       |      "maxDelayedSend": 0,
-      |      "submissionExtensions": []
+      |      "submissionExtensions": {}
       |    },
       |    "urn:ietf:params:jmap:core" : {
       |      "maxSizeUpload" : 20971520,
@@ -122,7 +122,7 @@ object CustomMethodContract {
       |      "accountCapabilities" : {
       |        "urn:ietf:params:jmap:submission": {
       |          "maxDelayedSend": 0,
-      |          "submissionExtensions": []
+      |          "submissionExtensions": {}
       |        },
       |        "urn:ietf:params:jmap:websocket": {
       |            "supportsPush": true,

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
@@ -45,7 +45,7 @@ object SessionRoutesContract {
                          |  "capabilities" : {
                          |    "urn:ietf:params:jmap:submission": {
                          |      "maxDelayedSend": 0,
-                         |      "submissionExtensions": []
+                         |      "submissionExtensions": {}
                          |    },
                          |    "urn:ietf:params:jmap:core" : {
                          |      "maxSizeUpload" : 20971520,
@@ -85,7 +85,7 @@ object SessionRoutesContract {
                          |      "accountCapabilities" : {
                          |        "urn:ietf:params:jmap:submission": {
                          |          "maxDelayedSend": 0,
-                         |          "submissionExtensions": []
+                         |          "submissionExtensions": {}
                          |        },
                          |        "urn:ietf:params:jmap:websocket": {
                          |            "supportsPush": true,
@@ -243,7 +243,7 @@ trait SessionRoutesContract {
                    |            "urn:apache:james:params:jmap:delegation": {},
                    |            "urn:ietf:params:jmap:submission": {
                    |                "maxDelayedSend": 0,
-                   |                "submissionExtensions": []
+                   |                "submissionExtensions": {}
                    |            },
                    |            "urn:ietf:params:jmap:websocket": {
                    |                "supportsPush": true,
@@ -292,7 +292,7 @@ trait SessionRoutesContract {
                    |            "urn:apache:james:params:jmap:delegation": {},
                    |            "urn:ietf:params:jmap:submission": {
                    |                "maxDelayedSend": 0,
-                   |                "submissionExtensions": []
+                   |                "submissionExtensions": {}
                    |            },
                    |            "urn:ietf:params:jmap:websocket": {
                    |                "supportsPush": true,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capability.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capability.scala
@@ -157,7 +157,8 @@ final case class WebSocketCapabilityProperties(supportsPush: SupportsPush,
 final case class SupportsPush(value: Boolean) extends AnyVal
 final case class MaxDelayedSend(value: Int) extends AnyVal
 final case class EhloName(value: String) extends AnyVal
-final case class EhloArgs(value: String) extends AnyVal
+final case class EhloArg(value: String) extends AnyVal
+final case class EhloArgs(values: List[EhloArg]) extends AnyVal
 
 final case class SubmissionCapability(identifier: CapabilityIdentifier = EMAIL_SUBMISSION,
                                       properties: SubmissionProperties = SubmissionProperties()) extends Capability
@@ -169,7 +170,7 @@ case object SubmissionCapabilityFactory extends CapabilityFactory {
 }
 
 final case class SubmissionProperties(maxDelayedSend: MaxDelayedSend = MaxDelayedSend(0),
-                                      submissionExtensions: Map[EhloName, List[EhloArgs]] = Map()) extends CapabilityProperties {
+                                      submissionExtensions: Map[EhloName, EhloArgs] = Map()) extends CapabilityProperties {
   override def jsonify(): JsObject = ResponseSerializer.submissionPropertiesWrites.writes(this)
 }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
@@ -90,7 +90,10 @@ object ResponseSerializer {
   val mailCapabilityWrites: OWrites[MailCapabilityProperties] = Json.writes[MailCapabilityProperties]
   private implicit val maxDelayedSendWrites: Writes[MaxDelayedSend] = Json.valueWrites[MaxDelayedSend]
   private implicit val ehloNameWrites: Writes[EhloName] = Json.valueWrites[EhloName]
+  private implicit val ehloArgWrites: Writes[EhloArg] = Json.valueWrites[EhloArg]
   private implicit val ehloArgsWrites: Writes[EhloArgs] = Json.valueWrites[EhloArgs]
+  private implicit val ehloArgsMapWrite: Writes[Map[EhloName, EhloArgs]] =
+    mapWrites[EhloName, EhloArgs](_.value, ehloArgsWrites)
   private implicit val supportsPushWrites: Writes[SupportsPush] = Json.valueWrites[SupportsPush]
   val submissionPropertiesWrites: OWrites[SubmissionProperties] = Json.writes[SubmissionProperties]
   val webSocketPropertiesWrites: OWrites[WebSocketCapabilityProperties] = Json.writes[WebSocketCapabilityProperties]

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/SessionRoutesTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/SessionRoutesTest.scala
@@ -130,7 +130,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |  "capabilities" : {
                          |    "urn:ietf:params:jmap:submission": {
                          |      "maxDelayedSend": 0,
-                         |      "submissionExtensions": []
+                         |      "submissionExtensions": {}
                          |    },
                          |    "urn:ietf:params:jmap:core" : {
                          |      "maxSizeUpload" : 31457280,
@@ -169,7 +169,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |      "accountCapabilities" : {
                          |        "urn:ietf:params:jmap:submission": {
                          |          "maxDelayedSend": 0,
-                         |          "submissionExtensions": []
+                         |          "submissionExtensions": {}
                          |        },
                          |        "urn:ietf:params:jmap:websocket": {
                          |            "supportsPush": true,


### PR DESCRIPTION
…d be a map

Default JSON formatting renders the map as an iterable, so as a JSON collection instead of the desired JSON object.