### PR TITLE
JAMES-3379 Support header:Name:all syntax

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailSetMethodContract.scala
@@ -153,8 +153,14 @@ trait EmailSetMethodContract {
   @ParameterizedTest
   @ValueSource(strings = Array(
     """"header:aheader": " a value"""",
+    """"header:aheader:all": [" a value"]""",
+    """"header:aheader:all": []""",
+    """"header:aheader:all": [" abc", " def"]""",
     """"header:aheader:asRaw": " a value"""",
     """"header:aheader:asText": "a value"""",
+    """"header:aheader:asText:all": []""",
+    """"header:aheader:asText:all": ["abc"]""",
+    """"header:aheader:asText:all": ["abc", "def"]""",
     """"header:aheader:asDate": "2020-10-29T06:39:04Z"""",
     """"header:aheader:asAddresses": [{"email": "rcpt1@apache.org"}, {"email": "rcpt2@apache.org"}]""",
     """"header:aheader:asURLs": ["url1", "url2"]""",

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailGetSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailGetSerializer.scala
@@ -87,6 +87,7 @@ object EmailGetSerializer {
   private implicit val hasAttachmentWrites: Writes[HasAttachment] = Json.valueWrites[HasAttachment]
   private implicit val headerNameWrites: Writes[EmailHeaderName] = Json.valueWrites[EmailHeaderName]
   private implicit val rawHeaderWrites: Writes[RawHeaderValue] = Json.valueWrites[RawHeaderValue]
+  private implicit val allHeaderWrites: Writes[AllHeaderValues] = Json.valueWrites[AllHeaderValues]
   private implicit val textHeaderWrites: Writes[TextHeaderValue] = Json.valueWrites[TextHeaderValue]
   private implicit val addressesHeaderWrites: Writes[AddressesHeaderValue] = Json.valueWrites[AddressesHeaderValue]
   private implicit val GroupNameWrites: Writes[GroupName] = Json.valueWrites[GroupName]
@@ -100,6 +101,7 @@ object EmailGetSerializer {
   private implicit val headerURLWrites: Writes[HeaderURL] = Json.valueWrites[HeaderURL]
   private implicit val urlsHeaderWrites: Writes[URLsHeaderValue] = Json.valueWrites[URLsHeaderValue]
   private implicit val emailHeaderWrites: Writes[EmailHeaderValue] = {
+    case headerValue: AllHeaderValues => JsArray(headerValue.values.map(h =>  Json.toJson[EmailHeaderValue](h)))
     case headerValue: RawHeaderValue => Json.toJson[RawHeaderValue](headerValue)
     case headerValue: TextHeaderValue => Json.toJson[TextHeaderValue](headerValue)
     case headerValue: AddressesHeaderValue => Json.toJson[AddressesHeaderValue](headerValue)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailHeader.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailHeader.scala
@@ -142,6 +142,10 @@ case class EmailHeaderName(value: String) extends AnyVal
 sealed trait EmailHeaderValue {
   def asField(name: EmailHeaderName): Field
 }
+case class AllHeaderValues(values: List[EmailHeaderValue]) extends EmailHeaderValue {
+  // Not to be used in Email Set
+  override def asField(name: EmailHeaderName): Field = throw new NotImplementedError()
+}
 case class RawHeaderValue(value: String) extends EmailHeaderValue {
   override def asField(name: EmailHeaderName): Field = new RawField(name.value, value.substring(1))
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailSet.scala
@@ -143,7 +143,7 @@ case class EmailCreationRequest(mailboxIds: MailboxIds,
           builder.setField(new RawField(FieldName.MESSAGE_ID, messageId.flatMap(_.asString).getOrElse(generateUniqueMessageId(maybeFrom))))
           validateSpecificHeaders(builder)
             .flatMap(_ => {
-              specificHeaders.map(_.asField).foreach(builder.addField)
+              specificHeaders.flatMap(_.asFields).foreach(builder.addField)
               attachments.filter(_.nonEmpty).map(attachments =>
                 createMultipartWithAttachments(maybeHtmlBody, maybeTextBody, attachments, blobResolvers, htmlTextExtractor, mailboxSession)
                   .map(multipartBuilder => {


### PR DESCRIPTION
Also supports typing header:Name:asType:all syntax

See related issue: https://github.com/iNPUTmice/jmap/issues/77

See long unhandled issue tracking this on the Linagora backlog: https://github.com/linagora/james-project/issues/3739

That's a quick evening contribution eventually solving some enduser related issues.