### PR TITLE
JAMES-3864 Update sample AMQP vhost configuration in rabbitmq.properties

### DIFF
--- a/server/apps/distributed-app/sample-configuration/rabbitmq.properties
+++ b/server/apps/distributed-app/sample-configuration/rabbitmq.properties
@@ -3,8 +3,9 @@
 # Read https://james.apache.org/server/config-rabbitmq.html for further details
 
 # Mandatory
+uri=amqp://rabbitmq:5672
 # If you use a vhost, specify it as well at the end of the URI
-uri=amqp://rabbitmq:5672/vhost
+# uri=amqp://rabbitmq:5672/vhost
 
 # Vhost to use for creating queues and exchanges
 # Optional, only use this if you have invalid URIs containing characters like '_'

--- a/server/apps/distributed-pop3-app/sample-configuration/rabbitmq.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/rabbitmq.properties
@@ -3,8 +3,9 @@
 # Read https://james.apache.org/server/config-rabbitmq.html for further details
 
 # Mandatory
+uri=amqp://rabbitmq:5672
 # If you use a vhost, specify it as well at the end of the URI
-uri=amqp://rabbitmq:5672/vhost
+# uri=amqp://rabbitmq:5672/vhost
 
 # Vhost to use for creating queues and exchanges
 # Optional, only use this if you have invalid URIs containing characters like '_'


### PR DESCRIPTION
The default rabbitmq container in docker-compose sample file is not ready `vhost`
-> when we run docker-compose.yml file, James will start failing


```
07:03:22.705 [1;31m[ERROR][0;39m o.a.j.GuiceJamesServer - Fatal error while starting James
java.lang.RuntimeException: Non recoverable exception status: 404
	at org.apache.james.backends.rabbitmq.RabbitMQManagementAPI.lambda$static$3(RabbitMQManagementAPI.java:447)
	at feign.AsyncResponseHandler.handleResponse(AsyncResponseHandler.java:98)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:141)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:91)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:100)
	at com.sun.proxy.$Proxy68.listVhostQueues(Unknown Source)
	at java.base/java.util.Optional.map(Unknown Source)
```

Ref: https://github.com/apache/james-project/pull/1349
