### PR TITLE
JAMES-3870 Prevent partial flush in IMAP

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapProcessor.java
@@ -65,5 +65,7 @@ public interface ImapProcessor {
          * @param message <code>not null</code>
          */
         void respond(ImapResponseMessage message);
+
+        void flush();
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
@@ -264,7 +264,4 @@ public interface ImapSession extends CommandDetectionSession {
 
     void schedule(Runnable runnable, Duration waitDelay);
 
-    default void flush() {
-
-    }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/ImapRequestStreamHandler.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/ImapRequestStreamHandler.java
@@ -74,7 +74,9 @@ public final class ImapRequestStreamHandler extends AbstractImapRequestHandler {
                 return false;
             }
 
-            ImapResponseComposerImpl response = new ImapResponseComposerImpl(new OutputStreamImapResponseWriter(output));
+            OutputStreamImapResponseWriter writer = new OutputStreamImapResponseWriter(output);
+            ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
+            writer.setFlushCallback(response::flush);
 
             if (doProcessRequest(request, response, session)) {
 
@@ -96,6 +98,11 @@ public final class ImapRequestStreamHandler extends AbstractImapRequestHandler {
                 LOGGER.debug("Connection was abandoned after request processing failed.");
                 result = false;
                 abandon(output, session);
+            }
+            try {
+                response.flush();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
         }
         return result;

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/OutputStreamImapResponseWriter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/OutputStreamImapResponseWriter.java
@@ -32,16 +32,29 @@ import org.apache.james.imap.message.Literal;
  * client.
  */
 public class OutputStreamImapResponseWriter implements ImapResponseWriter {
+    @FunctionalInterface
+    interface FlushCallback {
+        void run() throws IOException;
+    }
 
     public static final int BUFFER_SIZE = 1024;
     private final OutputStream output;
+    private FlushCallback flushCallback;
 
     public OutputStreamImapResponseWriter(OutputStream output) {
         this.output = output;
+        this.flushCallback = () -> {
+
+        };
+    }
+
+    public void setFlushCallback(FlushCallback flushCallback) {
+        this.flushCallback = flushCallback;
     }
 
     @Override
     public void write(Literal literal) throws IOException {
+        flushCallback.run();
         try (InputStream in = literal.getInputStream()) {
             IOUtils.copy(in, output, BUFFER_SIZE);
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/ImapResponseComposer.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/ImapResponseComposer.java
@@ -32,6 +32,8 @@ import org.apache.james.imap.message.Literal;
 
 public interface ImapResponseComposer {
 
+    void flush() throws IOException;
+
     /**
      * Writes an untagged NO response. Indicates that a warning. The command may
      * still complete sucessfully.

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
@@ -56,6 +56,7 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
     private static final int FLUSH_BUFFER_SIZE = Optional.ofNullable(System.getProperty("james.imap.flush.buffer.size"))
         .map(Integer::parseInt)
         .orElse(8192);
+    private static final byte[] CONTINUATION_BYTES = "+\r\n".getBytes(US_ASCII);
 
     private final ImapResponseWriter writer;
 
@@ -94,8 +95,8 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
 
     @Override
     public ImapResponseComposer continuationResponse() throws IOException {
-        buffer.write(CONTINUATION);
-        end();
+        flush();
+        writer.write(CONTINUATION_BYTES);
         return this;
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/main/AbstractImapRequestHandler.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/main/AbstractImapRequestHandler.java
@@ -88,6 +88,11 @@ public abstract class AbstractImapRequestHandler {
         public void respond(ImapResponseMessage message) {
             // Swallow
         }
+
+        @Override
+        public void flush() {
+
+        }
     }
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/main/ResponseEncoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/main/ResponseEncoder.java
@@ -55,4 +55,13 @@ public class ResponseEncoder implements Responder {
         return failure;
     }
 
+
+    @Override
+    public void flush() {
+        try {
+            composer.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -78,6 +78,7 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
                     session.setMailboxSession(mailboxSession);
                     provisionInbox(session, mailboxManager, mailboxSession);
                     okComplete(request, responder);
+                    responder.flush();
                     session.stopDetectingCommandInjection();
                 } catch (BadCredentialsException e) {
                     authFailure = true;
@@ -89,6 +90,7 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         } catch (MailboxException e) {
             LOGGER.error("Error encountered while login", e);
             no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
+            responder.flush();
         }
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -93,10 +93,12 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
                 } else {
                     session.executeSafely(() -> {
                         responder.respond(new AuthenticateResponse());
+                        responder.flush();
                         session.pushLineHandler((requestSession, data) -> {
                             doPlainAuth(extractInitialClientResponse(data), requestSession, request, responder);
                             // remove the handler now
                             requestSession.popLineHandler();
+                            responder.flush();
                         });
                     });
                 }
@@ -108,9 +110,11 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
             } else {
                 session.executeSafely(() -> {
                     responder.respond(new AuthenticateResponse());
+                    responder.flush();
                     session.pushLineHandler((requestSession, data) -> {
                         doOAuth(extractInitialClientResponse(data), requestSession, request, responder);
                         requestSession.popLineHandler();
+                        responder.flush();
                     });
                 });
             }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CompressProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CompressProcessor.java
@@ -62,7 +62,7 @@ public class CompressProcessor extends AbstractProcessor<CompressRequest> implem
                     } else {
                         StatusResponse response = factory.taggedOk(request.getTag(), request.getCommand(), HumanReadableText.DEFLATE_ACTIVE);
 
-                        if (session.startCompression(() -> responder.respond(response))) {
+                        if (activateCompression(responder, session, response)) {
                             session.setAttribute(COMPRESSED, true);
                         }
                     }
@@ -70,6 +70,13 @@ public class CompressProcessor extends AbstractProcessor<CompressRequest> implem
             } else {
                 responder.respond(factory.taggedBad(request.getTag(), request.getCommand(), HumanReadableText.UNKNOWN_COMMAND));
             }
+        });
+    }
+
+    private boolean activateCompression(Responder responder, ImapSession session, StatusResponse response) {
+        return session.startCompression(() -> {
+            responder.respond(response);
+            responder.flush();
         });
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -105,8 +105,10 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
                             "failed. " + message));
                 LOGGER.info(message);
                 responder.respond(response);
+                responder.flush();
             } else {
                 okComplete(request, responder);
+                responder.flush();
             }
             session1.popLineHandler();
             idleActive.set(false);
@@ -168,7 +170,7 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
         @Override
         public Publisher<Void> reactiveEvent(Event event) {
             return unsolicitedResponses(session, responder, false)
-                .then(Mono.fromRunnable(session::flush));
+                .then(Mono.fromRunnable(responder::flush));
         }
 
         @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
@@ -25,7 +25,6 @@ import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.request.LogoutRequest;
 import org.apache.james.mailbox.MailboxManager;
-import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 
@@ -40,11 +39,11 @@ public class LogoutProcessor extends AbstractMailboxProcessor<LogoutRequest> {
 
     @Override
     protected Mono<Void> processRequestReactive(LogoutRequest request, ImapSession session, Responder responder) {
-        MailboxSession mailboxSession = session.getMailboxSession();
         return session.logout()
             .then(Mono.fromRunnable(() -> {
                 bye(responder);
                 okComplete(request, responder);
+                responder.flush();
             }));
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StartTLSProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StartTLSProcessor.java
@@ -53,7 +53,10 @@ public class StartTLSProcessor extends AbstractProcessor<StartTLSRequest> implem
     protected Mono<Void> doProcess(StartTLSRequest request, Responder responder, ImapSession session) {
         return Mono.fromRunnable(() -> {
             if (session.supportStartTLS()) {
-                session.startTLS(() -> responder.respond(factory.taggedOk(request.getTag(), request.getCommand(), HumanReadableText.STARTTLS)));
+                session.startTLS(() -> {
+                    responder.respond(factory.taggedOk(request.getTag(), request.getCommand(), HumanReadableText.STARTTLS));
+                    responder.flush();
+                });
             } else {
                 responder.respond(factory.taggedBad(request.getTag(), request.getCommand(), HumanReadableText.UNKNOWN_COMMAND));
             }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/FetchResponseEncoderEnvelopeTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/FetchResponseEncoderEnvelopeTest.java
@@ -142,7 +142,8 @@ public class FetchResponseEncoderEnvelopeTest {
     void testShouldNilAllNullProperties() throws Exception {
         envelopExpects();
         encoder.encode(message, composer);
-        
+
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL))\r\n");
     }
 
@@ -153,6 +154,7 @@ public class FetchResponseEncoderEnvelopeTest {
         
         
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (\"a date\" NIL NIL NIL NIL NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -163,6 +165,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
         
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL \"some subject\" NIL NIL NIL NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -173,6 +176,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL NIL NIL \"some reply to\" NIL))\r\n");
     }
 
@@ -182,6 +186,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
         
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL NIL NIL NIL \"some message id\"))\r\n");
 
     }
@@ -191,6 +196,7 @@ public class FetchResponseEncoderEnvelopeTest {
         from = mockOneAddress();
         envelopExpects();
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")) NIL NIL NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -201,6 +207,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
         
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")(\"2NAME\" \"2DOMAIN LIST\" \"2MAILBOX\" \"2HOST\")) NIL NIL NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -211,6 +218,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
      
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")) NIL NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -221,6 +229,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
      
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")(\"2NAME\" \"2DOMAIN LIST\" \"2MAILBOX\" \"2HOST\")) NIL NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -232,6 +241,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")) NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -242,6 +252,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")(\"2NAME\" \"2DOMAIN LIST\" \"2MAILBOX\" \"2HOST\")) NIL NIL NIL NIL NIL))\r\n");
 
     }
@@ -252,6 +263,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")) NIL NIL NIL NIL))\r\n");
 
     }
@@ -262,6 +274,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")(\"2NAME\" \"2DOMAIN LIST\" \"2MAILBOX\" \"2HOST\")) NIL NIL NIL NIL))\r\n");
 
     }
@@ -272,6 +285,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
 
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")) NIL NIL NIL))\r\n");
 
     }
@@ -282,6 +296,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")(\"2NAME\" \"2DOMAIN LIST\" \"2MAILBOX\" \"2HOST\")) NIL NIL NIL))\r\n");
 
     }
@@ -292,6 +307,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")) NIL NIL))\r\n");
 
     }
@@ -302,6 +318,7 @@ public class FetchResponseEncoderEnvelopeTest {
         envelopExpects();
        
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL NIL ((\"NAME\" \"DOMAIN LIST\" \"MAILBOX\" \"HOST\")(\"2NAME\" \"2DOMAIN LIST\" \"2MAILBOX\" \"2HOST\")) NIL NIL))\r\n");
 
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/FetchResponseEncoderNoExtensionsTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/FetchResponseEncoderNoExtensionsTest.java
@@ -60,6 +60,7 @@ class FetchResponseEncoderNoExtensionsTest {
         FetchResponse message = new FetchResponse(MSN, flags, null, null, null, null, null,
                 null, null, null, null, null, null);
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (FLAGS (\\Deleted))\r\n");
     }
 
@@ -68,6 +69,7 @@ class FetchResponseEncoderNoExtensionsTest {
         FetchResponse message = new FetchResponse(MSN, null, MessageUid.of(72), null, null,
                 null, null, null, null, null, null, null, null);
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (UID 72)\r\n");
 
     }
@@ -77,6 +79,7 @@ class FetchResponseEncoderNoExtensionsTest {
         FetchResponse message = new FetchResponse(MSN, flags, MessageUid.of(72), null, null,
                 null, null, null, null, null, null, null, null);
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (FLAGS (\\Deleted) UID 72)\r\n");
 
     }
@@ -101,6 +104,7 @@ class FetchResponseEncoderNoExtensionsTest {
         when(stubStructure.getDescription()).thenReturn("");
 
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (FLAGS (\\Deleted) BODYSTRUCTURE (\"TEXT\" \"HTML\" (\"CHARSET\" \"US-ASCII\") \"\" \"\" \"7BIT\" 2279 48) UID 72)\r\n");
 
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/FetchResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/FetchResponseEncoderTest.java
@@ -54,6 +54,7 @@ class FetchResponseEncoderTest  {
         FetchResponse message = new FetchResponse(MSN, flags, null, null, null, null, null,
                 null, null, null, null, null, null);
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (FLAGS (\\Deleted))\r\n");
 
 
@@ -64,6 +65,7 @@ class FetchResponseEncoderTest  {
         FetchResponse message = new FetchResponse(MSN, null, MessageUid.of(72), null, null,
                 null, null, null, null, null, null, null, null);
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (UID 72)\r\n");
 
 
@@ -74,6 +76,7 @@ class FetchResponseEncoderTest  {
         FetchResponse message = new FetchResponse(MSN, flags, MessageUid.of(72), null, null,
                 null, null, null, null, null, null, null, null);
         encoder.encode(message, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* 100 FETCH (FLAGS (\\Deleted) UID 72)\r\n");
         
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/ImapResponseComposerImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/ImapResponseComposerImplTest.java
@@ -41,6 +41,7 @@ class ImapResponseComposerImplTest {
         Character c = 128;
         composer.quote(c.toString());
         composer.end();
+        composer.flush();
 
         assertThat(writer.getString()).isEqualTo(" \"?\"\r\n");
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/LSubResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/LSubResponseEncoderTest.java
@@ -46,6 +46,7 @@ class LSubResponseEncoderTest  {
     @Test
     void encoderShouldIncludeLSUBCommand() throws Exception {
         encoder.encode(new LSubResponse("name", true, '.'), composer);
+        composer.flush();
         assertThat(writer.getString()).startsWith("* LSUB");
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/ListResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/ListResponseEncoderTest.java
@@ -51,6 +51,7 @@ class ListResponseEncoderTest {
         encoder.encode(new ListResponse(MailboxMetaData.Children.HAS_CHILDREN, MailboxMetaData.Selectability.NONE,
             "name", '.', false,
             false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER), composer);
+        composer.flush();
         assertThat(writer.getString()).startsWith("* LIST");
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/ListingEncodingUtilsTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/ListingEncodingUtilsTest.java
@@ -46,6 +46,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.HAS_CHILDREN, Selectability.NONE, nameParameter, ((char) Character.UNASSIGNED), false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST (\\HasChildren) NIL \"mailbox\"\r\n");
     }
 
@@ -54,6 +55,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.HAS_CHILDREN, Selectability.NONE, nameParameter, '#', false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST (\\HasChildren) \"#\" \"mailbox\"\r\n");
     }
 
@@ -62,6 +64,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.CHILDREN_ALLOWED_BUT_UNKNOWN, MailboxMetaData.Selectability.NONE, nameParameter, '.', false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST () \".\" \"mailbox\"\r\n");
     }
 
@@ -70,6 +73,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.HAS_CHILDREN, Selectability.NONE, nameParameter, '.', false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST (\\HasChildren) \".\" \"mailbox\"\r\n");
     }
 
@@ -78,6 +82,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.HAS_NO_CHILDREN, Selectability.NONE, nameParameter, '.', false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST (\\HasNoChildren) \".\" \"mailbox\"\r\n");
     }
 
@@ -86,6 +91,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.NO_INFERIORS, Selectability.NOSELECT, nameParameter, '.', false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST (\\Noselect \\Noinferiors) \".\" \"mailbox\"\r\n");
     }
 
@@ -94,6 +100,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.CHILDREN_ALLOWED_BUT_UNKNOWN, Selectability.MARKED, nameParameter, '.', false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST (\\Marked) \".\" \"mailbox\"\r\n");
     }
 
@@ -102,6 +109,7 @@ public class ListingEncodingUtilsTest  {
         ListResponse input = new ListResponse(Children.CHILDREN_ALLOWED_BUT_UNKNOWN, Selectability.UNMARKED, nameParameter, '.', false, false, EnumSet.noneOf(ListResponse.ChildInfo.class), MailboxType.OTHER);
 
         ListingEncodingUtils.encodeListingResponse(LIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* LIST (\\Unmarked) \".\" \"mailbox\"\r\n");
     }
 
@@ -110,6 +118,7 @@ public class ListingEncodingUtilsTest  {
         XListResponse input = new XListResponse(Children.HAS_CHILDREN, Selectability.NONE, nameParameter, '.', MailboxType.INBOX);
 
         ListingEncodingUtils.encodeListingResponse(XLIST_COMMAND, composer, input);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* XLIST (\\HasChildren \\Inbox) \".\" \"mailbox\"\r\n");
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/MailboxStatusResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/MailboxStatusResponseEncoderTest.java
@@ -60,6 +60,7 @@ class MailboxStatusResponseEncoderTest  {
 
         encoder.encode(new MailboxStatusResponse(null, null, null, deletedStorage, messages, recent, uidNext,
                 null, uidValidity, unseen, mailbox, null), composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* STATUS \"A mailbox named desire\" (MESSAGES 2 DELETED-STORAGE 13 RECENT 3 UIDNEXT 5 UIDVALIDITY 7 UNSEEN 11)\r\n");
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/MetadataResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/MetadataResponseEncoderTest.java
@@ -55,6 +55,7 @@ class MetadataResponseEncoderTest {
         MetadataResponse response = new MetadataResponse(null, ImmutableList.of());
 
         encoder.encode(response, composer);
+        composer.flush();
 
         assertThat(byteImapResponseWriter.getString()).isEqualTo("* METADATA \"\"\r\n");
     }
@@ -64,6 +65,7 @@ class MetadataResponseEncoderTest {
         MetadataResponse response = new MetadataResponse("INBOX", ImmutableList.of());
 
         encoder.encode(response, composer);
+        composer.flush();
 
         assertThat(byteImapResponseWriter.getString()).isEqualTo("* METADATA \"INBOX\"\r\n");
     }
@@ -73,6 +75,7 @@ class MetadataResponseEncoderTest {
         MetadataResponse response = new MetadataResponse("INBOX", ImmutableList.of(PRIVATE_ANNOTATION));
 
         encoder.encode(response, composer);
+        composer.flush();
 
         assertThat(byteImapResponseWriter.getString()).isEqualTo("* METADATA \"INBOX\" (/private/comment \"My own comment\")\r\n");
     }
@@ -81,6 +84,7 @@ class MetadataResponseEncoderTest {
     void encodingShouldWellFormWhenManyReturnedAnnotations() throws Exception {
         MetadataResponse response = new MetadataResponse("INBOX", ImmutableList.of(PRIVATE_ANNOTATION, SHARED_ANNOTATION));
         encoder.encode(response, composer);
+        composer.flush();
 
         assertThat(byteImapResponseWriter.getString()).isEqualTo("* METADATA \"INBOX\" (/private/comment \"My own comment\" /shared/comment \"Shared comment\")\r\n");
     }
@@ -90,6 +94,7 @@ class MetadataResponseEncoderTest {
         MetadataResponse response = new MetadataResponse("INBOX", ImmutableList.of(MailboxAnnotation.nil(PRIVATE_KEY)));
 
         encoder.encode(response, composer);
+        composer.flush();
 
         assertThat(byteImapResponseWriter.getString()).isEqualTo("* METADATA \"INBOX\" ()\r\n");
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/QuotaResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/QuotaResponseEncoderTest.java
@@ -43,6 +43,7 @@ class QuotaResponseEncoderTest {
         ImapResponseComposer composer = new ImapResponseComposerImpl(byteImapResponseWriter, 1024);
         QuotaResponseEncoder encoder = new QuotaResponseEncoder();
         encoder.encode(response, composer);
+        composer.flush();
         String responseString = byteImapResponseWriter.getString();
         assertThat(responseString).isEqualTo("* QUOTA root (MESSAGE 231 1024)\r\n");
     }
@@ -55,6 +56,7 @@ class QuotaResponseEncoderTest {
         ImapResponseComposer composer = new ImapResponseComposerImpl(byteImapResponseWriter, 1024);
         QuotaResponseEncoder encoder = new QuotaResponseEncoder();
         encoder.encode(response, composer);
+        composer.flush();
         String responseString = byteImapResponseWriter.getString();
         assertThat(responseString).isEqualTo("* QUOTA root (STORAGE 231 1024)\r\n");
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/QuotaRootResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/QuotaRootResponseEncoderTest.java
@@ -37,6 +37,7 @@ class QuotaRootResponseEncoderTest {
         ImapResponseComposer composer = new ImapResponseComposerImpl(byteImapResponseWriter, 1024);
         QuotaRootResponseEncoder encoder = new QuotaRootResponseEncoder();
         encoder.encode(response, composer);
+        composer.flush();
         String responseString = byteImapResponseWriter.getString();
         assertThat(responseString).isEqualTo("* QUOTAROOT \"INBOX\" root\r\n");
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/SearchResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/SearchResponseEncoderTest.java
@@ -59,6 +59,7 @@ class SearchResponseEncoderTest {
     @Test
     void testEncode() throws Exception {
         encoder.encode(response, composer);
+        composer.flush();
         assertThat(writer.getString()).isEqualTo("* SEARCH 1 4 9 16\r\n");
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/encode/XListResponseEncoderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/encode/XListResponseEncoderTest.java
@@ -56,6 +56,7 @@ class XListResponseEncoderTest {
                 '.',
                 MailboxType.INBOX),
             composer);
+        composer.flush();
         assertThat(writer.getString()).startsWith("* XLIST");
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
@@ -147,11 +147,13 @@ class SelectProcessorTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
+        ImapResponseComposerImpl composer = new ImapResponseComposerImpl(new OutputStreamImapResponseWriter(outputStream));
         testee.process(message,
             new ResponseEncoder(
                 new DefaultImapEncoderFactory(new DefaultLocalizer(), true).buildImapEncoder(),
-                new ImapResponseComposerImpl(new OutputStreamImapResponseWriter(outputStream))),
+                composer),
             session);
+        composer.flush();
 
         assertThat(new String(outputStream.toByteArray()))
             .contains("* VANISHED (EARLIER) 2,4");

--- a/server/apps/memory-app/src/test/java/org/apache/james/IMAPIntegrationTest.java
+++ b/server/apps/memory-app/src/test/java/org/apache/james/IMAPIntegrationTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class IMAPIntegrationTest {
+class IMAPIntegrationTest {
 
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryJamesConfiguration>(tmpDir ->

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -183,7 +183,6 @@ public class NettyImapSession implements ImapSession, NettyConstants {
         }
         executeSafely(() -> {
             runnable.run();
-            channel.flush();
             channel.pipeline().addFirst(SSL_HANDLER, secure.sslHandler());
             stopDetectingCommandInjection();
         });
@@ -230,7 +229,6 @@ public class NettyImapSession implements ImapSession, NettyConstants {
 
         executeSafely(() -> {
             runnable.run();
-            channel.flush();
             ZlibDecoder decoder = new JZlibDecoder(ZlibWrapper.NONE);
             ZlibEncoder encoder = new JZlibEncoder(ZlibWrapper.NONE, 5);
 
@@ -308,10 +306,5 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     @Override
     public void schedule(Runnable runnable, Duration waitDelay) {
         channel.eventLoop().schedule(runnable, waitDelay.toMillis(), TimeUnit.MILLISECONDS);
-    }
-
-    @Override
-    public void flush() {
-        channel.flush();
     }
 }

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -977,7 +977,7 @@ class IMAPServerTest {
                 .doesNotThrowAnyException();
         }
 
-        @Test
+        @RepeatedTest(100)
         void authenticatePlainShouldSucceed() {
             assertThatCode(() ->
                 testIMAPClient.connect("127.0.0.1", port)


### PR DESCRIPTION
## Actual behaviour

![Screenshot from 2023-02-09 22-29-33](https://user-images.githubusercontent.com/6928740/217859625-11de22c2-fa78-45c7-96ac-ee260e9f5dfb.png)

```
Error fetching folders: status: expecting ')' or attribute
```

Here are IMAP debug logs:

```
* STATUS "Test email box" (MESSAGES'
[imapx:A] I/O: ' 0 UIDNEXT 1 UIDVALIDITY 748930662 UNSEEN 0)
```

Notice the IMAP STATUS response being split into 2 IMAP messages.

## Reason

Evolution do not support an IMAP message to be split into 2 TCP frames.

Avoid pushing partial TCP frames.

Suspect: https://github.com/apache/james-project/pull/1364

## Resolution test

 - [ ] QA to validate #1364 impact: revert and test live...
 - [ ] Find a way to disable partial sends with the netty stack
 - [ ] Write a test reproducing the partial send behaviour