### PR TITLE
[doc] adds quick help on how to run openjpa basesd tests

### DIFF
--- a/mailbox/spring/src/test/README.md
+++ b/mailbox/spring/src/test/README.md
@@ -1,0 +1,7 @@
+
+Running these tests requires applying the openjpa javaagent. This is configured for you when running the tests through maven. 
+In your IDE you will have to add the following JVM argument (the version may vary check the apache.openjpa.version property value in the top level pom.xml): 
+
+```
+-javaagent:${HOME}/.m2/repository/org/apache/openjpa/openjpa/3.2.0/openjpa-3.2.0.jar
+```


### PR DESCRIPTION
It took me a while (and matthieu's help) to figure out how to run testsuites that depend on openjpa.  
So I wanted to document somewhere for other developpers the steps to run the tests outside of maven. 
I must say, I am not sure how the tests work in maven as I couldn't find where the agent is configured yet the build still works without additional config. 

Since it is not easily discoverable from the point of failure, I think it is nice to document it. I am open to suggestions of a better approach :) 