### PR TITLE
JAMES-3890 Allow parallel execution of safe tasks

### DIFF
--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxTask.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExpireMailboxTask.java
@@ -26,13 +26,14 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.apache.james.task.Task;
+import org.apache.james.task.AsyncSafeTask;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 import org.apache.james.webadmin.service.ExpireMailboxService.Context;
 import org.apache.james.webadmin.service.ExpireMailboxService.RunningOptions;
+import org.reactivestreams.Publisher;
 
-public class ExpireMailboxTask implements Task {
+public class ExpireMailboxTask implements AsyncSafeTask {
     public static final TaskType TASK_TYPE = TaskType.of("ExpireMailboxTask");
 
     public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
@@ -108,9 +109,8 @@ public class ExpireMailboxTask implements Task {
     }
 
     @Override
-    public Result run() {
-        return expireMailboxService.expireMailboxes(context, runningOptions, new Date())
-            .block();
+    public Publisher<Result> runAsync() {
+        return expireMailboxService.expireMailboxes(context, runningOptions, new Date());
     }
 
     @Override

--- a/server/task/task-api/pom.xml
+++ b/server/task/task-api/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
             <artifactId>reactor-scala-extensions_${scala.base}</artifactId>
         </dependency>
         <dependency>

--- a/server/task/task-api/src/main/java/org/apache/james/task/AsyncSafeTask.java
+++ b/server/task/task-api/src/main/java/org/apache/james/task/AsyncSafeTask.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+/**
+ * Marker interface for a task that can safely run in parallel with other tasks.
+ * This means it will not likely interfere with the operations of other tasks, and be able to handle issues arising
+ * from parallel execution; e.g. if the task lists some messages and then tries to access them, it must gracefully
+ * handle the situation when they have been deleted in the meantime.
+ */
+public interface AsyncSafeTask extends Task {
+}


### PR DESCRIPTION
See JAMES-3890 for rationale. TL;DR: Long running tasks should not delay regular tasks.

I introduce the AsyncSafeTask for long running tasks that are allowed to execute in parallel with other tasks, converting ExpireMailboxTask as an example.

I patched the respective functionality into SerialTaskManagerWorker (name does not quite fit anymore). It gets a separate asyncTaskExceutor for such tasks, and uses a map instead of a reference to keep track of everything, e.g. to cancel running tasks. The "pollingMono" wrapper takes care of cleaning up the map once it finishes.

While this achieves the goal, I am not quite sure this is the best possible solution. I also may have missed some crucial edge cases. Any suggestions?