### PR TITLE
JAMES-2601 Implement a LDAP healthCheck

### DIFF
--- a/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
+++ b/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
@@ -45,7 +45,7 @@ public class LdapUsersRepositoryModule extends AbstractModule {
         bind(UsersRepository.class).to(ReadOnlyUsersLDAPRepository.class);
         bind(DelegationStore.class).to(NaiveDelegationStore.class);
         bind(Authorizator.class).to(UserRepositoryAuthorizator.class);
-        bind(HealthCheck.class).to(LdapHealthCheck.class);
+        Multibinder.newSetBinder(binder(), HealthCheck.class).addBinding().to(LdapHealthCheck.class);
     }
 
     @Provides

--- a/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
+++ b/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
@@ -18,7 +18,6 @@
  ****************************************************************/
 package org.apache.james.data;
 
-import com.google.inject.multibindings.Multibinder;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.adapter.mailbox.UserRepositoryAuthorizator;
 import org.apache.james.core.healthcheck.HealthCheck;
@@ -37,6 +36,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 
 public class LdapUsersRepositoryModule extends AbstractModule {

--- a/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
+++ b/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.data;
 
+import com.google.inject.multibindings.Multibinder;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.adapter.mailbox.UserRepositoryAuthorizator;
 import org.apache.james.core.healthcheck.HealthCheck;

--- a/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
+++ b/server/container/guice/data-ldap/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
@@ -20,10 +20,12 @@ package org.apache.james.data;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.adapter.mailbox.UserRepositoryAuthorizator;
+import org.apache.james.core.healthcheck.HealthCheck;
 import org.apache.james.mailbox.Authorizator;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.user.api.DelegationStore;
 import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.ldap.LdapHealthCheck;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
 import org.apache.james.user.ldap.ReadOnlyUsersLDAPRepository;
 import org.apache.james.user.memory.NaiveDelegationStore;
@@ -43,6 +45,7 @@ public class LdapUsersRepositoryModule extends AbstractModule {
         bind(UsersRepository.class).to(ReadOnlyUsersLDAPRepository.class);
         bind(DelegationStore.class).to(NaiveDelegationStore.class);
         bind(Authorizator.class).to(UserRepositoryAuthorizator.class);
+        bind(HealthCheck.class).to(LdapHealthCheck.class);
     }
 
     @Provides

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
@@ -50,9 +50,9 @@ public class LdapHealthCheck implements HealthCheck {
     @Override
     public Mono<Result> check() {
         return Mono.fromCallable(() -> ldapUserRepository.getUserByName(LDAP_TEST_USER))
-            .map(user -> Result.healthy(COMPONENT_NAME))
-            .onErrorResume(e -> Mono.just(Result.unhealthy(COMPONENT_NAME, "Error checking LDAP server!", e)))
+            .thenReturn(Result.healthy(COMPONENT_NAME))
             .doOnError(e -> LOGGER.error("Error in LDAP server", e))
+            .onErrorResume(e -> Mono.just(Result.unhealthy(COMPONENT_NAME, "Error checking LDAP server!", e)))
             .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
@@ -14,11 +14,11 @@ public class LdapHealthCheck implements HealthCheck {
     public static final ComponentName COMPONENT_NAME = new ComponentName("LDAP User Server");
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapHealthCheck.class);
 
-    private final ReadOnlyLDAPUsersDAO ldapUsersDAO;
+    private final ReadOnlyUsersLDAPRepository ldapUserRepository;
 
     @Inject
-    public LdapHealthCheck(ReadOnlyLDAPUsersDAO ldapUsersDAO) {
-        this.ldapUsersDAO = ldapUsersDAO;
+    public LdapHealthCheck(ReadOnlyUsersLDAPRepository ldapUserRepository) {
+        this.ldapUserRepository = ldapUserRepository;
     }
 
     @Override
@@ -28,7 +28,7 @@ public class LdapHealthCheck implements HealthCheck {
 
     @Override
     public Mono<Result> check() {
-        return Mono.fromCallable(() -> ldapUsersDAO.getUserByName(Username.of("test")))
+        return Mono.fromCallable(() -> ldapUserRepository.getUserByName(Username.of("test")))
             .map(user -> Result.healthy(COMPONENT_NAME))
             .onErrorResume(e -> Mono.just(Result.unhealthy(COMPONENT_NAME, "Error checking LDAP server!", e)))
             .doOnError(e -> LOGGER.error("Error in LDAP server", e));

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public class LdapHealthCheck implements HealthCheck {
     public static final ComponentName COMPONENT_NAME = new ComponentName("LDAP User Server");
@@ -51,6 +52,7 @@ public class LdapHealthCheck implements HealthCheck {
         return Mono.fromCallable(() -> ldapUserRepository.getUserByName(LDAP_TEST_USER))
             .map(user -> Result.healthy(COMPONENT_NAME))
             .onErrorResume(e -> Mono.just(Result.unhealthy(COMPONENT_NAME, "Error checking LDAP server!", e)))
-            .doOnError(e -> LOGGER.error("Error in LDAP server", e));
+            .doOnError(e -> LOGGER.error("Error in LDAP server", e))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
@@ -1,3 +1,21 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
 package org.apache.james.user.ldap;
 
 import javax.inject.Inject;

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
@@ -1,0 +1,36 @@
+package org.apache.james.user.ldap;
+
+import javax.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.core.healthcheck.ComponentName;
+import org.apache.james.core.healthcheck.HealthCheck;
+import org.apache.james.core.healthcheck.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+public class LdapHealthCheck implements HealthCheck {
+    public static final ComponentName COMPONENT_NAME = new ComponentName("LDAP User Server");
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapHealthCheck.class);
+
+    private final ReadOnlyLDAPUsersDAO ldapUsersDAO;
+
+    @Inject
+    public LdapHealthCheck(ReadOnlyLDAPUsersDAO ldapUsersDAO) {
+        this.ldapUsersDAO = ldapUsersDAO;
+    }
+
+    @Override
+    public ComponentName componentName() {
+        return COMPONENT_NAME;
+    }
+
+    @Override
+    public Mono<Result> check() {
+        return Mono.fromCallable(() -> ldapUsersDAO.getUserByName(Username.of("test")))
+            .map(user -> Result.healthy(COMPONENT_NAME))
+            .onErrorResume(e -> Mono.just(Result.unhealthy(COMPONENT_NAME, "Error checking LDAP server!", e)))
+            .doOnError(e -> LOGGER.error("Error in LDAP server", e));
+    }
+}

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
@@ -12,6 +12,7 @@ import reactor.core.publisher.Mono;
 
 public class LdapHealthCheck implements HealthCheck {
     public static final ComponentName COMPONENT_NAME = new ComponentName("LDAP User Server");
+    public static final Username LDAP_TEST_USER = Username.of("ldap-test");
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapHealthCheck.class);
 
     private final ReadOnlyUsersLDAPRepository ldapUserRepository;
@@ -28,7 +29,7 @@ public class LdapHealthCheck implements HealthCheck {
 
     @Override
     public Mono<Result> check() {
-        return Mono.fromCallable(() -> ldapUserRepository.getUserByName(Username.of("test")))
+        return Mono.fromCallable(() -> ldapUserRepository.getUserByName(LDAP_TEST_USER))
             .map(user -> Result.healthy(COMPONENT_NAME))
             .onErrorResume(e -> Mono.just(Result.unhealthy(COMPONENT_NAME, "Error checking LDAP server!", e)))
             .doOnError(e -> LOGGER.error("Error in LDAP server", e));

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/LdapHealthCheck.java
@@ -8,6 +8,7 @@ import org.apache.james.core.healthcheck.HealthCheck;
 import org.apache.james.core.healthcheck.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import reactor.core.publisher.Mono;
 
 public class LdapHealthCheck implements HealthCheck {

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
@@ -1,12 +1,11 @@
 package org.apache.james.user.ldap;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.james.core.healthcheck.Result;
 import org.apache.james.domainlist.api.mock.SimpleDomainList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LdapHealthCheckTest {
 

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
@@ -23,19 +23,17 @@ public class LdapHealthCheckTest {
 
     @Test
     void checkShouldReturnUnhealthyIfLdapIsDown() {
-        ldapContainer.stop();
+        ldapContainer.pause();
 
         Result checkResult = ldapHealthCheck.check().block();
         assertNotNull(checkResult);
         assertTrue(checkResult.isUnHealthy());
 
-        ldapContainer.start();
+        ldapContainer.unpause();
     }
 
     @Test
     void checkShouldReturnHealthyIfLdapIsRunning() {
-        ldapContainer.start();
-
         Result checkResult = ldapHealthCheck.check().block();
         assertNotNull(checkResult);
         assertTrue(checkResult.isHealthy());

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
@@ -34,7 +34,6 @@ public class LdapHealthCheckTest {
     @Test
     void checkShouldReturnHealthyIfLdapIsRunning() {
         Result checkResult = ldapHealthCheck.check().block();
-        assertNotNull(checkResult);
-        assertTrue(checkResult.isHealthy());
+        assertThat(checkResult.isHealthy()).isTrue();
     }
 }

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
@@ -26,8 +26,7 @@ public class LdapHealthCheckTest {
         ldapContainer.pause();
 
         Result checkResult = ldapHealthCheck.check().block();
-        assertNotNull(checkResult);
-        assertTrue(checkResult.isUnHealthy());
+        assertThat(checkResult.isUnHealthy()).isTrue();
 
         ldapContainer.unpause();
     }

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
@@ -1,3 +1,21 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
 package org.apache.james.user.ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/LdapHealthCheckTest.java
@@ -1,0 +1,43 @@
+package org.apache.james.user.ldap;
+
+import org.apache.james.core.healthcheck.Result;
+import org.apache.james.domainlist.api.mock.SimpleDomainList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LdapHealthCheckTest {
+
+    LdapHealthCheck ldapHealthCheck;
+    ReadOnlyUsersLDAPRepository ldapUserRepository;
+    LdapGenericContainer ldapContainer;
+
+    @BeforeEach
+    public void setUp() {
+        ldapUserRepository = new ReadOnlyUsersLDAPRepository(new SimpleDomainList());
+        ldapHealthCheck = new LdapHealthCheck(ldapUserRepository);
+        ldapContainer = DockerLdapSingleton.ldapContainer;
+    }
+
+    @Test
+    void checkShouldReturnUnhealthyIfLdapIsDown() {
+        ldapContainer.stop();
+
+        Result checkResult = ldapHealthCheck.check().block();
+        assertNotNull(checkResult);
+        assertTrue(checkResult.isUnHealthy());
+
+        ldapContainer.start();
+    }
+
+    @Test
+    void checkShouldReturnHealthyIfLdapIsRunning() {
+        ldapContainer.start();
+
+        Result checkResult = ldapHealthCheck.check().block();
+        assertNotNull(checkResult);
+        assertTrue(checkResult.isHealthy());
+    }
+}


### PR DESCRIPTION
As the title says, added a new health checker to check LDAP server's health and tested it.

Note: checkShouldReturnHealthyIfLdapIsRunning failed when I ran it locally. Apparently, there is an exception thrown by the ldap user repository that says "Unable check user existence from ldap".

I'm sure that the test container has started because I can view it from Docker Desktop, but for some reason, the exception is still thrown.

![image](https://user-images.githubusercontent.com/21198231/220434225-4fc8cec7-81fc-4c37-a23a-69c3df2d25f7.png)


