### PR TITLE
JAMES-3881 -Djmx.remote.x.mlet.allow.getMBeansFromURL=false [BACKPORT]

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -16,3 +16,7 @@
 # Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
 # be copied to temporary files?
 #james.message.usememorycopy=false
+
+# Disable Remote Code Execution feature from JMX
+# CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
+jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/operate/security.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/operate/security.adoc
@@ -61,7 +61,7 @@ for your outgoing emails to be trusted.
  - 8. Prevent access to JMX. This can be achieved through a strict firewalling policy
 (link:https://nickbloor.co.uk/2017/10/22/analysis-of-cve-2017-12628/[blocking port 9999 is not enough])
 or xref:configure/jmx.adoc[disabling JMX]. JMX is needed to use the existing CLI application but webadmin do offer similar
-features.
+features. Set the `jmx.remote.x.mlet.allow.getMBeansFromURL` to `false` to disable JMX remote code execution feature.
 
  - 9. If JMAP is enabled, be sure that JMAP PUSH cannot be used for server side request forgery. This can be
 xref:configure/jmap.adoc[configured] using the `push.prevent.server.side.request.forgery=true` property,

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -16,3 +16,7 @@
 # Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
 # be copied to temporary files?
 #james.message.usememorycopy=false
+
+# Disable Remote Code Execution feature from JMX
+# CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
+jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -16,3 +16,7 @@
 # Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
 # be copied to temporary files?
 #james.message.usememorycopy=false
+
+# Disable Remote Code Execution feature from JMX
+# CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
+jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -16,3 +16,7 @@
 # Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
 # be copied to temporary files?
 #james.message.usememorycopy=false
+
+# Disable Remote Code Execution feature from JMX
+# CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
+jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -16,3 +16,7 @@
 # Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
 # be copied to temporary files?
 #james.message.usememorycopy=false
+
+# Disable Remote Code Execution feature from JMX
+# CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
+jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -16,3 +16,7 @@
 # Should MimeMessageWrapper use a copy of the message in memory? Or should bigger message exceeding james.message.memory.threshold
 # be copied to temporary files?
 #james.message.usememorycopy=false
+
+# Disable Remote Code Execution feature from JMX
+# CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
+jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/spring-app/pom.xml
+++ b/server/apps/spring-app/pom.xml
@@ -49,10 +49,12 @@
         <javamail.system-property9>-Dmail.mime.decodeparameters=true</javamail.system-property9>
         <javamail.system-property10>-Dmail.mime.address.strict=false</javamail.system-property10>
         <javamail.system-property11>-Djames.jmx.unregister.log4j.mbeans=true</javamail.system-property11>
+        <javamail.system-property12>-Djmx.remote.x.mlet.allow.getMBeansFromURL=false</javamail.system-property12>
         <javamail.system-properties>${javamail.system-property1} ${javamail.system-property2}
             ${javamail.system-property3} ${javamail.system-property4} ${javamail.system-property5}
             ${javamail.system-property6} ${javamail.system-property7} ${javamail.system-property8}
-            ${javamail.system-property9} ${javamail.system-property10} ${javamail.system-property11}</javamail.system-properties>
+            ${javamail.system-property9} ${javamail.system-property10} ${javamail.system-property11}
+            ${javamail.system-property12} </javamail.system-properties>
 
         <!-- JMX system properties -->
         <!-- For more details see -->


### PR DESCRIPTION
This prevents the use of MLets for remote code executions and make life of attackers harder.