### PR TITLE
JAMES-3890 Allow parallel execution of safe tasks (3.7.x backport)

### DIFF
--- a/server/task/task-api/pom.xml
+++ b/server/task/task-api/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/server/task/task-api/src/main/java/org/apache/james/task/AsyncSafeTask.java
+++ b/server/task/task-api/src/main/java/org/apache/james/task/AsyncSafeTask.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+/**
+ * Marker interface for a task that can safely run in parallel with other tasks.
+ * This means it will not likely interfere with the operations of other tasks, and be able to handle issues arising
+ * from parallel execution; e.g. if the task lists some messages and then tries to access them, it must gracefully
+ * handle the situation when they have been deleted in the meantime.
+ */
+public interface AsyncSafeTask extends Task {
+}

--- a/server/task/task-memory/src/test/java/org/apache/james/task/SerialTaskManagerWorkerTest.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/SerialTaskManagerWorkerTest.java
@@ -233,7 +233,96 @@ class SerialTaskManagerWorkerTest {
         verify(listener, atLeastOnce()).cancelled(id, Optional.empty());
         verifyNoMoreInteractions(listener);
     }
+    
+    @Test
+    void theWorkerShouldCancelAnInProgressAsyncTask() throws InterruptedException {
+        TaskId id = TaskId.generateTaskId();
+        CountDownLatch latch = new CountDownLatch(1);
 
+        Task inProgressTask = new AsyncSafeTask() {
+            @Override
+            public Mono<Result> runAsync() {
+                return Mono.fromCallable(() -> {
+                    await(latch);
+                    return Task.Result.COMPLETED;
+                });
+            }
+
+            @Override
+            public TaskType type() {
+                return TaskType.of("async memory task");
+            }
+        };
+
+        TaskWithId taskWithId = new TaskWithId(id, inProgressTask);
+
+        Mono<Task.Result> resultMono = worker.executeTask(taskWithId).cache();
+        resultMono.subscribe();
+
+        Awaitility.waitAtMost(TEN_SECONDS)
+            .untilAsserted(() -> verify(listener, atLeastOnce()).started(id));
+
+        worker.cancelTask(id);
+
+        resultMono.block(Duration.ofSeconds(10));
+
+        // Due to the use of signals, cancellation cannot be instantaneous
+        // Let a grace period for the cancellation to complete to increase test stability
+        Thread.sleep(50);
+
+        verify(listener, atLeastOnce()).cancelled(eq(id), any());
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    void theWorkerShouldRunAsyncTasksInParallel() throws InterruptedException {
+        TaskId id1 = TaskId.generateTaskId();
+        TaskId id2 = TaskId.generateTaskId();
+        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch task1Started = new CountDownLatch(1);
+        CountDownLatch task2Started = new CountDownLatch(1);
+
+        Task inProgressTask1 = new AsyncSafeTask() {
+            @Override
+            public Mono<Result> runAsync() {
+                return Mono.fromCallable(() -> {
+                    task1Started.countDown();
+                    await(latch);
+                    return Task.Result.COMPLETED;
+                });
+            }
+
+            @Override
+            public TaskType type() {
+                return TaskType.of("async memory task");
+            }
+        };
+
+        Task inProgressTask2 = new AsyncSafeTask() {
+            @Override
+            public Mono<Result> runAsync() {
+                return Mono.fromCallable(() -> {
+                    task2Started.countDown();
+                    return Task.Result.COMPLETED;
+                });
+            }
+
+            @Override
+            public TaskType type() {
+                return TaskType.of("async memory task");
+            }
+        };
+
+        worker.executeTask(new TaskWithId(id1, inProgressTask1)).subscribe();
+        await(task1Started);
+
+        worker.executeTask(new TaskWithId(id2, inProgressTask2)).subscribe();
+        await(task2Started);
+
+        verify(listener, atLeastOnce()).started(id1);
+        verify(listener, atLeastOnce()).started(id2);
+        latch.countDown();
+    }
 
     private void await(CountDownLatch countDownLatch) throws InterruptedException {
         countDownLatch.await();


### PR DESCRIPTION
This is a backport of  #1452 to the 3.7.x branch. In order to keep it minimal, there are some notable changes compared to the master version:
- Task.runAsync() uses Schedulers.elastic() since ReactorUtils.BLOCKING_CALL_WRAPPER has not been introduced yet.
- SerialTaskManagerWorker.close() does not cancel and wait for tasks to finish. Seems that was introduced later an never backported. While I could add this as a potential stability improvement, I am not sure what the impact would be.
- There is no ExpireMailboxTask yet to use as a showcase, though I did a smoke test with a private extension that was its spiritual predecessor.