### PR TITLE
JAMES-3881 Set a JMX password (3.7.x)

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -17,6 +17,9 @@
 # be copied to temporary files?
 #james.message.usememorycopy=false
 
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+james.jmx.credential.generation=true
+
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/cli-integration-tests/src/test/java/org/apache/james/cli/JmxSecurityServerIntegrationTest.java
+++ b/server/apps/cli-integration-tests/src/test/java/org/apache/james/cli/JmxSecurityServerIntegrationTest.java
@@ -1,0 +1,115 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.cli;
+
+import static org.apache.james.MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.TemporaryJamesServer;
+import org.apache.james.cli.util.OutputCapture;
+import org.apache.james.data.UsersRepositoryModuleChooser;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+import org.apache.james.modules.data.MemoryUsersRepositoryModule;
+import org.apache.james.modules.server.JMXServerModule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.common.collect.ImmutableList;
+
+class JmxSecurityServerIntegrationTest {
+
+    private static final List<String> BASE_CONFIGURATION_FILE_NAMES = ImmutableList.of("dnsservice.xml",
+        "dnsservice.xml",
+        "imapserver.xml",
+        "jwt_publickey",
+        "lmtpserver.xml",
+        "mailetcontainer.xml",
+        "mailrepositorystore.xml",
+        "managesieveserver.xml",
+        "pop3server.xml",
+        "smtpserver.xml");
+
+    private GuiceJamesServer jamesServer;
+
+    @BeforeEach
+    void beforeEach(@TempDir Path workingPath) throws Exception {
+        TemporaryJamesServer temporaryJamesServer = new TemporaryJamesServer(workingPath.toFile(), BASE_CONFIGURATION_FILE_NAMES);
+        writeFile(workingPath + "/conf/jmx.properties", "jmx.address=127.0.0.1\n" +
+            "jmx.port=9999\n");
+        writeFile(workingPath + "/conf/jmxremote.password", "james-admin pass1\n");
+        writeFile(workingPath + "/conf/jmxremote.access", "james-admin readwrite\n");
+
+        jamesServer = temporaryJamesServer.getJamesServer()
+            .combineWith(IN_MEMORY_SERVER_AGGREGATE_MODULE)
+            .combineWith(new UsersRepositoryModuleChooser(new MemoryUsersRepositoryModule())
+                .chooseModules(UsersRepositoryModuleChooser.Implementation.DEFAULT))
+            .overrideWith(new JMXServerModule(),
+                binder -> binder.bind(ListeningMessageSearchIndex.class).toInstance(mock(ListeningMessageSearchIndex.class)));
+        jamesServer.start();
+
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (jamesServer != null && jamesServer.isStarted()) {
+            jamesServer.stop();
+        }
+    }
+
+    @Test
+    void jamesCliShouldFailWhenNotGiveAuthCredential() throws Exception {
+        OutputCapture outputCapture = new OutputCapture();
+
+        assertThatThrownBy(() -> ServerCmd.executeAndOutputToStream(new String[]{"-h", "127.0.0.1", "-p", "9999", "listdomains"}, outputCapture.getPrintStream()))
+            .isInstanceOf(SecurityException.class)
+            .hasMessageContaining("Authentication failed! Credentials required");
+    }
+
+    @Test
+    void jamesCliShouldWorkWhenGiveAuthCredential() throws Exception {
+        OutputCapture outputCapture = new OutputCapture();
+        ServerCmd.executeAndOutputToStream(new String[]{"-h", "127.0.0.1", "-p", "9999", "-username", "james-admin", "-password", "pass1",
+            "listdomains"}, outputCapture.getPrintStream());
+
+        assertThat(outputCapture.getContent()).contains("localhost");
+    }
+
+    private void writeFile(String fileNamePath, String data) {
+        File passwordFile = new File(fileNamePath);
+        try (OutputStream outputStream = new FileOutputStream(passwordFile)) {
+            IOUtils.write(data, outputStream, StandardCharsets.UTF_8);
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmx.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmx.adoc
@@ -22,3 +22,37 @@ in GIT to get some examples and hints.
 
 To access from a remote location, it has been reported that `-Dcom.sun.management.jmxremote.ssl=false` is needed as
 a JVM argument.
+
+
+== JMX Security
+
+In order to set up JMX authentication, we need to put `jmxremote.password` and `jmxremote.access` file
+to `/conf` directory.
+
+- `jmxremote.password`: define the username and password, that will be used by the client (here is james-cli)
+
+File's content example:
+```
+james-admin pass1
+```
+
+- `jmxremote.access`: define the pair of username and access permission
+
+File's content example:
+```
+james-admin readWrite
+```
+
+When James runs with option `-Djames.jmx.credential.generation=true`, James will automatically generate `jmxremote.password` if the file does not exist.
+Then the default username is `james-admin` and a random password.
+
+=== James-cli
+
+When the JMX server starts with authentication configuration, it will require the client need provide username/password for bypass.
+To do that, we need set arguments `-username` and `-password` for the command request.
+
+Command example:
+```
+james-cli -h 127.0.0.1 -p 9999 -username james-admin -password pass1 listdomains
+```
+

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmx.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmx.adoc
@@ -44,7 +44,7 @@ james-admin readWrite
 ```
 
 When James runs with option `-Djames.jmx.credential.generation=true`, James will automatically generate `jmxremote.password` if the file does not exist.
-Then the default username is `james-admin` and a random password.
+Then the default username is `james-admin` and a random password. This option defaults to true.
 
 === James-cli
 

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -17,6 +17,9 @@
 # be copied to temporary files?
 #james.message.usememorycopy=false
 
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+james.jmx.credential.generation=true
+
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -17,6 +17,9 @@
 # be copied to temporary files?
 #james.message.usememorycopy=false
 
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+james.jmx.credential.generation=true
+
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -302,6 +302,7 @@
                             <jvmFlag>-Dworking.directory=/root/</jvmFlag>
                             <!-- Prevents Logjam (CVE-2015-4000) -->
                             <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
+                            <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
                         </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         <volumes>

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -17,6 +17,9 @@
 # be copied to temporary files?
 #james.message.usememorycopy=false
 
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+james.jmx.credential.generation=true
+
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/jpa-smtp-app/pom.xml
+++ b/server/apps/jpa-smtp-app/pom.xml
@@ -269,6 +269,7 @@
                             <jvmFlag>-Dworking.directory=/root/</jvmFlag>
                             <!-- Prevents Logjam (CVE-2015-4000) -->
                             <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
+                            <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
                         </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         <volumes>

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -17,6 +17,9 @@
 # be copied to temporary files?
 #james.message.usememorycopy=false
 
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+james.jmx.credential.generation=true
+
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/memory-app/pom.xml
+++ b/server/apps/memory-app/pom.xml
@@ -297,7 +297,7 @@
                             <jvmFlag>-Dworking.directory=/root/</jvmFlag>
                             <!-- Prevents Logjam (CVE-2015-4000) -->
                             <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
-                            <jvmFlag>-Djames.jmx.credential.generation=true</jvmFlag>
+                            <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
                         </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         <volumes>

--- a/server/apps/memory-app/pom.xml
+++ b/server/apps/memory-app/pom.xml
@@ -297,6 +297,7 @@
                             <jvmFlag>-Dworking.directory=/root/</jvmFlag>
                             <!-- Prevents Logjam (CVE-2015-4000) -->
                             <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
+                            <jvmFlag>-Djames.jmx.credential.generation=true</jvmFlag>
                         </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         <volumes>

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -17,6 +17,9 @@
 # be copied to temporary files?
 #james.message.usememorycopy=false
 
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+james.jmx.credential.generation=true
+
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false

--- a/server/apps/spring-app/src/main/java/org/apache/james/app/spring/JamesAppSpringMain.java
+++ b/server/apps/spring-app/src/main/java/org/apache/james/app/spring/JamesAppSpringMain.java
@@ -40,11 +40,16 @@ public class JamesAppSpringMain implements Daemon {
     private static final ObjectName ALL_OBJECT_NAME = null;
     private static final QueryExp ALL_QUERY_EXP = null;
 
-    private static final Logger log = LoggerFactory.getLogger(JamesAppSpringMain.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(JamesAppSpringMain.class.getName());
     private JamesServerApplicationContext context;
 
     public static void main(String[] args) throws Exception {
         unregisterLog4JMBeans();
+
+        if (System.getProperty("com.sun.management.jmxremote.password.file") == null) {
+            LOGGER.warn("No authentication setted up for the JMX component. This expose you to local privilege escalation attacks risk. " +
+                "This can be done via the 'com.sun.management.jmxremote.password.file' system property.");
+        }
 
         long start = Calendar.getInstance().getTimeInMillis();
 
@@ -53,7 +58,7 @@ public class JamesAppSpringMain implements Daemon {
 
         long end = Calendar.getInstance().getTimeInMillis();
 
-        log.info("Apache James Server is successfully started in {} milliseconds.", end - start);
+        LOGGER.info("Apache James Server is successfully started in {} milliseconds.", end - start);
 
     }
 

--- a/server/container/guice/common/src/main/java/org/apache/james/TemporaryJamesServer.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/TemporaryJamesServer.java
@@ -1,0 +1,106 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.server.core.configuration.Configuration;
+
+import com.google.common.collect.ImmutableList;
+
+public class TemporaryJamesServer {
+    private static final List<String> CONFIGURATION_FILE_NAMES = ImmutableList.of(
+        "dnsservice.xml",
+        "domainlist.xml",
+        "imapserver.xml",
+        "keystore",
+        "listeners.xml",
+        "lmtpserver.xml",
+        "mailetcontainer.xml",
+        "mailrepositorystore.xml",
+        "managesieveserver.xml",
+        "pop3server.xml",
+        "smtpserver.xml",
+        "usersrepository.xml");
+
+    private final Configuration configuration;
+    private final File configurationFolder;
+    private final List<String> configurationFileNames;
+    private GuiceJamesServer jamesServer;
+
+    public TemporaryJamesServer(File workingDir) {
+        this(workingDir, CONFIGURATION_FILE_NAMES);
+    }
+
+    public TemporaryJamesServer(File workingDir, List<String> configurationFileNames) {
+        this.configurationFileNames = configurationFileNames;
+        Configuration configuration = Configuration.builder().workingDirectory(workingDir).build();
+        configurationFolder = workingDir.toPath().resolve("conf").toFile();
+        if (!configurationFolder.exists()) {
+            configurationFolder.mkdir();
+        }
+        copyResources(Paths.get(configurationFolder.getAbsolutePath()));
+        this.configuration = configuration;
+    }
+
+    public GuiceJamesServer getJamesServer() {
+        if (jamesServer == null) {
+            jamesServer = GuiceJamesServer.forConfiguration(configuration);
+        }
+        return jamesServer;
+    }
+
+    public void appendConfigurationFile(String configurationData, String configurationFileName) throws IOException {
+        try (OutputStream outputStream = new FileOutputStream(Paths.get(configurationFolder.getAbsolutePath(), configurationFileName).toFile())) {
+            IOUtils.write(configurationData, outputStream, StandardCharsets.UTF_8);
+        }
+    }
+
+    private void copyResources(Path resourcesFolder) {
+        configurationFileNames
+            .forEach(resourceName -> copyResource(resourcesFolder, resourceName));
+    }
+
+    public static void copyResource(Path resourcesFolder, String resourceName) {
+        var resolvedResource = resourcesFolder.resolve(resourceName);
+        try (OutputStream outputStream = new FileOutputStream(resolvedResource.toFile())) {
+            URL resource = ClassLoader.getSystemClassLoader().getResource(resourceName);
+            if (resource != null) {
+                try (InputStream stream = resource.openStream()) {
+                    stream.transferTo(outputStream);
+                }
+            } else {
+                throw new RuntimeException("Failed to load configuration resource " + resourceName);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
@@ -121,6 +121,10 @@ public class JMXServer implements Startable {
             restrictingRMISocketFactory = new RestrictingRMISocketFactory(jmxConfiguration.getHost().getHostName());
             LocateRegistry.createRegistry(jmxConfiguration.getHost().getPort(), restrictingRMISocketFactory, restrictingRMISocketFactory);
             generateJMXPasswordFileIfNeed();
+            
+            if (!existJmxPasswordFile()) {
+                LOGGER.warn("No authentication setted up for the JMX component. This expose you to local privilege escalation attacks risk.");
+            }
 
             Map<String, String> environment = Optional.of(existJmxPasswordFile())
                 .filter(FunctionalUtils.identityPredicate())

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
@@ -166,27 +166,31 @@ public class JMXServer implements Startable {
     }
 
     private void generateJMXPasswordFile() {
-        File passwordFile = new File(jmxPasswordFilePath);
-        if (!passwordFile.exists()) {
-            try (OutputStream outputStream = new FileOutputStream(passwordFile)) {
-                String randomPassword = RandomStringUtils.random(10, true, true);
-                IOUtils.write(JmxConfiguration.JAMES_ADMIN_USER_DEFAULT + " " + randomPassword + "\n", outputStream, StandardCharsets.UTF_8);
-                setPermissionOwnerOnly(passwordFile);
-                LOGGER.info("Generated JMX password file: " + passwordFile.getPath());
-            } catch (IOException e) {
-                throw new RuntimeException("Error when creating JMX password file: " + passwordFile.getPath(), e);
+        try {
+            File passwordFile = new File(jmxPasswordFilePath);
+            if (!passwordFile.exists()) {
+                try (OutputStream outputStream = new FileOutputStream(passwordFile)) {
+                    String randomPassword = RandomStringUtils.random(10, true, true);
+                    IOUtils.write(JmxConfiguration.JAMES_ADMIN_USER_DEFAULT + " " + randomPassword + "\n", outputStream, StandardCharsets.UTF_8);
+                    setPermissionOwnerOnly(passwordFile);
+                    LOGGER.info("Generated JMX password file: " + passwordFile.getPath());
+                } catch (IOException e) {
+                    throw new RuntimeException("Error when creating JMX password file: " + passwordFile.getPath(), e);
+                }
             }
-        }
 
-        File accessFile = new File(jmxAccessFilePath);
-        if (!accessFile.exists()) {
-            try (OutputStream outputStream = new FileOutputStream(accessFile)) {
-                IOUtils.write(JmxConfiguration.JAMES_ADMIN_USER_DEFAULT + " readwrite\n", outputStream, StandardCharsets.UTF_8);
-                setPermissionOwnerOnly(accessFile);
-                LOGGER.info("Generated JMX access file: " + accessFile.getPath());
-            } catch (IOException e) {
-                throw new RuntimeException("Error when creating JMX access file: " + accessFile.getPath(), e);
+            File accessFile = new File(jmxAccessFilePath);
+            if (!accessFile.exists()) {
+                try (OutputStream outputStream = new FileOutputStream(accessFile)) {
+                    IOUtils.write(JmxConfiguration.JAMES_ADMIN_USER_DEFAULT + " readwrite\n", outputStream, StandardCharsets.UTF_8);
+                    setPermissionOwnerOnly(accessFile);
+                    LOGGER.info("Generated JMX access file: " + accessFile.getPath());
+                } catch (IOException e) {
+                    throw new RuntimeException("Error when creating JMX access file: " + accessFile.getPath(), e);
+                }
             }
+        } catch (Exception e) {
+            LOGGER.warn("Failure to auto-generate JMX password, fallback to unsecure JMX", e);
         }
     }
 

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
@@ -35,7 +35,7 @@ public class JmxConfiguration {
     public static final int DEFAULT_PORT = 9999;
     public static final boolean ENABLED = true;
     public static final String JMX_CREDENTIAL_GENERATION_ENABLE_PROPERTY_KEY = "james.jmx.credential.generation";
-    public static final String JMX_CREDENTIAL_GENERATION_ENABLE_DEFAULT_VALUE = "false";
+    public static final String JMX_CREDENTIAL_GENERATION_ENABLE_DEFAULT_VALUE = "true";
     public static final String PASSWORD_FILE_NAME = "jmxremote.password";
     public static final String ACCESS_FILE_NAME = "jmxremote.access";
     public static final String JAMES_ADMIN_USER_DEFAULT = "james-admin";

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
@@ -34,6 +34,11 @@ public class JmxConfiguration {
     public static final String LOCALHOST = "localhost";
     public static final int DEFAULT_PORT = 9999;
     public static final boolean ENABLED = true;
+    public static final String JMX_CREDENTIAL_GENERATION_ENABLE_PROPERTY_KEY = "james.jmx.credential.generation";
+    public static final String JMX_CREDENTIAL_GENERATION_ENABLE_DEFAULT_VALUE = "false";
+    public static final String PASSWORD_FILE_NAME = "jmxremote.password";
+    public static final String ACCESS_FILE_NAME = "jmxremote.access";
+    public static final String JAMES_ADMIN_USER_DEFAULT = "james-admin";
 
     public static final JmxConfiguration DEFAULT_CONFIGURATION = new JmxConfiguration(ENABLED, Optional.of(Host.from(LOCALHOST, DEFAULT_PORT)));
     public static final JmxConfiguration DISABLED = new JmxConfiguration(!ENABLED, Optional.empty());

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -125,8 +125,34 @@
                     <dd>The port number the MBean Server will bind/listen to.</dd>
                 </dl>
 
-                <p>To access from a remote location, it has been reported that -Dcom.sun.management.jmxremote.ssl=false is
+                <p>To access from a remote location, it has been reported that <code>-Dcom.sun.management.jmxremote.ssl=false</code> is
                     needed in the startup script.</p>
+
+                <b>JMX Security</b>
+
+                <p>Guice only</p>
+
+                <p>In order to set up JMX authentication, we need to put <code>jmxremote.password</code> and <code>jmxremote.access</code> file
+                    to <code>/conf</code> directory.</p>
+
+                <p><code>jmxremote.password</code>: define the username and password, that will be used by the client (here is james-cli)</p>
+
+                <p>File's content example:</p>
+                <pre><code>
+                james-admin pass1
+                </code></pre>
+
+                <p><code>jmxremote.access</code>: define the pair of username and access permission</p>
+
+                <p>File's content example:</p>
+                <pre><code>
+                james-admin readWrite
+                </code></pre>
+
+                <p>When James runs with option <code>-Djames.jmx.credential.generation=true</code>, James will automatically
+                    generate <code>jmxremote.password</code> if the file does not exist.
+                    Then the default username is <code>james-admin</code> and a random password. This option defaults to true.</p>
+
 
             </subsection>
 


### PR DESCRIPTION
This is a quick cherry pick of the remaining JAMES-3881 commits to  the 3.7.x branch. Some of them were already in place:
JAMES-3881 -Djmx.remote.x.mlet.allow.getMBeansFromURL=false (#1460)
JAMES-3881 Prevent CommonsBeanutils1 deserialization exploit [BACKPORT] (#1455)
JAMES-3881 Unregister LOG4J MBeans (#1459)

DISCLAIMER: I was not involved in the original work. Someone more knowledgeable with JMX please review it.
I did a quick test on distributed-pop3-app: James creates the jmxremote files, and the CLI requires authentication. Given authentication it works. Apart from this I cannot really tell if there is anything missing.