### PR TITLE
JAMES-3885 - Change username - should migrate succeed when mailboxes from old user already exist on the new user

### DIFF
--- a/server/container/mailbox-adapter/src/test/java/org/apache/james/adapter/mailbox/MailboxUsernameChangeTaskStepTest.java
+++ b/server/container/mailbox-adapter/src/test/java/org/apache/james/adapter/mailbox/MailboxUsernameChangeTaskStepTest.java
@@ -182,7 +182,7 @@ class MailboxUsernameChangeTaskStepTest {
     }
 
     @Test
-    void shouldMigrateSubMailboxesWhenNewUserHasAlreadyMailbox() throws Exception {
+    void shouldMigrateMailboxesWhenNewUserHasAlreadyOtherMailboxes() throws Exception {
         MailboxSession fromSession = mailboxManager.createSystemSession(ALICE);
         mailboxManager.createMailbox(MailboxPath.forUser(ALICE, "test"), MailboxManager.CreateOption.NONE, fromSession);
         mailboxManager.createMailbox(MailboxPath.forUser(ALICE, "test.child"), MailboxManager.CreateOption.NONE, fromSession);


### PR DESCRIPTION
## Why

Script:
- Bob already has an inbox mailbox (no messages)
- Alice change her username to Bob by webadmin
- Get task status, the result is ABORTED
 
## How to fix it

Keep all old BOB mailbox data (messages, subscriptions...)

- Rename Bob X mailbox -> Bob X-migrating mailbox
- Rename Alice mailbox X -> Bob mailbox X
- Copy messages in Bob X-migrating mailbox to Bob mailbox X, and then delete Bob X-migrating mailbox