### PR TITLE
Add and enable build profiling extensions

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -19,4 +19,28 @@
     <artifactId>common-custom-user-data-maven-extension</artifactId>
     <version>2.0.1</version>
   </extension>
+
+
+<!--    <extension>-->
+<!--        &lt;!&ndash; outputs result directly to the build log &ndash;&gt;-->
+<!--        <groupId>com.soebes.maven.extensions</groupId>-->
+<!--        <artifactId>maven-buildtime-profiler</artifactId>-->
+<!--        <version>0.2.0</version>-->
+<!--    </extension>-->
+
+    <extension>
+        <!-- https://github.com/timgifford/maven-buildtime-extension -->
+        <!-- to run it add `-Dbuildtime.output.log=true` to the mvn command -->
+        <!-- to output to csv file: `-Dbuildtime.output.csv.file=buildtime.csv` -->
+        <groupId>co.leantechniques</groupId>
+        <artifactId>maven-buildtime-extension</artifactId>
+        <version>3.0.5</version>
+    </extension>
+
+    <extension>
+        <!-- requires enabling during execution: `-Dprofile -DprofileFormat=JSON,HTML` -->
+        <groupId>fr.jcgay.maven</groupId>
+        <artifactId>maven-profiler</artifactId>
+        <version>3.2</version>
+    </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Daether.dependencyCollector.impl=bf
+-Dmaven.artifact.threads=5


### PR DESCRIPTION
Adds and enables maven build profiling extensions as per discussion in https://www.mail-archive.com/server-dev@james.apache.org/msg72994.html

I enabled storing profiling artifacts in build - I hope it's ok (IMHO it's better than spamming stdout). `csv` (from `maven-buildtime-extension`) is about ~0,5M and `html` (from `maven-profiler`) is ~1,7M.

EDIT: https://issues.apache.org/jira/browse/JAMES-3879