### PR TITLE
JAMES-2080 Add a dedicated Subject search criterion

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
@@ -750,6 +750,10 @@ public class SearchQuery {
         return new MimeMessageIDCriterion(messageId);
     }
 
+    public static Criterion subject(String subject) {
+        return new SubjectCriterion(subject);
+    }
+
     public static Criterion threadId(ThreadId threadId) {
         return new ThreadIdCriterion(threadId);
     }
@@ -1152,6 +1156,44 @@ public class SearchQuery {
         public String toString() {
             return MoreObjects.toStringHelper(this)
                 .add("messageID", messageID)
+                .toString();
+        }
+    }
+
+    public static class SubjectCriterion extends Criterion {
+        private final String subject;
+
+        public SubjectCriterion(String subject) {
+            this.subject = subject;
+        }
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public HeaderCriterion asHeaderCriterion() {
+            return new HeaderCriterion("Subject", new ContainsOperator(subject));
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (o instanceof SubjectCriterion) {
+                SubjectCriterion that = (SubjectCriterion) o;
+
+                return java.util.Objects.equals(this.subject, that.subject);
+            }
+            return false;
+        }
+
+        @Override
+        public final int hashCode() {
+            return java.util.Objects.hash(subject);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                .add("subject", subject)
                 .toString();
         }
     }

--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
@@ -1245,6 +1245,9 @@ public class LuceneMessageSearchIndex extends ListeningMessageSearchIndex {
         } else if (criterion instanceof SearchQuery.MimeMessageIDCriterion) {
             SearchQuery.MimeMessageIDCriterion mimeMessageIDCriterion = (SearchQuery.MimeMessageIDCriterion) criterion;
             return createHeaderQuery(mimeMessageIDCriterion.asHeaderCriterion());
+        } else if (criterion instanceof SearchQuery.SubjectCriterion) {
+            SearchQuery.SubjectCriterion subjectCriterion = (SearchQuery.SubjectCriterion) criterion;
+            return createHeaderQuery(subjectCriterion.asHeaderCriterion());
         } else if (criterion instanceof SearchQuery.ThreadIdCriterion) {
             SearchQuery.ThreadIdCriterion threadIdCriterion = (SearchQuery.ThreadIdCriterion) criterion;
             return createTermQuery(THREAD_ID_FIELD, threadIdCriterion.getThreadId().serialize());

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/CriterionConverter.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/CriterionConverter.java
@@ -67,6 +67,7 @@ public class CriterionConverter {
         registerCriterionConverter(SearchQuery.MessageIdCriterion.class, this::convertMessageId);
         registerCriterionConverter(SearchQuery.ConjunctionCriterion.class, this::convertConjunction);
         registerCriterionConverter(SearchQuery.HeaderCriterion.class, this::convertHeader);
+        registerCriterionConverter(SearchQuery.SubjectCriterion.class, this::convertSubject);
         registerCriterionConverter(SearchQuery.TextCriterion.class, this::convertTextCriterion);
         registerCriterionConverter(SearchQuery.CustomFlagCriterion.class, this::convertCustomFlagCriterion);
         
@@ -422,6 +423,14 @@ public class CriterionConverter {
             .apply(
                 headerCriterion.getHeaderName().toLowerCase(Locale.US),
                 headerCriterion.getOperator());
+    }
+
+    private Query convertSubject(SearchQuery.SubjectCriterion headerCriterion) {
+        return new MatchQuery.Builder()
+            .field(JsonMessageConstants.SUBJECT)
+            .query(new FieldValue.Builder().stringValue(headerCriterion.getSubject()).build())
+            .build()
+            ._toQuery();
     }
 
     private Query manageAddressFields(String headerName, String value) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/SearchThreadIdGuessingAlgorithm.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/SearchThreadIdGuessingAlgorithm.java
@@ -93,7 +93,7 @@ public class SearchThreadIdGuessingAlgorithm implements ThreadIdGuessingAlgorith
         });
         SearchQuery.Criterion mimeMessageIdCriterion = SearchQuery.or(mimeMessageIdCriteriaBuilder.build());
 
-        SearchQuery.Criterion finalCriterion = subject.map(value -> SearchQuery.and(mimeMessageIdCriterion, SearchQuery.headerContains("Subject", SearchUtil.getBaseSubject(value.getValue()))))
+        SearchQuery.Criterion finalCriterion = subject.map(value -> SearchQuery.and(mimeMessageIdCriterion, SearchQuery.subject(SearchUtil.getBaseSubject(value.getValue()))))
             .orElse(mimeMessageIdCriterion);
 
         return MultimailboxesSearchQuery

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
@@ -188,6 +188,9 @@ public class MessageSearches implements Iterable<SimpleMessageSearchIndex.Search
         } else if (criterion instanceof SearchQuery.MimeMessageIDCriterion) {
             SearchQuery.MimeMessageIDCriterion mimeMessageIDCriterion = (SearchQuery.MimeMessageIDCriterion) criterion;
             return isMatch(mimeMessageIDCriterion.asHeaderCriterion(), message, recentMessageUids);
+        } else if (criterion instanceof SearchQuery.SubjectCriterion) {
+            SearchQuery.SubjectCriterion subjectCriterion = (SearchQuery.SubjectCriterion) criterion;
+            return isMatch(subjectCriterion.asHeaderCriterion(), message, recentMessageUids);
         } else if (criterion instanceof SearchQuery.ThreadIdCriterion) {
             SearchQuery.ThreadIdCriterion threadIdCriterion = (SearchQuery.ThreadIdCriterion) criterion;
             return matches(threadIdCriterion, message);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndex.java
@@ -133,7 +133,8 @@ public class SimpleMessageSearchIndex implements MessageSearchIndex {
         if (crit instanceof SearchQuery.AllCriterion || crit instanceof SearchQuery.TextCriterion) {
             return FetchType.FULL;
         }
-        if (crit instanceof SearchQuery.HeaderCriterion || crit instanceof SearchQuery.MimeMessageIDCriterion) {
+        if (crit instanceof SearchQuery.HeaderCriterion || crit instanceof SearchQuery.MimeMessageIDCriterion
+            || crit instanceof SearchQuery.SubjectCriterion) {
             return FetchType.HEADERS;
         }
         return FetchType.METADATA;

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
@@ -347,7 +347,7 @@ public class SearchProcessor extends AbstractMailboxProcessor<SearchRequest> imp
         case TYPE_SMALLER:
             return SearchQuery.sizeLessThan(key.getSize());
         case TYPE_SUBJECT:
-            return SearchQuery.headerContains(ImapConstants.RFC822_SUBJECT, key.getValue());
+            return SearchQuery.subject(key.getValue());
         case TYPE_TEXT:
             return SearchQuery.mailContains(key.getValue());
         case TYPE_TO:

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
@@ -77,7 +77,7 @@ import it.unimi.dsi.fastutil.longs.LongList;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class SearchProcessorTest {
+class SearchProcessorTest {
     private static final int DAY = 6;
 
     private static final int MONTH = 6;
@@ -424,8 +424,7 @@ public class SearchProcessorTest {
     @Test
     void testSUBJECT() throws Exception {
         expectsGetSelectedMailbox();
-        check(SearchKey.buildSubject(SUBJECT), SearchQuery.headerContains(
-                ImapConstants.RFC822_SUBJECT, SUBJECT));
+        check(SearchKey.buildSubject(SUBJECT), SearchQuery.subject(SUBJECT));
     }
 
     @Test

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/FilterToCriteria.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/utils/FilterToCriteria.java
@@ -56,7 +56,7 @@ public class FilterToCriteria {
                         SearchQuery.address(AddressType.To, text),
                         SearchQuery.address(AddressType.Cc, text),
                         SearchQuery.address(AddressType.Bcc, text),
-                        SearchQuery.headerContains("Subject", text),
+                        SearchQuery.subject(text),
                         SearchQuery.attachmentContains(text),
                         SearchQuery.bodyContains(text),
                         SearchQuery.attachmentFileName(text)))
@@ -65,7 +65,7 @@ public class FilterToCriteria {
         filter.getTo().ifPresent(to -> builder.add(SearchQuery.address(AddressType.To, to)));
         filter.getCc().ifPresent(cc -> builder.add(SearchQuery.address(AddressType.Cc, cc)));
         filter.getBcc().ifPresent(bcc -> builder.add(SearchQuery.address(AddressType.Bcc, bcc)));
-        filter.getSubject().ifPresent(subject -> builder.add(SearchQuery.headerContains("Subject", subject)));
+        filter.getSubject().ifPresent(subject -> builder.add(SearchQuery.subject(subject)));
         filter.getAttachments().ifPresent(attachments ->  builder.add(SearchQuery.attachmentContains(attachments)));
         filter.getBody().ifPresent(body ->  builder.add(SearchQuery.bodyContains(body)));
         filter.getAfter().ifPresent(after -> builder.add(SearchQuery.sentDateAfter(Date.from(after.toInstant()), DateResolution.Second)));

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/utils/FilterToCriteriaTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/utils/FilterToCriteriaTest.java
@@ -123,7 +123,7 @@ public class FilterToCriteriaTest {
                 .subject(subject)
                 .build());
 
-        assertThat(criteria).containsExactly(SearchQuery.headerContains("Subject", subject));
+        assertThat(criteria).containsExactly(SearchQuery.subject(subject));
     }
 
     @Test
@@ -158,7 +158,7 @@ public class FilterToCriteriaTest {
             SearchQuery.address(AddressType.To, text),
             SearchQuery.address(AddressType.Cc, text),
             SearchQuery.address(AddressType.Bcc, text),
-            SearchQuery.headerContains("Subject", text),
+            SearchQuery.subject(text),
             SearchQuery.bodyContains(text),
             SearchQuery.attachmentContains(text),
             SearchQuery.attachmentFileName(text))));
@@ -336,7 +336,7 @@ public class FilterToCriteriaTest {
         assertThat(criteria).containsExactly(SearchQuery.and(ImmutableList.of(
             SearchQuery.address(AddressType.From, from),
             SearchQuery.address(AddressType.To, to),
-            SearchQuery.headerContains("Subject", subject))));
+            SearchQuery.subject(subject))));
     }
 
     @Test
@@ -357,7 +357,7 @@ public class FilterToCriteriaTest {
         assertThat(criteria).containsExactly(SearchQuery.or(ImmutableList.of(
             SearchQuery.address(AddressType.From, from),
             SearchQuery.address(AddressType.To, to),
-            SearchQuery.headerContains("Subject", subject))));
+            SearchQuery.subject(subject))));
     }
 
     @Test
@@ -378,7 +378,7 @@ public class FilterToCriteriaTest {
         assertThat(criteria).containsExactly(SearchQuery.not(ImmutableList.of(
             SearchQuery.address(AddressType.From, from),
             SearchQuery.address(AddressType.To, to),
-            SearchQuery.headerContains("Subject", subject))));
+            SearchQuery.subject(subject))));
     }
 
     @Test

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/utils/search/MailboxFilter.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/utils/search/MailboxFilter.scala
@@ -249,7 +249,7 @@ object MailboxFilter {
               SearchQuery.address(AddressType.Cc, text.value),
               SearchQuery.address(AddressType.Bcc, text.value),
               SearchQuery.address(AddressType.From, text.value),
-              SearchQuery.headerContains("Subject", text.value),
+              SearchQuery.subject(text.value),
               SearchQuery.bodyContains(text.value))
             .asJava)))
         case None => Right(Nil)
@@ -287,7 +287,7 @@ object MailboxFilter {
   case object Subject extends ConditionFilter {
     override def toQuery(filterCondition: FilterCondition): Either[UnsupportedFilterException, List[Criterion]] =
       filterCondition.subject match {
-        case Some(subject) => Right(List(SearchQuery.headerContains("Subject", subject.value)))
+        case Some(subject) => Right(List(SearchQuery.subject(subject.value)))
         case None => Right(Nil)
       }
   }


### PR DESCRIPTION
This enable hitting the subject field whose indexing can be separately tuned (language?)

This also avoids relying on nested entities for subject search.

https://github.com/apache/james-project/pull/988