### PR TITLE
JAMES-3775 DockerClamAV - update waiting strategy

### DIFF
--- a/third-party/clamav/src/test/java/org/apache/james/clamav/DockerClamAV.java
+++ b/third-party/clamav/src/test/java/org/apache/james/clamav/DockerClamAV.java
@@ -22,6 +22,7 @@ package org.apache.james.clamav;
 import java.time.Duration;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 public class DockerClamAV {
@@ -36,7 +37,8 @@ public class DockerClamAV {
             .withExposedPorts(DEFAULT_PORT)
             .withEnv("CLAMAV_NO_FRESHCLAMD", "true")
             .withEnv("CLAMAV_NO_MILTERD", "true")
-            .withStartupTimeout(Duration.ofMinutes(2));
+            .waitingFor(new LogMessageWaitStrategy().withRegEx(".*clamd started.*\\n").withTimes(1)
+                .withStartupTimeout(Duration.ofMinutes(5)));
     }
 
     public Integer getPort() {


### PR DESCRIPTION
## Why

The CI sometimes fails because cannot start to succeed the docker ClamAV

```
Stable Tests
[ERROR] o.a.j.c.ClamAVScan - Exception thrown

java.net.ConnectException: maxPings exceeded: 2. Giving up. The clamd daemon seems not to be running
```
