### PR TITLE
JAMES-2080 Allow turning off header indexing in OpenSearch

### DIFF
--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/IndexHeaders.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/IndexHeaders.java
@@ -1,0 +1,24 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.opensearch;
+
+public enum IndexHeaders {
+    NO, YES
+}

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/OpenSearchMailboxConfiguration.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/OpenSearchMailboxConfiguration.java
@@ -34,12 +34,14 @@ public class OpenSearchMailboxConfiguration {
         private Optional<ReadAliasName> readAliasMailboxName;
         private Optional<WriteAliasName> writeAliasMailboxName;
         private Optional<IndexAttachments> indexAttachment;
+        private Optional<IndexHeaders> indexHeaders;
 
         Builder() {
             indexMailboxName = Optional.empty();
             readAliasMailboxName = Optional.empty();
             writeAliasMailboxName = Optional.empty();
             indexAttachment = Optional.empty();
+            indexHeaders = Optional.empty();
         }
 
         Builder indexMailboxName(Optional<IndexName> indexMailboxName) {
@@ -57,20 +59,23 @@ public class OpenSearchMailboxConfiguration {
             return this;
         }
 
-
         Builder indexAttachment(IndexAttachments indexAttachment) {
             this.indexAttachment = Optional.of(indexAttachment);
             return this;
         }
 
-
+        Builder indexHeaders(IndexHeaders indexHeaders) {
+            this.indexHeaders = Optional.of(indexHeaders);
+            return this;
+        }
 
         public OpenSearchMailboxConfiguration build() {
             return new OpenSearchMailboxConfiguration(
                 indexMailboxName.orElse(MailboxOpenSearchConstants.DEFAULT_MAILBOX_INDEX),
                 readAliasMailboxName.orElse(MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS),
                 writeAliasMailboxName.orElse(MailboxOpenSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
-                indexAttachment.orElse(IndexAttachments.YES));
+                indexAttachment.orElse(IndexAttachments.YES),
+                indexHeaders.orElse(IndexHeaders.YES));
         }
     }
 
@@ -85,7 +90,9 @@ public class OpenSearchMailboxConfiguration {
     private static final String OPENSEARCH_ALIAS_READ_MAILBOX_NAME = "opensearch.alias.read.mailbox.name";
     private static final String OPENSEARCH_ALIAS_WRITE_MAILBOX_NAME = "opensearch.alias.write.mailbox.name";
     private static final String OPENSEARCH_INDEX_ATTACHMENTS = "opensearch.indexAttachments";
+    private static final String OPENSEARCH_INDEX_HEADERS = "opensearch.indexHeaders";
     private static final boolean DEFAULT_INDEX_ATTACHMENTS = true;
+    private static final boolean DEFAULT_INDEX_HEADERS = true;
 
     public static final OpenSearchMailboxConfiguration DEFAULT_CONFIGURATION = builder().build();
 
@@ -95,6 +102,7 @@ public class OpenSearchMailboxConfiguration {
             .readAliasMailboxName(computeMailboxReadAlias(configuration))
             .writeAliasMailboxName(computeMailboxWriteAlias(configuration))
             .indexAttachment(provideIndexAttachments(configuration))
+            .indexHeaders(provideIndexHeaders(configuration))
             .build();
     }
 
@@ -119,28 +127,34 @@ public class OpenSearchMailboxConfiguration {
                 .map(ReadAliasName::new));
     }
 
-
     private static IndexAttachments provideIndexAttachments(Configuration configuration) {
         if (configuration.getBoolean(OPENSEARCH_INDEX_ATTACHMENTS, DEFAULT_INDEX_ATTACHMENTS)) {
             return IndexAttachments.YES;
         }
         return IndexAttachments.NO;
     }
-
+    
+    private static IndexHeaders provideIndexHeaders(Configuration configuration) {
+        if (configuration.getBoolean(OPENSEARCH_INDEX_HEADERS, DEFAULT_INDEX_HEADERS)) {
+            return IndexHeaders.YES;
+        }
+        return IndexHeaders.NO;
+    }
 
     private final IndexName indexMailboxName;
     private final ReadAliasName readAliasMailboxName;
     private final WriteAliasName writeAliasMailboxName;
     private final IndexAttachments indexAttachment;
+    private final IndexHeaders indexHeaders;
 
     private OpenSearchMailboxConfiguration(IndexName indexMailboxName, ReadAliasName readAliasMailboxName,
-                                           WriteAliasName writeAliasMailboxName, IndexAttachments indexAttachment) {
+                                           WriteAliasName writeAliasMailboxName, IndexAttachments indexAttachment, IndexHeaders indexHeaders) {
         this.indexMailboxName = indexMailboxName;
         this.readAliasMailboxName = readAliasMailboxName;
         this.writeAliasMailboxName = writeAliasMailboxName;
         this.indexAttachment = indexAttachment;
+        this.indexHeaders = indexHeaders;
     }
-
 
     public IndexName getIndexMailboxName() {
         return indexMailboxName;
@@ -158,12 +172,17 @@ public class OpenSearchMailboxConfiguration {
         return indexAttachment;
     }
 
+    public IndexHeaders getIndexHeaders() {
+        return indexHeaders;
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof OpenSearchMailboxConfiguration) {
             OpenSearchMailboxConfiguration that = (OpenSearchMailboxConfiguration) o;
 
             return Objects.equals(this.indexAttachment, that.indexAttachment)
+                && Objects.equals(this.indexHeaders, that.indexHeaders)
                 && Objects.equals(this.indexMailboxName, that.indexMailboxName)
                 && Objects.equals(this.readAliasMailboxName, that.readAliasMailboxName)
                 && Objects.equals(this.writeAliasMailboxName, that.writeAliasMailboxName);
@@ -173,6 +192,6 @@ public class OpenSearchMailboxConfiguration {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(indexMailboxName, readAliasMailboxName, writeAliasMailboxName, indexAttachment, writeAliasMailboxName);
+        return Objects.hash(indexMailboxName, readAliasMailboxName, writeAliasMailboxName, indexAttachment, indexHeaders, writeAliasMailboxName);
     }
 }

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/MessageToOpenSearchJson.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/json/MessageToOpenSearchJson.java
@@ -27,6 +27,7 @@ import javax.mail.Flags;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -44,19 +45,21 @@ public class MessageToOpenSearchJson {
     private final TextExtractor textExtractor;
     private final ZoneId zoneId;
     private final IndexAttachments indexAttachments;
+    private final IndexHeaders indexHeaders;
 
-    public MessageToOpenSearchJson(TextExtractor textExtractor, ZoneId zoneId, IndexAttachments indexAttachments) {
+    public MessageToOpenSearchJson(TextExtractor textExtractor, ZoneId zoneId, IndexAttachments indexAttachments, IndexHeaders indexHeaders) {
         this.textExtractor = textExtractor;
         this.zoneId = zoneId;
         this.indexAttachments = indexAttachments;
+        this.indexHeaders = indexHeaders;
         this.mapper = new ObjectMapper();
         this.mapper.registerModule(new GuavaModule());
         this.mapper.registerModule(new Jdk8Module());
     }
 
     @Inject
-    public MessageToOpenSearchJson(TextExtractor textExtractor, IndexAttachments indexAttachments) {
-        this(textExtractor, ZoneId.systemDefault(), indexAttachments);
+    public MessageToOpenSearchJson(TextExtractor textExtractor, IndexAttachments indexAttachments, IndexHeaders indexHeaders) {
+        this(textExtractor, ZoneId.systemDefault(), indexAttachments, indexHeaders);
     }
 
     public Mono<String> convertToJson(MailboxMessage message) {
@@ -67,6 +70,7 @@ public class MessageToOpenSearchJson {
             .extractor(textExtractor)
             .zoneId(zoneId)
             .indexAttachments(indexAttachments)
+            .indexHeaders(indexHeaders)
             .build()
             .map(Throwing.function(mapper::writeValueAsString));
     }
@@ -77,6 +81,7 @@ public class MessageToOpenSearchJson {
             .extractor(textExtractor)
             .zoneId(zoneId)
             .indexAttachments(IndexAttachments.NO)
+            .indexHeaders(indexHeaders)
             .build()
             .map(Throwing.function(mapper::writeValueAsString));
     }

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchIntegrationTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchIntegrationTest.java
@@ -135,7 +135,7 @@ class OpenSearchIntegrationTest extends AbstractMessageSearchIndexTest {
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
-                new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES),
+                new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory))
             .noPreDeletionHooks()
             .storeQuotaManager()

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndexTest.java
@@ -67,6 +67,7 @@ import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.opensearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.opensearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.opensearch.MailboxOpenSearchConstants;
@@ -188,7 +189,8 @@ class OpenSearchListeningMessageSearchIndexTest {
         MessageToOpenSearchJson messageToOpenSearchJson = new MessageToOpenSearchJson(
             new DefaultTextExtractor(),
             ZoneId.of("UTC"),
-            IndexAttachments.YES);
+            IndexAttachments.YES,
+            IndexHeaders.YES);
 
         InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
 
@@ -272,7 +274,8 @@ class OpenSearchListeningMessageSearchIndexTest {
         MessageToOpenSearchJson messageToOpenSearchJson = new MessageToOpenSearchJson(
             new FailingTextExtractor(),
             ZoneId.of("Europe/Paris"),
-            IndexAttachments.YES);
+            IndexAttachments.YES,
+            IndexHeaders.YES);
 
         testee = new OpenSearchListeningMessageSearchIndex(mapperFactory,
             ImmutableSet.of(), openSearchIndexer, openSearchSearcher,

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/IndexableMessageTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/json/IndexableMessageTest.java
@@ -44,6 +44,7 @@ import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.tika.TikaConfiguration;
@@ -112,6 +113,7 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.YES)
                 .build()
                 .block();
 
@@ -145,6 +147,7 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.NO)
+                .indexHeaders(IndexHeaders.YES)
                 .build()
                 .block();
 
@@ -176,11 +179,44 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.NO)
+                .indexHeaders(IndexHeaders.YES)
                 .build()
                 .block();
 
         // Then
         assertThat(indexableMessage.getAttachments()).isEmpty();
+    }
+
+    @Test
+    void headersShouldNotBeenIndexedWhenAsked() throws Exception {
+        //Given
+        MailboxMessage mailboxMessage = mock(MailboxMessage.class);
+        TestId mailboxId = TestId.of(1);
+        when(mailboxMessage.getMailboxId())
+            .thenReturn(mailboxId);
+        when(mailboxMessage.getModSeq())
+            .thenReturn(ModSeq.first());
+        when(mailboxMessage.getMessageId())
+            .thenReturn(InMemoryMessageId.of(42));
+        when(mailboxMessage.getFullContent())
+            .thenReturn(ClassLoader.getSystemResourceAsStream("eml/mailWithHeaders.eml"));
+        when(mailboxMessage.createFlags())
+            .thenReturn(new Flags());
+        when(mailboxMessage.getUid())
+            .thenReturn(MESSAGE_UID);
+
+        // When
+        IndexableMessage indexableMessage = IndexableMessage.builder()
+                .message(mailboxMessage)
+                .extractor(new DefaultTextExtractor())
+                .zoneId(ZoneId.of("Europe/Paris"))
+                .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.NO)
+                .build()
+                .block();
+
+        // Then
+        assertThat(indexableMessage.getHeaders()).isEmpty();
     }
 
     @Test
@@ -207,6 +243,7 @@ class IndexableMessageTest {
                 .extractor(new DefaultTextExtractor())
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.YES)
                 .build()
                 .block();
 
@@ -246,6 +283,7 @@ class IndexableMessageTest {
                 .extractor(textExtractor)
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.YES)
                 .build()
                 .block();
 
@@ -283,6 +321,7 @@ class IndexableMessageTest {
                 .extractor(textExtractor)
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.YES)
                 .build()
                 .block();
 
@@ -317,6 +356,7 @@ class IndexableMessageTest {
             .extractor(textExtractor)
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.YES)
             .build()
             .block();
 
@@ -348,6 +388,7 @@ class IndexableMessageTest {
                 .extractor(textExtractor)
                 .zoneId(ZoneId.of("Europe/Paris"))
                 .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.YES)
                 .build()
                 .block();
 
@@ -381,6 +422,7 @@ class IndexableMessageTest {
             .extractor(textExtractor)
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.YES)
+                .indexHeaders(IndexHeaders.YES)
             .build()
             .block();
 
@@ -415,6 +457,7 @@ class IndexableMessageTest {
             .extractor(new DefaultTextExtractor())
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.NO)
+            .indexHeaders(IndexHeaders.YES)
             .build()
             .block();
 
@@ -451,6 +494,7 @@ class IndexableMessageTest {
             .extractor(new DefaultTextExtractor())
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.NO)
+            .indexHeaders(IndexHeaders.YES)
             .build()
             .block();
 
@@ -486,6 +530,7 @@ class IndexableMessageTest {
             .extractor(new DefaultTextExtractor())
             .zoneId(ZoneId.of("Europe/Paris"))
             .indexAttachments(IndexAttachments.NO)
+            .indexHeaders(IndexHeaders.YES)
             .build()
             .block();
 

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcherTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcherTest.java
@@ -47,6 +47,7 @@ import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MultimailboxesSearchQuery;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.opensearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.opensearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.opensearch.MailboxOpenSearchConstants;
@@ -124,7 +125,7 @@ class OpenSearchSearcherTest {
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
-                new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES),
+                new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory))
             .noPreDeletionHooks()
             .storeQuotaManager()

--- a/mailbox/store/src/test/resources/eml/spamMailNoHeaders.json
+++ b/mailbox/store/src/test/resources/eml/spamMailNoHeaders.json
@@ -1,0 +1,45 @@
+{
+  "messageId":"184",
+  "threadId": "184",
+  "uid":25,
+  "mailboxId": "18",
+  "modSeq": 42,
+  "size": 25,
+  "date": "2015-06-07T00:00:00+0200",
+  "saveDate": null,
+  "mediaType": "plain",
+  "subtype": "text",
+  "mimeMessageID": "<VASs-IZaXqmZao@spam.minet.net>",
+  "userFlags": [],
+  "headers": [],
+  "from": [
+	{
+	  "name": "Content-filter at spam.minet.net",
+	  "address": "postmaster@minet.net",
+	  "domain": "minet"
+	}
+  ],
+  "to": [
+	{
+	  "name": null,
+	  "address": "root@listes.minet.net",
+      "domain": "listes.minet"
+	}
+  ],
+  "cc": [],
+  "bcc": [],
+  "subject": [
+	"[root] UNCHECKED contents in mail FROM <quentin.h@riseup.net>"
+  ],
+  "sentDate": "2015-06-03T09:05:46+0000",
+  "attachments": [],
+  "textBody": "No viruses were found.\r\n\r\nContent type: Unchecked\r\nInternal reference code for the message is 12583-16/Ss-IZaXqmZao\r\n\r\nAccording to a 'Received:' trace, the message apparently originated at:\r\n  [198.252.153.129], [127.0.0.1] localhost [127.0.0.1] Authenticated sender:\r\n  quentin.h\r\n\r\nReturn-Path: <quentin.h@riseup.net>\r\nFrom: Quentin <quentin.h@riseup.net>\r\nMessage-ID: <556EC361.6000308@riseup.net>\r\nSubject: =?UTF-8?B?UmU6IEZ3ZDogW1RtcGxhYl0gW0FQUEVMIEEgUEFSVElDSVBBVElPTl0=?=\r\n  =?UTF-8?B?IFdvb3QgZGV2aWNlcyAjMiAgOiB2ZW5leiBmYWlyZSBsZXVyIGhhY2tmw6p0ZSA=?=\r\n  =?UTF-8?B?YXV4IHBldGl0ZXMgbWFjaGluZXMgcHJvZ3JhbW1hYmxlcyBsZXMgNi03IGp1aW4=?=\r\n  =?UTF-8?B?IGF1IEphcmRpbiBkJ2FsaWNlL0JsYWNrbG9vcA==?=\r\nNot quarantined.\r\n\r\nThe message WILL BE relayed to:\r\n<yann@minet.net>\r\n\r\n",
+  "htmlBody": null,
+  "isAnswered": false,
+  "isDeleted": false,
+  "isDraft": false,
+  "isFlagged": false,
+  "isRecent": false,
+  "hasAttachment": false,
+  "isUnread": true
+}

--- a/mpt/impl/imap-mailbox/opensearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/OpenSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/opensearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/OpenSearchHostSystem.java
@@ -38,6 +38,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.opensearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.opensearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.opensearch.MailboxOpenSearchConstants;
@@ -103,7 +104,7 @@ public class OpenSearchHostSystem extends JamesImapHostSystem {
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), OpenSearchSearcher.DEFAULT_SEARCH_SIZE,
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
-                new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES),
+                new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory))
             .noPreDeletionHooks()
             .storeQuotaManager()

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/opensearch.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/opensearch.adoc
@@ -85,6 +85,12 @@ The target of the alias is the index name configured above.
 
 | opensearch.indexAttachments
 | Indicates if you wish to index attachments or not (default: true).
+
+| opensearch.indexHeaders
+| Indicates if you wish to index headers or not (default: true). Note that specific headers
+(From, To, Cc, Bcc, Subject, Message-Id, Date, Content-Type) are still indexed in their dedicated type.
+Header indexing is expensive as each header currently need to be stored as a nested document but
+turning off headers indexing result in non-strict compliance with the IMAP / JMAP standards.
 |===
 
 === Quota search

--- a/server/container/guice/opensearch/src/main/java/org/apache/james/modules/mailbox/OpenSearchMailboxModule.java
+++ b/server/container/guice/opensearch/src/main/java/org/apache/james/modules/mailbox/OpenSearchMailboxModule.java
@@ -39,6 +39,7 @@ import org.apache.james.lifecycle.api.StartUpCheck;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.opensearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.opensearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.opensearch.MailboxOpenSearchConstants;
@@ -180,11 +181,16 @@ public class OpenSearchMailboxModule extends AbstractModule {
         return configuration.getIndexAttachment();
     }
 
+    @Provides
+    @Singleton
+    public IndexHeaders provideIndexHeaders(OpenSearchMailboxConfiguration configuration) {
+        return configuration.getIndexHeaders();
+    }
+
     @ProvidesIntoSet
     InitializationOperation createIndex(MailboxIndexCreator instance) {
         return InitilizationOperationBuilder
             .forClass(MailboxIndexCreator.class)
             .init(instance::createIndex);
     }
-
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -67,6 +67,7 @@ import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.opensearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.opensearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.opensearch.MailboxOpenSearchConstants;
@@ -161,7 +162,7 @@ class MailboxesRoutesTest {
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
-                new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES),
+                new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory))
             .noPreDeletionHooks()
             .storeQuotaManager()

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -90,6 +90,7 @@ import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.opensearch.IndexAttachments;
+import org.apache.james.mailbox.opensearch.IndexHeaders;
 import org.apache.james.mailbox.opensearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.opensearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.opensearch.MailboxOpenSearchConstants;
@@ -1479,7 +1480,7 @@ class UserMailboxesRoutesTest {
                         MailboxOpenSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                     new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,
                         MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
-                    new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES),
+                    new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                     preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory))
                 .noPreDeletionHooks()
                 .storeQuotaManager()

--- a/src/site/xdoc/server/config-opensearch.xml
+++ b/src/site/xdoc/server/config-opensearch.xml
@@ -113,6 +113,11 @@
           <dd>Minimum delay between connection attempts</dd>
           <dt><strong>opensearch.indexAttachments</strong></dt>
           <dd>Indicates if you wish to index attachments or not (default: true).</dd>
+          <dt><strong>opensearch.indexHeaders</strong></dt>
+          <dd>Indicates if you wish to index headers or not (default: true). Note that specific headers
+              (From, To, Cc, Bcc, Subject, Message-Id, Date, Content-Type) are still indexed in their dedicated type.
+              Header indexing is expensive as each header currently need to be stored as a nested document but
+              turning off headers indexing result in non-strict compliance with the IMAP / JMAP standards.</dd>
           <dt><strong>opensearch.index.quota.ratio.name</strong></dt>
           <dd>Specify the OpenSearch alias name used for quotas</dd>
           <dt><strong>opensearch.alias.read.quota.ratio.name</strong></dt>


### PR DESCRIPTION
Indicates if you wish to index headers or not (default: true). Note that specific headers (From, To, Cc, Bcc, Subject, Message-Id, Date, Content-Type) are still indexed in their dedicated type. Header indexing is expensive as each header currently need to be stored as a nested document but turning off headers indexing result in non-strict compliance with the IMAP / JMAP standards.

## Before

Indexing 5.000 mails takes ~1 minute and occupies 26MB of index (5KB perf mail) which is consistant with our production mertics. The commit log is more bulky and with index occupies 185 MB.

## After

Indexing 10.000 takes ~ 76s and occupies 6.9 MB of index (690 B / mails). The commit log is more bulky and with index occupies 62 MB.

## Conclusion

This change allows a dramatic space reduction on OpenSearch (cost saving!) of ~ x8 for the tested workload. We also observed a x2 speedup of the indexation process.