### PR TITLE
JAMES-3777 Mitigate performance problems with JMAP filters

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmap.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmap.adoc
@@ -87,6 +87,11 @@ then `capabilities."urn:ietf:params:jmap:websocket".url` in response will be "ws
 | webpush.prevent.server.side.request.forgery
 | Optional boolean. Prevent server side request forgery by preventing calls to the private network ranges. Defaults to true, can be disabled for testing.
 
+| cassandra.filter.projection.activated
+|Optional boolean. Defaults to false. Casandra backends only. Whether to use or not the Cassandra projection
+for JMAP filters. This projection optimizes reads, but needs to be correctly populated. Turning it on on
+systems with filters already defined would result in those filters to be not read.
+
 |===
 
 == Wire tapping

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/operate/webadmin.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/operate/webadmin.adoc
@@ -1044,6 +1044,37 @@ Response codes:
 * 201: Success. Corresponding task id is returned.
 * 400: Error in the request. Details can be found in the reported error.
 
+==== Recomputing Cassandra filtering projection
+
+You can force the reset of the Cassandra filtering projection by calling the following
+endpoint:
+
+....
+curl -XPOST /mailboxes?task=populateFilteringProjection
+....
+
+Will schedule a task.
+
+link:#_endpoints_returning_a_task[More details about endpoints returning
+a task].
+
+The scheduled task will have the following type
+`PopulateFilteringProjectionTask` and the following
+`additionalInformation`:
+
+....
+{
+  "type":"RecomputeAllPreviewsTask",
+  "processedUserCount": 3,
+  "failedUserCount": 2
+}
+....
+
+Response codes:
+
+* 201: Success. Corresponding task id is returned.
+* 400: Error in the request. Details can be found in the reported error.
+
 ==== ReIndexing action
 
 Be also aware of the limits of this API:

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/data/CassandraJmapModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/data/CassandraJmapModule.java
@@ -82,6 +82,7 @@ public class CassandraJmapModule extends AbstractModule {
         bind(CustomIdentityDAO.class).to(CassandraCustomIdentityDAO.class);
 
         bind(CassandraFilteringProjection.class).in(Scopes.SINGLETON);
+        bind(EventSourcingFilteringManagement.ReadProjection.class).to(CassandraFilteringProjection.class);
 
         bind(CassandraPushSubscriptionRepository.class).in(Scopes.SINGLETON);
         bind(PushSubscriptionRepository.class).to(CassandraPushSubscriptionRepository.class);

--- a/server/container/guice/memory/src/main/java/org/apache/james/modules/data/MemoryDataJmapModule.java
+++ b/server/container/guice/memory/src/main/java/org/apache/james/modules/data/MemoryDataJmapModule.java
@@ -58,6 +58,7 @@ public class MemoryDataJmapModule extends AbstractModule {
 
         bind(EventSourcingFilteringManagement.class).in(Scopes.SINGLETON);
         bind(FilteringManagement.class).to(EventSourcingFilteringManagement.class);
+        bind(EventSourcingFilteringManagement.ReadProjection.class).to(EventSourcingFilteringManagement.NoReadProjection.class);
 
         bind(DefaultTextExtractor.class).in(Scopes.SINGLETON);
         bind(TextExtractor.class).to(JsoupTextExtractor.class);

--- a/server/container/guice/protocols/webadmin-jmap/src/main/java/org/apache/james/modules/server/JmapTaskSerializationModule.java
+++ b/server/container/guice/protocols/webadmin-jmap/src/main/java/org/apache/james/modules/server/JmapTaskSerializationModule.java
@@ -18,16 +18,20 @@
  ****************************************************************/
 package org.apache.james.modules.server;
 
+import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 import org.apache.james.server.task.json.dto.TaskDTO;
 import org.apache.james.server.task.json.dto.TaskDTOModule;
 import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.user.api.UsersRepository;
 import org.apache.james.webadmin.data.jmap.EmailQueryViewPopulator;
 import org.apache.james.webadmin.data.jmap.MessageFastViewProjectionCorrector;
 import org.apache.james.webadmin.data.jmap.PopulateEmailQueryViewTask;
 import org.apache.james.webadmin.data.jmap.PopulateEmailQueryViewTaskAdditionalInformationDTO;
+import org.apache.james.webadmin.data.jmap.PopulateFilteringProjectionTask;
+import org.apache.james.webadmin.data.jmap.PopulateFilteringProjectionTaskAdditionalInformationDTO;
 import org.apache.james.webadmin.data.jmap.RecomputeAllFastViewProjectionItemsTask;
 import org.apache.james.webadmin.data.jmap.RecomputeAllFastViewTaskAdditionalInformationDTO;
 import org.apache.james.webadmin.data.jmap.RecomputeUserFastViewProjectionItemsTask;
@@ -47,6 +51,13 @@ public class JmapTaskSerializationModule extends AbstractModule {
     @ProvidesIntoSet
     public TaskDTOModule<? extends Task, ? extends TaskDTO> populateEmailQueryViewTask(EmailQueryViewPopulator populator) {
         return PopulateEmailQueryViewTask.module(populator);
+    }
+
+    @ProvidesIntoSet
+    public TaskDTOModule<? extends Task, ? extends TaskDTO> populateFilteringProjectionTask(EventSourcingFilteringManagement.NoReadProjection noReadProjection,
+                                                                                            EventSourcingFilteringManagement.ReadProjection readProjection,
+                                                                                            UsersRepository usersRepository) {
+        return PopulateFilteringProjectionTask.module(noReadProjection, readProjection, usersRepository);
     }
 
     @ProvidesIntoSet
@@ -74,6 +85,17 @@ public class JmapTaskSerializationModule extends AbstractModule {
     @ProvidesIntoSet
     public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends  AdditionalInformationDTO> webAdminPopulateEmailQueryViewAdditionalInformation() {
         return PopulateEmailQueryViewTaskAdditionalInformationDTO.module();
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends  AdditionalInformationDTO> populateFilteringProjectionAdditionalInformation() {
+        return PopulateFilteringProjectionTaskAdditionalInformationDTO.module();
+    }
+
+    @Named(DTOModuleInjections.WEBADMIN_DTO)
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends  AdditionalInformationDTO> webAdminPopulateFilteringProjectionAdditionalInformation() {
+        return PopulateFilteringProjectionTaskAdditionalInformationDTO.module();
     }
 
     @ProvidesIntoSet

--- a/server/container/guice/protocols/webadmin-jmap/src/main/java/org/apache/james/modules/server/JmapTasksModule.java
+++ b/server/container/guice/protocols/webadmin-jmap/src/main/java/org/apache/james/modules/server/JmapTasksModule.java
@@ -20,6 +20,7 @@
 package org.apache.james.modules.server;
 
 import org.apache.james.webadmin.data.jmap.PopulateEmailQueryViewRequestToTask;
+import org.apache.james.webadmin.data.jmap.PopulateFilteringProjectionRequestToTask;
 import org.apache.james.webadmin.data.jmap.RecomputeAllFastViewProjectionItemsRequestToTask;
 import org.apache.james.webadmin.data.jmap.RecomputeUserFastViewProjectionItemsRequestToTask;
 import org.apache.james.webadmin.routes.MailboxesRoutes;
@@ -40,6 +41,9 @@ public class JmapTasksModule extends AbstractModule {
 
         Multibinder.newSetBinder(binder(), TaskFromRequestRegistry.TaskRegistration.class, Names.named(MailboxesRoutes.ALL_MAILBOXES_TASKS))
             .addBinding().to(PopulateEmailQueryViewRequestToTask.class);
+
+        Multibinder.newSetBinder(binder(), TaskFromRequestRegistry.TaskRegistration.class, Names.named(MailboxesRoutes.ALL_MAILBOXES_TASKS))
+            .addBinding().to(PopulateFilteringProjectionRequestToTask.class);
 
         Multibinder.newSetBinder(binder(), TaskFromRequestRegistry.TaskRegistration.class, Names.named(UserMailboxesRoutes.USER_MAILBOXES_OPERATIONS_INJECTION_KEY))
             .addBinding().to(RecomputeUserFastViewProjectionItemsRequestToTask.class);

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/CassandraFilteringProjection.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/CassandraFilteringProjection.java
@@ -17,7 +17,6 @@ import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
 import org.apache.james.core.Username;
 import org.apache.james.eventsourcing.Event;
 import org.apache.james.eventsourcing.ReactiveSubscriber;
-import org.apache.james.eventsourcing.Subscriber;
 import org.apache.james.jmap.api.filtering.Rules;
 import org.apache.james.jmap.api.filtering.Version;
 import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
@@ -91,7 +90,7 @@ public class CassandraFilteringProjection implements EventSourcingFilteringManag
     }
 
     @Override
-    public Optional<Subscriber> subscriber() {
+    public Optional<ReactiveSubscriber> subscriber() {
         return Optional.of(this);
     }
 

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/CassandraFilteringProjection.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/CassandraFilteringProjection.java
@@ -1,0 +1,119 @@
+package org.apache.james.jmap.cassandra.filtering;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
+import static org.apache.james.jmap.cassandra.filtering.CassandraFilteringProjectionModule.AGGREGATE_ID;
+import static org.apache.james.jmap.cassandra.filtering.CassandraFilteringProjectionModule.EVENT_ID;
+import static org.apache.james.jmap.cassandra.filtering.CassandraFilteringProjectionModule.RULES;
+import static org.apache.james.jmap.cassandra.filtering.CassandraFilteringProjectionModule.TABLE_NAME;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.core.Username;
+import org.apache.james.eventsourcing.Event;
+import org.apache.james.eventsourcing.ReactiveSubscriber;
+import org.apache.james.eventsourcing.Subscriber;
+import org.apache.james.jmap.api.filtering.Rules;
+import org.apache.james.jmap.api.filtering.Version;
+import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
+import org.apache.james.jmap.api.filtering.impl.FilteringAggregateId;
+import org.apache.james.jmap.api.filtering.impl.RuleSetDefined;
+import org.reactivestreams.Publisher;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import reactor.core.publisher.Mono;
+
+public class CassandraFilteringProjection implements EventSourcingFilteringManagement.ReadProjection, ReactiveSubscriber {
+    private final CassandraAsyncExecutor executor;
+
+    private final PreparedStatement insertStatement;
+    private final PreparedStatement readStatement;
+    private final PreparedStatement readVersionStatement;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public CassandraFilteringProjection(CqlSession session) {
+        executor = new CassandraAsyncExecutor(session);
+
+        insertStatement = session.prepare(insertInto(TABLE_NAME)
+            .value(AGGREGATE_ID, bindMarker(AGGREGATE_ID))
+            .value(EVENT_ID, bindMarker(EVENT_ID))
+            .value(RULES, bindMarker(RULES))
+            .build());
+        readStatement = session.prepare(selectFrom(TABLE_NAME).all()
+            .whereColumn(AGGREGATE_ID).isEqualTo(bindMarker(AGGREGATE_ID))
+            .build());
+        readVersionStatement = session.prepare(selectFrom(TABLE_NAME).column(EVENT_ID)
+            .whereColumn(AGGREGATE_ID).isEqualTo(bindMarker(AGGREGATE_ID))
+            .build());
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public Publisher<Rules> listRulesForUser(Username username) {
+        return executor.executeSingleRow(readStatement.bind()
+            .setString(AGGREGATE_ID, new FilteringAggregateId(username).asAggregateKey()))
+            .handle((row, sink) -> {
+                try {
+                    Rules rules = parseRules(row);
+                    sink.next(rules);
+                } catch (JsonProcessingException e) {
+                    sink.error(e);
+                }
+            });
+    }
+
+    @Override
+    public Publisher<Version> getLatestVersion(Username username) {
+        return executor.executeSingleRow(readVersionStatement.bind()
+            .setString(AGGREGATE_ID, new FilteringAggregateId(username).asAggregateKey()))
+            .map(this::parseVersion);
+    }
+
+    @Override
+    public Publisher<Void> handleReactive(Event event) {
+        if (event instanceof RuleSetDefined) {
+            return persist((RuleSetDefined) event);
+        }
+        throw new RuntimeException("Unsupported event");
+    }
+
+    @Override
+    public Optional<Subscriber> subscriber() {
+        return Optional.of(this);
+    }
+
+    private Mono<Void> persist(RuleSetDefined ruleSetDefined) {
+        try {
+            return executor.executeVoid(insertStatement.bind()
+                .setString(AGGREGATE_ID, ruleSetDefined.getAggregateId().asAggregateKey())
+                .setInt(EVENT_ID, ruleSetDefined.eventId().value())
+                .setString(RULES, objectMapper.writeValueAsString(RuleDTO.from(ruleSetDefined.getRules()))));
+        } catch (JsonProcessingException e) {
+            return Mono.error(e);
+        }
+    }
+
+    private Version parseVersion(Row row) {
+        return new Version(row.getInt(EVENT_ID));
+    }
+
+    private Rules parseRules(Row row) throws JsonProcessingException {
+        String serializedRules = row.getString(RULES);
+        List<RuleDTO> ruleDTOS = objectMapper.readValue(serializedRules, new TypeReference<>() {});
+        Version version = parseVersion(row);
+        return new Rules(RuleDTO.toRules(ruleDTOS), version);
+    }
+}

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/CassandraFilteringProjectionModule.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/CassandraFilteringProjectionModule.java
@@ -17,26 +17,26 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.jmap.api.filtering.impl;
+package org.apache.james.jmap.cassandra.filtering;
 
-import org.apache.james.eventsourcing.eventstore.EventStore;
-import org.apache.james.eventsourcing.eventstore.memory.InMemoryEventStore;
-import org.apache.james.eventsourcing.eventstore.memory.InMemoryEventStoreExtension;
-import org.apache.james.jmap.api.filtering.FilteringManagement;
-import org.apache.james.jmap.api.filtering.FilteringManagementContract;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
+import static com.datastax.oss.driver.api.core.type.DataTypes.INT;
+import static com.datastax.oss.driver.api.core.type.DataTypes.TEXT;
+import static com.datastax.oss.driver.api.core.type.DataTypes.frozenListOf;
 
-public class InMemoryEventSourcingFilteringManagementTest implements FilteringManagementContract {
-    private EventStore eventStore;
+import org.apache.james.backends.cassandra.components.CassandraModule;
 
-    @BeforeEach
-    void setUp() {
-        eventStore = new InMemoryEventStore();
-    }
+public interface CassandraFilteringProjectionModule {
+    String TABLE_NAME = "filters_projection";
 
-    @Override
-    public FilteringManagement instantiateFilteringManagement() {
-        return new EventSourcingFilteringManagement(eventStore);
-    }
+    String AGGREGATE_ID = "aggregate_id";
+    String EVENT_ID = "event_id";
+    String RULES = "rules";
+
+    CassandraModule MODULE = CassandraModule.table(TABLE_NAME)
+        .comment("Holds read projection for the event sourcing system managing JMAP filters.")
+        .statement(statement -> types -> statement
+            .withPartitionKey(AGGREGATE_ID, TEXT)
+            .withColumn(EVENT_ID, INT)
+            .withColumn(RULES, TEXT))
+        .build();
 }

--- a/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/filtering/CassandraEventSourcingFilteringManagementTest.java
+++ b/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/filtering/CassandraEventSourcingFilteringManagementTest.java
@@ -19,16 +19,38 @@
 
 package org.apache.james.jmap.cassandra.filtering;
 
-import org.apache.james.eventsourcing.eventstore.cassandra.CassandraEventStoreExtension;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.eventsourcing.eventstore.EventStore;
+import org.apache.james.eventsourcing.eventstore.cassandra.CassandraEventStore;
+import org.apache.james.eventsourcing.eventstore.cassandra.CassandraEventStoreModule$;
+import org.apache.james.eventsourcing.eventstore.cassandra.EventStoreDao;
 import org.apache.james.eventsourcing.eventstore.cassandra.JsonEventSerializer;
+import org.apache.james.jmap.api.filtering.FilteringManagement;
 import org.apache.james.jmap.api.filtering.FilteringManagementContract;
+import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class CassandraEventSourcingFilteringManagementTest implements FilteringManagementContract {
     @RegisterExtension
-    static CassandraEventStoreExtension eventStoreExtension =
-        new CassandraEventStoreExtension(JsonEventSerializer.forModules(
+    static CassandraClusterExtension eventStoreExtension = new CassandraClusterExtension(CassandraModule.aggregateModules(
+        CassandraEventStoreModule$.MODULE$.MODULE(),
+        CassandraFilteringProjectionModule.MODULE));
+
+    private EventStore eventStore;
+
+    @BeforeEach
+    void setUp() {
+        eventStore = new CassandraEventStore(new EventStoreDao(eventStoreExtension.getCassandraCluster().getConf(),
+            JsonEventSerializer.forModules(
                 FilteringRuleSetDefineDTOModules.FILTERING_RULE_SET_DEFINED,
-                FilteringRuleSetDefineDTOModules.FILTERING_INCREMENT)
-            .withoutNestedType());
+                FilteringRuleSetDefineDTOModules.FILTERING_INCREMENT).withoutNestedType()));
+    }
+
+    @Override
+    public FilteringManagement instantiateFilteringManagement() {
+        return new EventSourcingFilteringManagement(eventStore,
+            new CassandraFilteringProjection(eventStoreExtension.getCassandraCluster().getConf()));
+    }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Version.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Version.java
@@ -69,4 +69,11 @@ public class Version {
     public int asInteger() {
         return version;
     }
+
+    public Optional<EventId> asEventId() {
+        if (version == -1) {
+            return Optional.empty();
+        }
+        return Optional.of(EventId.apply(version));
+    }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Version.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Version.java
@@ -20,11 +20,20 @@
 package org.apache.james.jmap.api.filtering;
 
 import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.james.eventsourcing.EventId;
 
 import com.google.common.base.MoreObjects;
 
 public class Version {
     public static final Version INITIAL = new Version(-1);
+
+    public static Version from(Optional<EventId> eventId) {
+        return eventId.map(EventId::value)
+            .map(Version::new)
+            .orElse(Version.INITIAL);
+    }
 
     private final int version;
 

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/EventSourcingFilteringManagement.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/EventSourcingFilteringManagement.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import org.apache.james.core.Username;
 import org.apache.james.eventsourcing.Event;
 import org.apache.james.eventsourcing.EventSourcingSystem;
+import org.apache.james.eventsourcing.ReactiveSubscriber;
 import org.apache.james.eventsourcing.Subscriber;
 import org.apache.james.eventsourcing.eventstore.EventStore;
 import org.apache.james.eventsourcing.eventstore.History;
@@ -49,7 +50,7 @@ public class EventSourcingFilteringManagement implements FilteringManagement {
 
         Publisher<Version> getLatestVersion(Username username);
 
-        Optional<Subscriber> subscriber();
+        Optional<ReactiveSubscriber> subscriber();
     }
 
     public static class NoReadProjection implements ReadProjection {
@@ -84,7 +85,7 @@ public class EventSourcingFilteringManagement implements FilteringManagement {
         }
 
         @Override
-        public Optional<Subscriber> subscriber() {
+        public Optional<ReactiveSubscriber> subscriber() {
             return Optional.empty();
         }
     }
@@ -103,7 +104,7 @@ public class EventSourcingFilteringManagement implements FilteringManagement {
         this.readProjection = new NoReadProjection(eventStore);
         this.eventSourcingSystem = EventSourcingSystem.fromJava(
             ImmutableSet.of(new DefineRulesCommandHandler(eventStore)),
-            readProjection.subscriber().map(ImmutableSet::of).orElse(NO_SUBSCRIBER),
+            readProjection.subscriber().map(Subscriber.class::cast).map(ImmutableSet::of).orElse(NO_SUBSCRIBER),
             eventStore);
     }
 

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/EventSourcingFilteringManagement.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/EventSourcingFilteringManagement.java
@@ -60,10 +60,10 @@ public class EventSourcingFilteringManagement implements FilteringManagement {
     @Override
     public Publisher<Version> defineRulesForUser(Username username, List<Rule> rules, Optional<Version> ifInState) {
         return Mono.from(eventSourcingSystem.dispatch(new DefineRulesCommand(username, rules, ifInState)))
-            .then(Mono.from(eventStore.getEventsOfAggregate(new FilteringAggregateId(username)))
-                .map(History::getVersionAsJava)
-                .map(eventIdOptional -> eventIdOptional.map(eventId -> new Version(eventId.value()))
-                    .orElse(Version.INITIAL)));
+            .map(events -> Version.from(events.stream()
+                .map(Event::eventId)
+                .sorted(Comparator.reverseOrder())
+                .findFirst()));
     }
 
     @Override

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregateId.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregateId.java
@@ -49,6 +49,10 @@ public class FilteringAggregateId implements AggregateId {
         return PREFIX + SEPARATOR + username.asString();
     }
 
+    public Username getUsername() {
+        return username;
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof FilteringAggregateId) {

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/FilteringManagementContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/FilteringManagementContract.java
@@ -46,26 +46,24 @@ public interface FilteringManagementContract {
     String BART_SIMPSON_CARTOON = "bart@simpson.cartoon";
     Username USERNAME = Username.of(BART_SIMPSON_CARTOON);
 
-    default FilteringManagement instantiateFilteringManagement(EventStore eventStore) {
-        return new EventSourcingFilteringManagement(eventStore);
-    }
+    FilteringManagement instantiateFilteringManagement();
 
     @Test
-    default void listingRulesForUnknownUserShouldReturnEmptyList(EventStore eventStore) {
-        assertThat(Mono.from(instantiateFilteringManagement(eventStore).listRulesForUser(USERNAME)).block())
+    default void listingRulesForUnknownUserShouldReturnEmptyList() {
+        assertThat(Mono.from(instantiateFilteringManagement().listRulesForUser(USERNAME)).block())
             .isEqualTo(new Rules(ImmutableList.of(), new Version(-1)));
     }
 
     @Test
-    default void listingRulesShouldThrowWhenNullUser(EventStore eventStore) {
+    default void listingRulesShouldThrowWhenNullUser() {
         Username username = null;
-        assertThatThrownBy(() -> instantiateFilteringManagement(eventStore).listRulesForUser(username))
+        assertThatThrownBy(() -> instantiateFilteringManagement().listRulesForUser(username))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    default void listingRulesShouldReturnDefinedRules(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void listingRulesShouldReturnDefinedRules() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_1, RULE_2)).block();
 
@@ -74,8 +72,8 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void listingRulesShouldReturnLastDefinedRules(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void listingRulesShouldReturnLastDefinedRules() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_1, RULE_2)).block();
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_2, RULE_1)).block();
@@ -85,24 +83,24 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void definingRulesShouldThrowWhenDuplicateRules(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void definingRulesShouldThrowWhenDuplicateRules() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_1, RULE_1)).block())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    default void definingRulesShouldThrowWhenNullUser(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void definingRulesShouldThrowWhenNullUser() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(null, Optional.empty(), RULE_1, RULE_1)).block())
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    default void definingRulesShouldThrowWhenNullRuleList(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void definingRulesShouldThrowWhenNullRuleList() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         List<Rule> rules = null;
         assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, rules, Optional.empty())).block())
@@ -110,8 +108,8 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void definingRulesShouldKeepOrdering(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void definingRulesShouldKeepOrdering() {
+        FilteringManagement testee = instantiateFilteringManagement();
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
 
 
@@ -120,8 +118,8 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void definingEmptyRuleListShouldRemoveExistingRules(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void definingEmptyRuleListShouldRemoveExistingRules() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
         Mono.from(testee.clearRulesForUser(USERNAME)).block();
@@ -131,8 +129,8 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void allFieldsAndComparatorShouldWellBeStored(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void allFieldsAndComparatorShouldWellBeStored() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_FROM, RULE_RECIPIENT, RULE_SUBJECT, RULE_TO, RULE_1)).block();
 
@@ -141,16 +139,16 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void setRulesWithEmptyVersionShouldSucceed(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void setRulesWithEmptyVersionShouldSucceed() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         assertThat(Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block())
             .isEqualTo(new Version(0));
     }
 
     @Test
-    default void modifyExistingRulesWithWrongCurrentVersionShouldFail(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void modifyExistingRulesWithWrongCurrentVersionShouldFail() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
 
@@ -159,8 +157,8 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void modifyExistingRulesWithRightVersionShouldSucceed(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void modifyExistingRulesWithRightVersionShouldSucceed() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
 
@@ -169,8 +167,8 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void givenARulesWithVersionIsOneThenUpdateRulesWithIfInStateIsOneShouldSucceed(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void givenARulesWithVersionIsOneThenUpdateRulesWithIfInStateIsOneShouldSucceed() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2)).block();
@@ -183,16 +181,16 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void setRulesWithEmptyIfInStateWhenNonStateIsDefinedShouldSucceed(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void setRulesWithEmptyIfInStateWhenNonStateIsDefinedShouldSucceed() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         assertThat(Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2)).block())
             .isEqualTo(new Version(0));
     }
 
     @Test
-    default void setRulesWithEmptyIfInStateWhenAStateIsDefinedShouldSucceed(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void setRulesWithEmptyIfInStateWhenAStateIsDefinedShouldSucceed() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2)).block();
 
@@ -201,16 +199,16 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void setRulesWithIfInStateIsInitialWhenNonStateIsDefinedShouldSucceed(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void setRulesWithIfInStateIsInitialWhenNonStateIsDefinedShouldSucceed() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         assertThat(Mono.from(testee.defineRulesForUser(USERNAME, Optional.of(Version.INITIAL), RULE_3, RULE_2)).block())
             .isEqualTo(new Version(0));
     }
 
     @Test
-    default void setRulesWithIfInStateIsInitialWhenAStateIsDefinedShouldFail(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void setRulesWithIfInStateIsInitialWhenAStateIsDefinedShouldFail() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
 
@@ -222,24 +220,24 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void setRulesWithIfInStateIsOneWhenNonStateIsDefinedShouldFail(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void setRulesWithIfInStateIsOneWhenNonStateIsDefinedShouldFail() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         assertThatThrownBy(() -> Mono.from(testee.defineRulesForUser(USERNAME, Optional.of(new Version(1)), RULE_2, RULE_1)).block())
             .isInstanceOf(StateMismatchException.class);
     }
 
     @Test
-    default void getLatestVersionWhenNonVersionIsDefinedShouldReturnVersionInitial(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void getLatestVersionWhenNonVersionIsDefinedShouldReturnVersionInitial() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         assertThat(Mono.from(testee.getLatestVersion(USERNAME)).block())
             .isEqualTo(Version.INITIAL);
     }
 
     @Test
-    default void getLatestVersionAfterSetRulesFirstTimeShouldReturnVersionZero(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void getLatestVersionAfterSetRulesFirstTimeShouldReturnVersionZero() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
 
@@ -248,8 +246,8 @@ public interface FilteringManagementContract {
     }
 
     @Test
-    default void getLatestVersionAfterSetRulesNotSucceedShouldReturnOldVersion(EventStore eventStore) {
-        FilteringManagement testee = instantiateFilteringManagement(eventStore);
+    default void getLatestVersionAfterSetRulesNotSucceedShouldReturnOldVersion() {
+        FilteringManagement testee = instantiateFilteringManagement();
 
         Mono.from(testee.defineRulesForUser(USERNAME, Optional.empty(), RULE_3, RULE_2, RULE_1)).block();
         assertThat(Mono.from(testee.getLatestVersion(USERNAME)).block())

--- a/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationImmutableTest.java
+++ b/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationImmutableTest.java
@@ -142,4 +142,21 @@ public abstract class WebAdminServerIntegrationImmutableTest {
             .body("status", is("completed"))
             .body("type", is("RecomputeAllFastViewProjectionItemsTask"));
     }
+
+    @Test
+    void jmapFilteringProjectionTasksShouldBeExposed() {
+        String taskId = with()
+            .queryParam("task", "populateFilteringProjection")
+            .post("/mailboxes")
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", is("completed"))
+            .body("type", is("PopulateFilteringProjectionTask"));
+    }
 }

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/Constants.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/Constants.java
@@ -24,4 +24,5 @@ import org.apache.james.webadmin.tasks.TaskRegistrationKey;
 public interface Constants {
     TaskRegistrationKey TASK_REGISTRATION_KEY = TaskRegistrationKey.of("recomputeFastViewProjectionItems");
     TaskRegistrationKey POPULATE_EMAIL_QUERY_VIEW = TaskRegistrationKey.of("populateEmailQueryView");
+    TaskRegistrationKey POPULATE_FILTERING_PROJECTION = TaskRegistrationKey.of("populateFilteringProjection");
 }

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionRequestToTask.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionRequestToTask.java
@@ -17,25 +17,22 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.jmap.cassandra.filtering;
+package org.apache.james.webadmin.data.jmap;
 
-import static com.datastax.oss.driver.api.core.type.DataTypes.INT;
-import static com.datastax.oss.driver.api.core.type.DataTypes.TEXT;
+import static org.apache.james.webadmin.data.jmap.Constants.POPULATE_FILTERING_PROJECTION;
 
-import org.apache.james.backends.cassandra.components.CassandraModule;
+import javax.inject.Inject;
 
-public interface CassandraFilteringProjectionModule {
-    String TABLE_NAME = "filters_projection";
+import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.webadmin.tasks.TaskFromRequestRegistry;
 
-    String AGGREGATE_ID = "aggregate_id";
-    String EVENT_ID = "event_id";
-    String RULES = "rules";
-
-    CassandraModule MODULE = CassandraModule.table(TABLE_NAME)
-        .comment("Holds read projection for the event sourcing system managing JMAP filters.")
-        .statement(statement -> types -> statement
-            .withPartitionKey(AGGREGATE_ID, TEXT)
-            .withColumn(EVENT_ID, INT)
-            .withColumn(RULES, TEXT))
-        .build();
+public class PopulateFilteringProjectionRequestToTask extends TaskFromRequestRegistry.TaskRegistration {
+    @Inject
+    PopulateFilteringProjectionRequestToTask(EventSourcingFilteringManagement.NoReadProjection noReadProjection,
+                                             EventSourcingFilteringManagement.ReadProjection readProjection,
+                                             UsersRepository usersRepository) {
+        super(POPULATE_FILTERING_PROJECTION,
+            request -> new PopulateFilteringProjectionTask(noReadProjection, readProjection, usersRepository));
+    }
 }

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTask.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTask.java
@@ -1,0 +1,164 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.data.jmap;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.james.core.Username;
+import org.apache.james.eventsourcing.EventId;
+import org.apache.james.jmap.api.filtering.Rules;
+import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
+import org.apache.james.jmap.api.filtering.impl.FilteringAggregateId;
+import org.apache.james.jmap.api.filtering.impl.RuleSetDefined;
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+import org.apache.james.user.api.UsersRepository;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class PopulateFilteringProjectionTask implements Task {
+    static final TaskType TASK_TYPE = TaskType.of("PopulateFilteringProjectionTask");
+
+    public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
+        private static AdditionalInformation from(AtomicLong processedUserCount, AtomicLong failedUserCount) {
+            return new AdditionalInformation(processedUserCount.get(),
+                failedUserCount.get(),
+                Clock.systemUTC().instant());
+        }
+
+        private final long processedUserCount;
+        private final long failedUserCount;
+        private final Instant timestamp;
+
+        public AdditionalInformation(long processedUserCount, long failedUserCount, Instant timestamp) {
+            this.processedUserCount = processedUserCount;
+            this.failedUserCount = failedUserCount;
+            this.timestamp = timestamp;
+        }
+
+        public long getProcessedUserCount() {
+            return processedUserCount;
+        }
+
+        public long getFailedUserCount() {
+            return failedUserCount;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return timestamp;
+        }
+    }
+
+    public static class PopulateFilteringProjectionTaskDTO implements TaskDTO {
+        private final String type;
+
+        public PopulateFilteringProjectionTaskDTO(@JsonProperty("type") String type) {
+            this.type = type;
+        }
+
+        @Override
+        public String getType() {
+            return type;
+        }
+    }
+
+    public static TaskDTOModule<PopulateFilteringProjectionTask, PopulateFilteringProjectionTaskDTO> module(EventSourcingFilteringManagement.NoReadProjection noReadProjection,
+                                                                                                            EventSourcingFilteringManagement.ReadProjection readProjection,
+                                                                                                            UsersRepository usersRepository) {
+        return DTOModule
+            .forDomainObject(PopulateFilteringProjectionTask.class)
+            .convertToDTO(PopulateFilteringProjectionTaskDTO.class)
+            .toDomainObjectConverter(dto -> asTask(noReadProjection, readProjection, usersRepository))
+            .toDTOConverter(PopulateFilteringProjectionTask::asDTO)
+            .typeName(TASK_TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    private static PopulateFilteringProjectionTaskDTO asDTO(PopulateFilteringProjectionTask task, String type) {
+        return new PopulateFilteringProjectionTaskDTO(type);
+    }
+
+    private static PopulateFilteringProjectionTask asTask(EventSourcingFilteringManagement.NoReadProjection noReadProjection,
+                                                          EventSourcingFilteringManagement.ReadProjection readProjection,
+                                                          UsersRepository usersRepository) {
+        return new PopulateFilteringProjectionTask(noReadProjection, readProjection, usersRepository);
+    }
+
+    private final EventSourcingFilteringManagement.NoReadProjection noReadProjection;
+    private final EventSourcingFilteringManagement.ReadProjection readProjection;
+    private final UsersRepository usersRepository;
+    private final AtomicLong processedUserCount = new AtomicLong(0L);
+    private final AtomicLong failedUserCount = new AtomicLong(0L);
+
+    public PopulateFilteringProjectionTask(EventSourcingFilteringManagement.NoReadProjection noReadProjection,
+                                           EventSourcingFilteringManagement.ReadProjection readProjection,
+                                           UsersRepository usersRepository) {
+        this.noReadProjection = noReadProjection;
+        this.readProjection = readProjection;
+        this.usersRepository = usersRepository;
+    }
+
+    @Override
+    public Result run() {
+        return Flux.from(usersRepository.listReactive())
+            .concatMap(user -> Mono.from(noReadProjection.listRulesForUser(user))
+                .flatMap(rules ->
+                    rules.getVersion().asEventId()
+                        .flatMap(eventId -> readProjection.subscriber()
+                            .map(s -> Mono.from(s.handleReactive(asEvent(user, rules, eventId)))))
+                        .orElse(Mono.empty()))
+                .thenReturn(Result.COMPLETED)
+                .doOnNext(next -> processedUserCount.incrementAndGet())
+                .onErrorResume(e -> {
+                    LOGGER.error("Failed populating Cassandra filter read projection for {}", user);
+                    failedUserCount.incrementAndGet();
+                    return Mono.just(Result.PARTIAL);
+                }))
+            .reduce(Task::combine)
+            .switchIfEmpty(Mono.just(Result.COMPLETED))
+            .block();
+    }
+
+    private RuleSetDefined asEvent(Username user, Rules rules, EventId eventId) {
+        return new RuleSetDefined(new FilteringAggregateId(user), eventId, ImmutableList.copyOf(rules.getRules()));
+    }
+
+    @Override
+    public TaskType type() {
+        return TASK_TYPE;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        return Optional.of(AdditionalInformation.from(processedUserCount, failedUserCount));
+    }
+}

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTask.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTask.java
@@ -133,7 +133,7 @@ public class PopulateFilteringProjectionTask implements Task {
             .concatMap(user -> Mono.from(noReadProjection.listRulesForUser(user))
                 .flatMap(rules ->
                     rules.getVersion().asEventId()
-                        .flatMap(eventId -> readProjection.subscriber()
+                        .flatMap(eventId -> readProjection.subscriber(any -> Mono.empty())
                             .map(s -> Mono.from(s.handleReactive(asEvent(user, rules, eventId)))))
                         .orElse(Mono.empty()))
                 .thenReturn(Result.COMPLETED)

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTaskAdditionalInformationDTO.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTaskAdditionalInformationDTO.java
@@ -1,0 +1,89 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.data.jmap;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+
+public class PopulateFilteringProjectionTaskAdditionalInformationDTO implements AdditionalInformationDTO {
+    public static AdditionalInformationDTOModule<PopulateFilteringProjectionTask.AdditionalInformation, PopulateFilteringProjectionTaskAdditionalInformationDTO> module() {
+        return DTOModule.forDomainObject(PopulateFilteringProjectionTask.AdditionalInformation.class)
+            .convertToDTO(PopulateFilteringProjectionTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(PopulateFilteringProjectionTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(PopulateFilteringProjectionTaskAdditionalInformationDTO::toDTO)
+            .typeName(PopulateFilteringProjectionTask.TASK_TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+    }
+
+    private static PopulateFilteringProjectionTask.AdditionalInformation toDomainObject(PopulateFilteringProjectionTaskAdditionalInformationDTO dto) {
+        return new PopulateFilteringProjectionTask.AdditionalInformation(
+            dto.getProcessedUserCount(),
+            dto.getFailedUserCount(),
+            dto.timestamp);
+    }
+
+    private static PopulateFilteringProjectionTaskAdditionalInformationDTO toDTO(PopulateFilteringProjectionTask.AdditionalInformation details, String type) {
+        return new PopulateFilteringProjectionTaskAdditionalInformationDTO(
+            type,
+            details.timestamp(),
+            details.getProcessedUserCount(),
+            details.getFailedUserCount());
+    }
+
+    private final String type;
+    private final Instant timestamp;
+    private final long processedUserCount;
+    private final long failedUserCount;
+
+    @VisibleForTesting
+    PopulateFilteringProjectionTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+                                                            @JsonProperty("timestamp") Instant timestamp,
+                                                            @JsonProperty("processedUserCount") long processedUserCount,
+                                                            @JsonProperty("failedUserCount") long failedUserCount) {
+        this.type = type;
+        this.timestamp = timestamp;
+        this.processedUserCount = processedUserCount;
+        this.failedUserCount = failedUserCount;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public long getProcessedUserCount() {
+        return processedUserCount;
+    }
+
+    public long getFailedUserCount() {
+        return failedUserCount;
+    }
+}

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionItemsTaskAdditionalInformationDTOTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionItemsTaskAdditionalInformationDTOTest.java
@@ -17,25 +17,26 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.jmap.cassandra.filtering;
+package org.apache.james.webadmin.data.jmap;
 
-import static com.datastax.oss.driver.api.core.type.DataTypes.INT;
-import static com.datastax.oss.driver.api.core.type.DataTypes.TEXT;
+import java.time.Instant;
 
-import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.util.ClassLoaderUtils;
+import org.junit.jupiter.api.Test;
 
-public interface CassandraFilteringProjectionModule {
-    String TABLE_NAME = "filters_projection";
+class PopulateFilteringProjectionItemsTaskAdditionalInformationDTOTest {
+    private static final Instant INSTANT = Instant.parse("2007-12-03T10:15:30.00Z");
+    private static final PopulateFilteringProjectionTask.AdditionalInformation DOMAIN_OBJECT = new PopulateFilteringProjectionTask.AdditionalInformation(
+        1,
+        2,
+        INSTANT);
 
-    String AGGREGATE_ID = "aggregate_id";
-    String EVENT_ID = "event_id";
-    String RULES = "rules";
-
-    CassandraModule MODULE = CassandraModule.table(TABLE_NAME)
-        .comment("Holds read projection for the event sourcing system managing JMAP filters.")
-        .statement(statement -> types -> statement
-            .withPartitionKey(AGGREGATE_ID, TEXT)
-            .withColumn(EVENT_ID, INT)
-            .withColumn(RULES, TEXT))
-        .build();
+    @Test
+    void shouldMatchJsonSerializationContract() throws Exception {
+        JsonSerializationVerifier.dtoModule(PopulateFilteringProjectionTaskAdditionalInformationDTO.module())
+            .bean(DOMAIN_OBJECT)
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/populateFilters.additionalInformation.json"))
+            .verify();
+    }
 }

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionRequestToTaskTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionRequestToTaskTest.java
@@ -1,0 +1,250 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.data.jmap;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static io.restassured.RestAssured.with;
+import static javax.mail.Flags.Flag.DELETED;
+import static org.apache.james.jmap.api.filtering.Rule.Condition.Comparator.CONTAINS;
+import static org.apache.james.jmap.api.filtering.Rule.Condition.Field.SUBJECT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import javax.mail.Flags;
+
+import org.apache.james.core.Username;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.eventsourcing.Event;
+import org.apache.james.eventsourcing.EventId;
+import org.apache.james.eventsourcing.ReactiveSubscriber;
+import org.apache.james.jmap.api.filtering.Rule;
+import org.apache.james.jmap.api.filtering.Rules;
+import org.apache.james.jmap.api.filtering.Version;
+import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
+import org.apache.james.jmap.api.filtering.impl.FilteringAggregateId;
+import org.apache.james.jmap.api.filtering.impl.RuleSetDefined;
+import org.apache.james.jmap.memory.projections.MemoryEmailQueryView;
+import org.apache.james.json.DTOConverter;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.extension.PreDeletionHook;
+import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.TaskManager;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.memory.MemoryUsersRepository;
+import org.apache.james.util.streams.Limit;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.routes.TasksRoutes;
+import org.apache.james.webadmin.tasks.TaskFromRequestRegistry;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableList;
+
+import io.restassured.RestAssured;
+import reactor.core.publisher.Mono;
+import spark.Service;
+
+class PopulateFilteringProjectionRequestToTaskTest {
+    private static final String UNSCRAMBLED_SUBJECT = "this is the subject Frédéric MARTIN of the mail";
+
+    private EventSourcingFilteringManagement.NoReadProjection noReadProjection;
+    private EventSourcingFilteringManagement.ReadProjection readProjection;
+
+    private static final class JMAPRoutes implements Routes {
+        private final TaskManager taskManager;
+        private final EventSourcingFilteringManagement.NoReadProjection noReadProjection;
+        private final EventSourcingFilteringManagement.ReadProjection readProjection;
+        private final UsersRepository usersRepository;
+
+        private JMAPRoutes(EventSourcingFilteringManagement.NoReadProjection noReadProjection,
+                           EventSourcingFilteringManagement.ReadProjection readProjection,
+                           UsersRepository usersRepository,
+                           TaskManager taskManager) {
+            this.noReadProjection = noReadProjection;
+            this.readProjection = readProjection;
+            this.usersRepository = usersRepository;
+            this.taskManager = taskManager;
+        }
+
+        @Override
+        public String getBasePath() {
+            return BASE_PATH;
+        }
+
+        @Override
+        public void define(Service service) {
+            service.post(BASE_PATH,
+                TaskFromRequestRegistry.builder()
+                    .registrations(new PopulateFilteringProjectionRequestToTask(noReadProjection, readProjection, usersRepository))
+                    .buildAsRoute(taskManager),
+                new JsonTransformer());
+        }
+    }
+
+    static final String BASE_PATH = "/mailboxes";
+
+    static final DomainList NO_DOMAIN_LIST = null;
+    static final Username BOB = Username.of("bob");
+
+    private WebAdminServer webAdminServer;
+    private MemoryTaskManager taskManager;
+    private MailboxId bobInboxboxId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        JsonTransformer jsonTransformer = new JsonTransformer();
+        taskManager = new MemoryTaskManager(new Hostname("foo"));
+
+        InMemoryMailboxManager mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
+        MemoryUsersRepository usersRepository = MemoryUsersRepository.withoutVirtualHosting(NO_DOMAIN_LIST);
+        usersRepository.addUser(BOB, "pass");
+        MailboxSession bobSession = mailboxManager.createSystemSession(BOB);
+        bobInboxboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), bobSession)
+            .get();
+
+        noReadProjection = mock(EventSourcingFilteringManagement.NoReadProjection.class);
+        readProjection = mock(EventSourcingFilteringManagement.ReadProjection.class);
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+            new TasksRoutes(taskManager, jsonTransformer,
+                DTOConverter.of(PopulateFilteringProjectionTaskAdditionalInformationDTO.module())),
+            new JMAPRoutes(
+                noReadProjection,
+                readProjection,
+                usersRepository,
+                taskManager))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
+            .setBasePath("/mailboxes")
+            .build();
+    }
+
+    @AfterEach
+    void afterEach() {
+        webAdminServer.destroy();
+        taskManager.stop();
+    }
+
+    @Test
+    void actionRequestParameterShouldBeCompulsory() {
+        when()
+            .post()
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("statusCode", is(400))
+            .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+            .body("message", is("Invalid arguments supplied in the user request"))
+            .body("details", is("'action' query parameter is compulsory. Supported values are [populateFilteringProjection]"));
+    }
+
+    @Test
+    void postShouldFailUponEmptyAction() {
+        given()
+            .queryParam("action", "")
+            .post()
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("statusCode", is(400))
+            .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+            .body("message", is("Invalid arguments supplied in the user request"))
+            .body("details", is("'action' query parameter cannot be empty or blank. Supported values are [populateFilteringProjection]"));
+    }
+
+    @Test
+    void postShouldFailUponInvalidAction() {
+        given()
+            .queryParam("action", "invalid")
+            .post()
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("statusCode", is(400))
+            .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+            .body("message", is("Invalid arguments supplied in the user request"))
+            .body("details", is("Invalid value supplied for query parameter 'action': invalid. Supported values are [populateFilteringProjection]"));
+    }
+
+    @Test
+    void postShouldCreateANewTask() {
+        given()
+            .queryParam("action", "populateFilteringProjection")
+            .post()
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .body("taskId", notNullValue());
+    }
+
+    @Test
+    void populateShouldUpdateProjection() {
+        Rule rule = Rule.builder()
+            .id(Rule.Id.of("2"))
+            .name("rule 2")
+            .condition(Rule.Condition.of(SUBJECT, CONTAINS, UNSCRAMBLED_SUBJECT))
+            .action(Rule.Action.of(Rule.Action.AppendInMailboxes.withMailboxIds(ImmutableList.of(bobInboxboxId.serialize()))))
+            .build();
+
+        Mockito.when(noReadProjection.listRulesForUser(any()))
+            .thenReturn(Mono.just(new Rules(ImmutableList.of(rule), new Version(4))));
+        ReactiveSubscriber subscriber = mock(ReactiveSubscriber.class);
+        Mockito.when(readProjection.subscriber()).thenReturn(Optional.of(subscriber));
+        Mockito.when(subscriber.handleReactive(any())).thenReturn(Mono.empty());
+
+        String taskId = with()
+            .queryParam("action", "populateFilteringProjection")
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        with()
+            .basePath(TasksRoutes.BASE)
+            .get(taskId + "/await");
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(subscriber, times(1)).handleReactive(captor.capture());
+
+        assertThat(captor.getValue().eventId()).isEqualTo(EventId.fromSerialized(4));
+        assertThat(captor.getValue().getAggregateId()).isEqualTo(new FilteringAggregateId(BOB));
+        assertThat(captor.getValue()).isInstanceOf(RuleSetDefined.class);
+        RuleSetDefined ruleSetDefined = (RuleSetDefined) captor.getValue();
+        assertThat(ruleSetDefined.getRules()).containsOnly(rule);
+    }
+}

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionRequestToTaskTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionRequestToTaskTest.java
@@ -225,7 +225,7 @@ class PopulateFilteringProjectionRequestToTaskTest {
         Mockito.when(noReadProjection.listRulesForUser(any()))
             .thenReturn(Mono.just(new Rules(ImmutableList.of(rule), new Version(4))));
         ReactiveSubscriber subscriber = mock(ReactiveSubscriber.class);
-        Mockito.when(readProjection.subscriber()).thenReturn(Optional.of(subscriber));
+        Mockito.when(readProjection.subscriber(any())).thenReturn(Optional.of(subscriber));
         Mockito.when(subscriber.handleReactive(any())).thenReturn(Mono.empty());
 
         String taskId = with()

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTaskSerializationTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/PopulateFilteringProjectionTaskSerializationTest.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.data.jmap;
+
+import static org.mockito.Mockito.mock;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.eventsourcing.eventstore.EventStore;
+import org.apache.james.jmap.api.filtering.impl.EventSourcingFilteringManagement;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.util.ClassLoaderUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PopulateFilteringProjectionTaskSerializationTest {
+    private EventSourcingFilteringManagement.NoReadProjection noReadProjection;
+    private EventSourcingFilteringManagement.ReadProjection readProjection;
+    private UsersRepository usersRepository;
+
+    @BeforeEach
+    void setUp() {
+        noReadProjection = new EventSourcingFilteringManagement.NoReadProjection(mock(EventStore.class));
+        readProjection = mock(EventSourcingFilteringManagement.ReadProjection.class);
+        usersRepository = mock(UsersRepository.class);
+    }
+
+    @Test
+    void shouldMatchJsonSerializationContract() throws Exception {
+        JsonSerializationVerifier.dtoModule(PopulateFilteringProjectionTask.module(noReadProjection, readProjection, usersRepository))
+            .bean(new PopulateFilteringProjectionTask(noReadProjection, readProjection, usersRepository))
+            .json(ClassLoaderUtils.getSystemResourceAsString("json/populateFilters.task.json"))
+            .verify();
+    }
+}

--- a/server/protocols/webadmin/webadmin-jmap/src/test/resources/json/populateFilters.additionalInformation.json
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/resources/json/populateFilters.additionalInformation.json
@@ -1,0 +1,6 @@
+{
+  "type":"PopulateFilteringProjectionTask",
+  "timestamp":"2007-12-03T10:15:30Z",
+  "processedUserCount":1,
+  "failedUserCount":2
+}

--- a/server/protocols/webadmin/webadmin-jmap/src/test/resources/json/populateFilters.task.json
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/resources/json/populateFilters.task.json
@@ -1,0 +1,3 @@
+{
+  "type":"PopulateFilteringProjectionTask"
+}

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -1545,6 +1545,36 @@ Response codes:
  - 201: Success. Corresponding task id is returned.
  - 400: Error in the request. Details can be found in the reported error.
  - 404: User not found.
+ 
+ 
+### Recomputing Cassandra filtering projection
+
+You can force the reset of the Cassandra filtering projection by calling the following
+endpoint:
+
+```
+curl -XPOST /mailboxes?task=populateFilteringProjection
+```
+
+Will schedule a task.
+
+[More details about endpoints returning a task](#Endpoints_returning_a_task).
+
+The scheduled task will have the following type
+`PopulateFilteringProjectionTask` and the following
+`additionalInformation`:
+
+```{
+  "type":"RecomputeAllPreviewsTask",
+  "processedUserCount": 3,
+  "failedUserCount": 2
+}
+```
+
+Response codes:
+
+ - 201: Success. Corresponding task id is returned.
+ - 400: Error in the request. Details can be found in the reported error.
 
 ## Administrating quotas by users
 

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -125,6 +125,12 @@
                     <dd>Optional boolean. Prevent server side request forgery by preventing calls to the private network
                         ranges. Defaults to true, can be disabled for testing.
                     </dd>
+
+                    <dt><strong>cassandra.filter.projection.activated</strong></dt>
+                    <dd>Optional boolean. Defaults to false. Casandra backends only. Whether to use or not the Cassandra projection
+                        for JMAP filters. This projection optimizes reads, but needs to be correctly populated. Turning it on on
+                        systems with filters already defined would result in those filters to be not read.
+                    </dd>
                 </dl>
 
             </subsection>


### PR DESCRIPTION
Uses a read projection (optional)

This prevents loading the full aggregate history (O(n2)) and doing LWTs upon receiving emails.

A route allows resetting the projection.

Possible enhancement:
 - Allow individual filter addition, removal (history in O(N) )
 - (Snapshots for the event sourcing system in James ?)