### PR TITLE
Revert "[ENHANCEMENT] NettyStreamImapRequestLineReader: Buffer comman…

### DIFF
--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyStreamImapRequestLineReader.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyStreamImapRequestLineReader.java
@@ -30,7 +30,6 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.decode.DecodingException;
 import org.apache.james.imap.message.Literal;
 import org.apache.james.imap.utils.EolInputStream;
-import org.apache.james.util.io.UnsynchronizedBufferedInputStream;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.io.ByteStreams;
@@ -88,7 +87,7 @@ public class NettyStreamImapRequestLineReader extends AbstractNettyImapRequestLi
         super(channel, retry);
         this.backingFile = file;
         try {
-            this.in = new CountingInputStream(new UnsynchronizedBufferedInputStream(new FileInputStream(file)));
+            this.in = new CountingInputStream(new FileInputStream(file));
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
…d parsing"

This reverts commit f71681a87c491fda6a47db6949a5c2e7043303af.

This non-critical enhancement generated the following errors upon provisionning

```
22:27:43.628 [ERROR] o.a.j.i.p.AbstractMailboxProcessor - Unexpected error during IMAP processing
org.apache.james.imap.decode.DecodingException: Expected end-of-line, found 'Y'.
	at org.apache.james.imap.decode.ImapRequestLineReader.eol(ImapRequestLineReader.java:378)
	at org.apache.james.imap.utils.EolInputStream.eol(EolInputStream.java:66)
	at org.apache.james.imap.utils.EolInputStream.read(EolInputStream.java:60)
	at com.google.common.io.ByteStreams.copy(ByteStreams.java:114)
	at com.google.common.io.ByteSource.copyTo(ByteSource.java:257)
	at com.google.common.io.ByteSource.hash(ByteSource.java:340)
	at org.apache.james.blob.api.HashBlobId$Factory.forPayload(HashBlobId.java:46)
	... 12 common frames omitted
Wrapped by: java.lang.RuntimeException: org.apache.james.imap.decode.DecodingException: Expected end-of-line, found 'Y'.
	at org.apache.james.blob.api.HashBlobId$Factory.forPayload(HashBlobId.java:48)
	at org.apache.james.server.blob.deduplication.GenerationAwareBlobId$Factory.forPayload(GenerationAwareBlobId.java:132)
	at org.apache.james.server.blob.deduplication.GenerationAwareBlobId$Factory.forPayload(GenerationAwareBlobId.java:114)
	at org.apache.james.server.blob.deduplication.DeDuplicationBlobStore.$anonfun$save$1(DeDuplicationBlobStore.scala:62)
	at reactor.core.publisher.MonoCallable.call(MonoCallable.java:72)
	at reactor.core.publisher.FluxSubscribeOnCallable$CallableSubscribeOnSubscription.run(FluxSubscribeOnCallable.java:227)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

I propose to revert it...