### PR TITLE
Support `start-dev` argument when running Memory James server

### DIFF
--- a/examples/custom-james-assembly/src/main/java/org/apache/james/examples/CustomJamesServerMain.java
+++ b/examples/custom-james-assembly/src/main/java/org/apache/james/examples/CustomJamesServerMain.java
@@ -26,6 +26,7 @@ import org.apache.james.MemoryJamesConfiguration;
 import org.apache.james.data.UsersRepositoryModuleChooser;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.MemoryDataModule;
 import org.apache.james.modules.data.MemoryDelegationStoreModule;
 import org.apache.james.modules.data.MemoryUsersRepositoryModule;
@@ -73,6 +74,7 @@ public class CustomJamesServerMain implements JamesServerMain {
             .build();
 
         JamesServerMain.main(GuiceJamesServer.forConfiguration(configuration)
+            .combineWith(RunArgumentsModule.EMPTY)
             .combineWith(CUSTOM_SERVER_AGGREGATE_MODULE)
             .combineWith(new UsersRepositoryModuleChooser(new MemoryUsersRepositoryModule())
                                              .chooseModules(configuration.getUsersRepositoryImplementation()))

--- a/examples/custom-james-assembly/src/main/java/org/apache/james/examples/CustomJamesServerMain.java
+++ b/examples/custom-james-assembly/src/main/java/org/apache/james/examples/CustomJamesServerMain.java
@@ -26,7 +26,6 @@ import org.apache.james.MemoryJamesConfiguration;
 import org.apache.james.data.UsersRepositoryModuleChooser;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
-import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.MemoryDataModule;
 import org.apache.james.modules.data.MemoryDelegationStoreModule;
 import org.apache.james.modules.data.MemoryUsersRepositoryModule;
@@ -74,7 +73,6 @@ public class CustomJamesServerMain implements JamesServerMain {
             .build();
 
         JamesServerMain.main(GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(RunArgumentsModule.EMPTY)
             .combineWith(CUSTOM_SERVER_AGGREGATE_MODULE)
             .combineWith(new UsersRepositoryModuleChooser(new MemoryUsersRepositoryModule())
                                              .chooseModules(configuration.getUsersRepositoryImplementation()))

--- a/server/apps/cassandra-app/README.adoc
+++ b/server/apps/cassandra-app/README.adoc
@@ -77,7 +77,7 @@ For security reasons you are required to generate your own keystore, that you ca
 [source]
 ----
 keytool -genkey -alias james -keyalg RSA -keystore keystore
-docker run --network james -v $PWD/keystore:/root/conf/keystore docker run apache/james:cassandra-latest
+docker run --network james -v $PWD/keystore:/root/conf/keystore apache/james:cassandra-latest
 ----
 
 Use the [JAVA_TOOL_OPTIONS environment option](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#jvm-flags)

--- a/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -28,7 +28,6 @@ import org.apache.james.modules.BlobExportMechanismModule;
 import org.apache.james.modules.CassandraConsistencyTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
-import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.CassandraDLPConfigurationStoreModule;
 import org.apache.james.modules.data.CassandraDelegationStoreModule;
 import org.apache.james.modules.data.CassandraDomainListModule;
@@ -183,7 +182,7 @@ public class CassandraJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
+            .combineWith(new JMXServerModule());
 
         JamesServerMain.main(server);
     }

--- a/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -28,6 +28,7 @@ import org.apache.james.modules.BlobExportMechanismModule;
 import org.apache.james.modules.CassandraConsistencyTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.CassandraDLPConfigurationStoreModule;
 import org.apache.james.modules.data.CassandraDelegationStoreModule;
 import org.apache.james.modules.data.CassandraDomainListModule;
@@ -182,7 +183,7 @@ public class CassandraJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule());
+            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
 
         JamesServerMain.main(server);
     }

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/AuthenticatedCassandraJamesServerTest.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/AuthenticatedCassandraJamesServerTest.java
@@ -38,7 +38,7 @@ class AuthenticatedCassandraJamesServerTest {
     private final CassandraExtension cassandraExtension = new CassandraExtension();
 
     @Nested
-    class AuthenticationTest implements JamesServerContract {
+    class AuthenticationTest implements JamesServerConcreteContract {
         @RegisterExtension
         JamesServerExtension testExtension = TestingDistributedJamesServerBuilder.withSearchConfiguration(SearchConfiguration.openSearch())
             .extension(new DockerOpenSearchExtension())

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraDuplicatingJamesServerTest.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraDuplicatingJamesServerTest.java
@@ -26,7 +26,7 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.server.blob.deduplication.StorageStrategy;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class CassandraDuplicatingJamesServerTest implements JamesServerContract, JmapJamesServerContract {
+class CassandraDuplicatingJamesServerTest implements JamesServerConcreteContract, JmapJamesServerContract {
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerBuilder<CassandraJamesServerConfiguration>(tmpDir ->
         CassandraJamesServerConfiguration.builder()

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraJamesServerTest.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraJamesServerTest.java
@@ -27,7 +27,7 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class CassandraJamesServerTest implements JamesServerContract, JmapJamesServerContract {
+class CassandraJamesServerTest implements JamesServerConcreteContract, JmapJamesServerContract {
     @RegisterExtension
     static JamesServerExtension testExtension = TestingDistributedJamesServerBuilder.withSearchConfiguration(SearchConfiguration.openSearch())
         .extension(new DockerOpenSearchExtension())

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraLdapJamesServerTest.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraLdapJamesServerTest.java
@@ -43,7 +43,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class CassandraLdapJamesServerTest implements JamesServerContract {
+class CassandraLdapJamesServerTest implements JamesServerConcreteContract {
     private static Duration slowPacedPollInterval = ONE_HUNDRED_MILLISECONDS;
     private static ConditionFactory calmlyAwait = Awaitility.with()
         .pollInterval(slowPacedPollInterval)

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraWithTikaTest.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/CassandraWithTikaTest.java
@@ -22,7 +22,7 @@ package org.apache.james;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class CassandraWithTikaTest implements JamesServerContract {
+class CassandraWithTikaTest implements JamesServerConcreteContract {
     @RegisterExtension
     static JamesServerExtension testExtension = TestingDistributedJamesServerBuilder.withSearchConfiguration(SearchConfiguration.openSearch())
         .extension(new CassandraExtension())

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/JamesServerConcreteContract.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/JamesServerConcreteContract.java
@@ -19,14 +19,34 @@
 
 package org.apache.james;
 
-import org.apache.james.jmap.draft.JmapJamesServerContract;
-import org.apache.james.modules.AwsS3BlobStoreExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.LmtpGuiceProbe;
+import org.apache.james.modules.protocols.Pop3GuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
 
-public class WithDefaultAwsS3ImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
-    @RegisterExtension
-    static JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture.baseExtensionBuilder()
-        .extension(new AwsS3BlobStoreExtension())
-        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
-        .build();
+public interface JamesServerConcreteContract extends JamesServerContract {
+    @Override
+    default int imapPort(GuiceJamesServer server) {
+        return server.getProbe(ImapGuiceProbe.class).getImapPort();
+    }
+
+    @Override
+    default int imapsPort(GuiceJamesServer server) {
+        return server.getProbe(ImapGuiceProbe.class).getImapsPort();
+    }
+
+    @Override
+    default int smtpPort(GuiceJamesServer server) {
+        return server.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue();
+    }
+
+    @Override
+    default int lmtpPort(GuiceJamesServer server) {
+        return server.getProbe(LmtpGuiceProbe.class).getLmtpPort();
+    }
+
+    @Override
+    default int pop3Port(GuiceJamesServer server) {
+        return server.getProbe(Pop3GuiceProbe.class).getPop3Port();
+    }
 }

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/MailsShouldBeWellReceivedConcreteContract.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/MailsShouldBeWellReceivedConcreteContract.java
@@ -19,14 +19,17 @@
 
 package org.apache.james;
 
-import org.apache.james.jmap.draft.JmapJamesServerContract;
-import org.apache.james.modules.AwsS3BlobStoreExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
 
-public class WithDefaultAwsS3ImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
-    @RegisterExtension
-    static JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture.baseExtensionBuilder()
-        .extension(new AwsS3BlobStoreExtension())
-        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
-        .build();
+public interface MailsShouldBeWellReceivedConcreteContract extends MailsShouldBeWellReceived {
+    @Override
+    default int imapPort(GuiceJamesServer server) {
+        return server.getProbe(ImapGuiceProbe.class).getImapPort();
+    }
+
+    @Override
+    default int smtpPort(GuiceJamesServer server) {
+        return server.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue();
+    }
 }

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/WithCassandraBlobStoreImmutableTest.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/WithCassandraBlobStoreImmutableTest.java
@@ -23,7 +23,7 @@ import org.apache.james.jmap.draft.JmapJamesServerContract;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class WithCassandraBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerContract {
+class WithCassandraBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = baseExtensionBuilder()
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)

--- a/server/apps/cassandra-app/src/test/java/org/apache/james/WithCassandraBlobStoreTest.java
+++ b/server/apps/cassandra-app/src/test/java/org/apache/james/WithCassandraBlobStoreTest.java
@@ -21,7 +21,7 @@ package org.apache.james;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class WithCassandraBlobStoreTest implements MailsShouldBeWellReceived {
+class WithCassandraBlobStoreTest implements MailsShouldBeWellReceivedConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = WithCassandraBlobStoreImmutableTest.baseExtensionBuilder()
         .lifeCycle(JamesServerExtension.Lifecycle.PER_TEST)

--- a/server/apps/distributed-app/README.adoc
+++ b/server/apps/distributed-app/README.adoc
@@ -47,6 +47,14 @@ Once everything is set up, you just have to run the jar with:
 $ java -Dworking.directory=. -Dlogback.configurationFile=conf/logback.xml -Djdk.tls.ephemeralDHKeySize=2048 -jar james-server-distributed-app.jar
 ----
 
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
+James will auto-generate keystore file with the default setting that is declared in `jmap.properties` (tls.keystoreURL, tls.secret)
+
+[source]
+----
+$ java -Dworking.directory=. -Dlogback.configurationFile=conf/logback.xml -Djdk.tls.ephemeralDHKeySize=2048 -jar james-server-distributed-app.jar --generate-keystore
+----
+
 Note that binding ports below 1024 requires administrative rights.
 
 == Docker distribution
@@ -70,7 +78,15 @@ For security reasons you are required to generate your own keystore, that you ca
 [source]
 ----
 keytool -genkey -alias james -keyalg RSA -keystore keystore
-docker run --network james -v $PWD/keystore:/root/conf/keystore docker run apache/james:distributed-latest
+docker run --network james -v $PWD/keystore:/root/conf/keystore apache/james:distributed-latest
+----
+
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
+James will auto-generate keystore file with the default setting that is declared in `jmap.properties` (tls.keystoreURL, tls.secret)
+
+[source]
+----
+docker run --network james apache/james:distributed-latest --generate-keystore
 ----
 
 Use the [JAVA_TOOL_OPTIONS environment option](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#jvm-flags)

--- a/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -31,6 +31,7 @@ import org.apache.james.modules.DistributedTaskManagerModule;
 import org.apache.james.modules.DistributedTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.TasksCleanupTaskSerializationModule;
 import org.apache.james.modules.blobstore.BlobStoreCacheModulesChooser;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
@@ -181,7 +182,7 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule());
+            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
 
         JamesServerMain.main(server);
     }

--- a/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -182,7 +182,8 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
+            .combineWith(new JMXServerModule())
+            .overrideWith(new RunArgumentsModule(args));
 
         JamesServerMain.main(server);
     }

--- a/server/apps/distributed-app/src/test/java/org/apache/james/CassandraRabbitMQLdapJmapJamesServerTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/CassandraRabbitMQLdapJmapJamesServerTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import org.apache.commons.net.imap.IMAPClient;
 import org.apache.james.data.LdapTestExtension;
 import org.apache.james.data.UsersRepositoryModuleChooser;
-import org.apache.james.jmap.draft.JmapJamesServerContract;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
 import org.apache.james.modules.RabbitMQExtension;
 import org.apache.james.modules.TestJMAPServerModule;
@@ -51,7 +50,7 @@ class CassandraRabbitMQLdapJmapJamesServerTest {
         }
     }
 
-    interface ContractSuite extends JmapJamesServerContract, UserFromLdapShouldLogin, JamesServerContract {}
+    interface ContractSuite extends JamesServerConcreteContract, UserFromLdapShouldLogin, JamesServerContract {}
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithCacheImmutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithCacheImmutableTest.java
@@ -27,7 +27,7 @@ import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 
-class WithCacheImmutableTest implements JmapJamesServerContract, JamesServerContract {
+class WithCacheImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = baseExtensionBuilder()
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithCacheMutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithCacheMutableTest.java
@@ -21,7 +21,7 @@ package org.apache.james;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class WithCacheMutableTest implements MailsShouldBeWellReceived {
+class WithCacheMutableTest implements MailsShouldBeWellReceivedConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = WithCacheImmutableTest.baseExtensionBuilder()
         .lifeCycle(JamesServerExtension.Lifecycle.PER_TEST)

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraDeduplicationBlobStoreImmutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraDeduplicationBlobStoreImmutableTest.java
@@ -25,7 +25,7 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WithCassandraDeduplicationBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerContract {
+public class WithCassandraDeduplicationBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<CassandraRabbitMQJamesConfiguration>(tmpDir ->
         CassandraRabbitMQJamesConfiguration.builder()

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraDeduplicationBlobStoreMutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraDeduplicationBlobStoreMutableTest.java
@@ -48,7 +48,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 
-public class WithCassandraDeduplicationBlobStoreMutableTest implements MailsShouldBeWellReceived {
+public class WithCassandraDeduplicationBlobStoreMutableTest implements MailsShouldBeWellReceivedConcreteContract {
     private static final String JAMES_SERVER_HOST = "127.0.0.1";
     private static final String YET_ANOTHER_USER = "yet-another-user@" + DOMAIN;
 

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraPassThroughBlobStoreImmutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraPassThroughBlobStoreImmutableTest.java
@@ -25,7 +25,7 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WithCassandraPassThroughBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerContract {
+public class WithCassandraPassThroughBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<CassandraRabbitMQJamesConfiguration>(tmpDir ->
         CassandraRabbitMQJamesConfiguration.builder()

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraPassThroughBlobStoreMutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithCassandraPassThroughBlobStoreMutableTest.java
@@ -48,7 +48,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 
-public class WithCassandraPassThroughBlobStoreMutableTest implements MailsShouldBeWellReceived {
+public class WithCassandraPassThroughBlobStoreMutableTest implements MailsShouldBeWellReceivedConcreteContract {
     private static final String JAMES_SERVER_HOST = "127.0.0.1";
     private static final String YET_ANOTHER_USER = "yet-another-user@" + DOMAIN;
 

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithDefaultAwsS3MutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithDefaultAwsS3MutableTest.java
@@ -22,7 +22,7 @@ package org.apache.james;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WithDefaultAwsS3MutableTest implements MailsShouldBeWellReceived {
+public class WithDefaultAwsS3MutableTest implements MailsShouldBeWellReceivedConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture.baseExtensionBuilder()
         .extension(new AwsS3BlobStoreExtension())

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithEncryptedBlobStoreImmutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithEncryptedBlobStoreImmutableTest.java
@@ -26,7 +26,7 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WithEncryptedBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerContract {
+public class WithEncryptedBlobStoreImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<CassandraRabbitMQJamesConfiguration>(tmpDir ->
         CassandraRabbitMQJamesConfiguration.builder()

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithEncryptedBlobStoreMutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithEncryptedBlobStoreMutableTest.java
@@ -25,7 +25,7 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WithEncryptedBlobStoreMutableTest implements MailsShouldBeWellReceived {
+public class WithEncryptedBlobStoreMutableTest implements MailsShouldBeWellReceivedConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<CassandraRabbitMQJamesConfiguration>(tmpDir ->
         CassandraRabbitMQJamesConfiguration.builder()

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithScanningSearchImmutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithScanningSearchImmutableTest.java
@@ -26,7 +26,7 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class WithScanningSearchImmutableTest implements JmapJamesServerContract, JamesServerContract {
+class WithScanningSearchImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
     static JamesServerBuilder<CassandraRabbitMQJamesConfiguration> baseExtension() {
         return new JamesServerBuilder<CassandraRabbitMQJamesConfiguration>(tmpDir ->
             CassandraRabbitMQJamesConfiguration.builder()

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithScanningSearchMutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithScanningSearchMutableTest.java
@@ -21,7 +21,7 @@ package org.apache.james;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class WithScanningSearchMutableTest implements MailsShouldBeWellReceived {
+class WithScanningSearchMutableTest implements MailsShouldBeWellReceivedConcreteContract {
     @RegisterExtension
     JamesServerExtension jamesServerExtension = WithScanningSearchImmutableTest.baseExtension()
         .lifeCycle(JamesServerExtension.Lifecycle.PER_TEST)

--- a/server/apps/distributed-app/src/test/java/org/apache/james/WithoutMailQueueViewImmutableTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/WithoutMailQueueViewImmutableTest.java
@@ -27,7 +27,7 @@ import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.apache.james.modules.queue.rabbitmq.MailQueueViewChoice;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class WithoutMailQueueViewImmutableTest implements JmapJamesServerContract, JamesServerContract {
+class WithoutMailQueueViewImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
     static JamesServerBuilder<CassandraRabbitMQJamesConfiguration> baseExtension() {
         return new JamesServerBuilder<CassandraRabbitMQJamesConfiguration>(tmpDir ->
             CassandraRabbitMQJamesConfiguration.builder()

--- a/server/apps/distributed-pop3-app/README.adoc
+++ b/server/apps/distributed-pop3-app/README.adoc
@@ -45,7 +45,15 @@ For security reasons you are required to generate your own keystore, that you ca
 [source]
 ----
 keytool -genkey -alias james -keyalg RSA -keystore keystore
-docker run --network james -v $PWD/keystore:/root/conf/keystore docker run apache/james:distributed-pop3-latest
+docker run --network james -v $PWD/keystore:/root/conf/keystore apache/james:distributed-pop3-latest
+----
+
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
+James will auto-generate keystore file with the default setting that is declared in `jmap.properties` (tls.keystoreURL, tls.secret)
+
+[source]
+----
+docker run --network james apache/james:distributed-pop3-latest --generate-keystore
 ----
 
 Use the [JAVA_TOOL_OPTIONS environment option](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#jvm-flags)

--- a/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesServerMain.java
+++ b/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesServerMain.java
@@ -41,6 +41,7 @@ import org.apache.james.modules.DistributedTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.Pop3FixInconsistenciesWebAdminModule;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.TasksCleanupTaskSerializationModule;
 import org.apache.james.modules.blobstore.BlobStoreCacheModulesChooser;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
@@ -178,7 +179,7 @@ public class DistributedPOP3JamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule());
+            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
 
         JamesServerMain.main(server);
     }

--- a/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesServerMain.java
+++ b/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesServerMain.java
@@ -179,7 +179,8 @@ public class DistributedPOP3JamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
+            .combineWith(new JMXServerModule())
+            .overrideWith(new RunArgumentsModule(args));
 
         JamesServerMain.main(server);
     }

--- a/server/apps/jpa-app/README.adoc
+++ b/server/apps/jpa-app/README.adoc
@@ -66,6 +66,14 @@ keytool -genkey -alias james -keyalg RSA -keystore keystore
 docker run -v $PWD/keystore:/root/conf/keystore apache/james:jpa-latest
 ----
 
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
+James will auto-generate keystore file with the default setting that is declared in `jmap.properties` (tls.keystoreURL, tls.secret)
+
+[source]
+----
+docker run --network james apache/james:jpa-latest --generate-keystore
+----
+
 [Glowroot APM](https://glowroot.org/) is packaged as part of the docker distribution to easily enable valuable performances insights.
 Disabled by default, its java agent can easily be enabled:
 

--- a/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -104,7 +104,8 @@ public class JPAJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
+            .combineWith(new JMXServerModule())
+            .overrideWith(new RunArgumentsModule(args));
 
         JamesServerMain.main(server);
     }

--- a/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -22,6 +22,7 @@ package org.apache.james;
 import org.apache.james.data.UsersRepositoryModuleChooser;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.JPADataModule;
 import org.apache.james.modules.data.JPAUsersRepositoryModule;
 import org.apache.james.modules.data.SieveJPARepositoryModules;
@@ -103,7 +104,7 @@ public class JPAJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new JMXServerModule());
+            .combineWith(new JMXServerModule(), RunArgumentsModule.EMPTY);
 
         JamesServerMain.main(server);
     }

--- a/server/apps/jpa-app/src/test/java/org/apache/james/JPAJamesServerTest.java
+++ b/server/apps/jpa-app/src/test/java/org/apache/james/JPAJamesServerTest.java
@@ -39,8 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Strings;
 
-class JPAJamesServerTest implements JamesServerContract {
-
+class JPAJamesServerTest implements JamesServerConcreteContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<JPAJamesConfiguration>(tmpDir ->
         JPAJamesConfiguration.builder()

--- a/server/apps/jpa-app/src/test/java/org/apache/james/JamesServerConcreteContract.java
+++ b/server/apps/jpa-app/src/test/java/org/apache/james/JamesServerConcreteContract.java
@@ -19,14 +19,34 @@
 
 package org.apache.james;
 
-import org.apache.james.jmap.draft.JmapJamesServerContract;
-import org.apache.james.modules.AwsS3BlobStoreExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.LmtpGuiceProbe;
+import org.apache.james.modules.protocols.Pop3GuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
 
-public class WithDefaultAwsS3ImmutableTest implements JmapJamesServerContract, JamesServerConcreteContract {
-    @RegisterExtension
-    static JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture.baseExtensionBuilder()
-        .extension(new AwsS3BlobStoreExtension())
-        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
-        .build();
+public interface JamesServerConcreteContract extends JamesServerContract {
+    @Override
+    default int imapPort(GuiceJamesServer server) {
+        return server.getProbe(ImapGuiceProbe.class).getImapPort();
+    }
+
+    @Override
+    default int imapsPort(GuiceJamesServer server) {
+        return server.getProbe(ImapGuiceProbe.class).getImapsPort();
+    }
+
+    @Override
+    default int smtpPort(GuiceJamesServer server) {
+        return server.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue();
+    }
+
+    @Override
+    default int lmtpPort(GuiceJamesServer server) {
+        return server.getProbe(LmtpGuiceProbe.class).getLmtpPort();
+    }
+
+    @Override
+    default int pop3Port(GuiceJamesServer server) {
+        return server.getProbe(Pop3GuiceProbe.class).getPop3Port();
+    }
 }

--- a/server/apps/jpa-smtp-app/README.adoc
+++ b/server/apps/jpa-smtp-app/README.adoc
@@ -61,6 +61,14 @@ keytool -genkey -alias james -keyalg RSA -keystore keystore
 docker run -v $PWD/keystore:/root/conf/keystore apache/james:jpa-smtp-latest
 ----
 
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
+James will auto-generate keystore file with the default setting that is declared in `jmap.properties` (tls.keystoreURL, tls.secret)
+
+[source]
+----
+docker run --network james apache/james:jpa-smtp-latest --generate-keystore
+----
+
 Use the [JAVA_TOOL_OPTIONS environment option](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#jvm-flags)
 to pass extra JVM flags. For instance:
 

--- a/server/apps/jpa-smtp-app/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/apps/jpa-smtp-app/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -21,6 +21,7 @@ package org.apache.james;
 
 import org.apache.james.data.UsersRepositoryModuleChooser;
 import org.apache.james.modules.MailetProcessingModule;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.JPAAuthorizatorModule;
 import org.apache.james.modules.data.JPADataModule;
 import org.apache.james.modules.data.JPAEntityManagerModule;
@@ -72,6 +73,7 @@ public class JPAJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration);
+        server.combineWith(RunArgumentsModule.EMPTY);
 
         JamesServerMain.main(server);
     }

--- a/server/apps/jpa-smtp-app/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/apps/jpa-smtp-app/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -72,8 +72,8 @@ public class JPAJamesServerMain implements JamesServerMain {
             .build();
 
         LOGGER.info("Loading configuration {}", configuration.toString());
-        GuiceJamesServer server = createServer(configuration);
-        server.combineWith(RunArgumentsModule.EMPTY);
+        GuiceJamesServer server = createServer(configuration)
+            .overrideWith(new RunArgumentsModule(args));
 
         JamesServerMain.main(server);
     }

--- a/server/apps/memory-app/README.md
+++ b/server/apps/memory-app/README.md
@@ -32,6 +32,14 @@ keytool -genkey -alias james -keyalg RSA -keystore keystore
 docker run -v $PWD/keystore:/root/conf/keystore apache/james:memory-latest
 ```
 
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `start-dev` when running,
+James will auto-generate keystore file with the default setting:
+
+```
+docker run apache/james:memory-latest start-dev
+```
+
+
 Use the [JAVA_TOOL_OPTIONS environment option](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#jvm-flags) 
 to pass extra JVM flags. For instance:
 

--- a/server/apps/memory-app/README.md
+++ b/server/apps/memory-app/README.md
@@ -32,11 +32,11 @@ keytool -genkey -alias james -keyalg RSA -keystore keystore
 docker run -v $PWD/keystore:/root/conf/keystore apache/james:memory-latest
 ```
 
-In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `start-dev` when running,
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
 James will auto-generate keystore file with the default setting:
 
 ```
-docker run apache/james:memory-latest start-dev
+docker run apache/james:memory-latest --generate-keystore
 ```
 
 

--- a/server/apps/memory-app/README.md
+++ b/server/apps/memory-app/README.md
@@ -32,11 +32,12 @@ keytool -genkey -alias james -keyalg RSA -keystore keystore
 docker run -v $PWD/keystore:/root/conf/keystore apache/james:memory-latest
 ```
 
-In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
-James will auto-generate keystore file with the default setting:
+In the case of quick start James without manually creating a keystore (e.g. for development),
+James memory server will auto-generate keystore file with the default setting that is declared in `jmap.properties` (tls.keystoreURL, tls.secret)
+Hence just run docker command:
 
 ```
-docker run apache/james:memory-latest --generate-keystore
+docker run apache/james:memory-latest
 ```
 
 

--- a/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -159,7 +159,7 @@ public class MemoryJamesServerMain implements JamesServerMain {
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
             .combineWith(new FakeSearchMailboxModule(), new JMXServerModule())
-            .overrideWith(new RunArgumentsModule(args).mergeArgs(RunArguments.Argument.GENERATE_KEYSTORE.getRawValue()));
+            .overrideWith(new RunArgumentsModule(args));
 
         JamesServerMain.main(server);
     }

--- a/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -158,8 +158,8 @@ public class MemoryJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(new RunArgumentsModule(args))
-            .combineWith(new FakeSearchMailboxModule(), new JMXServerModule());
+            .combineWith(new FakeSearchMailboxModule(), new JMXServerModule())
+            .overrideWith(new RunArgumentsModule(args).mergeArgs(RunArguments.Argument.GENERATE_KEYSTORE.getRawValue()));
 
         JamesServerMain.main(server);
     }

--- a/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -29,6 +29,7 @@ import org.apache.james.modules.BlobExportMechanismModule;
 import org.apache.james.modules.BlobMemoryModule;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.MemoryDataJmapModule;
 import org.apache.james.modules.data.MemoryDataModule;
 import org.apache.james.modules.data.MemoryDelegationStoreModule;
@@ -157,6 +158,7 @@ public class MemoryJamesServerMain implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
+            .combineWith(new RunArgumentsModule(args))
             .combineWith(new FakeSearchMailboxModule(), new JMXServerModule());
 
         JamesServerMain.main(server);

--- a/server/apps/memory-app/src/test/java/org/apache/james/GuiceJamesServerTest.java
+++ b/server/apps/memory-app/src/test/java/org/apache/james/GuiceJamesServerTest.java
@@ -1,3 +1,22 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
 package org.apache.james;
 
 import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;

--- a/server/apps/memory-app/src/test/java/org/apache/james/MemoryJamesServerTest.java
+++ b/server/apps/memory-app/src/test/java/org/apache/james/MemoryJamesServerTest.java
@@ -22,9 +22,38 @@ package org.apache.james;
 import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
 
 import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.LmtpGuiceProbe;
+import org.apache.james.modules.protocols.Pop3GuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class MemoryJamesServerTest implements JamesServerContract {
+    @Override
+    public int imapPort(GuiceJamesServer server) {
+        return server.getProbe(ImapGuiceProbe.class).getImapPort();
+    }
+
+    @Override
+    public int imapsPort(GuiceJamesServer server) {
+        return server.getProbe(ImapGuiceProbe.class).getImapsPort();
+    }
+
+    @Override
+    public int smtpPort(GuiceJamesServer server) {
+        return server.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue();
+    }
+
+    @Override
+    public int lmtpPort(GuiceJamesServer server) {
+        return server.getProbe(LmtpGuiceProbe.class).getLmtpPort();
+    }
+
+    @Override
+    public int pop3Port(GuiceJamesServer server) {
+        return server.getProbe(Pop3GuiceProbe.class).getPop3Port();
+    }
+
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryJamesConfiguration>(tmpDir ->
         MemoryJamesConfiguration.builder()

--- a/server/apps/memory-app/src/test/java/org/apache/james/MemoryJmapJamesServerTest.java
+++ b/server/apps/memory-app/src/test/java/org/apache/james/MemoryJmapJamesServerTest.java
@@ -27,6 +27,8 @@ import org.apache.james.jmap.draft.JMAPConfigurationStartUpCheck;
 import org.apache.james.jmap.draft.JMAPDraftConfiguration;
 import org.apache.james.jmap.draft.JmapJamesServerContract;
 import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -46,6 +48,16 @@ class MemoryJmapJamesServerTest {
 
     @Nested
     class JmapJamesServerTest implements JmapJamesServerContract, MailsShouldBeWellReceived {
+        @Override
+        public int imapPort(GuiceJamesServer server) {
+            return server.getProbe(ImapGuiceProbe.class).getImapPort();
+        }
+
+        @Override
+        public int smtpPort(GuiceJamesServer server) {
+            return server.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue();
+        }
+
         @RegisterExtension
         JamesServerExtension jamesServerExtension = extensionBuilder().build();
     }

--- a/server/apps/scaling-pulsar-smtp/README.md
+++ b/server/apps/scaling-pulsar-smtp/README.md
@@ -44,6 +44,13 @@ keytool -genkey -alias james -keyalg RSA -keystore keystore
 docker run -v $PWD/keystore:/root/conf/keystore apache/james:scaling-pulsar-smtp-latest
 ```
 
+In the case of quick start James without manually creating a keystore (e.g. for development), just input the command argument `--generate-keystore` when running,
+James will auto-generate keystore file with the default setting that is declared in `jmap.properties` (tls.keystoreURL, tls.secret)
+
+```
+docker run --network james apache/james:scaling-pulsar-smtp-latest --generate-keystore
+```
+
 Use the [JAVA_TOOL_OPTIONS environment option](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#jvm-flags) 
 to pass extra JVM flags. For instance:
 

--- a/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
+++ b/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
@@ -120,7 +120,7 @@ public class Main implements JamesServerMain {
 
         LOGGER.info("Loading configuration {}", configuration.toString());
         GuiceJamesServer server = createServer(configuration)
-            .combineWith(RunArgumentsModule.EMPTY);
+            .overrideWith(new RunArgumentsModule(args));
 
         try {
             JamesServerMain.main(server);

--- a/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
+++ b/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
@@ -28,6 +28,7 @@ import org.apache.james.blob.cassandra.CassandraBlobStoreDAO;
 import org.apache.james.mailrepository.api.MailRepositoryUrlStore;
 import org.apache.james.mailrepository.cassandra.CassandraMailRepositoryUrlModule;
 import org.apache.james.mailrepository.cassandra.CassandraMailRepositoryUrlStore;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.data.CassandraDelegationStoreModule;
 import org.apache.james.modules.data.CassandraDomainListModule;
 import org.apache.james.modules.data.CassandraRecipientRewriteTableModule;
@@ -118,7 +119,8 @@ public class Main implements JamesServerMain {
                 .build();
 
         LOGGER.info("Loading configuration {}", configuration.toString());
-        GuiceJamesServer server = createServer(configuration);
+        GuiceJamesServer server = createServer(configuration)
+            .combineWith(RunArgumentsModule.EMPTY);
 
         try {
             JamesServerMain.main(server);

--- a/server/container/guice/common/pom.xml
+++ b/server/container/guice/common/pom.xml
@@ -62,16 +62,6 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-guice-imap</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-guice-lmtp</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-mailbox</artifactId>
             <scope>test</scope>
         </dependency>
@@ -82,16 +72,6 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-netty</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-guice-pop</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-guice-smtp</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/server/container/guice/common/src/main/java/org/apache/james/ConfigurationSanitizingPerformer.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/ConfigurationSanitizingPerformer.java
@@ -17,19 +17,25 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.modules;
+package org.apache.james;
+
+import java.util.Set;
+
+import javax.inject.Inject;
 
 import org.apache.james.lifecycle.api.ConfigurationSanitizer;
-import org.apache.james.lifecycle.api.StartUpCheck;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.Multibinder;
+import com.github.fge.lambdas.Throwing;
 
-public class StartUpChecksModule extends AbstractModule {
+public class ConfigurationSanitizingPerformer {
+    private final Set<ConfigurationSanitizer> sanitizers;
 
-    @Override
-    protected void configure() {
-        Multibinder.newSetBinder(binder(), StartUpCheck.class);
-        Multibinder.newSetBinder(binder(), ConfigurationSanitizer.class);
+    @Inject
+    public ConfigurationSanitizingPerformer(Set<ConfigurationSanitizer> sanitizers) {
+        this.sanitizers = sanitizers;
+    }
+
+    public void sanitize() throws Exception {
+        sanitizers.forEach(Throwing.consumer(ConfigurationSanitizer::sanitize));
     }
 }

--- a/server/container/guice/common/src/main/java/org/apache/james/GuiceJamesServer.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/GuiceJamesServer.java
@@ -88,8 +88,8 @@ public class GuiceJamesServer {
             guiceProbeProvider = injector.getInstance(GuiceProbeProvider.class);
             preDestroy = injector.getInstance(Key.get(new TypeLiteral<Stager<PreDestroy>>() {
             }));
-            injector.getInstance(StartUpChecksPerformer.class)
-                .performCheck();
+            injector.getInstance(ConfigurationSanitizingPerformer.class).sanitize();
+            injector.getInstance(StartUpChecksPerformer.class).performCheck();
             injector.getInstance(InitializationOperations.class).initModules();
             isStartedProbe.notifyStarted();
             LOGGER.info("JAMES server started");

--- a/server/container/guice/common/src/main/java/org/apache/james/ProtocolConfigurationSanitizer.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/ProtocolConfigurationSanitizer.java
@@ -1,0 +1,75 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.RunArguments;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
+import org.apache.james.protocols.lib.SslConfig;
+import org.apache.james.server.core.configuration.ConfigurationProvider;
+import org.apache.james.utils.KeystoreCreator;
+
+public class ProtocolConfigurationSanitizer implements ConfigurationSanitizer {
+    private final ConfigurationProvider configurationProvider;
+    private final KeystoreCreator keystoreCreator;
+    private final FileSystem fileSystem;
+    private final RunArguments runArguments;
+    private final String component;
+
+    public ProtocolConfigurationSanitizer(ConfigurationProvider configurationProvider, KeystoreCreator keystoreCreator,
+                                          FileSystem fileSystem, RunArguments runArguments, String component) {
+        this.configurationProvider = configurationProvider;
+        this.keystoreCreator = keystoreCreator;
+        this.fileSystem = fileSystem;
+        this.runArguments = runArguments;
+        this.component = component;
+    }
+
+    @Override
+    public void sanitize() throws Exception {
+        if (runArguments.contain(RunArguments.Argument.GENERATE_KEYSTORE)) {
+            HierarchicalConfiguration<ImmutableNode> config = configurationProvider.getConfiguration(component);
+            List<HierarchicalConfiguration<ImmutableNode>> configs = config.configurationsAt(component);
+
+            for (HierarchicalConfiguration<ImmutableNode> serverConfig : configs) {
+                SslConfig sslConfig = SslConfig.parse(serverConfig);
+
+                if (sslConfig.getKeystore() != null
+                    && !exists(sslConfig.getKeystore())) {
+
+                    keystoreCreator.generateKeystore(sslConfig.getKeystore(), sslConfig.getSecret(), sslConfig.getKeystoreType());
+                }
+            }
+        }
+    }
+
+    private boolean exists(String file) {
+        try {
+            return fileSystem.getFile(file).exists();
+        } catch (FileNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/server/container/guice/common/src/main/java/org/apache/james/RunArguments.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/RunArguments.java
@@ -36,15 +36,23 @@ public class RunArguments {
     }
 
     public enum Argument {
-        START_DEV;
+        GENERATE_KEYSTORE("--generate-keystore");
+
+        private final String rawValue;
+
+        Argument(String rawValue) {
+            this.rawValue = rawValue;
+        }
 
         public static Argument parse(String arg) {
-            switch (arg) {
-                case "start-dev":
-                    return START_DEV;
-                default:
-                    throw new IllegalArgumentException("Invalid running argument: " + arg);
-            }
+            return Arrays.stream(Argument.values())
+                .filter(argument -> argument.rawValue.equals(arg))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid running argument: " + arg));
+        }
+
+        public String getRawValue() {
+            return rawValue;
         }
     }
 
@@ -58,7 +66,7 @@ public class RunArguments {
         return arguments;
     }
 
-    public boolean containStartDev() {
-        return getArguments().contains(Argument.START_DEV);
+    public boolean contain(Argument argument) {
+        return getArguments().contains(argument);
     }
 }

--- a/server/container/guice/common/src/main/java/org/apache/james/RunArguments.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/RunArguments.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RunArguments {
+
+    public static RunArguments empty() {
+        return new RunArguments(Set.of());
+    }
+
+    public static RunArguments from(String[] args) {
+        return new RunArguments(Arrays.stream(args)
+            .map(Argument::parse)
+            .collect(Collectors.toSet()));
+    }
+
+    public enum Argument {
+        START_DEV;
+
+        public static Argument parse(String arg) {
+            switch (arg) {
+                case "start-dev":
+                    return START_DEV;
+                default:
+                    throw new IllegalArgumentException("Invalid running argument: " + arg);
+            }
+        }
+    }
+
+    private final Set<Argument> arguments;
+
+    public RunArguments(Set<Argument> arguments) {
+        this.arguments = arguments;
+    }
+
+    public Set<Argument> getArguments() {
+        return arguments;
+    }
+
+    public boolean containStartDev() {
+        return getArguments().contains(Argument.START_DEV);
+    }
+}

--- a/server/container/guice/common/src/main/java/org/apache/james/modules/CommonServicesModule.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/modules/CommonServicesModule.java
@@ -62,6 +62,7 @@ public class CommonServicesModule extends AbstractModule {
         install(new ClockModule());
         install(new PeriodicalHealthChecksModule());
         install(new ErrorMailRepositoryEmptyHealthCheckModule());
+        install(RunArgumentsModule.EMPTY);
 
         bind(FileSystem.class).toInstance(fileSystem);
         bind(Configuration.class).toInstance(configuration);

--- a/server/container/guice/common/src/main/java/org/apache/james/modules/RunArgumentsModule.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/modules/RunArgumentsModule.java
@@ -19,22 +19,17 @@
 
 package org.apache.james.modules;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.james.RunArguments;
 
 import com.google.inject.AbstractModule;
 
 public class RunArgumentsModule extends AbstractModule {
-    public static RunArgumentsModule EMPTY = new RunArgumentsModule(new String[0]);
+    public static final RunArgumentsModule EMPTY = new RunArgumentsModule(new String[0]);
 
     public final String[] args;
 
     public RunArgumentsModule(String[] args) {
         this.args = args;
-    }
-
-    public RunArgumentsModule mergeArgs(String... mergeArgs) {
-       return new RunArgumentsModule(ArrayUtils.addAll(this.args, mergeArgs));
     }
 
     @Override

--- a/server/container/guice/common/src/main/java/org/apache/james/modules/RunArgumentsModule.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/modules/RunArgumentsModule.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.modules;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.james.RunArguments;
 
 import com.google.inject.AbstractModule;
@@ -30,6 +31,10 @@ public class RunArgumentsModule extends AbstractModule {
 
     public RunArgumentsModule(String[] args) {
         this.args = args;
+    }
+
+    public RunArgumentsModule mergeArgs(String... mergeArgs) {
+       return new RunArgumentsModule(ArrayUtils.addAll(this.args, mergeArgs));
     }
 
     @Override

--- a/server/container/guice/common/src/main/java/org/apache/james/modules/RunArgumentsModule.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/modules/RunArgumentsModule.java
@@ -1,0 +1,39 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules;
+
+import org.apache.james.RunArguments;
+
+import com.google.inject.AbstractModule;
+
+public class RunArgumentsModule extends AbstractModule {
+    public static RunArgumentsModule EMPTY = new RunArgumentsModule(new String[0]);
+
+    public final String[] args;
+
+    public RunArgumentsModule(String[] args) {
+        this.args = args;
+    }
+
+    @Override
+    protected void configure() {
+        bind(RunArguments.class).toInstance(RunArguments.from(args));
+    }
+}

--- a/server/container/guice/common/src/test/java/org/apache/james/JamesServerContract.java
+++ b/server/container/guice/common/src/test/java/org/apache/james/JamesServerContract.java
@@ -26,19 +26,25 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.james.modules.protocols.ImapGuiceProbe;
-import org.apache.james.modules.protocols.LmtpGuiceProbe;
-import org.apache.james.modules.protocols.Pop3GuiceProbe;
-import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.junit.jupiter.api.Test;
 
 public interface JamesServerContract {
     String JAMES_SERVER_HOST = "127.0.0.1";
 
+    int imapPort(GuiceJamesServer server);
+
+    int imapsPort(GuiceJamesServer server);
+
+    int smtpPort(GuiceJamesServer server);
+    
+    int lmtpPort(GuiceJamesServer server);
+
+    int pop3Port(GuiceJamesServer server);
+
     @Test
     default void connectIMAPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
         try (SocketChannel socketChannel = SocketChannel.open()) {
-            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort()));
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, imapPort(jamesServer)));
             assertThat(getServerConnectionResponse(socketChannel)).startsWith("* OK JAMES IMAP4rev1 Server");
         }
     }
@@ -46,7 +52,7 @@ public interface JamesServerContract {
     @Test
     default void connectOnSecondaryIMAPServerIMAPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
         try (SocketChannel socketChannel = SocketChannel.open()) {
-            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(ImapGuiceProbe.class).getImapsPort()));
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, imapsPort(jamesServer)));
             assertThat(getServerConnectionResponse(socketChannel)).startsWith("* OK JAMES IMAP4rev1 Server");
         }
     }
@@ -54,7 +60,7 @@ public interface JamesServerContract {
     @Test
     default void connectPOP3ServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
         try (SocketChannel socketChannel = SocketChannel.open()) {
-            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(Pop3GuiceProbe.class).getPop3Port()));
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, pop3Port(jamesServer)));
             assertThat(getServerConnectionResponse(socketChannel)).contains("POP3 server (JAMES POP3 Server ) ready");
         }
     }
@@ -62,7 +68,7 @@ public interface JamesServerContract {
     @Test
     default void connectSMTPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
         try (SocketChannel socketChannel = SocketChannel.open()) {
-            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue()));
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, smtpPort(jamesServer)));
             assertThat(getServerConnectionResponse(socketChannel)).startsWith("220 Apache JAMES awesome SMTP Server");
         }
     }
@@ -70,7 +76,7 @@ public interface JamesServerContract {
     @Test
     default void connectLMTPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
         try (SocketChannel socketChannel = SocketChannel.open()) {
-            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(LmtpGuiceProbe.class).getLmtpPort()));
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, lmtpPort(jamesServer)));
             assertThat(getServerConnectionResponse(socketChannel)).contains("LMTP Server (JAMES Protocols Server) ready");
         }
     }

--- a/server/container/guice/configuration/pom.xml
+++ b/server/container/guice/configuration/pom.xml
@@ -59,6 +59,14 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/KeystoreCreator.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/KeystoreCreator.java
@@ -38,6 +38,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
+import javax.inject.Inject;
+
 import org.apache.james.filesystem.api.FileSystem;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -52,6 +54,7 @@ public class KeystoreCreator {
 
     private final FileSystem fileSystem;
 
+    @Inject
     public KeystoreCreator(FileSystem fileSystem) {
         this.fileSystem = fileSystem;
     }

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/KeystoreCreator.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/KeystoreCreator.java
@@ -1,0 +1,100 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.utils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.apache.james.filesystem.api.FileSystem;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KeystoreCreator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeystoreCreator.class);
+
+    private final FileSystem fileSystem;
+
+    public KeystoreCreator(FileSystem fileSystem) {
+        this.fileSystem = fileSystem;
+    }
+
+    public void generateKeystore(String location, String passwordString, String keystoreType) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(4096);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        X500Name subjName = new X500Name("CN=james");
+        X509CertificateHolder x509CertificateHolder = new JcaX509v3CertificateBuilder(subjName,
+            new BigInteger(64, new SecureRandom()),
+            Date.from(Instant.now()),
+            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+            subjName, keyPair.getPublic())
+            .build(new JcaContentSignerBuilder("SHA256WITHRSA")
+                .build(keyPair.getPrivate()));
+
+        X509Certificate mySelfSignedCert = new JcaX509CertificateConverter().getCertificate(
+            x509CertificateHolder);
+
+        char[] password = passwordString.toCharArray();
+
+        KeyStore keystore = KeyStore.getInstance(keystoreType);
+        keystore.load(null, password);
+
+        KeyStore.PrivateKeyEntry privKeyEntry = new KeyStore.PrivateKeyEntry(keyPair.getPrivate(),
+            new Certificate[] {mySelfSignedCert});
+        keystore.setEntry("james", privKeyEntry, new KeyStore.PasswordProtection(password));
+
+        storeFile(location, password, keystore);
+    }
+
+    private void storeFile(String location, char[] password, KeyStore keystore) throws KeyStoreException, NoSuchAlgorithmException, CertificateException, FileNotFoundException {
+        File keystoreFile = fileSystem.getFile(location);
+
+        if (!keystoreFile.exists()) {
+            try (OutputStream outputStream = new FileOutputStream(keystoreFile)) {
+                keystore.store(outputStream, password);
+                LOGGER.info("Generated keystore file: {}", keystoreFile.getPath());
+            } catch (IOException e) {
+                throw new RuntimeException("Error when creating Keystore file: " + keystoreFile.getPath(), e);
+            }
+        }
+    }
+}

--- a/server/container/guice/protocols/imap/pom.xml
+++ b/server/container/guice/protocols/imap/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-configuration</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/protocols/imap/src/main/java/org/apache/james/modules/protocols/IMAPServerModule.java
+++ b/server/container/guice/protocols/imap/src/main/java/org/apache/james/modules/protocols/IMAPServerModule.java
@@ -27,6 +27,8 @@ import javax.inject.Provider;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.ProtocolConfigurationSanitizer;
+import org.apache.james.RunArguments;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.imap.api.display.Localizer;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
@@ -55,6 +57,7 @@ import org.apache.james.imap.processor.SelectProcessor;
 import org.apache.james.imap.processor.base.AbstractProcessor;
 import org.apache.james.imap.processor.base.UnknownRequestProcessor;
 import org.apache.james.imapserver.netty.IMAPServerFactory;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
 import org.apache.james.metrics.api.GaugeRegistry;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
@@ -63,6 +66,7 @@ import org.apache.james.utils.GuiceGenericLoader;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.utils.KeystoreCreator;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
@@ -209,5 +213,11 @@ public class IMAPServerModule extends AbstractModule {
                 Function.identity()));
 
         return new ImapParserFactory(decoders);
+    }
+
+    @ProvidesIntoSet
+    ConfigurationSanitizer configurationSanitizer(ConfigurationProvider configurationProvider, KeystoreCreator keystoreCreator,
+                                                      FileSystem fileSystem, RunArguments runArguments) {
+        return new ProtocolConfigurationSanitizer(configurationProvider, keystoreCreator, fileSystem, runArguments, "imapserver");
     }
 }

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
@@ -38,6 +38,7 @@ import org.apache.james.jmap.draft.model.message.view.MessageHeaderViewFactory;
 import org.apache.james.jmap.draft.model.message.view.MessageMetadataViewFactory;
 import org.apache.james.jmap.draft.send.MailSpool;
 import org.apache.james.jmap.event.ComputeMessageFastViewProjectionListener;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
 import org.apache.james.lifecycle.api.StartUpCheck;
 import org.apache.james.util.date.DefaultZonedDateTimeProvider;
 import org.apache.james.util.date.ZonedDateTimeProvider;
@@ -86,6 +87,9 @@ public class JMAPCommonModule extends AbstractModule {
 
         Multibinder.newSetBinder(binder(), StartUpCheck.class)
             .addBinding().to(JMAPConfigurationStartUpCheck.class);
+
+        Multibinder.newSetBinder(binder(), ConfigurationSanitizer.class)
+            .addBinding().to(JmapConfigurationSanitizer.class);
     }
 
     @ProvidesIntoSet

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPConfigurationStartUpCheck.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPConfigurationStartUpCheck.java
@@ -19,12 +19,40 @@
 
 package org.apache.james.jmap.draft;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
 import javax.inject.Inject;
 
+import org.apache.james.RunArguments;
+import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.jmap.draft.crypto.SecurityKeyLoader;
 import org.apache.james.lifecycle.api.StartUpCheck;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
 
 public class JMAPConfigurationStartUpCheck implements StartUpCheck {
 
@@ -33,11 +61,18 @@ public class JMAPConfigurationStartUpCheck implements StartUpCheck {
 
     private final SecurityKeyLoader securityKeyLoader;
     private final JMAPDraftConfiguration jmapConfiguration;
+    private final RunArguments runArguments;
+    private final FileSystem fileSystem;
 
     @Inject
-    JMAPConfigurationStartUpCheck(SecurityKeyLoader securityKeyLoader, JMAPDraftConfiguration jmapConfiguration) {
+    JMAPConfigurationStartUpCheck(SecurityKeyLoader securityKeyLoader,
+                                  JMAPDraftConfiguration jmapConfiguration,
+                                  RunArguments runArguments,
+                                  FileSystem fileSystem) {
         this.securityKeyLoader = securityKeyLoader;
         this.jmapConfiguration = jmapConfiguration;
+        this.runArguments = runArguments;
+        this.fileSystem = fileSystem;
     }
 
     @Override
@@ -54,7 +89,7 @@ public class JMAPConfigurationStartUpCheck implements StartUpCheck {
 
     private CheckResult checkSecurityKey() {
         try {
-            securityKeyLoader.load();
+            loadSecurityKey();
             return CheckResult.builder()
                 .checkName(checkName())
                 .resultType(ResultType.GOOD)
@@ -69,8 +104,71 @@ public class JMAPConfigurationStartUpCheck implements StartUpCheck {
         }
     }
 
+    private void loadSecurityKey() throws Exception {
+        try {
+            securityKeyLoader.load();
+        } catch (FileNotFoundException e) {
+            if (runArguments.containStartDev()) {
+                LOGGER.warn("Can not load asymmetric key from configuration file" + e.getMessage());
+                LOGGER.warn("James will try the auto-generate an asymmetric key. It is just for development, should not use it on production");
+                generateKeystore();
+            } else {
+                throw e;
+            }
+        }
+    }
+
     @Override
     public String checkName() {
         return CHECK_NAME;
+    }
+
+    private void generateKeystore() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(4096);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        X500Name subjName = new X500Name("CN=james");
+        X509CertificateHolder x509CertificateHolder = new JcaX509v3CertificateBuilder(subjName,
+            new BigInteger(64, new SecureRandom()),
+            Date.from(Instant.now()),
+            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+            subjName, keyPair.getPublic())
+            .build(new JcaContentSignerBuilder("SHA256WITHRSA")
+                .build(keyPair.getPrivate()));
+
+        X509Certificate mySelfSignedCert = new JcaX509CertificateConverter().getCertificate(
+            x509CertificateHolder);
+
+        final char[] password =  jmapConfiguration.getSecret()
+            .orElseGet(() -> {
+                String dummyPass = new String(new byte[8]);
+                LOGGER.warn("Keystore dummy password: " + dummyPass);
+                return dummyPass;
+            }).toCharArray();
+
+        KeyStore keystore = KeyStore.getInstance(jmapConfiguration.getKeystoreType());
+        keystore.load(null, password);
+
+        KeyStore.PrivateKeyEntry privKeyEntry = new KeyStore.PrivateKeyEntry(keyPair.getPrivate(),
+            new Certificate[] {mySelfSignedCert});
+        keystore.setEntry("james", privKeyEntry, new KeyStore.PasswordProtection(password));
+
+        storeFile(password, keystore);
+    }
+
+    private void storeFile(char[] password, KeyStore keystore) throws KeyStoreException, NoSuchAlgorithmException, CertificateException {
+        File keystoreFile = jmapConfiguration.getKeystore()
+            .map(Throwing.function(fileSystem::getFile))
+            .orElseThrow(() -> new IllegalArgumentException("tls.keystoreURL was not defined"));
+
+        if (!keystoreFile.exists()) {
+            try (OutputStream outputStream = new FileOutputStream(keystoreFile)) {
+                keystore.store(outputStream, password);
+                LOGGER.info("Generated keystore file: " + keystoreFile.getPath());
+            } catch (IOException e) {
+                throw new RuntimeException("Error when creating Keystore file: " + keystoreFile.getPath(), e);
+            }
+        }
     }
 }

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPConfigurationStartUpCheck.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPConfigurationStartUpCheck.java
@@ -41,6 +41,7 @@ import java.util.Date;
 import javax.inject.Inject;
 
 import org.apache.james.RunArguments;
+import org.apache.james.RunArguments.Argument;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.jmap.draft.crypto.SecurityKeyLoader;
 import org.apache.james.lifecycle.api.StartUpCheck;
@@ -108,7 +109,7 @@ public class JMAPConfigurationStartUpCheck implements StartUpCheck {
         try {
             securityKeyLoader.load();
         } catch (FileNotFoundException e) {
-            if (runArguments.containStartDev()) {
+            if (runArguments.contain(Argument.GENERATE_KEYSTORE)) {
                 LOGGER.warn("Can not load asymmetric key from configuration file" + e.getMessage());
                 LOGGER.warn("James will try the auto-generate an asymmetric key. It is just for development, should not use it on production");
                 generateKeystore();

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPConfigurationStartUpCheck.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPConfigurationStartUpCheck.java
@@ -19,41 +19,17 @@
 
 package org.apache.james.jmap.draft;
 
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.math.BigInteger;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
 import javax.inject.Inject;
 
 import org.apache.james.RunArguments;
 import org.apache.james.RunArguments.Argument;
-import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.jmap.draft.crypto.SecurityKeyLoader;
 import org.apache.james.lifecycle.api.StartUpCheck;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.apache.james.utils.KeystoreCreator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.github.fge.lambdas.Throwing;
 
 public class JMAPConfigurationStartUpCheck implements StartUpCheck {
 
@@ -63,17 +39,17 @@ public class JMAPConfigurationStartUpCheck implements StartUpCheck {
     private final SecurityKeyLoader securityKeyLoader;
     private final JMAPDraftConfiguration jmapConfiguration;
     private final RunArguments runArguments;
-    private final FileSystem fileSystem;
+    private final KeystoreCreator keystoreCreator;
 
     @Inject
     JMAPConfigurationStartUpCheck(SecurityKeyLoader securityKeyLoader,
                                   JMAPDraftConfiguration jmapConfiguration,
                                   RunArguments runArguments,
-                                  FileSystem fileSystem) {
+                                  KeystoreCreator keystoreCreator) {
         this.securityKeyLoader = securityKeyLoader;
         this.jmapConfiguration = jmapConfiguration;
         this.runArguments = runArguments;
-        this.fileSystem = fileSystem;
+        this.keystoreCreator = keystoreCreator;
     }
 
     @Override
@@ -110,9 +86,17 @@ public class JMAPConfigurationStartUpCheck implements StartUpCheck {
             securityKeyLoader.load();
         } catch (FileNotFoundException e) {
             if (runArguments.contain(Argument.GENERATE_KEYSTORE)) {
-                LOGGER.warn("Can not load asymmetric key from configuration file" + e.getMessage());
-                LOGGER.warn("James will try the auto-generate an asymmetric key. It is just for development, should not use it on production");
-                generateKeystore();
+                LOGGER.warn("Can not load asymmetric key from configuration file", e);
+                LOGGER.warn("James will auto-generate an asymmetric key.");
+
+                keystoreCreator.generateKeystore(
+                    jmapConfiguration.getKeystore()
+                        .orElseThrow(() -> new IllegalArgumentException("Can not auto-generate keystore as the keystore location is missing from the configuration")),
+                    jmapConfiguration.getSecret()
+                        .orElseThrow(() -> new IllegalArgumentException("Can not auto-generate keystore as the keystore secret is missing from the configuration")),
+                    jmapConfiguration.getKeystoreType());
+
+                securityKeyLoader.load();
             } else {
                 throw e;
             }
@@ -124,52 +108,4 @@ public class JMAPConfigurationStartUpCheck implements StartUpCheck {
         return CHECK_NAME;
     }
 
-    private void generateKeystore() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(4096);
-        KeyPair keyPair = kpg.generateKeyPair();
-
-        X500Name subjName = new X500Name("CN=james");
-        X509CertificateHolder x509CertificateHolder = new JcaX509v3CertificateBuilder(subjName,
-            new BigInteger(64, new SecureRandom()),
-            Date.from(Instant.now()),
-            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
-            subjName, keyPair.getPublic())
-            .build(new JcaContentSignerBuilder("SHA256WITHRSA")
-                .build(keyPair.getPrivate()));
-
-        X509Certificate mySelfSignedCert = new JcaX509CertificateConverter().getCertificate(
-            x509CertificateHolder);
-
-        final char[] password =  jmapConfiguration.getSecret()
-            .orElseGet(() -> {
-                String dummyPass = new String(new byte[8]);
-                LOGGER.warn("Keystore dummy password: " + dummyPass);
-                return dummyPass;
-            }).toCharArray();
-
-        KeyStore keystore = KeyStore.getInstance(jmapConfiguration.getKeystoreType());
-        keystore.load(null, password);
-
-        KeyStore.PrivateKeyEntry privKeyEntry = new KeyStore.PrivateKeyEntry(keyPair.getPrivate(),
-            new Certificate[] {mySelfSignedCert});
-        keystore.setEntry("james", privKeyEntry, new KeyStore.PasswordProtection(password));
-
-        storeFile(password, keystore);
-    }
-
-    private void storeFile(char[] password, KeyStore keystore) throws KeyStoreException, NoSuchAlgorithmException, CertificateException {
-        File keystoreFile = jmapConfiguration.getKeystore()
-            .map(Throwing.function(fileSystem::getFile))
-            .orElseThrow(() -> new IllegalArgumentException("tls.keystoreURL was not defined"));
-
-        if (!keystoreFile.exists()) {
-            try (OutputStream outputStream = new FileOutputStream(keystoreFile)) {
-                keystore.store(outputStream, password);
-                LOGGER.info("Generated keystore file: " + keystoreFile.getPath());
-            } catch (IOException e) {
-                throw new RuntimeException("Error when creating Keystore file: " + keystoreFile.getPath(), e);
-            }
-        }
-    }
 }

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JmapConfigurationSanitizer.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JmapConfigurationSanitizer.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.draft;
+
+import java.io.FileNotFoundException;
+
+import javax.inject.Inject;
+
+import org.apache.james.RunArguments;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
+import org.apache.james.utils.KeystoreCreator;
+
+public class JmapConfigurationSanitizer implements ConfigurationSanitizer {
+    private final JMAPDraftConfiguration jmapDraftConfiguration;
+    private final KeystoreCreator keystoreCreator;
+    private final FileSystem fileSystem;
+    private final RunArguments runArguments;
+
+    @Inject
+    public JmapConfigurationSanitizer(JMAPDraftConfiguration jmapDraftConfiguration, KeystoreCreator keystoreCreator, FileSystem fileSystem, RunArguments runArguments) {
+        this.jmapDraftConfiguration = jmapDraftConfiguration;
+        this.keystoreCreator = keystoreCreator;
+        this.fileSystem = fileSystem;
+        this.runArguments = runArguments;
+    }
+
+    @Override
+    public void sanitize() throws Exception {
+        if (jmapDraftConfiguration.isEnabled()
+            && jmapDraftConfiguration.getKeystore().isPresent()
+            && !keystoreExists()
+            && runArguments.contain(RunArguments.Argument.GENERATE_KEYSTORE)) {
+
+            keystoreCreator.generateKeystore(jmapDraftConfiguration.getKeystore().get(),
+                jmapDraftConfiguration.getSecret()
+                    .orElseThrow(() -> new IllegalArgumentException("Can not auto-generate keystore as the keystore secret is missing from the configuration")),
+                jmapDraftConfiguration.getKeystoreType());
+        }
+    }
+
+    private boolean keystoreExists() {
+        try {
+            return fileSystem.getFile(jmapDraftConfiguration.getKeystore().get()).exists();
+        } catch (FileNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/server/container/guice/protocols/lmtp/pom.xml
+++ b/server/container/guice/protocols/lmtp/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-configuration</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/protocols/lmtp/src/main/java/org/apache/james/modules/protocols/LMTPServerModule.java
+++ b/server/container/guice/protocols/lmtp/src/main/java/org/apache/james/modules/protocols/LMTPServerModule.java
@@ -19,12 +19,17 @@
 
 package org.apache.james.modules.protocols;
 
+import org.apache.james.ProtocolConfigurationSanitizer;
+import org.apache.james.RunArguments;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
 import org.apache.james.lmtpserver.netty.LMTPServerFactory;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.util.LoggingLevel;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.utils.KeystoreCreator;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -47,5 +52,11 @@ public class LMTPServerModule extends AbstractModule {
                 lmtpServerFactory.configure(configurationProvider.getConfiguration("lmtpserver", LoggingLevel.INFO));
                 lmtpServerFactory.init();
             });
+    }
+
+    @ProvidesIntoSet
+    ConfigurationSanitizer configurationSanitizer(ConfigurationProvider configurationProvider, KeystoreCreator keystoreCreator,
+                                                      FileSystem fileSystem, RunArguments runArguments) {
+        return new ProtocolConfigurationSanitizer(configurationProvider, keystoreCreator, fileSystem, runArguments, "lmtpserver");
     }
 }

--- a/server/container/guice/protocols/managedsieve/pom.xml
+++ b/server/container/guice/protocols/managedsieve/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-configuration</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/protocols/managedsieve/src/main/java/org/apache/james/modules/protocols/ManageSieveServerModule.java
+++ b/server/container/guice/protocols/managedsieve/src/main/java/org/apache/james/modules/protocols/ManageSieveServerModule.java
@@ -18,6 +18,10 @@
  ****************************************************************/
 package org.apache.james.modules.protocols;
 
+import org.apache.james.ProtocolConfigurationSanitizer;
+import org.apache.james.RunArguments;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
 import org.apache.james.managesieve.api.commands.CoreCommands;
 import org.apache.james.managesieve.core.CoreProcessor;
 import org.apache.james.managesieveserver.netty.ManageSieveServerFactory;
@@ -26,6 +30,7 @@ import org.apache.james.util.LoggingLevel;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.utils.KeystoreCreator;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
@@ -48,5 +53,11 @@ public class ManageSieveServerModule extends AbstractModule {
                 manageSieveServerFactory.configure(configurationProvider.getConfiguration("managesieveserver", LoggingLevel.INFO));
                 manageSieveServerFactory.init();
             });
+    }
+
+    @ProvidesIntoSet
+    ConfigurationSanitizer configurationSanitizer(ConfigurationProvider configurationProvider, KeystoreCreator keystoreCreator,
+                                                      FileSystem fileSystem, RunArguments runArguments) {
+        return new ProtocolConfigurationSanitizer(configurationProvider, keystoreCreator, fileSystem, runArguments, "managesieveserver");
     }
 }

--- a/server/container/guice/protocols/pop/pom.xml
+++ b/server/container/guice/protocols/pop/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-configuration</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/protocols/pop/src/main/java/org/apache/james/modules/protocols/POP3ServerModule.java
+++ b/server/container/guice/protocols/pop/src/main/java/org/apache/james/modules/protocols/POP3ServerModule.java
@@ -19,6 +19,10 @@
 
 package org.apache.james.modules.protocols;
 
+import org.apache.james.ProtocolConfigurationSanitizer;
+import org.apache.james.RunArguments;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
 import org.apache.james.pop3server.mailbox.DefaultMailboxAdapterFactory;
 import org.apache.james.pop3server.mailbox.MailboxAdapterFactory;
 import org.apache.james.pop3server.netty.POP3ServerFactory;
@@ -26,6 +30,7 @@ import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.utils.KeystoreCreator;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -51,5 +56,11 @@ public class POP3ServerModule extends AbstractModule {
                 pop3ServerFactory.configure(configurationProvider.getConfiguration("pop3server"));
                 pop3ServerFactory.init();
             });
+    }
+
+    @ProvidesIntoSet
+    ConfigurationSanitizer configurationSanitizer(ConfigurationProvider configurationProvider, KeystoreCreator keystoreCreator,
+                                                      FileSystem fileSystem, RunArguments runArguments) {
+        return new ProtocolConfigurationSanitizer(configurationProvider, keystoreCreator, fileSystem, runArguments, "pop3server");
     }
 }

--- a/server/container/guice/protocols/smtp/pom.xml
+++ b/server/container/guice/protocols/smtp/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-configuration</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SMTPServerModule.java
+++ b/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SMTPServerModule.java
@@ -19,12 +19,17 @@
 
 package org.apache.james.modules.protocols;
 
+import org.apache.james.ProtocolConfigurationSanitizer;
+import org.apache.james.RunArguments;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.lifecycle.api.ConfigurationSanitizer;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.smtpserver.SendMailHandler;
 import org.apache.james.smtpserver.netty.SMTPServerFactory;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.utils.KeystoreCreator;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -53,4 +58,9 @@ public class SMTPServerModule extends AbstractModule {
             });
     }
 
+    @ProvidesIntoSet
+    ConfigurationSanitizer configurationSanitizer(ConfigurationProvider configurationProvider, KeystoreCreator keystoreCreator,
+                                                      FileSystem fileSystem, RunArguments runArguments) {
+        return new ProtocolConfigurationSanitizer(configurationProvider, keystoreCreator, fileSystem, runArguments, "smtpserver");
+    }
 }

--- a/server/container/lifecycle-api/src/main/java/org/apache/james/lifecycle/api/ConfigurationSanitizer.java
+++ b/server/container/lifecycle-api/src/main/java/org/apache/james/lifecycle/api/ConfigurationSanitizer.java
@@ -17,19 +17,8 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.modules;
+package org.apache.james.lifecycle.api;
 
-import org.apache.james.lifecycle.api.ConfigurationSanitizer;
-import org.apache.james.lifecycle.api.StartUpCheck;
-
-import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.Multibinder;
-
-public class StartUpChecksModule extends AbstractModule {
-
-    @Override
-    protected void configure() {
-        Multibinder.newSetBinder(binder(), StartUpCheck.class);
-        Multibinder.newSetBinder(binder(), ConfigurationSanitizer.class);
-    }
+public interface ConfigurationSanitizer {
+    void sanitize() throws Exception;
 }

--- a/server/mailet/integration-testing/src/main/java/org/apache/james/mailets/TemporaryJamesServer.java
+++ b/server/mailet/integration-testing/src/main/java/org/apache/james/mailets/TemporaryJamesServer.java
@@ -40,6 +40,7 @@ import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.SmtpConfiguration;
+import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.data.MemoryUsersRepositoryModule;
 import org.apache.james.server.core.configuration.Configuration;
@@ -155,6 +156,7 @@ public class TemporaryJamesServer {
             .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
             .overrideWith(additionalModules)
             .overrideWith(new TestJMAPServerModule())
+            .overrideWith(RunArgumentsModule.EMPTY)
             .overrideWith((binder) -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION));
     }
 

--- a/server/mailet/integration-testing/src/main/java/org/apache/james/mailets/TemporaryJamesServer.java
+++ b/server/mailet/integration-testing/src/main/java/org/apache/james/mailets/TemporaryJamesServer.java
@@ -40,7 +40,6 @@ import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.SmtpConfiguration;
-import org.apache.james.modules.RunArgumentsModule;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.data.MemoryUsersRepositoryModule;
 import org.apache.james.server.core.configuration.Configuration;
@@ -156,7 +155,6 @@ public class TemporaryJamesServer {
             .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
             .overrideWith(additionalModules)
             .overrideWith(new TestJMAPServerModule())
-            .overrideWith(RunArgumentsModule.EMPTY)
             .overrideWith((binder) -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION));
     }
 

--- a/server/protocols/jmap-draft/pom.xml
+++ b/server/protocols/jmap-draft/pom.xml
@@ -118,6 +118,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-jmap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/server/protocols/jmap-draft/pom.xml
+++ b/server/protocols/jmap-draft/pom.xml
@@ -118,10 +118,6 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-guice-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-jmap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/crypto/SecurityKeyLoader.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/crypto/SecurityKeyLoader.java
@@ -96,7 +96,6 @@ public class SecurityKeyLoader {
         Preconditions.checkState(jmapDraftConfiguration.isEnabled(), "JMAP is not enabled");
 
         try {
-            LOGGER.info("tung keystore" + jmapDraftConfiguration.getKeystore());
             if (jmapDraftConfiguration.getKeystore().isPresent()) {
                 return loadFromKeystore();
             }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/crypto/SecurityKeyLoader.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/crypto/SecurityKeyLoader.java
@@ -19,46 +19,24 @@
 
 package org.apache.james.jmap.draft.crypto;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.SecureRandom;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Optional;
 
 import javax.inject.Inject;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.james.RunArguments;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.jmap.draft.JMAPDraftConfiguration;
 import org.apache.james.jwt.PublicKeyReader;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
@@ -67,47 +45,25 @@ import nl.altindag.ssl.util.KeyStoreUtils;
 import nl.altindag.ssl.util.PemUtils;
 
 public class SecurityKeyLoader {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityKeyLoader.class);
     private static final String ALIAS = "james";
 
     private final FileSystem fileSystem;
     private final JMAPDraftConfiguration jmapDraftConfiguration;
 
-    private final RunArguments runArguments;
-
     @VisibleForTesting
     @Inject
-    SecurityKeyLoader(FileSystem fileSystem,
-                      JMAPDraftConfiguration jmapDraftConfiguration,
-                      RunArguments runArguments) {
+    SecurityKeyLoader(FileSystem fileSystem, JMAPDraftConfiguration jmapDraftConfiguration) {
         this.fileSystem = fileSystem;
         this.jmapDraftConfiguration = jmapDraftConfiguration;
-        this.runArguments = runArguments;
-    }
-
-    SecurityKeyLoader(FileSystem fileSystem,
-                      JMAPDraftConfiguration jmapDraftConfiguration) {
-        this.fileSystem = fileSystem;
-        this.jmapDraftConfiguration = jmapDraftConfiguration;
-        this.runArguments = RunArguments.empty();
     }
 
     public AsymmetricKeys load() throws Exception {
         Preconditions.checkState(jmapDraftConfiguration.isEnabled(), "JMAP is not enabled");
 
-        try {
-            if (jmapDraftConfiguration.getKeystore().isPresent()) {
-                return loadFromKeystore();
-            }
-            return loadFromPEM();
-        } catch (FileNotFoundException e) {
-            if (runArguments.containStartDev()) {
-                LOGGER.warn("Can not load asymmetric key from configuration file" + e.getMessage());
-                LOGGER.warn("James will try the auto-generate an asymmetric key. It is just for development, should not use it on production");
-                return generateAsymmetricKeys();
-            }
-            throw e;
+        if (jmapDraftConfiguration.getKeystore().isPresent()) {
+            return loadFromKeystore();
         }
+        return loadFromPEM();
     }
 
     private AsymmetricKeys loadFromKeystore() throws Exception {
@@ -155,56 +111,4 @@ public class SecurityKeyLoader {
                 .orElseThrow(() -> new IllegalArgumentException("Key must either be a valid certificate or a public key"));
         }
     }
-
-    private AsymmetricKeys generateAsymmetricKeys() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(4096);
-        KeyPair keyPair = kpg.generateKeyPair();
-
-        X500Name subjName = new X500Name("CN=james");
-        X509CertificateHolder x509CertificateHolder = new JcaX509v3CertificateBuilder(subjName,
-            new BigInteger(64, new SecureRandom()),
-            Date.from(Instant.now()),
-            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
-            subjName, keyPair.getPublic())
-            .build(new JcaContentSignerBuilder("SHA256WITHRSA")
-                .build(keyPair.getPrivate()));
-
-        X509Certificate mySelfSignedCert = new JcaX509CertificateConverter().getCertificate(
-            x509CertificateHolder);
-
-        final char[] password =  jmapDraftConfiguration.getSecret()
-            .orElseGet(() -> {
-                String dummyPass = new String(new byte[8]);
-                LOGGER.warn("Keystore dummy password: " + dummyPass);
-                return dummyPass;
-            }).toCharArray();
-
-        KeyStore keystore = KeyStore.getInstance(jmapDraftConfiguration.getKeystoreType());
-        keystore.load(null, password);
-
-        KeyStore.PrivateKeyEntry privKeyEntry = new KeyStore.PrivateKeyEntry(keyPair.getPrivate(),
-            new Certificate[] {mySelfSignedCert});
-        keystore.setEntry(ALIAS, privKeyEntry, new KeyStore.PasswordProtection(password));
-
-        storeFile(password, keystore);
-
-        return new AsymmetricKeys(keyPair.getPrivate(), keyPair.getPublic());
-    }
-
-    private void storeFile(char[] password, KeyStore keystore) throws KeyStoreException, NoSuchAlgorithmException, CertificateException {
-        File keystoreFile = jmapDraftConfiguration.getKeystore()
-            .map(Throwing.function(fileSystem::getFile))
-            .orElseThrow(() -> new IllegalArgumentException("tls.keystoreURL was not defined"));
-
-        if (!keystoreFile.exists()) {
-            try (OutputStream outputStream = new FileOutputStream(keystoreFile)) {
-                keystore.store(outputStream, password);
-                LOGGER.info("Generated keystore file: " + keystoreFile.getPath());
-            } catch (IOException e) {
-                throw new RuntimeException("Error when creating Keystore file: " + keystoreFile.getPath(), e);
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
- James will auto-generate keystore file with the default setting

## Why?

- Currently, when running James server (JMAP Server),  For security reasons you are required to generate your own keystore, which you can mount into the container via a volume. -> Sometimes in the case of development, this requirement is a bit verbose

- Easier for newbies in the first step 
- Security is a low priority for memory server

## How 

- Make James support `start-dev` argument when starting (now available only for the memory server)
- If keystore file is not found & `start-dev`, James will auto-generate keystore file with the default setting