### PR TITLE
JAMES-3777 Incremental events for Filters

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -53,3 +53,8 @@ james.jmx.credential.generation=true
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
+
+# Disabling JMAP filters event source increments is necessary during rolling adoption of this change.
+# Defaults to true, meaning James will use JMAP filters event source increments, thus transparently and significantly
+# improving JMAP filter storage efficiency.
+# james.jmap.filters.eventsource.increments.enabled=true

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -53,3 +53,8 @@ james.jmx.credential.generation=true
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
+
+# Disabling JMAP filters event source increments is necessary during rolling adoption of this change.
+# Defaults to true, meaning James will use JMAP filters event source increments, thus transparently and significantly
+# improving JMAP filter storage efficiency.
+# james.jmap.filters.eventsource.increments.enabled=true

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/data/CassandraJmapModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/data/CassandraJmapModule.java
@@ -101,6 +101,7 @@ public class CassandraJmapModule extends AbstractModule {
 
         Multibinder<EventDTOModule<? extends Event, ? extends EventDTO>> eventDTOModuleBinder = Multibinder.newSetBinder(binder(), new TypeLiteral<>() {});
         eventDTOModuleBinder.addBinding().toInstance(FilteringRuleSetDefineDTOModules.FILTERING_RULE_SET_DEFINED);
+        eventDTOModuleBinder.addBinding().toInstance(FilteringRuleSetDefineDTOModules.FILTERING_INCREMENT);
 
 
         Multibinder.newSetBinder(binder(), UsernameChangeTaskStep.class)

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/FilteringIncrementalRuleChangeDTO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/FilteringIncrementalRuleChangeDTO.java
@@ -1,0 +1,141 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.cassandra.filtering;
+
+import java.util.Objects;
+
+import org.apache.james.eventsourcing.EventId;
+import org.apache.james.eventsourcing.eventstore.cassandra.dto.EventDTO;
+import org.apache.james.jmap.api.filtering.Rule;
+import org.apache.james.jmap.api.filtering.impl.FilteringAggregateId;
+import org.apache.james.jmap.api.filtering.impl.IncrementalRuleChange;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class FilteringIncrementalRuleChangeDTO implements EventDTO {
+
+    public static FilteringIncrementalRuleChangeDTO from(IncrementalRuleChange event, String type) {
+        return new FilteringIncrementalRuleChangeDTO(
+            type, event.eventId().serialize(),
+            event.getAggregateId().asAggregateKey(),
+            RuleDTO.from(event.getRulesPrepended()),
+            RuleDTO.from(event.getRulesPostPended()),
+            RuleDTO.from(event.getRulesUpdated()),
+            event.getRulesDeleted().stream()
+                .map(id -> id.asString())
+                .collect(ImmutableSet.toImmutableSet()));
+    }
+
+    public static FilteringIncrementalRuleChangeDTO from(IncrementalRuleChange event) {
+        return from(event, FilteringRuleSetDefineDTOModules.TYPE_INCREMENTAL);
+    }
+
+    private final String type;
+    private final int eventId;
+    private final String aggregateId;
+    private final ImmutableList<RuleDTO> prepended;
+    private final ImmutableList<RuleDTO> postpended;
+    private final ImmutableSet<String> deleted;
+    private final ImmutableList<RuleDTO> updated;
+
+
+    @JsonCreator
+    public FilteringIncrementalRuleChangeDTO(@JsonProperty("type") String type,
+                                             @JsonProperty("eventId") int eventId,
+                                             @JsonProperty("aggregateId") String aggregateId,
+                                             @JsonProperty("prepended") ImmutableList<RuleDTO> prepended,
+                                             @JsonProperty("postpended") ImmutableList<RuleDTO> postpended,
+                                             @JsonProperty("updated") ImmutableList<RuleDTO> updated,
+                                             @JsonProperty("deleted") ImmutableSet<String> deleted) {
+        this.type = type;
+        this.eventId = eventId;
+        this.aggregateId = aggregateId;
+        this.prepended = prepended;
+        this.postpended = postpended;
+        this.updated = updated;
+        this.deleted = deleted;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public int getEventId() {
+        return eventId;
+    }
+
+    public String getAggregateId() {
+        return aggregateId;
+    }
+
+    public ImmutableList<RuleDTO> getPrepended() {
+        return prepended;
+    }
+
+    public ImmutableList<RuleDTO> getPostpended() {
+        return postpended;
+    }
+
+    public ImmutableSet<String> getDeleted() {
+        return deleted;
+    }
+
+    public ImmutableList<RuleDTO> getUpdated() {
+        return updated;
+    }
+
+    @JsonIgnore
+    public IncrementalRuleChange toEvent() {
+        return new IncrementalRuleChange(
+            FilteringAggregateId.parse(aggregateId),
+            EventId.fromSerialized(eventId),
+            RuleDTO.toRules(prepended),
+            RuleDTO.toRules(postpended),
+            deleted.stream()
+                .map(Rule.Id::of)
+                .collect(ImmutableSet.toImmutableSet()),
+            RuleDTO.toRules(updated));
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof FilteringIncrementalRuleChangeDTO) {
+            FilteringIncrementalRuleChangeDTO that = (FilteringIncrementalRuleChangeDTO) o;
+
+            return Objects.equals(this.eventId, that.eventId)
+                && Objects.equals(this.type, that.type)
+                && Objects.equals(this.aggregateId, that.aggregateId)
+                && Objects.equals(this.prepended, that.prepended)
+                && Objects.equals(this.postpended, that.postpended)
+                && Objects.equals(this.updated, that.updated)
+                && Objects.equals(this.deleted, that.deleted);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(type, eventId, aggregateId, prepended, postpended, deleted, updated);
+    }
+}

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/FilteringRuleSetDefineDTOModules.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/FilteringRuleSetDefineDTOModules.java
@@ -20,11 +20,13 @@
 package org.apache.james.jmap.cassandra.filtering;
 
 import org.apache.james.eventsourcing.eventstore.cassandra.dto.EventDTOModule;
+import org.apache.james.jmap.api.filtering.impl.IncrementalRuleChange;
 import org.apache.james.jmap.api.filtering.impl.RuleSetDefined;
 
 public interface FilteringRuleSetDefineDTOModules {
 
     String TYPE = "filtering-rule-set-defined";
+    String TYPE_INCREMENTAL = "filtering-increment";
 
     EventDTOModule<RuleSetDefined, FilteringRuleSetDefinedDTO> FILTERING_RULE_SET_DEFINED =
         EventDTOModule
@@ -33,6 +35,15 @@ public interface FilteringRuleSetDefineDTOModules {
             .toDomainObjectConverter(FilteringRuleSetDefinedDTO::toEvent)
             .toDTOConverter(FilteringRuleSetDefinedDTO::from)
             .typeName(TYPE)
+            .withFactory(EventDTOModule::new);
+
+    EventDTOModule<IncrementalRuleChange, FilteringIncrementalRuleChangeDTO> FILTERING_INCREMENT =
+        EventDTOModule
+            .forEvent(IncrementalRuleChange.class)
+            .convertToDTO(FilteringIncrementalRuleChangeDTO.class)
+            .toDomainObjectConverter(FilteringIncrementalRuleChangeDTO::toEvent)
+            .toDTOConverter(FilteringIncrementalRuleChangeDTO::from)
+            .typeName(TYPE_INCREMENTAL)
             .withFactory(EventDTOModule::new);
 
 }

--- a/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/filtering/CassandraEventSourcingFilteringManagementTest.java
+++ b/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/filtering/CassandraEventSourcingFilteringManagementTest.java
@@ -27,5 +27,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class CassandraEventSourcingFilteringManagementTest implements FilteringManagementContract {
     @RegisterExtension
     static CassandraEventStoreExtension eventStoreExtension =
-        new CassandraEventStoreExtension(JsonEventSerializer.forModules(FilteringRuleSetDefineDTOModules.FILTERING_RULE_SET_DEFINED).withoutNestedType());
+        new CassandraEventStoreExtension(JsonEventSerializer.forModules(
+                FilteringRuleSetDefineDTOModules.FILTERING_RULE_SET_DEFINED,
+                FilteringRuleSetDefineDTOModules.FILTERING_INCREMENT)
+            .withoutNestedType());
 }

--- a/server/data/data-jmap-cassandra/src/test/resources/json/increment.json
+++ b/server/data/data-jmap-cassandra/src/test/resources/json/increment.json
@@ -1,0 +1,31 @@
+{
+  "type":"filtering-increment",
+  "eventId":0,
+  "aggregateId":"FilteringRule/bart",
+  "prepended":[
+    {
+    "id":"id-from",
+    "name":"a name",
+    "condition":{"field":"from","comparator":"contains","value":"A value to match 4"},
+    "action":{"appendIn":{"mailboxIds":["mbx1"]}}
+    },
+    {
+      "id":"id-to",
+      "name":"a name",
+      "condition":{"field":"to","comparator":"exactly-equals","value":"A value to match 1"},
+      "action":{"appendIn":{"mailboxIds":["mbx1"]}}
+    }],
+  "postpended":[{
+    "id":"id-rcpt",
+    "name":"a name",
+    "condition":{"field":"recipient","comparator":"not-exactly-equals","value":"A value to match 3"},
+    "action":{"appendIn":{"mailboxIds":["mbx1"]}}
+  }],
+  "updated":[{
+    "id":"id-subject",
+    "name":"a name",
+    "condition":{"field":"subject","comparator":"not-contains","value":"A value to match 2"},
+    "action":{"appendIn":{"mailboxIds":["mbx1"]}}
+  }],
+  "deleted":["abdcd"]
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregate.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/FilteringAggregate.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 public class FilteringAggregate {
+    private static final boolean ENABLE_INCREMENTS = Boolean.parseBoolean(System.getProperty("james.jmap.filters.eventsource.increments.enabled", "true"));
 
     public static FilteringAggregate load(FilteringAggregateId aggregateId, History eventsOfAggregate) {
         return new FilteringAggregate(aggregateId, eventsOfAggregate);
@@ -70,12 +71,19 @@ public class FilteringAggregate {
     public List<? extends Event> defineRules(DefineRulesCommand storeCommand) {
         Preconditions.checkArgument(shouldNotContainDuplicates(storeCommand.getRules()));
         StateMismatchException.checkState(expectedState(storeCommand.getIfInState()), "Provided state must be as same as the current state");
-
-        ImmutableList<Event> events = IncrementalRuleChange.ofDiff(aggregateId, history.getNextEventId(), state.rules, storeCommand.getRules())
-            .map(ImmutableList::<Event>of)
-            .orElseGet(() -> ImmutableList.of(new RuleSetDefined(aggregateId, history.getNextEventId(), ImmutableList.copyOf(storeCommand.getRules()))));
+        ImmutableList<Event> events = generateEvents(storeCommand);
         events.forEach(this::apply);
         return events;
+    }
+
+    private ImmutableList<Event> generateEvents(DefineRulesCommand storeCommand) {
+        if (ENABLE_INCREMENTS) {
+            return IncrementalRuleChange.ofDiff(aggregateId, history.getNextEventId(), state.rules, storeCommand.getRules())
+                .map(ImmutableList::<Event>of)
+                .orElseGet(() -> ImmutableList.of(new RuleSetDefined(aggregateId, history.getNextEventId(), ImmutableList.copyOf(storeCommand.getRules()))));
+        } else {
+            return ImmutableList.of(new RuleSetDefined(aggregateId, history.getNextEventId(), ImmutableList.copyOf(storeCommand.getRules())));
+        }
     }
 
     private boolean shouldNotContainDuplicates(List<Rule> rules) {

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChange.java
@@ -1,0 +1,205 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.filtering.impl;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.james.eventsourcing.AggregateId;
+import org.apache.james.eventsourcing.Event;
+import org.apache.james.eventsourcing.EventId;
+import org.apache.james.jmap.api.filtering.Rule;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+
+public class IncrementalRuleChange implements Event {
+    public static Optional<IncrementalRuleChange> ofDiff(FilteringAggregateId aggregateId, EventId eventId, List<Rule> before, List<Rule> after) {
+        ImmutableSet<Rule.Id> idsBefore = before.stream().map(Rule::getId).collect(ImmutableSet.toImmutableSet());
+        ImmutableSet<Rule.Id> idsAfter = after.stream().map(Rule::getId).collect(ImmutableSet.toImmutableSet());
+
+        ImmutableMap<Rule.Id, Rule> beforeIndexed = before.stream()
+            .collect(ImmutableMap.toImmutableMap(Rule::getId, rule -> rule));
+
+        ImmutableMap<Rule.Id, Rule> afterIndexed = after.stream()
+            .collect(ImmutableMap.toImmutableMap(Rule::getId, rule -> rule));
+
+        // Deleted elements appears in
+        ImmutableSet<Rule.Id> deleted = Sets.difference(idsBefore, idsAfter).immutableCopy();
+
+        List<Rule.Id> commonElements = ImmutableList.copyOf(Sets.intersection(idsBefore, idsAfter).immutableCopy());
+
+        ImmutableList<Rule.Id> idsAfterList = idsAfter.asList();
+        int prependedItems = 0;
+        int postPendedItems = 0;
+        boolean inPrepended = true;
+        boolean inCommonSection = false;
+        boolean inPostpended = false;
+        int position = 0;
+        while (position < idsAfter.size()) {
+            Rule.Id id = idsAfterList.get(position);
+            if (inPrepended) {
+                if (commonElements.contains(id)) {
+                    inPrepended = false;
+                    inCommonSection = true;
+                    continue;
+                } else {
+                    prependedItems++;
+                    position++;
+                    continue;
+                }
+            }
+            if (inPostpended) {
+                if (commonElements.contains(id)) {
+                    return Optional.empty();
+                } else {
+                    postPendedItems++;
+                    position++;
+                    continue;
+                }
+            }
+            if (inCommonSection) {
+                if (!commonElements.contains(id)) {
+                    inCommonSection = false;
+                    inPostpended = true;
+                    continue;
+                }
+                int positionInCommonElements = position - prependedItems;
+                if (positionInCommonElements > commonElements.size()) {
+                    // Safeguard
+                    return Optional.empty();
+                }
+                if (!commonElements.get(positionInCommonElements).equals(id)) {
+                    // Order of commons items changed
+                    return Optional.empty();
+                }
+                if (!beforeIndexed.get(id).equals(afterIndexed.get(id))) {
+                    // Rule content changed
+                    return Optional.empty();
+                }
+                // All fine
+                position++;
+                continue;
+            }
+            throw new RuntimeException("Unexpected status");
+        }
+
+        ImmutableList<Rule> preprended = idsAfter.stream()
+            .limit(prependedItems)
+            .map(afterIndexed::get)
+            .collect(ImmutableList.toImmutableList());
+
+        ImmutableList<Rule> postPended = idsAfter.asList()
+            .reverse()
+            .stream()
+            .limit(postPendedItems)
+            .map(afterIndexed::get)
+            .collect(ImmutableList.toImmutableList())
+            .reverse();
+
+        return Optional.of(new IncrementalRuleChange(aggregateId, eventId,
+            preprended, postPended, deleted));
+    }
+
+    private final FilteringAggregateId aggregateId;
+    private final EventId eventId;
+    private final ImmutableList<Rule> rulesPrepended;
+    private final ImmutableList<Rule> rulesPostpended;
+    private final ImmutableSet<Rule.Id> rulesDeleted;
+
+    public IncrementalRuleChange(FilteringAggregateId aggregateId, EventId eventId, ImmutableList<Rule> rulesPrepended, ImmutableList<Rule> rulesPostpended, ImmutableSet<Rule.Id> rulesDeleted) {
+        this.aggregateId = aggregateId;
+        this.eventId = eventId;
+        this.rulesPrepended = rulesPrepended;
+        this.rulesPostpended = rulesPostpended;
+        this.rulesDeleted = rulesDeleted;
+    }
+
+    @Override
+    public EventId eventId() {
+        return eventId;
+    }
+
+    @Override
+    public AggregateId getAggregateId() {
+        return aggregateId;
+    }
+
+    public ImmutableList<Rule> getRulesPrepended() {
+        return rulesPrepended;
+    }
+
+    public ImmutableList<Rule> getRulesPostPended() {
+        return rulesPostpended;
+    }
+
+    public ImmutableSet<Rule.Id> getRulesDeleted() {
+        return rulesDeleted;
+    }
+
+    public ImmutableList<Rule> apply(ImmutableList<Rule> rules) {
+        return ImmutableList.<Rule>builder()
+            .addAll(rulesPrepended)
+            .addAll(rules.stream()
+                .filter(rule -> !rulesDeleted.contains(rule.getId()))
+                .collect(ImmutableList.toImmutableList()))
+            .addAll(rulesPostpended)
+            .build();
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IncrementalRuleChange that = (IncrementalRuleChange) o;
+        return Objects.equals(aggregateId, that.aggregateId) &&
+            Objects.equals(eventId, that.eventId) &&
+            Objects.equals(rulesDeleted, that.rulesDeleted) &&
+            Objects.equals(rulesPrepended, that.rulesPrepended) &&
+            Objects.equals(rulesPostpended, that.rulesPostpended);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(aggregateId, eventId, rulesPrepended, rulesPostpended, rulesDeleted);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("aggregateId", aggregateId)
+            .add("eventId", eventId)
+            .add("rulesDeleted", rulesDeleted)
+            .add("rulesPrepended", rulesPrepended)
+            .add("rulesPostpended", rulesPostpended)
+            .toString();
+    }
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChange.java
@@ -162,6 +162,10 @@ public class IncrementalRuleChange implements Event {
         return rulesDeleted;
     }
 
+    public ImmutableList<Rule> getRulesUpdated() {
+        return rulesUpdated;
+    }
+
     public ImmutableList<Rule> apply(ImmutableList<Rule> rules) {
         ImmutableMap<Rule.Id, Rule> indexedUpdates = rulesUpdated.stream()
             .collect(ImmutableMap.toImmutableMap(

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
@@ -25,6 +25,7 @@ public interface RuleFixture {
     Rule.Action ACTION = Rule.Action.of(Rule.Action.AppendInMailboxes.withMailboxIds("id-01"));
     Rule.Builder RULE_BUILDER = Rule.builder().name(NAME).condition(CONDITION).action(ACTION);
     Rule RULE_1 = RULE_BUILDER.id(Rule.Id.of("1")).build();
+    Rule RULE_1_MODIFIED = RULE_BUILDER.id(Rule.Id.of("1")).name("newname").build();
     Rule RULE_2 = RULE_BUILDER.id(Rule.Id.of("2")).build();
     Rule RULE_3 = RULE_BUILDER.id(Rule.Id.of("3")).build();
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
@@ -25,7 +25,12 @@ public interface RuleFixture {
     Rule.Action ACTION = Rule.Action.of(Rule.Action.AppendInMailboxes.withMailboxIds("id-01"));
     Rule.Builder RULE_BUILDER = Rule.builder().name(NAME).condition(CONDITION).action(ACTION);
     Rule RULE_1 = RULE_BUILDER.id(Rule.Id.of("1")).build();
-    Rule RULE_1_MODIFIED = RULE_BUILDER.id(Rule.Id.of("1")).name("newname").build();
+    Rule RULE_1_MODIFIED = Rule.builder()
+        .condition(CONDITION)
+        .action(ACTION)
+        .id(Rule.Id.of("1"))
+        .name("newname")
+        .build();
     Rule RULE_2 = RULE_BUILDER.id(Rule.Id.of("2")).build();
     Rule RULE_3 = RULE_BUILDER.id(Rule.Id.of("3")).build();
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChangeTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChangeTest.java
@@ -1,0 +1,207 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.filtering.impl;
+
+import static org.apache.james.jmap.api.filtering.RuleFixture.RULE_1;
+import static org.apache.james.jmap.api.filtering.RuleFixture.RULE_1_MODIFIED;
+import static org.apache.james.jmap.api.filtering.RuleFixture.RULE_2;
+import static org.apache.james.jmap.api.filtering.RuleFixture.RULE_3;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.core.Username;
+import org.apache.james.eventsourcing.EventId;
+import org.apache.james.jmap.api.filtering.Rule;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+class IncrementalRuleChangeTest {
+    public static final FilteringAggregateId AGGREGATE_ID = new FilteringAggregateId(Username.of("bob"));
+    public static final EventId EVENT_ID = EventId.first();
+
+    @Test
+    void removingOneRule() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1),
+            ImmutableList.of()))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
+                ImmutableSet.of(RULE_1.getId())));
+    }
+
+    @Test
+    void removingOneRuleOutOfTwo() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1, RULE_2),
+            ImmutableList.of(RULE_2)))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
+                ImmutableSet.of(RULE_1.getId())));
+    }
+
+    @Test
+    void removingMiddleRule() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1, RULE_2, RULE_3),
+            ImmutableList.of(RULE_1, RULE_3)))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
+                ImmutableSet.of(RULE_2.getId())));
+    }
+
+    @Test
+    void noop() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1, RULE_2, RULE_3),
+            ImmutableList.of(RULE_1, RULE_2, RULE_3)))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(), ImmutableSet.of()));
+    }
+
+    @Test
+    void reorderingRuleIsNotManagedByIncrements() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1, RULE_2, RULE_3),
+            ImmutableList.of(RULE_1, RULE_3, RULE_2)))
+            .isEmpty();
+    }
+
+    @Test
+    void addingRuleInTheMiddleIsNotManagedByIncrement() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1, RULE_2),
+            ImmutableList.of(RULE_1, RULE_3, RULE_2)))
+            .isEmpty();
+    }
+
+    @Test
+    void postPendingOneRule() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1, RULE_2),
+            ImmutableList.of(RULE_1, RULE_2, RULE_3)))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(RULE_3), ImmutableSet.of()));
+    }
+
+    @Test
+    void prependingOneRule() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1, RULE_2),
+            ImmutableList.of(RULE_3, RULE_1, RULE_2)))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(), ImmutableSet.of()));
+    }
+
+    @Test
+    void prependingAndPostpending() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1),
+            ImmutableList.of(RULE_3, RULE_1, RULE_2)))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of()));
+    }
+
+    @Test
+    void prependingAndPostpendingAndRemoval() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1),
+            ImmutableList.of(RULE_3, RULE_2)))
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3, RULE_2), ImmutableList.of(), ImmutableSet.of(RULE_1.getId())));
+    }
+
+    @Test
+    void ruleModificationIsNotManagedByIncrement() {
+        assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
+            ImmutableList.of(RULE_1),
+            ImmutableList.of(RULE_1_MODIFIED)))
+            .isEmpty();
+    }
+
+    @Test
+    void removingOneRuleShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1);
+        IncrementalRuleChange incrementalChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
+            ImmutableSet.of(RULE_1.getId()));
+        assertThat(incrementalChange.apply(origin))
+            .isEqualTo(ImmutableList.of());
+    }
+
+    @Test
+    void removingOneRuleOutOfTwoShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2);
+        IncrementalRuleChange incrementalChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
+            ImmutableSet.of(RULE_1.getId()));
+        assertThat(incrementalChange.apply(origin))
+            .isEqualTo(ImmutableList.of(RULE_2));
+    }
+
+    @Test
+    void removingMiddleRuleShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2, RULE_3);
+        IncrementalRuleChange incrementalChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
+            ImmutableSet.of(RULE_2.getId()));
+        assertThat(incrementalChange.apply(origin))
+            .isEqualTo(ImmutableList.of(RULE_1, RULE_3));
+    }
+
+    @Test
+    void noopShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2, RULE_3);
+
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(), ImmutableSet.of());
+
+        assertThat(incrementalRuleChange.apply(origin))
+            .isEqualTo(origin);
+    }
+
+    @Test
+    void postPendingOneRuleShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2);
+
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(RULE_3), ImmutableSet.of());
+
+        assertThat(incrementalRuleChange.apply(origin))
+            .isEqualTo(ImmutableList.of(RULE_1, RULE_2, RULE_3));
+    }
+
+    @Test
+    void prependingOneRuleShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2);
+
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(), ImmutableSet.of());
+
+        assertThat(incrementalRuleChange.apply(origin))
+            .isEqualTo(ImmutableList.of(RULE_3, RULE_1, RULE_2));
+    }
+
+    @Test
+    void prependingAndPostpendingShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1);
+
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of());
+
+        assertThat(incrementalRuleChange.apply(origin))
+            .isEqualTo(ImmutableList.of(RULE_3, RULE_1, RULE_2));
+    }
+
+    @Test
+    void prependingAndPostpendingAndRemovalShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1);
+
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of(RULE_1.getId()));
+
+        assertThat(incrementalRuleChange.apply(origin))
+            .isEqualTo(ImmutableList.of(RULE_3, RULE_2));
+    }
+}

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChangeTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/impl/IncrementalRuleChangeTest.java
@@ -43,7 +43,7 @@ class IncrementalRuleChangeTest {
             ImmutableList.of(RULE_1),
             ImmutableList.of()))
             .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
-                ImmutableSet.of(RULE_1.getId())));
+                ImmutableSet.of(RULE_1.getId()), ImmutableList.of()));
     }
 
     @Test
@@ -52,7 +52,7 @@ class IncrementalRuleChangeTest {
             ImmutableList.of(RULE_1, RULE_2),
             ImmutableList.of(RULE_2)))
             .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
-                ImmutableSet.of(RULE_1.getId())));
+                ImmutableSet.of(RULE_1.getId()), ImmutableList.of()));
     }
 
     @Test
@@ -61,7 +61,7 @@ class IncrementalRuleChangeTest {
             ImmutableList.of(RULE_1, RULE_2, RULE_3),
             ImmutableList.of(RULE_1, RULE_3)))
             .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
-                ImmutableSet.of(RULE_2.getId())));
+                ImmutableSet.of(RULE_2.getId()), ImmutableList.of()));
     }
 
     @Test
@@ -69,7 +69,7 @@ class IncrementalRuleChangeTest {
         assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
             ImmutableList.of(RULE_1, RULE_2, RULE_3),
             ImmutableList.of(RULE_1, RULE_2, RULE_3)))
-            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(), ImmutableSet.of()));
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(), ImmutableSet.of(), ImmutableList.of()));
     }
 
     @Test
@@ -93,7 +93,7 @@ class IncrementalRuleChangeTest {
         assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
             ImmutableList.of(RULE_1, RULE_2),
             ImmutableList.of(RULE_1, RULE_2, RULE_3)))
-            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(RULE_3), ImmutableSet.of()));
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(RULE_3), ImmutableSet.of(), ImmutableList.of()));
     }
 
     @Test
@@ -101,7 +101,7 @@ class IncrementalRuleChangeTest {
         assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
             ImmutableList.of(RULE_1, RULE_2),
             ImmutableList.of(RULE_3, RULE_1, RULE_2)))
-            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(), ImmutableSet.of()));
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(), ImmutableSet.of(), ImmutableList.of()));
     }
 
     @Test
@@ -109,7 +109,7 @@ class IncrementalRuleChangeTest {
         assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
             ImmutableList.of(RULE_1),
             ImmutableList.of(RULE_3, RULE_1, RULE_2)))
-            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of()));
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of(), ImmutableList.of()));
     }
 
     @Test
@@ -117,22 +117,23 @@ class IncrementalRuleChangeTest {
         assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
             ImmutableList.of(RULE_1),
             ImmutableList.of(RULE_3, RULE_2)))
-            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3, RULE_2), ImmutableList.of(), ImmutableSet.of(RULE_1.getId())));
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3, RULE_2), ImmutableList.of(), ImmutableSet.of(RULE_1.getId()), ImmutableList.of()));
     }
 
     @Test
-    void ruleModificationIsNotManagedByIncrement() {
+    void ruleModification() {
         assertThat(IncrementalRuleChange.ofDiff(AGGREGATE_ID, EVENT_ID,
             ImmutableList.of(RULE_1),
             ImmutableList.of(RULE_1_MODIFIED)))
-            .isEmpty();
+            .contains(new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(), ImmutableSet.of(),
+                ImmutableList.of(RULE_1_MODIFIED)));
     }
 
     @Test
     void removingOneRuleShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1);
         IncrementalRuleChange incrementalChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
-            ImmutableSet.of(RULE_1.getId()));
+            ImmutableSet.of(RULE_1.getId()), ImmutableList.of());
         assertThat(incrementalChange.apply(origin))
             .isEqualTo(ImmutableList.of());
     }
@@ -141,7 +142,7 @@ class IncrementalRuleChangeTest {
     void removingOneRuleOutOfTwoShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2);
         IncrementalRuleChange incrementalChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
-            ImmutableSet.of(RULE_1.getId()));
+            ImmutableSet.of(RULE_1.getId()), ImmutableList.of());
         assertThat(incrementalChange.apply(origin))
             .isEqualTo(ImmutableList.of(RULE_2));
     }
@@ -150,7 +151,7 @@ class IncrementalRuleChangeTest {
     void removingMiddleRuleShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2, RULE_3);
         IncrementalRuleChange incrementalChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(),
-            ImmutableSet.of(RULE_2.getId()));
+            ImmutableSet.of(RULE_2.getId()), ImmutableList.of());
         assertThat(incrementalChange.apply(origin))
             .isEqualTo(ImmutableList.of(RULE_1, RULE_3));
     }
@@ -159,7 +160,7 @@ class IncrementalRuleChangeTest {
     void noopShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2, RULE_3);
 
-        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(), ImmutableSet.of());
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(), ImmutableSet.of(), ImmutableList.of());
 
         assertThat(incrementalRuleChange.apply(origin))
             .isEqualTo(origin);
@@ -169,7 +170,7 @@ class IncrementalRuleChangeTest {
     void postPendingOneRuleShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2);
 
-        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(RULE_3), ImmutableSet.of());
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(), ImmutableList.of(RULE_3), ImmutableSet.of(), ImmutableList.of());
 
         assertThat(incrementalRuleChange.apply(origin))
             .isEqualTo(ImmutableList.of(RULE_1, RULE_2, RULE_3));
@@ -179,7 +180,7 @@ class IncrementalRuleChangeTest {
     void prependingOneRuleShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1, RULE_2);
 
-        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(), ImmutableSet.of());
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(), ImmutableSet.of(), ImmutableList.of());
 
         assertThat(incrementalRuleChange.apply(origin))
             .isEqualTo(ImmutableList.of(RULE_3, RULE_1, RULE_2));
@@ -189,7 +190,7 @@ class IncrementalRuleChangeTest {
     void prependingAndPostpendingShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1);
 
-        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of());
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of(), ImmutableList.of());
 
         assertThat(incrementalRuleChange.apply(origin))
             .isEqualTo(ImmutableList.of(RULE_3, RULE_1, RULE_2));
@@ -199,9 +200,19 @@ class IncrementalRuleChangeTest {
     void prependingAndPostpendingAndRemovalShouldBeWellApplied() {
         ImmutableList<Rule> origin = ImmutableList.of(RULE_1);
 
-        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of(RULE_1.getId()));
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(RULE_3), ImmutableList.of(RULE_2), ImmutableSet.of(RULE_1.getId()), ImmutableList.of());
 
         assertThat(incrementalRuleChange.apply(origin))
             .isEqualTo(ImmutableList.of(RULE_3, RULE_2));
+    }
+
+    @Test
+    void ruleModificationShouldBeWellApplied() {
+        ImmutableList<Rule> origin = ImmutableList.of(RULE_1);
+        IncrementalRuleChange incrementalRuleChange = new IncrementalRuleChange(AGGREGATE_ID, EVENT_ID, ImmutableList.of(),
+            ImmutableList.of(), ImmutableSet.of(), ImmutableList.of(RULE_1_MODIFIED));
+
+        assertThat(incrementalRuleChange.apply(origin))
+            .isEqualTo(ImmutableList.of(RULE_1_MODIFIED));
     }
 }

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -28,6 +28,21 @@ Change list:
 - [Adding delegatedUser column to user_table](#adding-delegatedusers-column-to-user-table)
 - [DeletedMessageVaultHook should not be used on Cassandra based products](#deleted-message-vault-is-now-deactivated-by-default)
 
+### JMAP filters event sourcing increments and snapshots
+
+Date: 19/04/2023
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-3777
+
+Concerned products: Distributed James, Cassandra James Server
+
+We recommend disabling increments during rolling updates (as older nodes in the cluster won't support them).
+This can be done with the following system property:
+
+```
+-Djames.jmap.filters.eventsource.increments.enabled=false
+```
+
 ### DeletedMessageVaultHook should not be used on Cassandra based products
 
 Date: 10/02/2023


### PR DESCRIPTION
Goals: capture most changes of the filtering aggregate to reduce the complexity of this aggregate.

This work (in progress) proposes an incremental update that covers:
 - Rules addition at the beginning of the rule set or at the end
 - Rules deletion
 - Rules modification
 
 Actions falling outside of this scope cannot be captured in an incremental fashion and would lead to a full reset (todays behaviour). This is the case when:
  - Rules are being reordered.
  - Rules are added in the middle of existing rules.
  
I suspect no UI allows this. Hence this is more that likely enough.

## Work remaining

 - [x] Plug the Incremental events into the aggregate
 - [x] Serialization for this incremental event
 - [x] Conditionally disable incremental change via ENV and explain that it should be disable during rolling update of the upgrade.
 - [x] Tests with 1.000 rule changes