### PR TITLE
JAMES-3900 Snapshots for polled updates

### DIFF
--- a/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/DecisionProjection.scala
+++ b/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/DecisionProjection.scala
@@ -32,7 +32,7 @@ case class DecisionProjection(status: Status, latestUpdateAdditionalInformationU
         case event: Cancelled => DecisionProjection(Status.CANCELLED, event.additionalInformation.map(_.timestamp))
         case event: Completed => DecisionProjection(Status.COMPLETED, event.additionalInformation.map(_.timestamp))
         case event: Failed => DecisionProjection(Status.FAILED, event.additionalInformation.map(_.timestamp))
-        case event: AdditionalInformationUpdated => DecisionProjection(status, Some(event.additionalInformation.timestamp))
+        case event: AdditionalInformationUpdated => DecisionProjection(Status.IN_PROGRESS, Some(event.additionalInformation.timestamp))
       }
   }
 
@@ -41,6 +41,11 @@ case class DecisionProjection(status: Status, latestUpdateAdditionalInformationU
 }
 
 object DecisionProjection {
-  def initial(created : Created): DecisionProjection = DecisionProjection(Status.WAITING, None)
+  def initial(taskEvent : TaskEvent): DecisionProjection = {
+    taskEvent match {
+      case _: Created => DecisionProjection(Status.WAITING, None)
+      case updated: AdditionalInformationUpdated => DecisionProjection(Status.IN_PROGRESS, Some(updated.additionalInformation.timestamp))
+    }
+  }
 }
 

--- a/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/Events.scala
+++ b/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/Events.scala
@@ -33,7 +33,9 @@ case class Created(aggregateId: TaskAggregateId, override val eventId: EventId, 
 
 case class Started(aggregateId: TaskAggregateId, override val eventId: EventId, hostname: Hostname) extends TaskEvent(aggregateId, eventId)
 
-case class AdditionalInformationUpdated(aggregateId: TaskAggregateId, override val eventId: EventId, additionalInformation: AdditionalInformation) extends TaskEvent(aggregateId, eventId)
+case class AdditionalInformationUpdated(aggregateId: TaskAggregateId, override val eventId: EventId, additionalInformation: AdditionalInformation) extends TaskEvent(aggregateId, eventId) {
+  override val isASnapshot = true
+}
 
 case class CancelRequested(aggregateId: TaskAggregateId, override val eventId: EventId, hostname: Hostname) extends TaskEvent(aggregateId, eventId)
 

--- a/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/TaskAggregate.scala
+++ b/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/TaskAggregate.scala
@@ -25,16 +25,23 @@ import org.apache.james.task.TaskExecutionDetails.AdditionalInformation
 import org.apache.james.task.TaskManager.Status
 import org.apache.james.task.{Hostname, Task}
 
-class TaskAggregate private(val aggregateId: TaskAggregateId, private val history: History) {
+import scala.util.{Failure, Success}
 
-  private val initialEvent: TaskEvent = history.getEvents.head match {
-    case created @ Created(_, _, _, _) if created.eventId.equals(EventId.first) => created
-    case any: TaskEvent => if (any.eventId.equals(EventId.first)) {
-      throw new IllegalArgumentException("History must start with Created event")
-    } else {
-      any
+class TaskAggregate private(val aggregateId: TaskAggregateId, private val history: History) {
+  private val initialEvent: TaskEvent = history.getEvents.headOption
+    .map(e => Success(initialEvent(e)))
+    .getOrElse(Failure(new IllegalArgumentException("History must start with Created event")))
+    .get
+
+  private def initialEvent(event: Event) =
+    event match {
+      case created@Created(_, _, _, _) if created.eventId.equals(EventId.first) => created
+      case any: TaskEvent => if (any.eventId.equals(EventId.first)) {
+        throw new IllegalArgumentException("History must start with Created event")
+      } else {
+        any
+      }
     }
-  }
 
   private val currentDecisionProjection: DecisionProjection = history
     .getEvents

--- a/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/TaskAggregate.scala
+++ b/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/TaskAggregate.scala
@@ -27,9 +27,13 @@ import org.apache.james.task.{Hostname, Task}
 
 class TaskAggregate private(val aggregateId: TaskAggregateId, private val history: History) {
 
-  val initialEvent = history.getEvents.headOption match {
-    case Some(created @ Created(_, _, _, _)) => created
-    case _ => throw new IllegalArgumentException("History must start with Created event")
+  private val initialEvent: TaskEvent = history.getEvents.head match {
+    case created @ Created(_, _, _, _) if created.eventId.equals(EventId.first) => created
+    case any: TaskEvent => if (any.eventId.equals(EventId.first)) {
+      throw new IllegalArgumentException("History must start with Created event")
+    } else {
+      any
+    }
   }
 
   private val currentDecisionProjection: DecisionProjection = history


### PR DESCRIPTION
They fully capture the state of the aggregate.

This prevents loading the full history for looong
running tasks and prevents timeouts upon polling updates.

Before the aggregate was containing a lot of events, that were periodically loaded:

```
Widest Partitions:
   [Task/2d534232-fade-47aa-8c6f-1ec2d0f238f9] 1855
   [Task/d8499ec7-a62a-4541-970a-7339fccf23e8] 779
```

Eventually resulting in timeouts as the full partition was loaded...

```
reactor.core.Exceptions$ErrorCallbackNotImplemented: com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT5S
Caused by: com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT5S
	at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.lambda$scheduleTimeout$1(CqlRequestHandler.java:207)
	at io.netty.util.HashedWheelTimer$HashedWheelTimeout.run(HashedWheelTimer.java:715)
	at io.netty.util.concurrent.ImmediateExecutor.execute(ImmediateExecutor.java:34)
	at io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:703)
	at io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:790)
	at io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:503)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```

With this work, this is mitigated by loading only the latest event...