### PR TITLE
Don't add gateway if no gateway is configured (empty value)

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
@@ -202,7 +202,7 @@ public class RemoteDeliveryConfiguration {
     }
 
     private List<String> computeGatewayServers(String gatewayPort, String gateway) {
-        if (gateway != null) {
+        if (gateway != null && !gateway.isBlank()) {
             ImmutableList.Builder<String> builder = ImmutableList.builder();
             Iterable<String> gatewayParts = Splitter.on(',').split(gateway);
             for (String gatewayPart : gatewayParts) {


### PR DESCRIPTION
If there is an empty `<gateway/>` element in configuration then RemoteDelivery adds empty values to collection resulting in entry `[:]` which then fails to deliver. I'd argue that in that case James should skip such configuration and use `serviceNoGateway()` method.

Example configuration:
```xml
<processor state="relay" enableJmx="true">
    <mailet match="All" class="RemoteDelivery">
        <outgoingQueue>outgoing</outgoingQueue>
        <delayTime>5000, 100000, 500000</delayTime>
        <maxRetries>3</maxRetries>
        <maxDnsProblemRetries>0</maxDnsProblemRetries>
        <deliveryThreads>10</deliveryThreads>
        <sendpartial>true</sendpartial>
        <bounceProcessor>bounces</bounceProcessor>
        <debug>true</debug>
        <gateway></gateway>
        <gatewayPort></gatewayPort>
        <gatewayUsername></gatewayUsername>
        <gatewayPassword></gatewayPassword>
    </mailet>
</processor>
```