### PR TITLE
POC Protocol restart - easy with current james code base

### DIFF
--- a/server/apps/memory-app/src/main/java/org/apache/james/ImapRoutes.java
+++ b/server/apps/memory-app/src/main/java/org/apache/james/ImapRoutes.java
@@ -1,0 +1,40 @@
+package org.apache.james;
+
+import javax.inject.Inject;
+
+import org.apache.james.imapserver.netty.IMAPServerFactory;
+import org.apache.james.server.core.configuration.ConfigurationProvider;
+import org.apache.james.webadmin.Routes;
+
+import com.google.common.base.Preconditions;
+
+import spark.Service;
+
+public class ImapRoutes implements Routes {
+    private final IMAPServerFactory imapServerFactory;
+    private final ConfigurationProvider configurationProvider;
+
+    @Inject
+    public ImapRoutes(IMAPServerFactory imapServerFactory, ConfigurationProvider configurationProvider) {
+        this.imapServerFactory = imapServerFactory;
+        this.configurationProvider = configurationProvider;
+    }
+
+    @Override
+    public String getBasePath() {
+        return "imap";
+    }
+
+    @Override
+    public void define(Service service) {
+        service.post("imap", (req, res) -> {
+            Preconditions.checkArgument(req.queryParams().contains("restart"), "'restart' query parameter shall be specified");
+
+            imapServerFactory.destroy();
+            imapServerFactory.configure(configurationProvider.getConfiguration("imapserver"));
+            imapServerFactory.init();
+
+            return "";
+        });
+    }
+}

--- a/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/apps/memory-app/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -64,6 +64,7 @@ import org.apache.james.modules.server.VacationRoutesModule;
 import org.apache.james.modules.server.WebAdminServerModule;
 import org.apache.james.modules.vault.DeletedMessageVaultModule;
 import org.apache.james.modules.vault.DeletedMessageVaultRoutesModule;
+import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.WebAdminConfiguration;
 import org.apache.james.webadmin.authentication.AuthenticationFilter;
 import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
@@ -71,6 +72,7 @@ import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 import com.google.inject.util.Modules;
 
 public class MemoryJamesServerMain implements JamesServerMain {
@@ -78,6 +80,7 @@ public class MemoryJamesServerMain implements JamesServerMain {
     public static final Module WEBADMIN = Modules.combine(
         new WebAdminServerModule(),
         new DataRoutesModules(),
+        binder -> Multibinder.newSetBinder(binder, Routes.class).addBinding().to(ImapRoutes.class),
         new VacationRoutesModule(),
         new DeletedMessageVaultRoutesModule(),
         new DLPRoutesModule(),

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractServerFactory.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractServerFactory.java
@@ -68,6 +68,6 @@ public abstract class AbstractServerFactory implements Configurable {
         for (AbstractConfigurableAsyncServer server: servers) {
             server.destroy();
         }
+        servers.clear();
     }
- 
 }

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/memory/MemoryWebAdminServerIntegrationImmutableTest.java
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/memory/MemoryWebAdminServerIntegrationImmutableTest.java
@@ -19,7 +19,9 @@
 
 package org.apache.james.webadmin.integration.memory;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static io.restassured.RestAssured.with;
 import static org.apache.james.JamesServerExtension.Lifecycle.PER_CLASS;
 import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,5 +64,27 @@ class MemoryWebAdminServerIntegrationImmutableTest extends WebAdminServerIntegra
 
         assertThat(listComponentNames).containsOnly("Guice application lifecycle", "MailReceptionCheck",
             "EventDeadLettersHealthCheck", "EmptyErrorMailRepository", "MessageFastViewProjection");
+    }
+
+    @Test
+    void testImapRestart() {
+        given()
+            .queryParam("restart")
+            .post("imap")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void testImapRestartShouldBeIndempotent() {
+        with()
+            .queryParam("restart")
+            .post("imap");
+
+        given()
+            .queryParam("restart")
+            .post("imap")
+        .then()
+            .statusCode(200);
     }
 }

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/imapserver.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/imapserver.xml
@@ -36,6 +36,7 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
         <plainAuthDisallowed>false</plainAuthDisallowed>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
@@ -51,5 +52,6 @@ under the License.
         </tls>
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
+        <gracefulShutdown>false</gracefulShutdown>
     </imapserver>
 </imapservers>

--- a/testing/base/src/main/resources/logback-test.xml
+++ b/testing/base/src/main/resources/logback-test.xml
@@ -17,10 +17,6 @@
                 <encoder>
                         <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
                 </encoder>
-                <immediateFlush>false</immediateFlush>
-                <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                        <level>ERROR</level>
-                </filter>
         </appender>
 
         <root level="WARN">


### PR DESCRIPTION
To unwip this we would need:

 - [ ] Log based assertions that the IMAP servers are well restarted
 - [ ] Dedicated maven modules for webadmin routes for protocol restart (for webadmin, guice injections can go in existing guice modules for protocols I bet)

Complementary work:

 - [ ] Other protocols support: IMAP SMTP JMAP POP3 ManageSieve
 - [ ] Explore restarting the mailet container / spooler?