### PR TITLE
[REFACTORING] Make PropertiesProvider singleton & avoid load multi times from FileSystem

### DIFF
--- a/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerConfiguration.java
+++ b/server/apps/cassandra-app/src/main/java/org/apache/james/CassandraJamesServerConfiguration.java
@@ -116,12 +116,12 @@ public class CassandraJamesServerConfiguration implements Configuration {
                 .orElseThrow(() -> new MissingArgumentException("Server needs a working.directory env entry")));
 
             FileSystemImpl fileSystem = new FileSystemImpl(directories);
+            PropertiesProvider propertiesProvider = new PropertiesProvider(fileSystem, configurationPath);
             SearchConfiguration searchConfiguration = this.searchConfiguration.orElseGet(Throwing.supplier(
-                () -> SearchConfiguration.parse(new PropertiesProvider(fileSystem, configurationPath))));
+                () -> SearchConfiguration.parse(propertiesProvider)));
 
             BlobStoreConfiguration blobStoreConfiguration = this.blobStoreConfiguration.orElseGet(Throwing.supplier(
-                () -> BlobStoreConfiguration.parse(
-                    new PropertiesProvider(fileSystem, configurationPath))));
+                () -> BlobStoreConfiguration.parse(propertiesProvider)));
 
             FileConfigurationProvider configurationProvider = new FileConfigurationProvider(fileSystem, Basic.builder()
                 .configurationPath(configurationPath)

--- a/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesConfiguration.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/CassandraRabbitMQJamesConfiguration.java
@@ -117,13 +117,12 @@ public class CassandraRabbitMQJamesConfiguration implements Configuration {
                 .orElseThrow(() -> new MissingArgumentException("Server needs a working.directory env entry")));
 
             FileSystemImpl fileSystem = new FileSystemImpl(directories);
+            PropertiesProvider propertiesProvider = new PropertiesProvider(fileSystem, configurationPath);
             BlobStoreConfiguration blobStoreConfiguration = this.blobStoreConfiguration.orElseGet(Throwing.supplier(
-                () -> BlobStoreConfiguration.parse(
-                    new PropertiesProvider(fileSystem, configurationPath))));
+                () -> BlobStoreConfiguration.parse(propertiesProvider)));
 
             SearchConfiguration searchConfiguration = this.searchConfiguration.orElseGet(Throwing.supplier(
-                () -> SearchConfiguration.parse(
-                    new PropertiesProvider(fileSystem, configurationPath))));
+                () -> SearchConfiguration.parse(propertiesProvider)));
 
             FileConfigurationProvider configurationProvider = new FileConfigurationProvider(fileSystem, Basic.builder()
                 .configurationPath(configurationPath)
@@ -133,8 +132,7 @@ public class CassandraRabbitMQJamesConfiguration implements Configuration {
                 () -> UsersRepositoryModuleChooser.Implementation.parse(configurationProvider));
 
             MailQueueViewChoice mailQueueViewChoice = this.mailQueueViewChoice.orElseGet(Throwing.supplier(
-                () -> MailQueueViewChoice.parse(
-                    new PropertiesProvider(fileSystem, configurationPath))));
+                () -> MailQueueViewChoice.parse(propertiesProvider)));
 
             VaultConfiguration vaultConfiguration = this.vaultConfiguration.orElseGet(() -> {
                 try {

--- a/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesConfiguration.java
+++ b/server/apps/distributed-pop3-app/src/main/java/org/apache/james/DistributedPOP3JamesConfiguration.java
@@ -113,13 +113,12 @@ public class DistributedPOP3JamesConfiguration implements Configuration {
                 .orElseThrow(() -> new MissingArgumentException("Server needs a working.directory env entry")));
 
             FileSystemImpl fileSystem = new FileSystemImpl(directories);
+            PropertiesProvider propertiesProvider = new PropertiesProvider(fileSystem, configurationPath);
             BlobStoreConfiguration blobStoreConfiguration = this.blobStoreConfiguration.orElseGet(Throwing.supplier(
-                () -> BlobStoreConfiguration.parse(
-                    new PropertiesProvider(fileSystem, configurationPath))));
+                () -> BlobStoreConfiguration.parse(propertiesProvider)));
 
             SearchConfiguration searchConfiguration = this.searchConfiguration.orElseGet(Throwing.supplier(
-                () -> SearchConfiguration.parse(
-                    new PropertiesProvider(fileSystem, configurationPath))));
+                () -> SearchConfiguration.parse(propertiesProvider)));
 
             FileConfigurationProvider configurationProvider = new FileConfigurationProvider(fileSystem, Basic.builder()
                 .configurationPath(configurationPath)
@@ -129,8 +128,7 @@ public class DistributedPOP3JamesConfiguration implements Configuration {
                 () -> UsersRepositoryModuleChooser.Implementation.parse(configurationProvider));
 
             MailQueueViewChoice mailQueueViewChoice = this.mailQueueViewChoice.orElseGet(Throwing.supplier(
-                () -> MailQueueViewChoice.parse(
-                    new PropertiesProvider(fileSystem, configurationPath))));
+                () -> MailQueueViewChoice.parse(propertiesProvider)));
 
 
             VaultConfiguration vaultConfiguration = this.vaultConfiguration.orElseGet(() -> {

--- a/server/container/guice/common/src/main/java/org/apache/james/modules/CommonServicesModule.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/modules/CommonServicesModule.java
@@ -33,6 +33,7 @@ import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.ExtensionModule;
 import org.apache.james.utils.GuiceProbe;
+import org.apache.james.utils.PropertiesProvider;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -83,5 +84,10 @@ public class CommonServicesModule extends AbstractModule {
     public JamesDirectoriesProvider directories() {
         return configuration.directories();
     }
-    
+
+    @Provides
+    @Singleton
+    public PropertiesProvider providePropertiesProvider(FileSystem fileSystem, Configuration.ConfigurationPath configurationPrefix) {
+        return new PropertiesProvider(fileSystem, configurationPrefix);
+    }
 }


### PR DESCRIPTION
When I started James, I saw several logs `Load configuration file` from the same file. 
First I think has an error somewhere. But no, we re-IO load file for separate configuration. 

-> 
I make the `PropertiesProvider` singleton and add the guava cache (in 10 minutes) for file configuration


Before:
```
9:08:33.126 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/extensions.properties
2023-05-05T09:08:33.143397454Z 09:08:33.143 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/jmap.properties
2023-05-05T09:08:33.146069684Z 09:08:33.145 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/jmap.properties
2023-05-05T09:08:33.307942017Z 09:08:33.307 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/jmap.properties
2023-05-05T09:08:33.333059630Z 09:08:33.332 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/jmap.properties
2023-05-05T09:08:33.335618931Z 09:08:33.335 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/linagora-ecosystem.properties
2023-05-05T09:08:33.338538081Z 09:08:33.338 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/jmap.properties
2023-05-05T09:08:33.428401644Z 09:08:33.428 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/webadmin.properties
2023-05-05T09:08:33.476672429Z 09:08:33.476 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/healthcheck.properties
2023-05-05T09:08:33.477542683Z 09:08:33.477 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/healthcheck.properties
2023-05-05T09:08:33.480282419Z 09:08:33.480 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/deletedMessageVault.properties
```


