### PR TITLE
[PERF] Avoid using Non-Preemptive authentication for OpenSearch

### DIFF
--- a/backends-common/opensearch/src/main/java/org/apache/james/backends/opensearch/ClientProvider.java
+++ b/backends-common/opensearch/src/main/java/org/apache/james/backends/opensearch/ClientProvider.java
@@ -169,7 +169,6 @@ public class ClientProvider implements Provider<ReactorOpenSearchClient> {
         }
 
         private void configureAuthentication(HttpAsyncClientBuilder builder) {
-            builder.disableAuthCaching();
             configuration.getCredential()
                 .ifPresent(credential -> {
                     CredentialsProvider credentialsProvider = new BasicCredentialsProvider();


### PR DESCRIPTION
Before, we were using Non-Preemptive authentication for OpenSearch that makes 1 normal OpenSearch request to be 2 round trips (1 authenticated 401 request and 1 normal request).
![image](https://github.com/apache/james-project/assets/55171818/3875b46e-8c62-4b9c-9a6a-1332bdbc9591)


This likely negatively affected our search performance. We should avoid that.

rf: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/master/_basic_authentication.html