### PR TITLE
[FIX] JPA blocking calls should be moved to bounded elastic

### DIFF
--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -134,6 +134,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <forkCount>1</forkCount>
+                    <argLine>-Djava.library.path=
+                        -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
+                        -Xms512m -Xmx1024m -Dopenjpa.Multithreaded=true</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.openjpa</groupId>
                 <artifactId>openjpa-maven-plugin</artifactId>
                 <version>${apache.openjpa.version}</version>

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -103,6 +103,12 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
     }
 
     @Override
+    public Flux<MailboxMessage> findInMailboxReactive(Mailbox mailbox, MessageRange messageRange, FetchType ftype, int limitAsInt) {
+        return Flux.defer(Throwing.supplier(() -> Flux.fromIterable(findAsList(mailbox.getMailboxId(), messageRange, limitAsInt))).sneakyThrow())
+            .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @Override
     public Iterator<MailboxMessage> findInMailbox(Mailbox mailbox, MessageRange set, FetchType fType, int max)
             throws MailboxException {
 

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/openjpa/OpenJPAMessageManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/openjpa/OpenJPAMessageManager.java
@@ -20,14 +20,18 @@
 package org.apache.james.mailbox.jpa.openjpa;
 
 import java.time.Clock;
+import java.util.EnumSet;
 
 import javax.mail.Flags;
 
 import org.apache.james.events.EventBus;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.mailbox.store.BatchSizes;
@@ -37,23 +41,35 @@ import org.apache.james.mailbox.store.PreDeletionHooks;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.mailbox.store.StoreMessageManager;
 import org.apache.james.mailbox.store.StoreRightManager;
+import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.ThreadIdGuessingAlgorithm;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
+
+import com.github.fge.lambdas.Throwing;
+
+import reactor.core.publisher.Mono;
 
 /**
  * OpenJPA implementation of Mailbox
  */
 public class OpenJPAMessageManager extends StoreMessageManager {
+    private final MailboxSessionMapperFactory mapperFactory;
+    private final StoreRightManager storeRightManager;
+    private final Mailbox mailbox;
 
     public OpenJPAMessageManager(MailboxSessionMapperFactory mapperFactory,
                                  MessageSearchIndex index, EventBus eventBus,
                                  MailboxPathLocker locker, Mailbox mailbox,
                                  QuotaManager quotaManager, QuotaRootResolver quotaRootResolver,
                                  MessageId.Factory messageIdFactory, BatchSizes batchSizes,
-                                 StoreRightManager storeRightManager, ThreadIdGuessingAlgorithm threadIdGuessingAlgorithm, Clock clock) {
+                                 StoreRightManager storeRightManager, ThreadIdGuessingAlgorithm threadIdGuessingAlgorithm,
+                                 Clock clock) {
         super(StoreMailboxManager.DEFAULT_NO_MESSAGE_CAPABILITIES, mapperFactory, index, eventBus, locker, mailbox,
             quotaManager, quotaRootResolver, batchSizes, storeRightManager, PreDeletionHooks.NO_PRE_DELETION_HOOK,
             new MessageStorer.WithoutAttachment(mapperFactory, messageIdFactory, new OpenJPAMessageFactory(OpenJPAMessageFactory.AdvancedFeature.None), threadIdGuessingAlgorithm, clock));
+        this.storeRightManager = storeRightManager;
+        this.mapperFactory = mapperFactory;
+        this.mailbox = mailbox;
     }
 
     /**
@@ -64,5 +80,24 @@ public class OpenJPAMessageManager extends StoreMessageManager {
         Flags flags =  super.getPermanentFlags(session);
         flags.add(Flags.Flag.USER);
         return flags;
+    }
+
+    public Mono<MailboxMetaData> getMetaDataReactive(MailboxMetaData.RecentMode recentMode, MailboxSession mailboxSession, EnumSet<MailboxMetaData.Item> items) throws MailboxException {
+        MailboxACL resolvedAcl = getResolvedAcl(mailboxSession);
+        if (!storeRightManager.hasRight(mailbox, MailboxACL.Right.Read, mailboxSession)) {
+            return Mono.just(MailboxMetaData.sensibleInformationFree(resolvedAcl, getMailboxEntity().getUidValidity(), isWriteable(mailboxSession)));
+        }
+        Flags permanentFlags = getPermanentFlags(mailboxSession);
+        UidValidity uidValidity = getMailboxEntity().getUidValidity();
+        MessageMapper messageMapper = mapperFactory.getMessageMapper(mailboxSession);
+
+        return messageMapper.executeReactive(
+            nextUid(messageMapper, items)
+                .flatMap(nextUid -> highestModSeq(messageMapper, items)
+                    .flatMap(highestModSeq -> firstUnseen(messageMapper, items)
+                        .flatMap(Throwing.function(firstUnseen -> recent(recentMode, mailboxSession)
+                            .flatMap(recents -> mailboxCounters(messageMapper, items)
+                                .map(counters -> new MailboxMetaData(recents, permanentFlags, uidValidity, nextUid, highestModSeq, counters.getCount(),
+                                    counters.getUnseen(), firstUnseen.orElse(null), isWriteable(mailboxSession), resolvedAcl))))))));
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -658,7 +658,7 @@ public class StoreMailboxManager implements MailboxManager {
                 return mailboxId;
             })
             .then(Mono.from(locker.executeReactiveWithLockReactive(from, mapper.findMailboxWithPathLike(query)
-                    .flatMap(sub -> {
+                    .concatMap(sub -> {
                         String subOriginalName = sub.getName();
                         String subNewName = newMailboxPath.getName() + subOriginalName.substring(from.getName().length());
                         MailboxPath fromPath = new MailboxPath(from, subOriginalName);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -578,7 +578,7 @@ public class StoreMailboxManager implements MailboxManager {
             return subscriptionMapper.findSubscriptionsForUserReactive(fromSession.getUser())
                 .collectList()
                 .flatMap(subscriptions -> Flux.fromIterable(renamedResults)
-                    .flatMap(renamedResult -> {
+                    .concatMap(renamedResult -> {
                         Function<Subscription, Mono<Void>> renameFunction = subscription -> subscriptionMapper.deleteReactive(subscription)
                             .then(subscriptionMapper.saveReactive(new Subscription(toSession.getUser(), renamedResult.getDestinationPath().asEscapedString())));
                         Subscription legacySubscription = new Subscription(fromSession.getUser(), renamedResult.getOriginPath().getName());

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -594,14 +594,14 @@ public class StoreMessageManager implements MessageManager {
                 t5.getT4().getUnseen(), t5.getT3().orElse(null), isWriteable(mailboxSession), resolvedAcl)));
     }
 
-    private Mono<ModSeq> highestModSeq(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
+    protected Mono<ModSeq> highestModSeq(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
         if (items.contains(MailboxMetaData.Item.HighestModSeq)) {
             return messageMapper.getHighestModSeqReactive(mailbox);
         }
         return Mono.just(ModSeq.first());
     }
 
-    private Mono<MessageUid> nextUid(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
+    protected Mono<MessageUid> nextUid(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
         if (items.contains(MailboxMetaData.Item.NextUid)) {
             return messageMapper.getLastUidReactive(mailbox)
                 .map(optional -> optional
@@ -611,14 +611,14 @@ public class StoreMessageManager implements MessageManager {
         return Mono.just(MessageUid.MIN_VALUE);
     }
 
-    private Mono<Optional<MessageUid>> firstUnseen(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
+    protected Mono<Optional<MessageUid>> firstUnseen(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
         if (items.contains(MailboxMetaData.Item.FirstUnseen)) {
             return messageMapper.findFirstUnseenMessageUidReactive(getMailboxEntity());
         }
         return Mono.just(Optional.empty());
     }
 
-    private Mono<MailboxCounters> mailboxCounters(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
+    protected Mono<MailboxCounters> mailboxCounters(MessageMapper messageMapper, EnumSet<MailboxMetaData.Item> items) {
         if (items.contains(MailboxMetaData.Item.MailboxCounters)) {
             return messageMapper.getMailboxCountersReactive(getMailboxEntity());
         }
@@ -777,7 +777,7 @@ public class StoreMessageManager implements MessageManager {
      * Return a List which holds all uids of recent messages and optional reset
      * the recent flag on the messages for the uids
      */
-    private Mono<List<MessageUid>> recent(RecentMode recentMode, MailboxSession mailboxSession) throws MailboxException {
+    protected Mono<List<MessageUid>> recent(RecentMode recentMode, MailboxSession mailboxSession) throws MailboxException {
         MessageMapper messageMapper = mapperFactory.getMessageMapper(mailboxSession);
 
         switch (recentMode) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AnnotationMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AnnotationMapper.java
@@ -30,6 +30,7 @@ import org.reactivestreams.Publisher;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public interface AnnotationMapper extends Mapper {
     /**
@@ -42,7 +43,8 @@ public interface AnnotationMapper extends Mapper {
     List<MailboxAnnotation> getAllAnnotations(MailboxId mailboxId);
 
     default Publisher<MailboxAnnotation> getAllAnnotationsReactive(MailboxId mailboxId) {
-        return Flux.fromIterable(getAllAnnotations(mailboxId));
+        return Flux.fromIterable(getAllAnnotations(mailboxId))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -56,7 +58,8 @@ public interface AnnotationMapper extends Mapper {
     List<MailboxAnnotation> getAnnotationsByKeys(MailboxId mailboxId, Set<MailboxAnnotationKey> keys);
 
     default Publisher<MailboxAnnotation> getAnnotationsByKeysReactive(MailboxId mailboxId, Set<MailboxAnnotationKey> keys) {
-        return Flux.fromIterable(getAnnotationsByKeys(mailboxId, keys));
+        return Flux.fromIterable(getAnnotationsByKeys(mailboxId, keys))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -70,7 +73,8 @@ public interface AnnotationMapper extends Mapper {
     List<MailboxAnnotation> getAnnotationsByKeysWithOneDepth(MailboxId mailboxId, Set<MailboxAnnotationKey> keys);
 
     default Publisher<MailboxAnnotation> getAnnotationsByKeysWithOneDepthReactive(MailboxId mailboxId, Set<MailboxAnnotationKey> keys) {
-        return Flux.fromIterable(getAnnotationsByKeysWithOneDepth(mailboxId, keys));
+        return Flux.fromIterable(getAnnotationsByKeysWithOneDepth(mailboxId, keys))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -84,7 +88,8 @@ public interface AnnotationMapper extends Mapper {
     List<MailboxAnnotation> getAnnotationsByKeysWithAllDepth(MailboxId mailboxId, Set<MailboxAnnotationKey> keys);
 
     default Publisher<MailboxAnnotation> getAnnotationsByKeysWithAllDepthReactive(MailboxId mailboxId, Set<MailboxAnnotationKey> keys) {
-        return Flux.fromIterable(getAnnotationsByKeysWithAllDepth(mailboxId, keys));
+        return Flux.fromIterable(getAnnotationsByKeysWithAllDepth(mailboxId, keys))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -96,7 +101,9 @@ public interface AnnotationMapper extends Mapper {
     void deleteAnnotation(MailboxId mailboxId, MailboxAnnotationKey key);
 
     default Publisher<Void> deleteAnnotationReactive(MailboxId mailboxId, MailboxAnnotationKey key) {
-        return Mono.fromRunnable(() -> deleteAnnotation(mailboxId, key));
+        return Mono.fromRunnable(() -> deleteAnnotation(mailboxId, key))
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
     }
 
     /**
@@ -109,7 +116,9 @@ public interface AnnotationMapper extends Mapper {
     void insertAnnotation(MailboxId mailboxId, MailboxAnnotation mailboxAnnotation);
 
     default Publisher<Void> insertAnnotationReactive(MailboxId mailboxId, MailboxAnnotation mailboxAnnotation) {
-        return Mono.fromRunnable(() -> insertAnnotation(mailboxId, mailboxAnnotation));
+        return Mono.fromRunnable(() -> insertAnnotation(mailboxId, mailboxAnnotation))
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
     }
 
     /**
@@ -122,7 +131,8 @@ public interface AnnotationMapper extends Mapper {
     boolean exist(MailboxId mailboxId, MailboxAnnotation mailboxAnnotation);
 
     default Publisher<Boolean> existReactive(MailboxId mailboxId, MailboxAnnotation mailboxAnnotation) {
-        return Mono.fromCallable(() -> exist(mailboxId, mailboxAnnotation));
+        return Mono.fromCallable(() -> exist(mailboxId, mailboxAnnotation))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -132,6 +142,7 @@ public interface AnnotationMapper extends Mapper {
     int countAnnotations(MailboxId mailboxId);
 
     default Publisher<Integer> countAnnotationsReactive(MailboxId mailboxId) {
-        return Mono.fromCallable(() -> countAnnotations(mailboxId));
+        return Mono.fromCallable(() -> countAnnotations(mailboxId))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/ModSeqProvider.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/ModSeqProvider.java
@@ -24,6 +24,7 @@ import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Take care of provide mod-seqences for a given {@link Mailbox}. Be aware that implementations
@@ -55,7 +56,8 @@ public interface ModSeqProvider {
     ModSeq highestModSeq(Mailbox mailbox) throws MailboxException;
 
     default Mono<ModSeq> highestModSeqReactive(Mailbox mailbox) {
-        return Mono.fromCallable(() -> highestModSeq(mailbox));
+        return Mono.fromCallable(() -> highestModSeq(mailbox))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -64,6 +66,7 @@ public interface ModSeqProvider {
     ModSeq highestModSeq(MailboxId mailboxId) throws MailboxException;
 
     default Mono<ModSeq> nextModSeqReactive(MailboxId mailboxId) {
-        return Mono.fromCallable(() -> nextModSeq(mailboxId));
+        return Mono.fromCallable(() -> nextModSeq(mailboxId))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/UidProvider.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Take care of provide uids for a given {@link Mailbox}. Be aware that implementations
@@ -50,13 +51,15 @@ public interface UidProvider {
     Optional<MessageUid> lastUid(Mailbox mailbox) throws MailboxException;
 
     default Mono<Optional<MessageUid>> lastUidReactive(Mailbox mailbox) {
-        return Mono.fromCallable(() -> lastUid(mailbox));
+        return Mono.fromCallable(() -> lastUid(mailbox))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     MessageUid nextUid(MailboxId mailboxId) throws MailboxException;
 
     default Mono<MessageUid> nextUidReactive(MailboxId mailboxId) {
-        return Mono.fromCallable(() -> nextUid(mailboxId));
+        return Mono.fromCallable(() -> nextUid(mailboxId))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     default Mono<List<MessageUid>> nextUids(MailboxId mailboxId, int count) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/user/SubscriptionMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/user/SubscriptionMapper.java
@@ -30,6 +30,7 @@ import com.google.common.base.Functions;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Mapper for {@link Subscription}
@@ -43,7 +44,9 @@ public interface SubscriptionMapper extends Mapper {
     void save(Subscription subscription) throws SubscriptionException;
 
     default Mono<Void> saveReactive(Subscription subscription) {
-        return Mono.fromRunnable(Throwing.runnable(() -> save(subscription)));
+        return Mono.fromRunnable(Throwing.runnable(() -> save(subscription)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
     }
 
     /**
@@ -55,7 +58,8 @@ public interface SubscriptionMapper extends Mapper {
 
     default Flux<Subscription> findSubscriptionsForUserReactive(Username user) {
         return Mono.fromCallable(() -> findSubscriptionsForUser(user))
-            .flatMapIterable(Functions.identity());
+            .flatMapIterable(Functions.identity())
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -65,6 +69,8 @@ public interface SubscriptionMapper extends Mapper {
     void delete(Subscription subscription) throws SubscriptionException;
 
     default Mono<Void> deleteReactive(Subscription subscription) {
-        return Mono.fromRunnable(Throwing.runnable(() -> delete(subscription)));
+        return Mono.fromRunnable(Throwing.runnable(() -> delete(subscription)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
     }
 }

--- a/mpt/impl/imap-mailbox/jpa/pom.xml
+++ b/mpt/impl/imap-mailbox/jpa/pom.xml
@@ -104,6 +104,9 @@
                 <configuration>
                     <reuseForks>true</reuseForks>
                     <forkCount>1C</forkCount>
+                    <argLine>-Djava.library.path=
+                        -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
+                        -Xms512m -Xmx1024m -Dopenjpa.Multithreaded=true</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -357,6 +357,9 @@
                     <reuseForks>false</reuseForks>
                     <!-- Speed up a bit things -->
                     <forkCount>1C</forkCount>
+                    <argLine>-Djava.library.path=
+                        -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
+                        -Xms512m -Xmx1024m -Dopenjpa.Multithreaded=true</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -50,3 +50,4 @@ james.jmx.credential.generation=true
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
+openjpa.Multithreaded=true

--- a/server/apps/jpa-smtp-app/pom.xml
+++ b/server/apps/jpa-smtp-app/pom.xml
@@ -235,6 +235,19 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Isolation issues with Derby inMemory database -->
+                    <reuseForks>false</reuseForks>
+                    <!-- Speed up a bit things -->
+                    <forkCount>1C</forkCount>
+                    <argLine>-Djava.library.path=
+                        -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
+                        -Xms512m -Xmx1024m -Dopenjpa.Multithreaded=true</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -50,3 +50,4 @@ james.jmx.credential.generation=true
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
+openjpa.Multithreaded=true

--- a/server/apps/spring-app/pom.xml
+++ b/server/apps/spring-app/pom.xml
@@ -70,7 +70,8 @@
         <james.system-property1>-Djames.message.usememorycopy=false</james.system-property1>
         <!-- Prevents Logjam (CVE-2015-4000) -->
         <james.system-property2>-Djdk.tls.ephemeralDHKeySize=2048</james.system-property2>
-        <james.system-properties>${james.system-property1} ${james.system-property2}</james.system-properties>
+        <james.system-property3>-openjpa.Multithreaded=true</james.system-property3>
+        <james.system-properties>${james.system-property1} ${james.system-property2} ${james.system-property3}</james.system-properties>
         <!-- this name is used for James's folders on Debian systems and james user -->
         <james.debian.user>apache-james</james.debian.user>
 


### PR DESCRIPTION
## Before

openjpa (blocking) calls on the IMAP event loop

![Screenshot from 2023-06-02 14-29-32](https://github.com/apache/james-project/assets/6928740/e2f2df50-85ca-40c5-b2c6-698feebf64f8)


## After

No openjpa (blocking) calls on the IMAP event loop

![Screenshot from 2023-06-02 14-28-42](https://github.com/apache/james-project/assets/6928740/3927d778-8614-4b69-bb12-b20db587846b)
