### PR TITLE
JAMES-3913 + JAMES-3914 Fix Sieve mailet (big) bugs

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/ActionUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/ActionUtils.java
@@ -41,21 +41,6 @@ public class ActionUtils {
     private static final String ATTRIBUTE_PREFIX = ActionUtils.class.getPackage().getName() + ".";
 
     /**
-     * Answers the sole intended recipient for aMail.
-     */
-    public static MailAddress getSoleRecipient(Mail aMail) throws MessagingException {
-        if (aMail.getRecipients() == null) {
-            throw new MessagingException("Invalid number of recipients - 0"
-                    + ". Exactly 1 recipient is expected.");
-        } else if (1 != aMail.getRecipients().size()) {
-            throw new MessagingException("Invalid number of recipients - "
-                + aMail.getRecipients().size()
-                + ". Exactly 1 recipient is expected.");
-        }
-        return aMail.getRecipients().iterator().next();
-    }
-
-    /**
      * Detect and handle locally looping mail. External loop detection is left
      * to the MTA.
      */

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/ActionUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/ActionUtils.java
@@ -59,9 +59,8 @@ public class ActionUtils {
      * Detect and handle locally looping mail. External loop detection is left
      * to the MTA.
      */
-    public static void detectAndHandleLocalLooping(Mail aMail, String anAttributeSuffix)
-            throws MessagingException {
-        MailAddress thisRecipient = getSoleRecipient(aMail);
+    public static void detectAndHandleLocalLooping(Mail aMail, ActionContext context, String anAttributeSuffix) {
+        MailAddress thisRecipient = context.getRecipient();
         AttributeName attributeName = AttributeName.of(ATTRIBUTE_PREFIX + anAttributeSuffix);
         AttributeUtils
             .getValueAndCastFromMail(aMail, attributeName, String.class)

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/FileIntoAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/FileIntoAction.java
@@ -20,7 +20,6 @@ package org.apache.james.transport.mailets.jsieve;
 
 import javax.mail.MessagingException;
 
-import org.apache.james.core.MailAddress;
 import org.apache.jsieve.mail.Action;
 import org.apache.jsieve.mail.ActionFileInto;
 import org.apache.mailet.Mail;
@@ -64,26 +63,22 @@ public class FileIntoAction implements MailAction {
      * When IMAP support is added to James, it will be possible to support
      * sub-folders of <code>INBOX</code> fully.
      * </p>
-     * 
-     * @param anAction
-     * @param aMail
+     *
      * @param context not null
-     * @throws MessagingException
      */
     public void execute(ActionFileInto anAction, Mail aMail, final ActionContext context) throws MessagingException {
-        String destinationMailbox = anAction.getDestination();
-        MailAddress recipient;
-        recipient = ActionUtils.getSoleRecipient(aMail);
-
-        if (!(destinationMailbox.length() > 0
-            && destinationMailbox.charAt(0) == HIERARCHY_DELIMITER)) {
-            destinationMailbox =  HIERARCHY_DELIMITER + destinationMailbox;
-        }
-
+        String destinationMailbox = getDestinationMailbox(anAction);
         String mailbox = destinationMailbox.replace(HIERARCHY_DELIMITER, '/');
-        String url = "mailbox://" + recipient.asString() + mailbox;
+        String url = "mailbox://" + context.getRecipient().asString() + mailbox;
 
         context.post(url, aMail);
         LOGGER.debug("Filed Message ID: {} into destination: \"{}\"", aMail.getMessage().getMessageID(), destinationMailbox);
+    }
+
+    private String getDestinationMailbox(ActionFileInto anAction) {
+        if (!(anAction.getDestination().length() > 0 && anAction.getDestination().charAt(0) == HIERARCHY_DELIMITER)) {
+            return HIERARCHY_DELIMITER + anAction.getDestination();
+        }
+        return anAction.getDestination();
     }
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RedirectAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RedirectAction.java
@@ -56,7 +56,7 @@ public class RedirectAction implements MailAction {
      * @throws MessagingException
      */
     public void execute(ActionRedirect anAction, Mail aMail, ActionContext context) throws MessagingException {
-        ActionUtils.detectAndHandleLocalLooping(aMail, "redirect");
+        ActionUtils.detectAndHandleLocalLooping(aMail, context, "redirect");
 
         MailImpl redirectedMail = MailImpl.builder()
             .name("redirect-" + aMail.getName())

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
@@ -109,8 +109,7 @@ public class RejectAction implements MailAction {
             originalRecipient = originalRecipients[0];
         }
 
-        MailAddress soleRecipient = ActionUtils.getSoleRecipient(aMail);
-        String finalRecipient = soleRecipient.asString();
+        String finalRecipient = context.getRecipient().asString();
         String originalMessageId = aMail.getMessage().getMessageID();
 
         Multipart multipart = MDN.builder()
@@ -133,7 +132,7 @@ public class RejectAction implements MailAction {
 
         // Send the message
         MimeMessage reply = (MimeMessage) aMail.getMessage().reply(false);
-        soleRecipient.toInternetAddress()
+        context.getRecipient().toInternetAddress()
             .ifPresent(Throwing.<Address>consumer(reply::setFrom).sneakyThrow());
         reply.setContent(multipart);
         reply.saveChanges();

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
@@ -62,8 +62,8 @@ public class RejectAction implements MailAction {
         if (action instanceof ActionReject) {
             final ActionReject actionReject = (ActionReject) action;
             execute(actionReject, mail, context);
+            DiscardAction.removeRecipient(mail, context);
         }
-
     }
 
     /**

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
@@ -81,7 +81,7 @@ public class RejectAction implements MailAction {
      * @throws MessagingException
      */
     public void execute(ActionReject anAction, Mail aMail, ActionContext context) throws MessagingException {
-        ActionUtils.detectAndHandleLocalLooping(aMail, "reject");
+        ActionUtils.detectAndHandleLocalLooping(aMail, context, "reject");
 
         // Create the MDN part
         StringBuilder humanText = new StringBuilder(128);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationReply.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationReply.java
@@ -81,7 +81,7 @@ public class VacationReply {
 
         public VacationReply build() throws MessagingException {
             Preconditions.checkState(eitherReasonOrMime());
-            ActionUtils.detectAndHandleLocalLooping(originalMail, "vacation");
+            ActionUtils.detectAndHandleLocalLooping(originalMail,  context, "vacation");
 
             MimeMessage reply = (MimeMessage) originalMail.getMessage().reply(false);
             reply.setSubject(generateNotificationSubject());

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
@@ -182,6 +182,8 @@ class SieveIntegrationTest {
         assertThatAttribute(mail.getAttribute(ATTRIBUTE_NAME)).isEqualTo(ATTRIBUTE_INBOX_ANY);
     }
 
+
+    // ANCHOR
     @Test
     void shouldSupportSeveralRecipientsWhenFileInto() throws Exception {
         prepareTestUsingScript("org/apache/james/transport/mailets/delivery/fileinto.script");
@@ -860,6 +862,26 @@ class SieveIntegrationTest {
         prepareTestUsingScript("org/apache/james/transport/mailets/delivery/vacationReason.script");
 
         FakeMail mail = createMail();
+        testee.service(mail);
+
+        assertThatAttribute(mail.getAttribute(ATTRIBUTE_NAME)).isEqualTo(ATTRIBUTE_INBOX);
+
+        FakeMailContext.SentMail expectedSentMail = FakeMailContext.sentMailBuilder()
+            .sender(new MailAddress(RECEIVER_DOMAIN_COM))
+            .recipient(new MailAddress("sender@any.com"))
+            .fromMailet()
+            .build();
+        assertThat(fakeMailContext.getSentMails()).containsExactly(expectedSentMail);
+    }
+
+    @Test
+    void vacationShouldWorkWhenSeveralRecipients() throws Exception {
+        prepareTestUsingScript("org/apache/james/transport/mailets/delivery/vacationReason.script");
+        when(usersRepository.getUsername(new MailAddress("other@domain.tld"))).thenReturn(Username.of("other@domain.tld"));
+        when(resourceLocator.get(new MailAddress("other@domain.tld"))).thenThrow(new ScriptNotFoundException());
+
+        FakeMail mail = createMail();
+        mail.setRecipients(ImmutableList.of(new MailAddress(RECEIVER_DOMAIN_COM), new MailAddress("other@domain.tld")));
         testee.service(mail);
 
         assertThatAttribute(mail.getAttribute(ATTRIBUTE_NAME)).isEqualTo(ATTRIBUTE_INBOX);

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
@@ -490,6 +490,22 @@ class SieveIntegrationTest {
     }
 
     @Test
+    void rejectShouldWork() throws Exception {
+        prepareTestUsingScript("org/apache/james/transport/mailets/delivery/reject.script");
+
+        FakeMail mail = createMail();
+        testee.service(mail);
+
+        FakeMailContext.SentMail expectedSentMail = FakeMailContext.sentMailBuilder()
+            .recipient("sender@any.com")
+            .fromMailet()
+            .build();
+        assertThat(fakeMailContext.getSentMails())
+            .containsExactly(expectedSentMail);
+        assertThat(mail.getRecipients()).isEmpty();
+    }
+
+    @Test
     void redirectShouldWorkWhenSeveralRecipients() throws Exception {
         prepareTestUsingScript("org/apache/james/transport/mailets/delivery/redirect.script");
         when(usersRepository.getUsername(new MailAddress("other@domain.tld"))).thenReturn(Username.of("other@domain.tld"));

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
@@ -183,6 +183,19 @@ class SieveIntegrationTest {
     }
 
     @Test
+    void shouldSupportSeveralRecipientsWhenFileInto() throws Exception {
+        prepareTestUsingScript("org/apache/james/transport/mailets/delivery/fileinto.script");
+        when(usersRepository.getUsername(new MailAddress("other@domain.tld"))).thenReturn(Username.of("other@domain.tld"));
+        when(resourceLocator.get(new MailAddress("other@domain.tld"))).thenThrow(new ScriptNotFoundException());
+
+        FakeMail mail = createMail();
+        mail.setRecipients(ImmutableList.of(new MailAddress(RECEIVER_DOMAIN_COM), new MailAddress("other@domain.tld")));
+        testee.service(mail);
+
+        assertThatAttribute(mail.getAttribute(ATTRIBUTE_NAME)).isEqualTo(ATTRIBUTE_INBOX_ANY);
+    }
+
+    @Test
     void allOfAllFalseScriptShouldWork() throws Exception {
         prepareTestUsingScript("org/apache/james/transport/mailets/delivery/allofAllFalse.script");
 

--- a/server/mailet/mailets/src/test/resources/org/apache/james/transport/mailets/delivery/reject.script
+++ b/server/mailet/mailets/src/test/resources/org/apache/james/transport/mailets/delivery/reject.script
@@ -1,0 +1,19 @@
+################################################################
+# Licensed to the Apache Software Foundation (ASF) under one   #
+# or more contributor license agreements.  See the NOTICE file #
+# distributed with this work for additional information        #
+# regarding copyright ownership.  The ASF licenses this file   #
+# to you under the Apache License, Version 2.0 (the            #
+# "License"); you may not use this file except in compliance   #
+# with the License.  You may obtain a copy of the License at   #
+#                                                              #
+#   http://www.apache.org/licenses/LICENSE-2.0                 #
+#                                                              #
+# Unless required by applicable law or agreed to in writing,   #
+# software distributed under the License is distributed on an  #
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       #
+# KIND, either express or implied.  See the License for the    #
+# specific language governing permissions and limitations      #
+# under the License.                                           #
+################################################################
+reject "Spam not consumed here!";


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JAMES-3913 Sieve REJECT action still deliveres the mail

https://issues.apache.org/jira/browse/JAMES-3914 When processing an email with several recipients the following SIEVE actions fails:

  - FileInto
  - Vacation
  - Redirect
  - Reject