### PR TITLE
FIX Proxy for SMTPS

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/AbstractSSLAwareChannelPipelineFactory.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/AbstractSSLAwareChannelPipelineFactory.java
@@ -57,7 +57,7 @@ public abstract class AbstractSSLAwareChannelPipelineFactory<C extends SocketCha
 
         if (isSSLSocket()) {
             if (proxyRequired) {
-                channel.pipeline().addAfter("proxyInformationHandler", HandlerConstants.SSL_HANDLER, secure.get().sslHandler());
+                channel.pipeline().addAfter(HandlerConstants.PROXY_HANDLER, HandlerConstants.SSL_HANDLER, secure.get().sslHandler());
             } else {
                 channel.pipeline().addFirst(HandlerConstants.SSL_HANDLER, secure.get().sslHandler());
             }


### PR DESCRIPTION
CF https://github.com/apache/james-project/tree/master/examples/proxy-smtp on port 465

## Before

```
james      | 03:01:57.543 [WARN ] i.n.c.ChannelInitializer - Failed to initialize a channel. Closing: [id: 0xab45804e, L:/172.18.0.2:465 - R:/172.18.0.3:35036]
james      | java.util.NoSuchElementException: proxyInformationHandler
james      |    at io.netty.channel.DefaultChannelPipeline.getContextOrDie(DefaultChannelPipeline.java:1073)
james      |    at io.netty.channel.DefaultChannelPipeline.addAfter(DefaultChannelPipeline.java:302)
james      |    at io.netty.channel.DefaultChannelPipeline.addAfter(DefaultChannelPipeline.java:290)
james      |    at org.apache.james.protocols.netty.AbstractSSLAwareChannelPipelineFactory.initChannel(AbstractSSLAwareChannelPipelineFactory.java:58)
james      |    at org.apache.james.protocols.netty.AbstractSSLAwareChannelPipelineFactory.initChannel(AbstractSSLAwareChannelPipelineFactory.java:30)
james      |    at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:129)
james      |    at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:112)
james      |    at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:1114)
james      |    at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609)
james      |    at io.netty.channel.DefaultChannelPipeline.access$100(DefaultChannelPipeline.java:46)
james      |    at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1463)
james      |    at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1115)
james      |    at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:650)
james      |    at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:514)
james      |    at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429)
james      |    at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486)
james      |    at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
james      |    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
james      |    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
james      |    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
james      |    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
james      |    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
james      |    at java.base/java.lang.Thread.run(Unknown Source)
```

## After 

Works

Note: I did not succeed wiritng a non regression test: writing both the PROXY message then initializing SSL connection was overwhelming in Java...