### PR TITLE
JAMES-3922: Enforce non-null Property contract and add missing null-check in Prope

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Property.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Property.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+import reactor.util.annotation.NonNull;
+
 /**
  * <p>Values a namespaced property.</p>
  * <p>
@@ -51,11 +53,11 @@ public class Property {
      * @param localName not null
      * @param value not null
      */
-    public Property(String namespace, String localName, String value) {
+    public Property(@NonNull String namespace, @NonNull String localName, @NonNull String value) {
         super();
-        this.namespace = namespace;
-        this.localName = localName;
-        this.value = value;
+        this.namespace = Objects.requireNonNull(namespace);
+        this.localName = Objects.requireNonNull(localName);
+        this.value = Objects.requireNonNull(value);
     }
 
     public Property(Property property) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilder.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilder.java
@@ -111,7 +111,9 @@ public class PropertyBuilder {
         properties.removeIf(property -> property.isNamed(namespace, localName));
         if (values != null) {
             for (String value:values) {
-                properties.add(new Property(namespace, localName, value));
+                if (value != null) {
+                    properties.add(new Property(namespace, localName, value));
+                }
             }
         }
     }
@@ -126,7 +128,9 @@ public class PropertyBuilder {
     private void setProperties(String namespace, Map<String,String> valuesByLocalName) {
         properties.removeIf(property -> property.isInSpace(namespace));
         for (Map.Entry<String, String> valueByLocalName:valuesByLocalName.entrySet()) {
-            properties.add(new Property(namespace, valueByLocalName.getKey().toLowerCase(Locale.US), valueByLocalName.getValue()));
+            if (valueByLocalName.getValue() != null) {
+                properties.add(new Property(namespace, valueByLocalName.getKey().toLowerCase(Locale.US), valueByLocalName.getValue()));
+            }
         }
     }
     

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilderTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilderTest.java
@@ -26,7 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.james.mailbox.store.mail.model.Property;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 class PropertyBuilderTest {
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilderTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilderTest.java
@@ -26,10 +26,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.james.mailbox.store.mail.model.Property;
 import org.junit.jupiter.api.Test;
 
+import java.util.*;
+
 class PropertyBuilderTest {
     @Test
     void emptyPropertyBuilderShouldCreateEmptyProperties() {
         assertThat(new PropertyBuilder().toProperties()).isEmpty();
+    }
+
+    @Test
+    void nullValuePropertyBuilderShouldCreateEmptyProperties() {
+        List<String> listOfNulls = Arrays.asList(null, null, null);
+        Map <String,String> mapWithNullValues = Collections.singletonMap("k1", null);
+
+        PropertyBuilder builder = new PropertyBuilder();
+        builder.setContentLanguage(listOfNulls);
+        builder.setContentTypeParameters(mapWithNullValues);
+        builder.setCharset(null);
+
+        assertThat(builder.toProperties()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
`org.apache.james.mailbox.store.mail.model.Property#Property()` already had contract (in it's javadoc) specifying that all parameters must be non-null - I added explicit check for it.

Moreover, checking possible call places, one of `PropertyBuilder#setProperty()` already had null-check, so I added same check to remaining to methods responsible for setting properties (one taking `List` and one taking `Map`).

@chibenwa suggested filtering properties with null value before persisting, but IMHO this approach is better and should prevent any other similar issues.

(ref: https://issues.apache.org/jira/browse/JAMES-3922)