### PR TITLE
JAMES-3822: New properties for future release jmap in jmap.properties

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmap.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmap.adoc
@@ -92,6 +92,8 @@ then `capabilities."urn:ietf:params:jmap:websocket".url` in response will be "ws
 for JMAP filters. This projection optimizes reads, but needs to be correctly populated. Turning it on on
 systems with filters already defined would result in those filters to be not read.
 
+| delay.sends.enabled
+| Optional boolean. Defaults to false. Whether to support or not the delay send with JMAP protocol.
 |===
 
 == Wire tapping

--- a/server/apps/memory-app/sample-configuration/jmap.properties
+++ b/server/apps/memory-app/sample-configuration/jmap.properties
@@ -5,6 +5,7 @@ enabled=true
 
 tls.keystoreURL=file://conf/keystore
 tls.secret=james72laBalle
+delay.sends.enabled=true
 
 # Alternatively TLS keys can be supplied via PEM files
 # tls.privateKey=file://conf/private.nopass.key

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -131,6 +131,9 @@
                         for JMAP filters. This projection optimizes reads, but needs to be correctly populated. Turning it on on
                         systems with filters already defined would result in those filters to be not read.
                     </dd>
+
+                    <dt><strong>delay.sends.enabled</strong></dt>
+                    <dd>Optional boolean. Defaults to false. Whether to support or not the delay send with JMAP protocol. </dd>
                 </dl>
 
             </subsection>


### PR DESCRIPTION
In order to config future release extension for jmap. we need a new properties `delay.sends.enabled` in `jmap.properties`

- `delay.sends.enabled = true` => support for future release 
- `delay.sends.enabled = false` => no support for future release 

IMO, we need add doc for this properties in https://james.apache.org/server/config-jmap.html 