### PR TITLE
[BACKPORT] JAMES-3604 Fix issue when creating quorum rabbitmq queues

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -722,9 +722,9 @@ public class RabbitMQConfiguration {
         return sslConfiguration;
     }
 
-    public QueueArguments.Builder workQueueArgumentsBuilder() {
+    public QueueArguments.Builder workQueueArgumentsBuilder(boolean autoDeleteQueue) {
         QueueArguments.Builder builder = QueueArguments.builder();
-        if (useQuorumQueues) {
+        if (!autoDeleteQueue && useQuorumQueues) {
             builder.quorumQueue().replicationFactor(quorumQueueReplicationFactor);
         }
         queueTTL.ifPresent(builder::queueTTL);

--- a/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistration.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistration.java
@@ -128,7 +128,7 @@ class GroupRegistration implements Registration {
                 .durable(DURABLE)
                 .exclusive(!EXCLUSIVE)
                 .autoDelete(!AUTO_DELETE)
-                .arguments(configuration.workQueueArgumentsBuilder()
+                .arguments(configuration.workQueueArgumentsBuilder(!AUTO_DELETE)
                     .deadLetter(namingStrategy.deadLetterExchange())
                     .build()));
     }

--- a/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/GroupRegistrationHandler.java
@@ -104,7 +104,7 @@ class GroupRegistrationHandler {
                 .durable(DURABLE)
                 .exclusive(!EXCLUSIVE)
                 .autoDelete(!AUTO_DELETE)
-                .arguments(configuration.workQueueArgumentsBuilder()
+                .arguments(configuration.workQueueArgumentsBuilder(!AUTO_DELETE)
                     .deadLetter(namingStrategy.deadLetterExchange())
                     .build()),
             BindingSpecification.binding()

--- a/event-bus/distributed/src/main/java/org/apache/james/events/KeyReconnectionHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/KeyReconnectionHandler.java
@@ -55,7 +55,7 @@ public class KeyReconnectionHandler implements SimpleConnectionPool.Reconnection
         return Mono.fromRunnable(() -> {
             try (Channel channel = connection.createChannel()) {
                 channel.queueDeclare(namingStrategy.queueName(eventBusId).asString(), DURABLE, !EXCLUSIVE, AUTO_DELETE,
-                    configuration.workQueueArgumentsBuilder().build());
+                    configuration.workQueueArgumentsBuilder(AUTO_DELETE).build());
             } catch (Exception e) {
                 LOGGER.error("Error recovering connection", e);
             }

--- a/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistrationHandler.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/KeyRegistrationHandler.java
@@ -122,7 +122,7 @@ class KeyRegistrationHandler {
                 .durable(DURABLE)
                 .exclusive(!EXCLUSIVE)
                 .autoDelete(AUTO_DELETE)
-                .arguments(configuration.workQueueArgumentsBuilder().build()))
+                .arguments(configuration.workQueueArgumentsBuilder(AUTO_DELETE).build()))
             .timeout(TOPOLOGY_CHANGES_TIMEOUT)
             .map(AMQP.Queue.DeclareOk::getQueue)
             .retryWhen(Retry.backoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff()).jitter(retryBackoff.getJitterFactor()))

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
@@ -167,7 +167,7 @@ public class RabbitMQMailQueueFactory implements MailQueueFactory<RabbitMQMailQu
                 .durable(DURABLE)
                 .exclusive(!EXCLUSIVE)
                 .autoDelete(!AUTO_DELETE)
-                .arguments(configuration.workQueueArgumentsBuilder()
+                .arguments(configuration.workQueueArgumentsBuilder(!AUTO_DELETE)
                     .deadLetter(mailQueueName.toDeadLetterExchangeName())
                     .build())),
             sender.declareQueue(QueueSpecification.queue(mailQueueName.toDeadLetterQueueName())

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/FakeMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/FakeMailQueueView.java
@@ -54,8 +54,8 @@ public class FakeMailQueueView<V extends ManageableMailQueue.MailQueueItemView> 
     }
 
     @Override
-    public long delete(DeleteCondition deleteCondition) {
-        return 0;
+    public Mono<Long> delete(DeleteCondition deleteCondition) {
+        return Mono.just(0L);
     }
 
     @Override


### PR DESCRIPTION
We can't create a quorum queue and mark it as auto-delete, RabbitMQ does not allow it. So we keep the jmap event bus notification queues as classic for now.