### PR TITLE
Move rabbitMQ channel close operation to boundedElastic thread

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -685,7 +685,9 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
                 if (channel.isOpen()) {
                     channel.close();
                 }
-            })))
+            }))
+            .then()
+            .subscribeOn(Schedulers.boundedElastic()))
             .buildPool();
     }
 


### PR DESCRIPTION
This prevents the call from blocking the reactive pipeline.

JDC Flight Control performance (CPU and latency) results before fix:
<img width="1270" alt="JAMES-BEFORE" src="https://github.com/apache/james-project/assets/56495631/6530a133-d548-4052-a513-32198d22f142">
<img width="1451" alt="Screen Shot 2023-07-08 at 11 10 30 AM" src="https://github.com/apache/james-project/assets/56495631/850641bb-f26c-4228-8c93-aef45dfd6b60">


**CPU and latency after fix:**
<img width="1254" alt="JAMES-AFTER" src="https://github.com/apache/james-project/assets/56495631/dfbb810b-69a9-4013-8387-29efcbdb4dd1">
<img width="1257" alt="Screen Shot 2023-07-08 at 11 07 35 AM" src="https://github.com/apache/james-project/assets/56495631/ac9ff818-db5c-462c-b0c1-4dfadb7679c0">

