### PR TITLE
JAMES-2156 JPA Attachment Mapper

### DIFF
--- a/backends-common/jpa/pom.xml
+++ b/backends-common/jpa/pom.xml
@@ -44,6 +44,10 @@
             <version>2.9.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
             <scope>test</scope>

--- a/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/JPAConfiguration.java
+++ b/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/JPAConfiguration.java
@@ -16,17 +16,17 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
-package org.apache.james.modules.data;
+package org.apache.james.backends.jpa;
 
-import static org.apache.james.modules.data.JPAConfiguration.Credential.NO_CREDENTIAL;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.CUSTOM_DATASOURCE_PROPERTIES;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.CUSTOM_OPENJPA_PROPERTIES;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.NO_ATTACHMENT_STORAGE;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.NO_MAX_CONNECTIONS;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.NO_MULTITHREADED;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.NO_TEST_ON_BORROW;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.NO_VALIDATION_QUERY;
-import static org.apache.james.modules.data.JPAConfiguration.ReadyToBuild.NO_VALIDATION_QUERY_TIMEOUT_SEC;
+import static org.apache.james.backends.jpa.JPAConfiguration.Credential.NO_CREDENTIAL;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.CUSTOM_DATASOURCE_PROPERTIES;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.CUSTOM_OPENJPA_PROPERTIES;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.NO_ATTACHMENT_STORAGE;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.NO_MAX_CONNECTIONS;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.NO_MULTITHREADED;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.NO_TEST_ON_BORROW;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.NO_VALIDATION_QUERY;
+import static org.apache.james.backends.jpa.JPAConfiguration.ReadyToBuild.NO_VALIDATION_QUERY_TIMEOUT_SEC;
 
 import java.util.HashMap;
 import java.util.List;
@@ -41,21 +41,21 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class JPAConfiguration {
-    static final String JPA_CONNECTION_DRIVER_NAME = "openjpa.ConnectionDriverName";
-    static final String JPA_CONNECTION_USERNAME = "openjpa.ConnectionUserName";
-    static final String JPA_CONNECTION_PASSWORD = "openjpa.ConnectionPassword";
-    static final String JPA_CONNECTION_PROPERTIES = "openjpa.ConnectionProperties";
-    static final String JPA_CONNECTION_URL = "openjpa.ConnectionURL";
-    static final String JPA_MULTITHREADED = "openjpa.Multithreaded";
-    static List<String> DEFAULT_JPA_PROPERTIES = List.of(JPA_CONNECTION_DRIVER_NAME, JPA_CONNECTION_URL, JPA_MULTITHREADED, JPA_CONNECTION_USERNAME, JPA_CONNECTION_PASSWORD);
+    public static final String JPA_CONNECTION_DRIVER_NAME = "openjpa.ConnectionDriverName";
+    public static final String JPA_CONNECTION_USERNAME = "openjpa.ConnectionUserName";
+    public static final String JPA_CONNECTION_PASSWORD = "openjpa.ConnectionPassword";
+    public static final String JPA_CONNECTION_PROPERTIES = "openjpa.ConnectionProperties";
+    public static final String JPA_CONNECTION_URL = "openjpa.ConnectionURL";
+    public static final String JPA_MULTITHREADED = "openjpa.Multithreaded";
+    public static final List<String> DEFAULT_JPA_PROPERTIES = List.of(JPA_CONNECTION_DRIVER_NAME, JPA_CONNECTION_URL, JPA_MULTITHREADED, JPA_CONNECTION_USERNAME, JPA_CONNECTION_PASSWORD);
 
-    static final String DATASOURCE_TEST_ON_BORROW = "datasource.testOnBorrow";
-    static final String DATASOURCE_VALIDATION_QUERY_TIMEOUT_SEC = "datasource.validationQueryTimeoutSec";
-    static final String DATASOURCE_VALIDATION_QUERY = "datasource.validationQuery";
-    static final String DATASOURCE_MAX_TOTAL = "datasource.maxTotal";
-    static List<String> DEFAULT_DATASOURCE_PROPERTIES = List.of(DATASOURCE_TEST_ON_BORROW, DATASOURCE_VALIDATION_QUERY_TIMEOUT_SEC, DATASOURCE_VALIDATION_QUERY, DATASOURCE_MAX_TOTAL);
+    public static final String DATASOURCE_TEST_ON_BORROW = "datasource.testOnBorrow";
+    public static final String DATASOURCE_VALIDATION_QUERY_TIMEOUT_SEC = "datasource.validationQueryTimeoutSec";
+    public static final String DATASOURCE_VALIDATION_QUERY = "datasource.validationQuery";
+    public static final String DATASOURCE_MAX_TOTAL = "datasource.maxTotal";
+    public static final List<String> DEFAULT_DATASOURCE_PROPERTIES = List.of(DATASOURCE_TEST_ON_BORROW, DATASOURCE_VALIDATION_QUERY_TIMEOUT_SEC, DATASOURCE_VALIDATION_QUERY, DATASOURCE_MAX_TOTAL);
 
-    static final String ATTACHMENT_STORAGE = "attachmentStorage.enabled";
+    public static final String ATTACHMENT_STORAGE = "attachmentStorage.enabled";
 
     static {
     }

--- a/backends-common/jpa/src/test/java/org/apache/james/backends/jpa/JPAConfigurationTest.java
+++ b/backends-common/jpa/src/test/java/org/apache/james/backends/jpa/JPAConfigurationTest.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.modules.data;
+package org.apache.james.backends.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -31,6 +31,18 @@
     <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: JPA</name>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
+                <artifactId>james-server-guice</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -88,6 +100,17 @@
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-data-jpa</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-jpa-common-guice</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-jpa-common-guice</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -31,18 +31,6 @@
     <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: JPA</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${james.groupId}</groupId>
-                <artifactId>james-server-guice</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -100,16 +88,6 @@
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-data-jpa</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-jpa-common-guice</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-jpa-common-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -110,7 +110,6 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-jpa-common-guice</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.backends.jpa.EntityManagerUtils;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.jpa.mail.JPAAnnotationMapper;
+import org.apache.james.mailbox.jpa.mail.JPAAttachmentMapper;
 import org.apache.james.mailbox.jpa.mail.JPAMailboxMapper;
 import org.apache.james.mailbox.jpa.mail.JPAMessageMapper;
 import org.apache.james.mailbox.jpa.mail.JPAModSeqProvider;
@@ -33,6 +34,8 @@ import org.apache.james.mailbox.jpa.mail.JPAUidProvider;
 import org.apache.james.mailbox.jpa.user.JPASubscriptionMapper;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.AnnotationMapper;
+import org.apache.james.mailbox.store.mail.AttachmentMapper;
+import org.apache.james.mailbox.store.mail.AttachmentMapperFactory;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.MessageIdMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
@@ -44,11 +47,12 @@ import org.apache.james.mailbox.store.user.SubscriptionMapper;
  * JPA implementation of {@link MailboxSessionMapperFactory}
  *
  */
-public class JPAMailboxSessionMapperFactory extends MailboxSessionMapperFactory {
+public class JPAMailboxSessionMapperFactory extends MailboxSessionMapperFactory implements AttachmentMapperFactory {
 
     private final EntityManagerFactory entityManagerFactory;
     private final JPAUidProvider uidProvider;
     private final JPAModSeqProvider modSeqProvider;
+    private final AttachmentMapper attachmentMapper;
 
     @Inject
     public JPAMailboxSessionMapperFactory(EntityManagerFactory entityManagerFactory, JPAUidProvider uidProvider, JPAModSeqProvider modSeqProvider) {
@@ -56,6 +60,7 @@ public class JPAMailboxSessionMapperFactory extends MailboxSessionMapperFactory 
         this.uidProvider = uidProvider;
         this.modSeqProvider = modSeqProvider;
         EntityManagerUtils.safelyClose(createEntityManager());
+        this.attachmentMapper = new JPAAttachmentMapper(entityManagerFactory);
     }
     
     @Override
@@ -100,6 +105,16 @@ public class JPAMailboxSessionMapperFactory extends MailboxSessionMapperFactory 
     @Override
     public ModSeqProvider getModSeqProvider() {
         return modSeqProvider;
+    }
+
+    @Override
+    public AttachmentMapper createAttachmentMapper(MailboxSession session) {
+        return new JPAAttachmentMapper(entityManagerFactory);
+    }
+
+    @Override
+    public AttachmentMapper getAttachmentMapper(MailboxSession session) {
+        return attachmentMapper;
     }
 
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
@@ -42,6 +42,7 @@ import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.ModSeqProvider;
 import org.apache.james.mailbox.store.mail.UidProvider;
 import org.apache.james.mailbox.store.user.SubscriptionMapper;
+import org.apache.james.modules.data.JPAConfiguration;
 
 /**
  * JPA implementation of {@link MailboxSessionMapperFactory}
@@ -53,16 +54,19 @@ public class JPAMailboxSessionMapperFactory extends MailboxSessionMapperFactory 
     private final JPAUidProvider uidProvider;
     private final JPAModSeqProvider modSeqProvider;
     private final AttachmentMapper attachmentMapper;
+    private final JPAConfiguration jpaConfiguration;
 
     @Inject
-    public JPAMailboxSessionMapperFactory(EntityManagerFactory entityManagerFactory, JPAUidProvider uidProvider, JPAModSeqProvider modSeqProvider) {
+    public JPAMailboxSessionMapperFactory(EntityManagerFactory entityManagerFactory, JPAUidProvider uidProvider,
+                                          JPAModSeqProvider modSeqProvider, JPAConfiguration jpaConfiguration) {
         this.entityManagerFactory = entityManagerFactory;
         this.uidProvider = uidProvider;
         this.modSeqProvider = modSeqProvider;
         EntityManagerUtils.safelyClose(createEntityManager());
         this.attachmentMapper = new JPAAttachmentMapper(entityManagerFactory);
+        this.jpaConfiguration = jpaConfiguration;
     }
-    
+
     @Override
     public MailboxMapper createMailboxMapper(MailboxSession session) {
         return new JPAMailboxMapper(entityManagerFactory);
@@ -70,7 +74,7 @@ public class JPAMailboxSessionMapperFactory extends MailboxSessionMapperFactory 
 
     @Override
     public MessageMapper createMessageMapper(MailboxSession session) {
-        return new JPAMessageMapper(uidProvider, modSeqProvider, entityManagerFactory);
+        return new JPAMessageMapper(uidProvider, modSeqProvider, entityManagerFactory, jpaConfiguration);
     }
 
     @Override

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
@@ -24,6 +24,7 @@ import javax.persistence.EntityManagerFactory;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.backends.jpa.EntityManagerUtils;
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.jpa.mail.JPAAnnotationMapper;
 import org.apache.james.mailbox.jpa.mail.JPAAttachmentMapper;
@@ -42,7 +43,6 @@ import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.ModSeqProvider;
 import org.apache.james.mailbox.store.mail.UidProvider;
 import org.apache.james.mailbox.store.user.SubscriptionMapper;
-import org.apache.james.modules.data.JPAConfiguration;
 
 /**
  * JPA implementation of {@link MailboxSessionMapperFactory}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapper.java
@@ -93,11 +93,6 @@ public class JPAAttachmentMapper extends JPATransactionalMapper implements Attac
             .collect(ImmutableList.toImmutableList());
     }
 
-    @Override
-    public Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) {
-        throw new UnsupportedOperationException("JPA does not support MessageId");
-    }
-
     private AttachmentMetadata getAttachmentMetadata(AttachmentId attachmentId) {
         try {
             return getEntityManager().createNamedQuery("findAttachmentById", JPAAttachment.class)

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapper.java
@@ -1,0 +1,123 @@
+/***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.mail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.mailbox.exception.AttachmentNotFoundException;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.jpa.JPATransactionalMapper;
+import org.apache.james.mailbox.jpa.mail.model.JPAAttachment;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.apache.james.mailbox.model.AttachmentMetadata;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ParsedAttachment;
+import org.apache.james.mailbox.store.mail.AttachmentMapper;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+public class JPAAttachmentMapper extends JPATransactionalMapper implements AttachmentMapper {
+
+    private static final String ID_PARAM = "idParam";
+
+    public JPAAttachmentMapper(EntityManagerFactory entityManagerFactory) {
+        super(entityManagerFactory);
+    }
+
+    @Override
+    public InputStream loadAttachmentContent(AttachmentId attachmentId) {
+        Preconditions.checkArgument(attachmentId != null);
+        return getEntityManager().createNamedQuery("findAttachmentById", JPAAttachment.class)
+            .setParameter(ID_PARAM, attachmentId.getId())
+            .getSingleResult().getContent();
+    }
+
+    @Override
+    public AttachmentMetadata getAttachment(AttachmentId attachmentId) throws AttachmentNotFoundException {
+        Preconditions.checkArgument(attachmentId != null);
+        AttachmentMetadata attachmentMetadata = getAttachmentMetadata(attachmentId);
+        if (attachmentMetadata == null) {
+            throw new AttachmentNotFoundException(attachmentId.getId());
+        }
+        return attachmentMetadata;
+    }
+
+    @Override
+    public List<AttachmentMetadata> getAttachments(Collection<AttachmentId> attachmentIds) {
+        Preconditions.checkArgument(attachmentIds != null);
+        ImmutableList.Builder<AttachmentMetadata> builder = ImmutableList.builder();
+        for (AttachmentId attachmentId : attachmentIds) {
+            AttachmentMetadata attachmentMetadata = getAttachmentMetadata(attachmentId);
+            if (attachmentMetadata != null) {
+                builder.add(attachmentMetadata);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public List<MessageAttachmentMetadata> storeAttachments(Collection<ParsedAttachment> parsedAttachments, MessageId ownerMessageId) {
+        Preconditions.checkArgument(parsedAttachments != null);
+        Preconditions.checkArgument(ownerMessageId != null);
+        return parsedAttachments.stream()
+            .map(Throwing.<ParsedAttachment, MessageAttachmentMetadata>function(
+                    typedContent -> storeAttachmentForMessage(ownerMessageId, typedContent))
+                .sneakyThrow())
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) {
+        throw new UnsupportedOperationException("JPA does not support MessageId");
+    }
+
+    private AttachmentMetadata getAttachmentMetadata(AttachmentId attachmentId) {
+        try {
+            return getEntityManager().createNamedQuery("findAttachmentById", JPAAttachment.class)
+                .setParameter(ID_PARAM, attachmentId.getId())
+                .getSingleResult()
+                .toAttachmentMetadata();
+        } catch (NoResultException e) {
+            return null;
+        }
+    }
+
+    private MessageAttachmentMetadata storeAttachmentForMessage(MessageId ownerMessageId, ParsedAttachment parsedAttachment) throws MailboxException {
+        try {
+            byte[] bytes = IOUtils.toByteArray(parsedAttachment.getContent().openStream());
+            JPAAttachment persistedAttachment = new JPAAttachment(parsedAttachment.asMessageAttachment(AttachmentId.random(), ownerMessageId), bytes);
+            getEntityManager().persist(persistedAttachment);
+            AttachmentId attachmentId = AttachmentId.from(persistedAttachment.getAttachmentId());
+            return parsedAttachment.asMessageAttachment(attachmentId, bytes.length, ownerMessageId);
+        } catch (IOException e) {
+            throw new MailboxException("Failed to store attachment for message " + ownerMessageId, e);
+        }
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.mail.Flags;
 import javax.persistence.EntityManagerFactory;
@@ -36,6 +37,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.jpa.JPAId;
 import org.apache.james.mailbox.jpa.JPATransactionalMapper;
 import org.apache.james.mailbox.jpa.mail.MessageUtils.MessageChangedFlags;
+import org.apache.james.mailbox.jpa.mail.model.JPAAttachment;
 import org.apache.james.mailbox.jpa.mail.model.JPAMailbox;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMailboxMessage;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAEncryptedMailboxMessage;
@@ -44,6 +46,7 @@ import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAStreamingMailboxMessag
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageRange.Type;
@@ -295,10 +298,10 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
     public MessageMetaData move(Mailbox mailbox, MailboxMessage original) throws MailboxException {
         JPAId originalMailboxId = (JPAId) original.getMailboxId();
         JPAMailbox originalMailbox = getEntityManager().find(JPAMailbox.class, originalMailboxId.getRawId());
-        
+
         MessageMetaData messageMetaData = copy(mailbox, original);
         delete(originalMailbox.toMailbox(), original);
-        
+
         return messageMetaData;
     }
 
@@ -380,13 +383,36 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
             } else {
                 JPAMailboxMessage persistData = new JPAMailboxMessage(currentMailbox, message.getUid(), message.getModSeq(), message);
                 persistData.setFlags(message.createFlags());
-                getEntityManager().persist(persistData);
+
+                if (message.getAttachments().isEmpty()) {
+                    getEntityManager().persist(persistData);
+                } else {
+                    List<JPAAttachment> attachments = getAttachments(message);
+                    if (attachments.isEmpty()) {
+                        persistData.setAttachments(message.getAttachments().stream()
+                            .map(JPAAttachment::new)
+                            .collect(Collectors.toList()));
+                        getEntityManager().persist(persistData);
+                    } else {
+                        persistData.setAttachments(attachments);
+                        getEntityManager().merge(persistData);
+                    }
+                }
                 return persistData.metaData();
             }
 
         } catch (PersistenceException | ArgumentException e) {
             throw new MailboxException("Save of message " + message + " failed in mailbox " + mailbox, e);
         }
+    }
+
+    private List<JPAAttachment> getAttachments(MailboxMessage message) {
+        return message.getAttachments().stream()
+            .map(MessageAttachmentMetadata::getAttachmentId)
+            .map(attachmentId -> getEntityManager().createNamedQuery("findAttachmentById", JPAAttachment.class)
+                .setParameter("idParam", attachmentId.getId())
+                .getSingleResult())
+            .collect(Collectors.toList());
     }
 
     @SuppressWarnings("unchecked")

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -31,6 +31,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.mailbox.ApplicableFlagBuilder;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
@@ -56,7 +57,6 @@ import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.FlagsUpdateCalculator;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-import org.apache.james.modules.data.JPAConfiguration;
 import org.apache.openjpa.persistence.ArgumentException;
 
 import com.github.fge.lambdas.Throwing;

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAAttachment.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAAttachment.java
@@ -1,0 +1,193 @@
+/***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.mail.model;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
+import org.apache.james.mailbox.model.AttachmentId;
+import org.apache.james.mailbox.model.AttachmentMetadata;
+import org.apache.james.mailbox.model.Cid;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
+
+@Entity(name = "Attachment")
+@Table(name = "JAMES_ATTACHMENT")
+@NamedQuery(name = "findAttachmentById", query = "SELECT attachment FROM Attachment attachment WHERE attachment.attachmentId = :idParam")
+public class JPAAttachment {
+
+    private static final String TOSTRING_SEPARATOR = " ";
+    private static final byte[] EMPTY_ARRAY = new byte[]{};
+
+    @Id
+    @GeneratedValue
+    @Column(name = "ATTACHMENT_ID", nullable = false)
+    private String attachmentId;
+
+    @Basic(optional = false)
+    @Column(name = "TYPE", nullable = false)
+    private String type;
+
+    @Basic(optional = false)
+    @Column(name = "SIZE", nullable = false)
+    private long size;
+
+    @Basic(optional = false, fetch = FetchType.LAZY)
+    @Column(name = "CONTENT", nullable = false)
+    @Lob
+    private byte[] content;
+
+    @Basic(optional = true)
+    @Column(name = "NAME")
+    private String name;
+
+    @Basic(optional = true)
+    @Column(name = "CID")
+    private String cid;
+
+    @Basic(optional = false)
+    @Column(name = "INLINE", nullable = false)
+    private boolean isInline;
+
+    public JPAAttachment() {
+    }
+
+    public JPAAttachment(MessageAttachmentMetadata messageAttachmentMetadata, byte[] bytes) {
+        setMetadata(messageAttachmentMetadata, bytes);
+    }
+
+    public JPAAttachment(MessageAttachmentMetadata messageAttachmentMetadata) {
+        setMetadata(messageAttachmentMetadata, new byte[0]);
+    }
+
+    private void setMetadata(MessageAttachmentMetadata messageAttachmentMetadata, byte[] bytes) {
+        this.name = messageAttachmentMetadata.getName().orElse(null);
+        messageAttachmentMetadata.getCid()
+           .ifPresentOrElse(c -> this.cid = c.getValue(), () -> this.cid = "");
+        this.type = messageAttachmentMetadata.getAttachment().getType().asString();
+        this.size = messageAttachmentMetadata.getAttachment().getSize();
+        this.isInline = messageAttachmentMetadata.isInline();
+        this.content = bytes;
+    }
+
+    public AttachmentMetadata toAttachmentMetadata() {
+        return AttachmentMetadata.builder()
+            .attachmentId(AttachmentId.from(attachmentId))
+            .messageId(new DefaultMessageId())
+            .type(type)
+            .size(size)
+            .build();
+    }
+
+    public MessageAttachmentMetadata toMessageAttachmentMetadata() {
+        return MessageAttachmentMetadata.builder()
+            .attachment(toAttachmentMetadata())
+            .name(Optional.ofNullable(name))
+            .cid(Optional.of(Cid.from(cid)))
+            .isInline(isInline)
+            .build();
+    }
+
+    public String getAttachmentId() {
+        return attachmentId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isInline() {
+        return isInline;
+    }
+
+    public String getCid() {
+        return cid;
+    }
+
+    public InputStream getContent() {
+        return new ByteArrayInputStream(Objects.requireNonNullElse(content, EMPTY_ARRAY));
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public void setContent(byte[] bytes) {
+        this.content = bytes;
+    }
+
+    @Override
+    public String toString() {
+        return "Attachment ( "
+            + "attachmentId = " + this.attachmentId + TOSTRING_SEPARATOR
+            + "name = " + this.type + TOSTRING_SEPARATOR
+            + "type = " + this.type + TOSTRING_SEPARATOR
+            + "size = " + this.size + TOSTRING_SEPARATOR
+            + "cid = " + this.cid + TOSTRING_SEPARATOR
+            + "isInline = " + this.isInline + TOSTRING_SEPARATOR
+            + " )";
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof JPAAttachment) {
+            JPAAttachment that = (JPAAttachment) o;
+
+            return Objects.equals(this.size, that.size)
+                && Objects.equals(this.attachmentId, that.attachmentId)
+                && Objects.equals(this.cid, that.cid)
+                && Arrays.equals(this.content, that.content)
+                && Objects.equals(this.isInline, that.isInline)
+                && Objects.equals(this.name, that.name)
+                && Objects.equals(this.type, that.type);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(attachmentId, type, size, name, cid, isInline);
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAAttachment.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAAttachment.java
@@ -63,7 +63,7 @@ public class JPAAttachment {
     private long size;
 
     @Basic(optional = false, fetch = FetchType.LAZY)
-    @Column(name = "CONTENT", nullable = false)
+    @Column(name = "CONTENT", length = 1048576000, nullable = false)
     @Lob
     private byte[] content;
 

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import javax.mail.Flags;
 import javax.persistence.Basic;
@@ -38,7 +38,6 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
-import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
@@ -47,29 +46,26 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.jpa.JPAId;
+import org.apache.james.mailbox.jpa.mail.model.JPAAttachment;
 import org.apache.james.mailbox.jpa.mail.model.JPAMailbox;
 import org.apache.james.mailbox.jpa.mail.model.JPAProperty;
 import org.apache.james.mailbox.jpa.mail.model.JPAUserFlag;
-import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
-import org.apache.james.mailbox.model.ParsedAttachment;
 import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.DelegatingMailboxMessage;
 import org.apache.james.mailbox.store.mail.model.FlagsFactory;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.Property;
-import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.mail.model.impl.Properties;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.openjpa.persistence.jdbc.ElementJoinColumn;
 import org.apache.openjpa.persistence.jdbc.ElementJoinColumns;
 import org.apache.openjpa.persistence.jdbc.Index;
 
-import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
@@ -78,35 +74,35 @@ import com.google.common.collect.ImmutableList;
  * {@link DelegatingMailboxMessage}
  */
 @IdClass(AbstractJPAMailboxMessage.MailboxIdUidKey.class)
-@NamedQueries({
-        @NamedQuery(name = "findRecentMessageUidsInMailbox", query = "SELECT message.uid FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.recent = TRUE ORDER BY message.uid ASC"),
-        @NamedQuery(name = "listUidsInMailbox", query = "SELECT message.uid FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findUnseenMessagesInMailboxOrderByUid", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.seen = FALSE ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findMessagesInMailbox", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findMessagesInMailboxBetweenUIDs", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid BETWEEN :fromParam AND :toParam ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findMessagesInMailboxWithUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid=:uidParam ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findMessagesInMailboxAfterUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid>=:uidParam ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findDeletedMessagesInMailbox", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.deleted=TRUE ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findDeletedMessagesInMailboxBetweenUIDs", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid BETWEEN :fromParam AND :toParam AND message.deleted=TRUE ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findDeletedMessagesInMailboxWithUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid=:uidParam AND message.deleted=TRUE ORDER BY message.uid ASC"),
-        @NamedQuery(name = "findDeletedMessagesInMailboxAfterUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid>=:uidParam AND message.deleted=TRUE ORDER BY message.uid ASC"),
+@NamedQuery(name = "findRecentMessageUidsInMailbox", query = "SELECT message.uid FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.recent = TRUE ORDER BY message.uid ASC")
+@NamedQuery(name = "listUidsInMailbox", query = "SELECT message.uid FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.uid ASC")
+@NamedQuery(name = "findUnseenMessagesInMailboxOrderByUid", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.seen = FALSE ORDER BY message.uid ASC")
+@NamedQuery(name = "findMessagesInMailbox", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.uid ASC")
+@NamedQuery(name = "findMessagesInMailboxBetweenUIDs", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid BETWEEN :fromParam AND :toParam ORDER BY message.uid ASC")
+@NamedQuery(name = "findMessagesInMailboxWithUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid=:uidParam ORDER BY message.uid ASC")
+@NamedQuery(name = "findMessagesInMailboxAfterUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid>=:uidParam ORDER BY message.uid ASC")
+@NamedQuery(name = "findDeletedMessagesInMailbox", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.deleted=TRUE ORDER BY message.uid ASC")
+@NamedQuery(name = "findDeletedMessagesInMailboxBetweenUIDs", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid BETWEEN :fromParam AND :toParam AND message.deleted=TRUE ORDER BY message.uid ASC")
+@NamedQuery(name = "findDeletedMessagesInMailboxWithUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid=:uidParam AND message.deleted=TRUE ORDER BY message.uid ASC")
+@NamedQuery(name = "findDeletedMessagesInMailboxAfterUID", query = "SELECT message FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid>=:uidParam AND message.deleted=TRUE ORDER BY message.uid ASC")
 
-        @NamedQuery(name = "deleteMessagesInMailbox", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam"),
-        @NamedQuery(name = "deleteMessagesInMailboxBetweenUIDs", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid BETWEEN :fromParam AND :toParam"),
-        @NamedQuery(name = "deleteMessagesInMailboxWithUID", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid=:uidParam"),
-        @NamedQuery(name = "deleteMessagesInMailboxAfterUID", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid>=:uidParam"),
+@NamedQuery(name = "deleteMessagesInMailbox", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam")
+@NamedQuery(name = "deleteMessagesInMailboxBetweenUIDs", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid BETWEEN :fromParam AND :toParam")
+@NamedQuery(name = "deleteMessagesInMailboxWithUID", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid=:uidParam")
+@NamedQuery(name = "deleteMessagesInMailboxAfterUID", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.uid>=:uidParam")
 
-        @NamedQuery(name = "countUnseenMessagesInMailbox", query = "SELECT COUNT(message) FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.seen=FALSE"),
-        @NamedQuery(name = "countMessagesInMailbox", query = "SELECT COUNT(message) FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam"),
-        @NamedQuery(name = "deleteMessages", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam"),
-        @NamedQuery(name = "findLastUidInMailbox", query = "SELECT message.uid FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.uid DESC"),
-        @NamedQuery(name = "findHighestModSeqInMailbox", query = "SELECT message.modSeq FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.modSeq DESC")
-})
+@NamedQuery(name = "countUnseenMessagesInMailbox", query = "SELECT COUNT(message) FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam AND message.seen=FALSE")
+@NamedQuery(name = "countMessagesInMailbox", query = "SELECT COUNT(message) FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam")
+@NamedQuery(name = "deleteMessages", query = "DELETE FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam")
+@NamedQuery(name = "findLastUidInMailbox", query = "SELECT message.uid FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.uid DESC")
+@NamedQuery(name = "findHighestModSeqInMailbox", query = "SELECT message.modSeq FROM MailboxMessage message WHERE message.mailbox.mailboxId = :idParam ORDER BY message.modSeq DESC")
 @MappedSuperclass
 public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
     private static final String TOSTRING_SEPARATOR = " ";
 
-    /** Identifies composite key */
+    /**
+     * Identifies composite key
+     */
     @Embeddable
     public static class MailboxIdUidKey implements Serializable {
 
@@ -115,10 +111,14 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
         public MailboxIdUidKey() {
         }
 
-        /** The value for the mailbox field */
+        /**
+         * The value for the mailbox field
+         */
         public long mailbox;
 
-        /** The value for the uid field */
+        /**
+         * The value for the uid field
+         */
         public long uid;
 
         @Override
@@ -145,115 +145,153 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
             if (mailbox != other.mailbox) {
                 return false;
             }
-            if (uid != other.uid) {
-                return false;
-            }
-            return true;
+            return uid == other.uid;
         }
 
     }
 
-    /** The value for the mailboxId field */
+    /**
+     * The value for the mailboxId field
+     */
     @Id
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE}, fetch = FetchType.EAGER)
     @Column(name = "MAILBOX_ID", nullable = true)
     private JPAMailbox mailbox;
 
-    /** The value for the uid field */
+    /**
+     * The value for the uid field
+     */
     @Id
     @Column(name = "MAIL_UID")
     private long uid;
 
-    /** The value for the modSeq field */
+    /**
+     * The value for the modSeq field
+     */
     @Index
     @Column(name = "MAIL_MODSEQ")
     private long modSeq;
 
-    /** The value for the internalDate field */
+    /**
+     * The value for the internalDate field
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_DATE")
     private Date internalDate;
 
-    /** The value for the answered field */
+    /**
+     * The value for the answered field
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_IS_ANSWERED", nullable = false)
     private boolean answered = false;
 
-    /** The value for the deleted field */
+    /**
+     * The value for the deleted field
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_IS_DELETED", nullable = false)
     @Index
     private boolean deleted = false;
 
-    /** The value for the draft field */
+    /**
+     * The value for the draft field
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_IS_DRAFT", nullable = false)
     private boolean draft = false;
 
-    /** The value for the flagged field */
+    /**
+     * The value for the flagged field
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_IS_FLAGGED", nullable = false)
     private boolean flagged = false;
 
-    /** The value for the recent field */
+    /**
+     * The value for the recent field
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_IS_RECENT", nullable = false)
     @Index
     private boolean recent = false;
 
-    /** The value for the seen field */
+    /**
+     * The value for the seen field
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_IS_SEEN", nullable = false)
     @Index
     private boolean seen = false;
 
-    /** The first body octet */
+    /**
+     * The first body octet
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_BODY_START_OCTET", nullable = false)
     private int bodyStartOctet;
 
-    /** Number of octets in the full document content */
+    /**
+     * Number of octets in the full document content
+     */
     @Basic(optional = false)
     @Column(name = "MAIL_CONTENT_OCTETS_COUNT", nullable = false)
     private long contentOctets;
 
-    /** MIME media type */
+    /**
+     * MIME media type
+     */
     @Basic(optional = true)
     @Column(name = "MAIL_MIME_TYPE", nullable = true, length = 200)
     private String mediaType;
 
-    /** MIME sub type */
+    /**
+     * MIME subtype
+     */
     @Basic(optional = true)
     @Column(name = "MAIL_MIME_SUBTYPE", nullable = true, length = 200)
     private String subType;
 
-    /** THE CRFL count when this document is textual, null otherwise */
+    /**
+     * THE CRFL count when this document is textual, null otherwise
+     */
     @Basic(optional = true)
     @Column(name = "MAIL_TEXTUAL_LINE_COUNT", nullable = true)
     private Long textualLineCount;
 
-    /** Meta data for this message */
+    /**
+     * Metadata for this message
+     */
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @OrderBy("line")
-    @ElementJoinColumns({ @ElementJoinColumn(name = "MAILBOX_ID", referencedColumnName = "MAILBOX_ID"),
-            @ElementJoinColumn(name = "MAIL_UID", referencedColumnName = "MAIL_UID") })
+    @ElementJoinColumns({@ElementJoinColumn(name = "MAILBOX_ID", referencedColumnName = "MAILBOX_ID"),
+        @ElementJoinColumn(name = "MAIL_UID", referencedColumnName = "MAIL_UID")})
     private List<JPAProperty> properties;
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderBy("id")
-    @ElementJoinColumns({ @ElementJoinColumn(name = "MAILBOX_ID", referencedColumnName = "MAILBOX_ID"),
-            @ElementJoinColumn(name = "MAIL_UID", referencedColumnName = "MAIL_UID") })
+    @ElementJoinColumns({@ElementJoinColumn(name = "MAILBOX_ID", referencedColumnName = "MAILBOX_ID"),
+        @ElementJoinColumn(name = "MAIL_UID", referencedColumnName = "MAIL_UID")})
     private List<JPAUserFlag> userFlags;
 
-    public AbstractJPAMailboxMessage() {
+    /**
+     * Metadata for attachments
+     */
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OrderBy("attachmentId")
+    @ElementJoinColumns({@ElementJoinColumn(name = "MAILBOX_ID", referencedColumnName = "MAILBOX_ID"),
+        @ElementJoinColumn(name = "MAIL_UID", referencedColumnName = "MAIL_UID")})
+    private List<JPAAttachment> attachments;
 
+    protected AbstractJPAMailboxMessage() {
     }
 
-    public AbstractJPAMailboxMessage(JPAMailbox mailbox, Date internalDate, Flags flags, long contentOctets,
-            int bodyStartOctet, PropertyBuilder propertyBuilder) {
+    protected AbstractJPAMailboxMessage(JPAMailbox mailbox, Date internalDate, Flags flags, long contentOctets,
+                                     int bodyStartOctet, PropertyBuilder propertyBuilder) {
         this.mailbox = mailbox;
         this.internalDate = internalDate;
         userFlags = new ArrayList<>();
+        attachments = new ArrayList<>();
 
         setFlags(flags);
         this.contentOctets = contentOctets;
@@ -275,17 +313,13 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
      * Constructs a copy of the given message. All properties are cloned except
      * mailbox and UID.
      *
-     * @param mailbox
-     *            new mailbox
-     * @param uid
-     *            new UID
-     * @param modSeq
-     *            new modSeq
-     * @param original
-     *            message to be copied, not null
+     * @param mailbox  new mailbox
+     * @param uid      new UID
+     * @param modSeq   new modSeq
+     * @param original message to be copied, not null
      */
-    public AbstractJPAMailboxMessage(JPAMailbox mailbox, MessageUid uid, ModSeq modSeq, MailboxMessage original)
-            throws MailboxException {
+    protected AbstractJPAMailboxMessage(JPAMailbox mailbox, MessageUid uid, ModSeq modSeq, MailboxMessage original)
+        throws MailboxException {
         super();
         this.mailbox = mailbox;
         this.uid = uid.asLong();
@@ -310,6 +344,7 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
         for (Property property : properties) {
             this.properties.add(new JPAProperty(property, order++));
         }
+        this.attachments = new ArrayList<>();
     }
 
     @Override
@@ -322,7 +357,7 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
         if (obj instanceof AbstractJPAMailboxMessage) {
             AbstractJPAMailboxMessage other = (AbstractJPAMailboxMessage) obj;
             return Objects.equal(getMailboxId(), other.getMailboxId())
-                    && Objects.equal(uid, other.getUid());
+                && Objects.equal(uid, other.getUid());
         }
         return false;
     }
@@ -514,38 +549,29 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
 
     public String toString() {
         return "message("
-                + "mailboxId = " + this.getMailboxId() + TOSTRING_SEPARATOR
-                + "uid = " + this.uid + TOSTRING_SEPARATOR
-                + "internalDate = " + this.internalDate + TOSTRING_SEPARATOR
-                + "answered = " + this.answered + TOSTRING_SEPARATOR
-                + "deleted = " + this.deleted + TOSTRING_SEPARATOR
-                + "draft = " + this.draft + TOSTRING_SEPARATOR
-                + "flagged = " + this.flagged + TOSTRING_SEPARATOR
-                + "recent = " + this.recent + TOSTRING_SEPARATOR
-                + "seen = " + this.seen + TOSTRING_SEPARATOR
-                + " )";
+            + "mailboxId = " + this.getMailboxId() + TOSTRING_SEPARATOR
+            + "uid = " + this.uid + TOSTRING_SEPARATOR
+            + "internalDate = " + this.internalDate + TOSTRING_SEPARATOR
+            + "answered = " + this.answered + TOSTRING_SEPARATOR
+            + "deleted = " + this.deleted + TOSTRING_SEPARATOR
+            + "draft = " + this.draft + TOSTRING_SEPARATOR
+            + "flagged = " + this.flagged + TOSTRING_SEPARATOR
+            + "recent = " + this.recent + TOSTRING_SEPARATOR
+            + "seen = " + this.seen + TOSTRING_SEPARATOR
+            + " )";
+    }
+
+    /**
+     * Utility attachments' setter.
+     */
+    public void setAttachments(List<JPAAttachment> attachments) {
+        this.attachments = attachments;
     }
 
     @Override
     public List<MessageAttachmentMetadata> getAttachments() {
-        try {
-            AtomicInteger counter = new AtomicInteger(0);
-            MessageParser.ParsingResult parsingResult = new MessageParser().retrieveAttachments(getFullContent());
-            ImmutableList<MessageAttachmentMetadata> result = parsingResult
-                .getAttachments()
-                .stream()
-                .map(Throwing.<ParsedAttachment, MessageAttachmentMetadata>function(
-                    attachmentMetadata -> attachmentMetadata.asMessageAttachment(generateFixedAttachmentId(counter.incrementAndGet()), getMessageId()))
-                    .sneakyThrow())
-                .collect(ImmutableList.toImmutableList());
-            parsingResult.dispose();
-            return result;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private AttachmentId generateFixedAttachmentId(int position) {
-        return AttachmentId.from(getMailboxId().serialize() + "-" + getUid().asLong() + "-" + position);
+        return this.attachments.stream()
+            .map(JPAAttachment::toMessageAttachmentMetadata)
+            .collect(Collectors.toList());
     }
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/JPAMailboxMessageWithAttachmentStorage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/JPAMailboxMessageWithAttachmentStorage.java
@@ -1,0 +1,155 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox.jpa.mail.model.openjpa;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.mail.Flags;
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Lob;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import javax.persistence.Table;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.jpa.mail.model.JPAAttachment;
+import org.apache.james.mailbox.jpa.mail.model.JPAMailbox;
+import org.apache.james.mailbox.model.Content;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.openjpa.persistence.jdbc.ElementJoinColumn;
+import org.apache.openjpa.persistence.jdbc.ElementJoinColumns;
+
+@Entity(name = "MailboxMessage")
+@Table(name = "JAMES_MAIL")
+public class JPAMailboxMessageWithAttachmentStorage extends AbstractJPAMailboxMessage {
+
+    private static final byte[] EMPTY_ARRAY = new byte[] {};
+
+    /** The value for the body field. Lazy loaded */
+    /** We use a max length to represent 1gb data. Thats prolly overkill, but who knows */
+    @Basic(optional = false, fetch = FetchType.LAZY)
+    @Column(name = "MAIL_BYTES", length = 1048576000, nullable = false)
+    @Lob
+    private byte[] body;
+
+    /** The value for the header field. Lazy loaded */
+    /** We use a max length to represent 10mb data. Thats prolly overkill, but who knows */
+    @Basic(optional = false, fetch = FetchType.LAZY)
+    @Column(name = "HEADER_BYTES", length = 10485760, nullable = false)
+    @Lob private byte[] header;
+
+    /**
+     * Metadata for attachments
+     */
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OrderBy("attachmentId")
+    @ElementJoinColumns({@ElementJoinColumn(name = "MAILBOX_ID", referencedColumnName = "MAILBOX_ID"),
+        @ElementJoinColumn(name = "MAIL_UID", referencedColumnName = "MAIL_UID")})
+    private List<JPAAttachment> attachments;
+
+
+    public JPAMailboxMessageWithAttachmentStorage() {
+
+    }
+
+    public JPAMailboxMessageWithAttachmentStorage(JPAMailbox mailbox, Date internalDate, int size, Flags flags, Content content, int bodyStartOctet, PropertyBuilder propertyBuilder) throws MailboxException {
+        super(mailbox, internalDate, flags, size, bodyStartOctet, propertyBuilder);
+        try {
+            int headerEnd = bodyStartOctet;
+            if (headerEnd < 0) {
+                headerEnd = 0;
+            }
+            InputStream stream = content.getInputStream();
+            this.header = IOUtils.toByteArray(new BoundedInputStream(stream, headerEnd));
+            this.body = IOUtils.toByteArray(stream);
+
+        } catch (IOException e) {
+            throw new MailboxException("Unable to parse message",e);
+        }
+        attachments = new ArrayList<>();
+    }
+
+    /**
+     * Create a copy of the given message
+     */
+    public JPAMailboxMessageWithAttachmentStorage(JPAMailbox mailbox, MessageUid uid, ModSeq modSeq, MailboxMessage message) throws MailboxException {
+        super(mailbox, uid, modSeq, message);
+        try {
+            this.body = IOUtils.toByteArray(message.getBodyContent());
+            this.header = IOUtils.toByteArray(message.getHeaderContent());
+        } catch (IOException e) {
+            throw new MailboxException("Unable to parse message",e);
+        }
+        attachments = new ArrayList<>();
+
+    }
+
+    @Override
+    public InputStream getBodyContent() throws IOException {
+        if (body == null) {
+            return new ByteArrayInputStream(EMPTY_ARRAY);
+        }
+        return new ByteArrayInputStream(body);
+    }
+
+    @Override
+    public InputStream getHeaderContent() throws IOException {
+        if (header == null) {
+            return new ByteArrayInputStream(EMPTY_ARRAY);
+        }
+        return new ByteArrayInputStream(header);
+    }
+
+    @Override
+    public MailboxMessage copy(Mailbox mailbox) throws MailboxException {
+        return new JPAMailboxMessage(JPAMailbox.from(mailbox), getUid(), getModSeq(), this);
+    }
+
+    /**
+     * Utility attachments' setter.
+     */
+    public void setAttachments(List<JPAAttachment> attachments) {
+        this.attachments = attachments;
+    }
+
+    @Override
+    public List<MessageAttachmentMetadata> getAttachments() {
+
+        return this.attachments.stream()
+            .map(JPAAttachment::toMessageAttachmentMetadata)
+            .collect(Collectors.toList());
+    }
+}

--- a/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
+++ b/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
@@ -57,6 +57,7 @@
         <constructor-arg index="0" ref="entityManagerFactory"/>
         <constructor-arg index="1" ref="jpa-uidProvider"/>
         <constructor-arg index="2" ref="jpa-modSeqProvider"/>
+        <constructor-arg index="3" ref="jpa-configuration"/>
     </bean>
     <bean id="jpa-uidProvider" class="org.apache.james.mailbox.jpa.mail.JPAUidProvider">
         <constructor-arg index="0" ref="entityManagerFactory"/>
@@ -104,4 +105,5 @@
     <bean id="jpaCurrentQuotaManager" class="org.apache.james.mailbox.jpa.quota.JpaCurrentQuotaManager">
         <constructor-arg index="0" ref="entityManagerFactory"/>
     </bean>
+    <bean id="jpa-configuration" class="org.apache.james.modules.data.JPAConfiguration"/>
 </beans>

--- a/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
+++ b/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
@@ -105,5 +105,5 @@
     <bean id="jpaCurrentQuotaManager" class="org.apache.james.mailbox.jpa.quota.JpaCurrentQuotaManager">
         <constructor-arg index="0" ref="entityManagerFactory"/>
     </bean>
-    <bean id="jpa-configuration" class="org.apache.james.modules.data.JPAConfiguration"/>
+    <bean id="jpa-configuration" class="org.apache.james.backends.jpa.JPAConfiguration"/>
 </beans>

--- a/mailbox/jpa/src/main/resources/james-database.properties
+++ b/mailbox/jpa/src/main/resources/james-database.properties
@@ -44,3 +44,8 @@ openjpa.streaming=false
 # datasource.validationQueryTimeoutSec=2
 # This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
 # datasource.validationQuery=select 1
+
+# Attachment storage
+# *WARNING*: Is not made to store large binary content (no more than 1 GB of data)
+# Optional, Allowed values are: true, false, defaults to false
+# attachmentStorage.enabled=false

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
@@ -28,6 +28,7 @@ import org.apache.james.mailbox.jpa.mail.model.JPAProperty;
 import org.apache.james.mailbox.jpa.mail.model.JPAUserFlag;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMailboxMessage;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage;
+import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessageWithAttachmentStorage;
 import org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota;
 import org.apache.james.mailbox.jpa.quota.model.MaxDomainMessageCount;
 import org.apache.james.mailbox.jpa.quota.model.MaxDomainStorage;
@@ -49,7 +50,8 @@ public interface JPAMailboxFixture {
         JPAUserFlag.class,
         JPAMailboxAnnotation.class,
         JPASubscription.class,
-        JPAAttachment.class
+        JPAAttachment.class,
+        JPAMailboxMessageWithAttachmentStorage.class
     );
 
     List<Class<?>> QUOTA_PERSISTANCE_CLASSES = ImmutableList.of(

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.jpa;
 
 import java.util.List;
 
+import org.apache.james.mailbox.jpa.mail.model.JPAAttachment;
 import org.apache.james.mailbox.jpa.mail.model.JPAMailbox;
 import org.apache.james.mailbox.jpa.mail.model.JPAMailboxAnnotation;
 import org.apache.james.mailbox.jpa.mail.model.JPAProperty;
@@ -47,7 +48,8 @@ public interface JPAMailboxFixture {
         JPAProperty.class,
         JPAUserFlag.class,
         JPAMailboxAnnotation.class,
-        JPASubscription.class
+        JPASubscription.class,
+        JPAAttachment.class
     );
 
     List<Class<?>> QUOTA_PERSISTANCE_CLASSES = ImmutableList.of(
@@ -66,7 +68,8 @@ public interface JPAMailboxFixture {
         "JAMES_MAILBOX_ANNOTATION",
         "JAMES_MAILBOX",
         "JAMES_MAIL",
-        "JAMES_SUBSCRIPTION");
+        "JAMES_SUBSCRIPTION",
+        "JAMES_ATTACHMENT");
 
     List<String> QUOTA_TABLES_NAMES = ImmutableList.of(
         "JAMES_MAX_GLOBAL_MESSAGE_COUNT",

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPASubscriptionManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPASubscriptionManagerTest.java
@@ -31,6 +31,8 @@ import org.apache.james.mailbox.jpa.mail.JPAModSeqProvider;
 import org.apache.james.mailbox.jpa.mail.JPAUidProvider;
 import org.apache.james.mailbox.store.StoreSubscriptionManager;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.modules.data.JPAConfiguration;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -49,9 +51,15 @@ class JPASubscriptionManagerTest implements SubscriptionManagerContract {
     void setUp() {
         EntityManagerFactory entityManagerFactory = JPA_TEST_CLUSTER.getEntityManagerFactory();
 
+        JPAConfiguration jpaConfiguration = JPAConfiguration.builder()
+            .driverName("driverName")
+            .driverURL("driverUrl")
+            .build();
+
         JPAMailboxSessionMapperFactory mapperFactory = new JPAMailboxSessionMapperFactory(entityManagerFactory,
             new JPAUidProvider(entityManagerFactory),
-            new JPAModSeqProvider(entityManagerFactory));
+            new JPAModSeqProvider(entityManagerFactory),
+            jpaConfiguration);
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
         subscriptionManager = new StoreSubscriptionManager(mapperFactory, mapperFactory, eventBus);
     }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPASubscriptionManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPASubscriptionManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.james.mailbox.jpa;
 
 import javax.persistence.EntityManagerFactory;
 
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.events.EventBusTestFixture;
 import org.apache.james.events.InVMEventBus;
@@ -31,7 +32,6 @@ import org.apache.james.mailbox.jpa.mail.JPAModSeqProvider;
 import org.apache.james.mailbox.jpa.mail.JPAUidProvider;
 import org.apache.james.mailbox.store.StoreSubscriptionManager;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
-import org.apache.james.modules.data.JPAConfiguration;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerProvider.java
@@ -46,6 +46,7 @@ import org.apache.james.mailbox.store.quota.QuotaComponents;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.modules.data.JPAConfiguration;
 import org.apache.james.utils.UpdatableTickingClock;
 
 public class JpaMailboxManagerProvider {
@@ -55,7 +56,14 @@ public class JpaMailboxManagerProvider {
 
     public static OpenJPAMailboxManager provideMailboxManager(JpaTestCluster jpaTestCluster) {
         EntityManagerFactory entityManagerFactory = jpaTestCluster.getEntityManagerFactory();
-        JPAMailboxSessionMapperFactory mf = new JPAMailboxSessionMapperFactory(entityManagerFactory, new JPAUidProvider(entityManagerFactory), new JPAModSeqProvider(entityManagerFactory));
+
+        JPAConfiguration jpaConfiguration = JPAConfiguration.builder()
+            .driverName("driverName")
+            .driverURL("driverUrl")
+            .attachmentStorage(true)
+            .build();
+
+        JPAMailboxSessionMapperFactory mf = new JPAMailboxSessionMapperFactory(entityManagerFactory, new JPAUidProvider(entityManagerFactory), new JPAModSeqProvider(entityManagerFactory), jpaConfiguration);
 
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         MessageParser messageParser = new MessageParser();

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerProvider.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 
 import javax.persistence.EntityManagerFactory;
 
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.events.EventBusTestFixture;
 import org.apache.james.events.InVMEventBus;
@@ -46,7 +47,6 @@ import org.apache.james.mailbox.store.quota.QuotaComponents;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
-import org.apache.james.modules.data.JPAConfiguration;
 import org.apache.james.utils.UpdatableTickingClock;
 
 public class JpaMailboxManagerProvider {

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapperTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapperTest.java
@@ -1,0 +1,101 @@
+/***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ***************************************************************/
+
+
+package org.apache.james.mailbox.jpa.mail;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.james.backends.jpa.JpaTestCluster;
+import org.apache.james.mailbox.jpa.JPAMailboxFixture;
+import org.apache.james.mailbox.model.AttachmentMetadata;
+import org.apache.james.mailbox.model.ContentType;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ParsedAttachment;
+import org.apache.james.mailbox.store.mail.AttachmentMapper;
+import org.apache.james.mailbox.store.mail.model.AttachmentMapperTest;
+import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+class JPAAttachmentMapperTest extends AttachmentMapperTest {
+
+    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
+
+    @AfterEach
+    void cleanUp() {
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+    }
+
+    @Override
+    protected AttachmentMapper createAttachmentMapper() {
+        return new TransactionalAttachmentMapper(new JPAAttachmentMapper(JPA_TEST_CLUSTER.getEntityManagerFactory()));
+    }
+
+    @Override
+    protected MessageId generateMessageId() {
+        return new DefaultMessageId.Factory().generate();
+    }
+
+    @Test
+    @Override
+    public void getAttachmentsShouldReturnTheAttachmentsWhenSome() throws Exception {
+        //Given
+        ContentType content1 = ContentType.of("content");
+        byte[] bytes1 = "payload" .getBytes(StandardCharsets.UTF_8);
+        ContentType content2 = ContentType.of("content");
+        byte[] bytes2 = "payload" .getBytes(StandardCharsets.UTF_8);
+
+        MessageId messageId1 = generateMessageId();
+        AttachmentMetadata stored1 = attachmentMapper.storeAttachments(ImmutableList.of(ParsedAttachment.builder()
+                .contentType(content1)
+                .content(ByteSource.wrap(bytes1))
+                .noName()
+                .noCid()
+                .inline(false)), messageId1).get(0)
+            .getAttachment();
+        AttachmentMetadata stored2 = attachmentMapper.storeAttachments(ImmutableList.of(ParsedAttachment.builder()
+                .contentType(content2)
+                .content(ByteSource.wrap(bytes2))
+                .noName()
+                .noCid()
+                .inline(false)), messageId1).get(0)
+            .getAttachment();
+
+        // JPA does not support MessageId
+        assertThat(attachmentMapper.getAttachments(ImmutableList.of(stored1.getAttachmentId(), stored2.getAttachmentId())))
+            .extracting(
+                AttachmentMetadata::getAttachmentId,
+                AttachmentMetadata::getSize,
+                AttachmentMetadata::getType
+            )
+            .contains(
+                tuple(stored1.getAttachmentId(), stored1.getSize(), stored1.getType()),
+                tuple(stored2.getAttachmentId(), stored2.getSize(), stored2.getType())
+            );
+    }
+
+}

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapperTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAAttachmentMapperTest.java
@@ -1,4 +1,4 @@
-/***************************************************************
+/**************************************************************
  * Licensed to the Apache Software Foundation (ASF) under one   *
  * or more contributor license agreements.  See the NOTICE file *
  * distributed with this work for additional information        *
@@ -15,7 +15,8 @@
  * KIND, either express or implied.  See the License for the    *
  * specific language governing permissions and limitations      *
  * under the License.                                           *
- ***************************************************************/
+ **************************************************************/
+
 
 
 package org.apache.james.mailbox.jpa.mail;

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
@@ -39,6 +39,7 @@ import org.apache.james.mailbox.store.mail.MessageIdMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.MapperProvider;
+import org.apache.james.modules.data.JPAConfiguration;
 
 import com.google.common.collect.ImmutableList;
 
@@ -59,9 +60,16 @@ public class JPAMapperProvider implements MapperProvider {
     public MessageMapper createMessageMapper() {
         EntityManagerFactory entityManagerFactory = jpaTestCluster.getEntityManagerFactory();
 
+        JPAConfiguration jpaConfiguration = JPAConfiguration.builder()
+            .driverName("driverName")
+            .driverURL("driverUrl")
+            .attachmentStorage(true)
+            .build();
+
         JPAMessageMapper messageMapper = new JPAMessageMapper(new JPAUidProvider(entityManagerFactory),
             new JPAModSeqProvider(entityManagerFactory),
-            entityManagerFactory);
+            entityManagerFactory,
+            jpaConfiguration);
 
         return new TransactionalMessageMapper(messageMapper);
     }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.persistence.EntityManagerFactory;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
@@ -39,7 +40,6 @@ import org.apache.james.mailbox.store.mail.MessageIdMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.MapperProvider;
-import org.apache.james.modules.data.JPAConfiguration;
 
 import com.google.common.collect.ImmutableList;
 

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
@@ -68,7 +68,7 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public AttachmentMapper createAttachmentMapper() throws MailboxException {
-        throw new NotImplementedException("not implemented");
+        return new TransactionalAttachmentMapper(new JPAAttachmentMapper(jpaTestCluster.getEntityManagerFactory()));
     }
 
     @Override
@@ -88,7 +88,7 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public List<Capabilities> getSupportedCapabilities() {
-        return ImmutableList.of(Capabilities.ANNOTATION, Capabilities.MAILBOX, Capabilities.MESSAGE, Capabilities.MOVE);
+        return ImmutableList.of(Capabilities.ANNOTATION, Capabilities.MAILBOX, Capabilities.MESSAGE, Capabilities.MOVE, Capabilities.ATTACHMENT);
     }
 
     @Override

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMessageWithAttachmentMapperTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMessageWithAttachmentMapperTest.java
@@ -1,4 +1,4 @@
-/***************************************************************
+/**************************************************************
  * Licensed to the Apache Software Foundation (ASF) under one   *
  * or more contributor license agreements.  See the NOTICE file *
  * distributed with this work for additional information        *

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMessageWithAttachmentMapperTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMessageWithAttachmentMapperTest.java
@@ -1,0 +1,132 @@
+/***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.mail;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.james.backends.jpa.JpaTestCluster;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.jpa.JPAMailboxFixture;
+import org.apache.james.mailbox.model.AttachmentMetadata;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.MapperProvider;
+import org.apache.james.mailbox.store.mail.model.MessageAssert;
+import org.apache.james.mailbox.store.mail.model.MessageWithAttachmentMapperTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+class JPAMessageWithAttachmentMapperTest extends MessageWithAttachmentMapperTest {
+
+    static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
+
+    @Override
+    protected MapperProvider createMapperProvider() {
+        return new JPAMapperProvider(JPA_TEST_CLUSTER);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+    }
+
+    @Test
+    @Override
+    protected void messagesRetrievedUsingFetchTypeFullShouldHaveAttachmentsLoadedWhenOneAttachment() throws MailboxException {
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.FULL;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(messageWith1Attachment.getUid()), fetchType, LIMIT);
+
+        AttachmentMetadata attachment = messageWith1Attachment.getAttachments().get(0).getAttachment();
+        MessageAttachmentMetadata attachmentMetadata = messageWith1Attachment.getAttachments().get(0);
+        List<MessageAttachmentMetadata> messageAttachments = retrievedMessageIterator.next().getAttachments();
+
+        // JPA does not support MessageId
+        assertThat(messageAttachments)
+            .extracting(MessageAttachmentMetadata::getAttachment)
+            .extracting("attachmentId", "size", "type")
+            .containsExactlyInAnyOrder(
+                tuple(attachment.getAttachmentId(), attachment.getSize(), attachment.getType())
+            );
+        assertThat(messageAttachments)
+            .extracting(
+                MessageAttachmentMetadata::getAttachmentId,
+                MessageAttachmentMetadata::getName,
+                MessageAttachmentMetadata::getCid,
+                MessageAttachmentMetadata::isInline
+            )
+            .containsExactlyInAnyOrder(
+                tuple(attachmentMetadata.getAttachmentId(), attachmentMetadata.getName(), attachmentMetadata.getCid(), attachmentMetadata.isInline())
+            );
+    }
+
+    @Test
+    @Override
+    protected void messagesRetrievedUsingFetchTypeFullShouldHaveAttachmentsLoadedWhenTwoAttachments() throws MailboxException {
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.FULL;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(messageWith2Attachments.getUid()), fetchType, LIMIT);
+
+        AttachmentMetadata attachment1 = messageWith2Attachments.getAttachments().get(0).getAttachment();
+        AttachmentMetadata attachment2 = messageWith2Attachments.getAttachments().get(1).getAttachment();
+        MessageAttachmentMetadata attachmentMetadata1 = messageWith2Attachments.getAttachments().get(0);
+        MessageAttachmentMetadata attachmentMetadata2 = messageWith2Attachments.getAttachments().get(1);
+        List<MessageAttachmentMetadata> messageAttachments = retrievedMessageIterator.next().getAttachments();
+
+        // JPA does not support MessageId
+        assertThat(messageAttachments)
+            .extracting(MessageAttachmentMetadata::getAttachment)
+            .extracting("attachmentId", "size", "type")
+            .containsExactlyInAnyOrder(
+                tuple(attachment1.getAttachmentId(), attachment1.getSize(), attachment1.getType()),
+                tuple(attachment2.getAttachmentId(), attachment2.getSize(), attachment2.getType())
+            );
+        assertThat(messageAttachments)
+            .extracting(
+                MessageAttachmentMetadata::getAttachmentId,
+                MessageAttachmentMetadata::getName,
+                MessageAttachmentMetadata::getCid,
+                MessageAttachmentMetadata::isInline
+            )
+            .containsExactlyInAnyOrder(
+                tuple(attachmentMetadata1.getAttachmentId(), attachmentMetadata1.getName(), attachmentMetadata1.getCid(), attachmentMetadata1.isInline()),
+                tuple(attachmentMetadata2.getAttachmentId(), attachmentMetadata2.getName(), attachmentMetadata2.getCid(), attachmentMetadata2.isInline())
+            );
+    }
+
+    @Test
+    @Override
+    protected void messagesCanBeRetrievedInMailboxWithRangeTypeOne() throws MailboxException, IOException {
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.FULL;
+
+        // JPA does not support MessageId
+        MessageAssert.assertThat(messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(messageWith1Attachment.getUid()), fetchType, LIMIT).next())
+            .isEqualToWithoutAttachment(messageWith1Attachment, fetchType);
+    }
+}

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalAttachmentMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalAttachmentMapper.java
@@ -1,0 +1,84 @@
+/***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.mail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.james.mailbox.exception.AttachmentNotFoundException;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.apache.james.mailbox.model.AttachmentMetadata;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ParsedAttachment;
+import org.apache.james.mailbox.store.mail.AttachmentMapper;
+
+import reactor.core.publisher.Mono;
+
+public class TransactionalAttachmentMapper implements AttachmentMapper {
+    private final JPAAttachmentMapper attachmentMapper;
+
+    public TransactionalAttachmentMapper(JPAAttachmentMapper attachmentMapper) {
+        this.attachmentMapper = attachmentMapper;
+    }
+
+    @Override
+    public InputStream loadAttachmentContent(AttachmentId attachmentId) throws AttachmentNotFoundException, IOException {
+        return attachmentMapper.loadAttachmentContent(attachmentId);
+    }
+
+    @Override
+    public Mono<InputStream> loadAttachmentContentReactive(AttachmentId attachmentId) {
+        return attachmentMapper.executeReactive(attachmentMapper.loadAttachmentContentReactive(attachmentId));
+    }
+
+    @Override
+    public AttachmentMetadata getAttachment(AttachmentId attachmentId) throws AttachmentNotFoundException {
+        return attachmentMapper.getAttachment(attachmentId);
+    }
+
+    @Override
+    public Mono<AttachmentMetadata> getAttachmentReactive(AttachmentId attachmentId) {
+        return attachmentMapper.executeReactive(attachmentMapper.getAttachmentReactive(attachmentId));
+    }
+
+    @Override
+    public List<AttachmentMetadata> getAttachments(Collection<AttachmentId> attachmentIds) {
+        return attachmentMapper.getAttachments(attachmentIds);
+    }
+
+    @Override
+    public List<MessageAttachmentMetadata> storeAttachments(Collection<ParsedAttachment> attachments, MessageId ownerMessageId) throws MailboxException {
+        return attachmentMapper.execute(() -> attachmentMapper.storeAttachments(attachments, ownerMessageId));
+    }
+
+    @Override
+    public Mono<List<MessageAttachmentMetadata>> storeAttachmentsReactive(Collection<ParsedAttachment> attachments, MessageId ownerMessageId) {
+        return attachmentMapper.executeReactive(attachmentMapper.storeAttachmentsReactive(attachments, ownerMessageId));
+    }
+
+    @Override
+    public Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) throws MailboxException {
+        return attachmentMapper.getRelatedMessageIds(attachmentId);
+    }
+}

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalAttachmentMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalAttachmentMapper.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.mailbox.jpa.mail;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +42,7 @@ public class TransactionalAttachmentMapper implements AttachmentMapper {
     }
 
     @Override
-    public InputStream loadAttachmentContent(AttachmentId attachmentId) throws AttachmentNotFoundException, IOException {
+    public InputStream loadAttachmentContent(AttachmentId attachmentId) {
         return attachmentMapper.loadAttachmentContent(attachmentId);
     }
 
@@ -75,10 +74,5 @@ public class TransactionalAttachmentMapper implements AttachmentMapper {
     @Override
     public Mono<List<MessageAttachmentMetadata>> storeAttachmentsReactive(Collection<ParsedAttachment> attachments, MessageId ownerMessageId) {
         return attachmentMapper.executeReactive(attachmentMapper.storeAttachmentsReactive(attachments, ownerMessageId));
-    }
-
-    @Override
-    public Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) throws MailboxException {
-        return attachmentMapper.getRelatedMessageIds(attachmentId);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/task/JPARecomputeCurrentQuotasServiceTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/task/JPARecomputeCurrentQuotasServiceTest.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.quota.task.RecomputeCurrentQuotasServiceContract
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.mailbox.store.quota.CurrentQuotaCalculator;
 import org.apache.james.mailbox.store.quota.DefaultUserQuotaRootResolver;
+import org.apache.james.modules.data.JPAConfiguration;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.jpa.JPAUsersRepository;
 import org.apache.james.user.jpa.model.JPAUser;
@@ -69,9 +70,16 @@ class JPARecomputeCurrentQuotasServiceTest implements RecomputeCurrentQuotasServ
     @BeforeEach
     void setUp() throws Exception {
         EntityManagerFactory entityManagerFactory = JPA_TEST_CLUSTER.getEntityManagerFactory();
+
+        JPAConfiguration jpaConfiguration = JPAConfiguration.builder()
+            .driverName("driverName")
+            .driverURL("driverUrl")
+            .build();
+
         JPAMailboxSessionMapperFactory mapperFactory = new JPAMailboxSessionMapperFactory(entityManagerFactory,
             new JPAUidProvider(entityManagerFactory),
-            new JPAModSeqProvider(entityManagerFactory));
+            new JPAModSeqProvider(entityManagerFactory),
+            jpaConfiguration);
 
         usersRepository = new JPAUsersRepository(NO_DOMAIN_LIST);
         usersRepository.setEntityManagerFactory(JPA_TEST_CLUSTER.getEntityManagerFactory());

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/task/JPARecomputeCurrentQuotasServiceTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/task/JPARecomputeCurrentQuotasServiceTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.jpa.mail.task;
 import javax.persistence.EntityManagerFactory;
 
 import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.jpa.model.JPADomain;
@@ -40,7 +41,6 @@ import org.apache.james.mailbox.quota.task.RecomputeCurrentQuotasServiceContract
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.mailbox.store.quota.CurrentQuotaCalculator;
 import org.apache.james.mailbox.store.quota.DefaultUserQuotaRootResolver;
-import org.apache.james.modules.data.JPAConfiguration;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.jpa.JPAUsersRepository;
 import org.apache.james.user.jpa.model.JPAUser;

--- a/mailbox/jpa/src/test/resources/persistence.xml
+++ b/mailbox/jpa/src/test/resources/persistence.xml
@@ -28,6 +28,7 @@
         <class>org.apache.james.mailbox.jpa.mail.model.JPAUserFlag</class>
         <class>org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMailboxMessage</class>
         <class>org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage</class>
+        <class>org.apache.james.mailbox.jpa.mail.model.JPAAttachment</class>
         <class>org.apache.james.mailbox.jpa.mail.model.JPAProperty</class>
         <class>org.apache.james.mailbox.jpa.user.model.JPASubscription</class>
         <class>org.apache.james.mailbox.jpa.quota.model.MaxDomainMessageCount</class>

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
@@ -37,7 +37,6 @@ import com.google.common.io.ByteSource;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -122,7 +121,7 @@ public abstract class AttachmentMapperTest {
 
         MessageId messageId1 = generateMessageId();
         AttachmentMetadata stored = attachmentMapper.storeAttachments(ImmutableList.of(ParsedAttachment.builder()
-            .contentType("content")
+            .contentType(content)
             .content(ByteSource.wrap(bytes))
             .noName()
             .noCid()
@@ -147,7 +146,6 @@ public abstract class AttachmentMapperTest {
     }
 
     @Test
-    @Disabled
     protected void getAttachmentsShouldReturnTheAttachmentsWhenSome() throws Exception {
         //Given
         ContentType content1 = ContentType.of("content");

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
@@ -19,9 +19,6 @@
 
 package org.apache.james.mailbox.store.mail.model;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -34,19 +31,24 @@ import org.apache.james.mailbox.model.ContentType;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.ParsedAttachment;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
-import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class AttachmentMapperTest {
     private static final AttachmentId UNKNOWN_ATTACHMENT_ID = AttachmentId.from("unknown");
     private static final Username OWNER = Username.of("owner");
     private static final Username ADDITIONAL_OWNER = Username.of("additionalOwner");
 
-    private AttachmentMapper attachmentMapper;
+    protected AttachmentMapper attachmentMapper;
 
     protected abstract AttachmentMapper createAttachmentMapper();
 
@@ -145,7 +147,8 @@ public abstract class AttachmentMapperTest {
     }
 
     @Test
-    void getAttachmentsShouldReturnTheAttachmentsWhenSome() throws Exception {
+    @Disabled
+    protected void getAttachmentsShouldReturnTheAttachmentsWhenSome() throws Exception {
         //Given
         ContentType content1 = ContentType.of("content");
         byte[] bytes1 = "payload".getBytes(StandardCharsets.UTF_8);

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 
 import javax.persistence.EntityManagerFactory;
 
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.core.quota.QuotaCountLimit;
 import org.apache.james.core.quota.QuotaSizeLimit;
@@ -64,7 +65,6 @@ import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.logger.DefaultMetricFactory;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
-import org.apache.james.modules.data.JPAConfiguration;
 import org.apache.james.mpt.api.ImapFeatures;
 import org.apache.james.mpt.api.ImapFeatures.Feature;
 import org.apache.james.mpt.host.JamesImapHostSystem;

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
@@ -64,6 +64,7 @@ import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.logger.DefaultMetricFactory;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.modules.data.JPAConfiguration;
 import org.apache.james.mpt.api.ImapFeatures;
 import org.apache.james.mpt.api.ImapFeatures.Feature;
 import org.apache.james.mpt.host.JamesImapHostSystem;
@@ -99,7 +100,11 @@ public class JPAHostSystem extends JamesImapHostSystem {
         EntityManagerFactory entityManagerFactory = JPA_TEST_CLUSTER.getEntityManagerFactory();
         JPAUidProvider uidProvider = new JPAUidProvider(entityManagerFactory);
         JPAModSeqProvider modSeqProvider = new JPAModSeqProvider(entityManagerFactory);
-        JPAMailboxSessionMapperFactory mapperFactory = new JPAMailboxSessionMapperFactory(entityManagerFactory, uidProvider, modSeqProvider);
+        JPAConfiguration jpaConfiguration = JPAConfiguration.builder()
+            .driverName("driverName")
+            .driverURL("driverUrl")
+            .build();
+        JPAMailboxSessionMapperFactory mapperFactory = new JPAMailboxSessionMapperFactory(entityManagerFactory, uidProvider, modSeqProvider, jpaConfiguration);
 
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         MessageParser messageParser = new MessageParser();

--- a/server/apps/jpa-app/sample-configuration/james-database-mariadb.properties
+++ b/server/apps/jpa-app/sample-configuration/james-database-mariadb.properties
@@ -44,6 +44,6 @@ openjpa.streaming=false
 # datasource.maxTotal=8
 
 # Attachment storage
-# *WARNING*: Is not made to store large binary content
+# *WARNING*: Is not made to store large binary content (no more than 1 GB of data)
 # Optional, Allowed values are: true, false, defaults to false
 # attachmentStorage.enabled=false

--- a/server/apps/jpa-app/sample-configuration/james-database-mariadb.properties
+++ b/server/apps/jpa-app/sample-configuration/james-database-mariadb.properties
@@ -42,3 +42,8 @@ openjpa.streaming=false
 # datasource.validationQuery=select 1
 # The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
 # datasource.maxTotal=8
+
+# Attachment storage
+# *WARNING*: Is not made to store large binary content
+# Optional, Allowed values are: true, false, defaults to false
+# attachmentStorage.enabled=false

--- a/server/apps/jpa-app/sample-configuration/james-database.properties
+++ b/server/apps/jpa-app/sample-configuration/james-database.properties
@@ -48,6 +48,6 @@ openjpa.streaming=false
 # datasource.maxTotal=8
 
 # Attachment storage
-# *WARNING*: Is not made to store large binary content
+# *WARNING*: Is not made to store large binary content (no more than 1 GB of data)
 # Optional, Allowed values are: true, false, defaults to false
 # attachmentStorage.enabled=false

--- a/server/apps/jpa-app/sample-configuration/james-database.properties
+++ b/server/apps/jpa-app/sample-configuration/james-database.properties
@@ -46,3 +46,8 @@ openjpa.streaming=false
 # datasource.validationQuery=select 1
 # The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
 # datasource.maxTotal=8
+
+# Attachment storage
+# *WARNING*: Is not made to store large binary content
+# Optional, Allowed values are: true, false, defaults to false
+# attachmentStorage.enabled=false

--- a/server/apps/jpa-smtp-app/sample-configuration/james-database-mariadb.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/james-database-mariadb.properties
@@ -44,6 +44,6 @@ openjpa.streaming=false
 # datasource.maxTotal=8
 
 # Attachment storage
-# *WARNING*: Is not made to store large binary content
+# *WARNING*: Is not made to store large binary content (no more than 1 GB of data)
 # Optional, Allowed values are: true, false, defaults to false
 # attachmentStorage.enabled=false

--- a/server/apps/jpa-smtp-app/sample-configuration/james-database-mariadb.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/james-database-mariadb.properties
@@ -42,3 +42,8 @@ openjpa.streaming=false
 # datasource.validationQuery=select 1
 # The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
 # datasource.maxTotal=8
+
+# Attachment storage
+# *WARNING*: Is not made to store large binary content
+# Optional, Allowed values are: true, false, defaults to false
+# attachmentStorage.enabled=false

--- a/server/apps/jpa-smtp-app/sample-configuration/james-database.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/james-database.properties
@@ -48,6 +48,6 @@ openjpa.streaming=false
 # datasource.maxTotal=8
 
 # Attachment storage
-# *WARNING*: Is not made to store large binary content
+# *WARNING*: Is not made to store large binary content (no more than 1 GB of data)
 # Optional, Allowed values are: true, false, defaults to false
 # attachmentStorage.enabled=false

--- a/server/apps/jpa-smtp-app/sample-configuration/james-database.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/james-database.properties
@@ -46,3 +46,8 @@ openjpa.streaming=false
 # datasource.validationQuery=select 1
 # The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
 # datasource.maxTotal=8
+
+# Attachment storage
+# *WARNING*: Is not made to store large binary content
+# Optional, Allowed values are: true, false, defaults to false
+# attachmentStorage.enabled=false

--- a/server/apps/jpa-smtp-app/src/test/java/org/apache/james/mariadb/TestJPAMariaDBConfigurationModule.java
+++ b/server/apps/jpa-smtp-app/src/test/java/org/apache/james/mariadb/TestJPAMariaDBConfigurationModule.java
@@ -21,7 +21,7 @@ package org.apache.james.mariadb;
 
 import javax.inject.Singleton;
 
-import org.apache.james.modules.data.JPAConfiguration;
+import org.apache.james.backends.jpa.JPAConfiguration;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;

--- a/server/apps/spring-app/src/main/resources/james-database.properties
+++ b/server/apps/spring-app/src/main/resources/james-database.properties
@@ -46,7 +46,7 @@ openjpa.streaming=false
 # datasource.validationQuery=select 1
 
 # Attachment storage
-# *WARNING*: Is not made to store large binary content
+# *WARNING*: Is not made to store large binary content (no more than 1 GB of data)
 # Optional, Allowed values are: true, false, defaults to false
 # attachmentStorage.enabled=false
 

--- a/server/apps/spring-app/src/main/resources/james-database.properties
+++ b/server/apps/spring-app/src/main/resources/james-database.properties
@@ -44,3 +44,9 @@ openjpa.streaming=false
 # datasource.validationQueryTimeoutSec=2
 # This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
 # datasource.validationQuery=select 1
+
+# Attachment storage
+# *WARNING*: Is not made to store large binary content
+# Optional, Allowed values are: true, false, defaults to false
+# attachmentStorage.enabled=false
+

--- a/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAConfiguration.java
+++ b/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAConfiguration.java
@@ -60,6 +60,20 @@ public class JPAConfiguration {
     static {
     }
 
+    public JPAConfiguration() {
+        this.driverName = "";
+        this.driverURL = "";
+        this.credential = Optional.empty();
+        this.testOnBorrow = Optional.empty();
+        this.multithreaded = Optional.empty();
+        this.validationQueryTimeoutSec = Optional.empty();
+        this.validationQuery = Optional.empty();
+        this.maxConnections = Optional.empty();
+        this.customDatasourceProperties = Map.of();
+        this.customOpenjpaProperties = Map.of();
+        this.attachmentStorage = Optional.empty();
+    }
+
     public static class Credential {
         private static final Logger LOGGER = LoggerFactory.getLogger(Credential.class);
         static final Optional<Credential> NO_CREDENTIAL = Optional.empty();

--- a/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
+++ b/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
@@ -32,6 +32,7 @@ import javax.persistence.Persistence;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.backends.jpa.JPAConfiguration;
 import org.apache.james.utils.PropertiesProvider;
 
 import com.google.common.base.Joiner;

--- a/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
+++ b/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
@@ -65,9 +65,15 @@ public class JPAEntityManagerModule extends AbstractModule {
         properties.put(JPAConfiguration.JPA_CONNECTION_PROPERTIES, Joiner.on(",").join(connectionProperties));
         properties.putAll(jpaConfiguration.getCustomOpenjpaProperties());
 
-        if (jpaConfiguration.isMultithreaded().isPresent()) {
-            properties.put(JPAConfiguration.JPA_MULTITHREADED, jpaConfiguration.isMultithreaded().get().toString());
-        }
+        jpaConfiguration.isMultithreaded()
+            .ifPresent(isMultiThread ->
+                properties.put(JPAConfiguration.JPA_MULTITHREADED, jpaConfiguration.isMultithreaded().toString())
+            );
+
+        jpaConfiguration.isAttachmentStorageEnabled()
+            .ifPresent(isMultiThread ->
+                properties.put(JPAConfiguration.ATTACHMENT_STORAGE, jpaConfiguration.isAttachmentStorageEnabled().toString())
+            );
 
         return Persistence.createEntityManagerFactory("Global", properties);
     }
@@ -79,7 +85,6 @@ public class JPAEntityManagerModule extends AbstractModule {
 
         Map<String, String> openjpaProperties = getKeysForPrefix(dataSource, "openjpa", false);
         Map<String, String> datasourceProperties = getKeysForPrefix(dataSource, "datasource", true);
-
 
         return JPAConfiguration.builder()
                 .driverName(dataSource.getString("database.driverClassName"))
@@ -93,6 +98,7 @@ public class JPAEntityManagerModule extends AbstractModule {
                 .password(dataSource.getString("database.password"))
                 .setCustomOpenjpaProperties(openjpaProperties)
                 .setCustomDatasourceProperties(datasourceProperties)
+                .attachmentStorage(dataSource.getBoolean(JPAConfiguration.ATTACHMENT_STORAGE, false))
                 .build();
     }
 

--- a/server/container/guice/jpa-common/src/test/java/org/apache/james/TestJPAConfigurationModule.java
+++ b/server/container/guice/jpa-common/src/test/java/org/apache/james/TestJPAConfigurationModule.java
@@ -21,7 +21,7 @@ package org.apache.james;
 
 import javax.inject.Singleton;
 
-import org.apache.james.modules.data.JPAConfiguration;
+import org.apache.james.backends.jpa.JPAConfiguration;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;

--- a/server/container/guice/jpa-common/src/test/java/org/apache/james/TestJPAConfigurationModuleWithSqlValidation.java
+++ b/server/container/guice/jpa-common/src/test/java/org/apache/james/TestJPAConfigurationModuleWithSqlValidation.java
@@ -26,7 +26,7 @@ import java.sql.SQLException;
 
 import javax.inject.Singleton;
 
-import org.apache.james.modules.data.JPAConfiguration;
+import org.apache.james.backends.jpa.JPAConfiguration;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;

--- a/server/container/guice/jpa-common/src/test/java/org/apache/james/modules/data/JPAConfigurationTest.java
+++ b/server/container/guice/jpa-common/src/test/java/org/apache/james/modules/data/JPAConfigurationTest.java
@@ -36,6 +36,7 @@ class JPAConfigurationTest {
     private static final String USER_NAME = "username";
     private static final String PASSWORD = "password";
     private static final String EMPTY_STRING = "";
+    private static final boolean ATTACHMENT_STORAGE = true;
 
     @Test
     void buildShouldReturnCorrespondingProperties() {
@@ -48,6 +49,7 @@ class JPAConfigurationTest {
             .username(USER_NAME)
             .password(PASSWORD)
             .maxConnections(MAX_CONNECTIONS)
+            .attachmentStorage(ATTACHMENT_STORAGE)
             .build();
 
         SoftAssertions.assertSoftly(softly -> {
@@ -61,6 +63,7 @@ class JPAConfigurationTest {
                 softly.assertThat(credential.getUsername()).isEqualTo(USER_NAME);
             });
             softly.assertThat(configuration.getMaxConnections()).contains(MAX_CONNECTIONS);
+            softly.assertThat(configuration.isAttachmentStorageEnabled()).contains(ATTACHMENT_STORAGE);
         });
     }
 
@@ -80,6 +83,7 @@ class JPAConfigurationTest {
             softly.assertThat(configuration.getValidationQueryTimeoutSec()).isEmpty();
             softly.assertThat(configuration.getCredential()).isEmpty();
             softly.assertThat(configuration.getMaxConnections()).isEmpty();
+            softly.assertThat(configuration.isAttachmentStorageEnabled()).isEmpty();
         });
     }
 

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -86,7 +86,7 @@
                     <dd>Supported adapters are: DB2, DERBY, H2, HSQL, INFORMIX, MYSQL, ORACLE, POSTGRESQL, SQL_SERVER, SYBASE .</dd>
                     <dt><strong>openjpa.streaming</strong></dt>
                     <dd>true or false - Use streaming for Blobs. This is only supported on a limited set of databases atm. You
-                        should check if its supported by your DB before enable it. See <a href="http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html">http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html</a> (#7.11. LOB Streaming).</dd>
+                        should check if it's supported by your DB before enable it. See <a href="http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html">http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html</a> (#7.11. LOB Streaming).</dd>
                 </dl>
 
                 <p>NOTE: all<code>openjpa.*</code> properties will be passed to OpenJPA library as configuration See <a href="https://openjpa.apache.org/builds/3.2.2/apache-openjpa/docs/ref_guide_conf_openjpa.html">https://openjpa.apache.org/builds/3.2.2/apache-openjpa/docs/ref_guide_conf_openjpa.html</a> for a complete list </p>
@@ -110,8 +110,8 @@
                 <p>Attachment storage configuration</p>
                 <dl>
                     <dt><strong>attachmentStorage.enabled</strong></dt>
-                    <dd>(Guice only). The attachment storage configuration for JPA is used to enable the implementation of the attachment storage mechanism.
-                        *WARNING*: this configuration is not designed to store large binary content, as it is not optimized for this purpose.
+                    <dd>The attachment storage configuration for JPA is used to enable the implementation of the attachment storage mechanism.
+                        *WARNING*: this configuration is not designed to store large binary content (no more than 1 GB of data), as it is not optimized for this purpose.
                         Optional, Allowed values are: `true` or `false`, defaults to `false`</dd>
                 </dl>
             </subsection>

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -107,6 +107,13 @@
                     t0.mailbox_uid_validity, t0.user_name FROM public.james_mailbox t0 WHERE (t0.mailbox_name LIKE ?
                         ESCAPE '\\' AND t0.user_name = ? AND t0.mailbox_namespace = ?) [params=?, ?, ?]} [code=0, state=22025]"</code></p>
 
+                <p>Attachment storage configuration</p>
+                <dl>
+                    <dt><strong>attachmentStorage.enabled</strong></dt>
+                    <dd>(Guice only). The attachment storage configuration for JPA is used to enable the implementation of the attachment storage mechanism.
+                        *WARNING*: this configuration is not designed to store large binary content, as it is not optimized for this purpose.
+                        Optional, Allowed values are: `true` or `false`, defaults to `false`</dd>
+                </dl>
             </subsection>
 
             <subsection name="META-INF/persistence.xml">


### PR DESCRIPTION
Hi! I'm interested in implementing JPA Attachment Mapper as the first step to enable JPA support for JMAP. Here's what I done so far:

* Added JPAAttachment and JPAAttachmentMapper as implementations of AttachmentMapper, along with JPAAttachmentMapperTest as the corresponding test implementation.
* Included MessageAttachmentMetadata properties in AbstractJPAMboxMessage.
* Implemented MessageWithAttachmentMapperTest as JPAMessageWithAttachmentMapperTest.