### PR TITLE
JAMES-3822 Only invoke enqueue delay method when delay input is positive

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
@@ -83,6 +83,14 @@ public class RabbitMQMailQueue implements ManageableMailQueue {
     }
 
     @Override
+    public Publisher<Void> enqueueReactive(Mail mail, Duration delay) {
+        if (!delay.isNegative()) {
+            LOGGER.info("Ignored delay upon enqueue of {} : {}.", mail.getName(), delay);
+        }
+        return enqueueReactive(mail);
+    }
+
+    @Override
     public void enQueue(Mail mail) {
         Mono.from(enqueueReactive(mail)).block();
     }


### PR DESCRIPTION
- The invoke `SMono(queue.enqueueReactive(mail, delay))` when delay is zero/negative is unnecessary
- `RabbitMQMailQueue.java` does not exist override the delay method, so the invoke to default `enQueue(mail, delay)` makes blocking