### PR TITLE
Revert "[UPGRADE] - Maven - pl.project13.maven:git-commit-id-plugin 4…

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -73,16 +73,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>io.github.git-commit-id</groupId>
-        <artifactId>git-commit-id-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>get-the-git-infos</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3453,9 +3453,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>io.github.git-commit-id</groupId>
-                    <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>6.0.0</version>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>4.9.10</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -3592,8 +3592,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.github.git-commit-id</groupId>
-                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                     <prefix>git</prefix>
@@ -3937,8 +3937,8 @@
                         </plugin>
 
                         <plugin>
-                            <groupId>io.github.git-commit-id</groupId>
-                            <artifactId>git-commit-id-maven-plugin</artifactId>
+                            <groupId>pl.project13.maven</groupId>
+                            <artifactId>git-commit-id-plugin</artifactId>
                             <executions>
                                 <execution>
                                     <id>get-the-git-infos</id>


### PR DESCRIPTION
….9.10 -> io.github.git-commit-id:git-commit-id-maven-plugin 6.0.0"

This reverts commit ddac45efed084f34ddb2e25ce8cb456308b45241. Has a bug when using james-project with git submodule: https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/639 The bug is not closed