### PR TITLE
Exclude old JMS spec from dependencies

### DIFF
--- a/backends-common/jpa/pom.xml
+++ b/backends-common/jpa/pom.xml
@@ -52,6 +52,12 @@
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa</artifactId>
             <version>${apache.openjpa.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jms_1.1_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Exclude old JMS spec from dependencies to fix NoSuchMethodError when sending a message via SMTP