### PR TITLE
JAMES-3903 Do not run code coverage plugin locally

### DIFF
--- a/code-coverage-report/pom.xml
+++ b/code-coverage-report/pom.xml
@@ -1265,7 +1265,7 @@
                         <goals>
                             <goal>report-aggregate</goal>
                         </goals>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <configuration>
                             <dataFileIncludes>
                                 <dataFileInclude>**/jacoco.exec</dataFileInclude>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -63,7 +63,7 @@
             <goals>
               <goal>report-aggregate</goal>
             </goals>
-            <phase>package</phase>
+            <phase>none</phase>
             <configuration>
               <dataFileIncludes>
                 <dataFileInclude>**/jacoco.exec</dataFileInclude>


### PR DESCRIPTION
The HTML result files of code coverage make searching in IDE noisy locally. Explicitly running code coverage on Jenkins is enough IMO.

resolve https://github.com/linagora/james-project/issues/4838