### PR TITLE
[Build] Better stability with Cassandra docker containers and integration tests

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraWaitStrategy.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraWaitStrategy.java
@@ -34,7 +34,7 @@ import com.google.common.primitives.Ints;
 
 public class CassandraWaitStrategy implements WaitStrategy {
 
-    private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(2);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(5);
     private final GenericContainer<?> cassandraContainer;
     private final Duration timeout;
 

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
@@ -123,7 +123,7 @@ public class DockerCassandra {
     }
 
     private static final int CASSANDRA_PORT = 9042;
-    private static final int CASSANDRA_MEMORY = 750;
+    private static final int CASSANDRA_MEMORY = 1024;
 
     private static final String CASSANDRA_CONFIG_DIR = "$CASSANDRA_CONFIG";
     private static final String JVM_OPTIONS = CASSANDRA_CONFIG_DIR + "/jvm.options";

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeleteBlobStoreDAOContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeleteBlobStoreDAOContract.java
@@ -63,7 +63,7 @@ public interface DeleteBlobStoreDAOContract {
     default void deleteShouldNotThrowWhenBucketDoesNotExist() {
         BlobStoreDAO store = testee();
 
-        assertThatCode(() -> Mono.from(store.delete(BucketName.of("not_existing_bucket_name"), TEST_BLOB_ID)).block())
+        assertThatCode(() -> Mono.from(store.delete(BucketName.of("not-existing-bucket-name"), TEST_BLOB_ID)).block())
             .doesNotThrowAnyException();
     }
 

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
@@ -119,5 +119,4 @@ public class S3MinioTest implements BlobStoreDAOContract {
             .then()
             .block();
     }
-
 }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RequeueTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RequeueTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -179,7 +180,7 @@ class RequeueTest {
             .block();
 
         assertThat(mailQueueItem).isNotNull();
-        assertThat(Duration.between(enqueueTime, dequeueTime.get()).abs().toSeconds()).isZero();
+        assertThat(Duration.between(enqueueTime, dequeueTime.get()).abs().toSeconds()).isCloseTo(0L, offset(1L));
     }
 
     @Test


### PR DESCRIPTION
A lots of builds seems failing recently on Docker Cassandra container failing to start up correctly when trying to run integration tests. It's not impossible that Cassandra 4 requires more time and resources to setup than version 3. So let's try with this, run a couple of builds and see if it gets better.