### PR TITLE
[DUPLICATED] Better stability with Cassandra docker containers and integration tests

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraWaitStrategy.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraWaitStrategy.java
@@ -34,7 +34,7 @@ import com.google.common.primitives.Ints;
 
 public class CassandraWaitStrategy implements WaitStrategy {
 
-    private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(2);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(5);
     private final GenericContainer<?> cassandraContainer;
     private final Duration timeout;
 

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeleteBlobStoreDAOContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeleteBlobStoreDAOContract.java
@@ -63,7 +63,7 @@ public interface DeleteBlobStoreDAOContract {
     default void deleteShouldNotThrowWhenBucketDoesNotExist() {
         BlobStoreDAO store = testee();
 
-        assertThatCode(() -> Mono.from(store.delete(BucketName.of("not_existing_bucket_name"), TEST_BLOB_ID)).block())
+        assertThatCode(() -> Mono.from(store.delete(BucketName.of("not-existing-bucket-name"), TEST_BLOB_ID)).block())
             .doesNotThrowAnyException();
     }
 

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
@@ -119,5 +119,4 @@ public class S3MinioTest implements BlobStoreDAOContract {
             .then()
             .block();
     }
-
 }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RequeueTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RequeueTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -179,7 +180,7 @@ class RequeueTest {
             .block();
 
         assertThat(mailQueueItem).isNotNull();
-        assertThat(Duration.between(enqueueTime, dequeueTime.get()).abs().toSeconds()).isZero();
+        assertThat(Duration.between(enqueueTime, dequeueTime.get()).abs().toSeconds()).isCloseTo(0L, offset(1L));
     }
 
     @Test


### PR DESCRIPTION
Same as https://github.com/apache/james-project/pull/1672 but without the memory increase of Cassandra test container, as I ain't sure about what exactly is creating those timeouts in webadmin-cli (which I'm surprised as none of those commits should have a change on that)