### PR TITLE
[BUILD] Increase timeout of Cassandra Docker container wait strategy …

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraWaitStrategy.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraWaitStrategy.java
@@ -34,7 +34,7 @@ import com.google.common.primitives.Ints;
 
 public class CassandraWaitStrategy implements WaitStrategy {
 
-    private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(2);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(3);
     private final GenericContainer<?> cassandraContainer;
     private final Duration timeout;
 


### PR DESCRIPTION
…to 3 minutes

5 minutes seemed too much previously and created issues on test execution times, blocking potentially threads used by maven-surefire-plugin when testing in parallel.

But I still see some builds failing around with Cassandra container failing to start. So let's try with 3 minutes