### PR TITLE
[BUILD] Fix unstable SpamTrapHandlerTest.testSpamTrap test

### DIFF
--- a/protocols/smtp/pom.xml
+++ b/protocols/smtp/pom.xml
@@ -94,6 +94,11 @@
             <groupId>org.apache.james</groupId>
             <artifactId>james-server-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
@@ -57,8 +57,7 @@ public class SpamTrapHandler implements RcptHook {
 
     @Inject
     public SpamTrapHandler() {
-        this.blockedIps = new ConcurrentHashMap<>();
-        this.clock = Clock.systemUTC();
+        this(Clock.systemUTC());
     }
 
     @VisibleForTesting

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamTrapHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamTrapHandler.java
@@ -19,13 +19,21 @@
 
 package org.apache.james.smtpserver.fastfail;
 
+import java.time.Clock;
 import java.util.Arrays;
+
+import javax.inject.Inject;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.protocols.api.handler.ProtocolHandler;
 
 public class SpamTrapHandler extends org.apache.james.protocols.smtp.core.fastfail.SpamTrapHandler implements ProtocolHandler {
+
+    @Inject
+    public SpamTrapHandler(Clock clock) {
+        super(clock);
+    }
 
     @Override
     public void init(Configuration config) throws ConfigurationException {

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamTrapHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamTrapHandler.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.smtpserver.fastfail;
 
-import java.time.Clock;
 import java.util.Arrays;
 
 import javax.inject.Inject;
@@ -31,8 +30,8 @@ import org.apache.james.protocols.api.handler.ProtocolHandler;
 public class SpamTrapHandler extends org.apache.james.protocols.smtp.core.fastfail.SpamTrapHandler implements ProtocolHandler {
 
     @Inject
-    public SpamTrapHandler(Clock clock) {
-        super(clock);
+    public SpamTrapHandler() {
+        super();
     }
 
     @Override


### PR DESCRIPTION
resolve https://github.com/linagora/james-project/issues/4844

Rely on UpdatableTickingClock to avoid CPU resource race condition on the CI that leads to test unstable. 
