### PR TITLE
[FIX] VerifySenderIdentity makes sense when auth is not announced

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/smtpserver.xml
+++ b/server/apps/cassandra-app/sample-configuration/smtpserver.xml
@@ -51,7 +51,7 @@
             <plainAuthEnabled>true</plainAuthEnabled>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -102,7 +102,7 @@
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -153,7 +153,7 @@
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
         <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>

--- a/server/apps/distributed-app/sample-configuration/smtpserver.xml
+++ b/server/apps/distributed-app/sample-configuration/smtpserver.xml
@@ -51,7 +51,7 @@
             <plainAuthEnabled>true</plainAuthEnabled>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -101,8 +101,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -149,8 +148,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>

--- a/server/apps/distributed-pop3-app/sample-configuration/smtpserver.xml
+++ b/server/apps/distributed-pop3-app/sample-configuration/smtpserver.xml
@@ -41,7 +41,7 @@
             <plainAuthEnabled>true</plainAuthEnabled>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -78,8 +78,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -116,8 +115,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>

--- a/server/apps/jpa-app/sample-configuration/smtpserver.xml
+++ b/server/apps/jpa-app/sample-configuration/smtpserver.xml
@@ -51,7 +51,7 @@
             <plainAuthEnabled>true</plainAuthEnabled>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -98,8 +98,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -146,8 +145,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>

--- a/server/apps/jpa-smtp-app/sample-configuration/smtpserver.xml
+++ b/server/apps/jpa-smtp-app/sample-configuration/smtpserver.xml
@@ -51,7 +51,7 @@
             <plainAuthEnabled>true</plainAuthEnabled>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -98,8 +98,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -146,8 +145,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>

--- a/server/apps/memory-app/sample-configuration/smtpserver.xml
+++ b/server/apps/memory-app/sample-configuration/smtpserver.xml
@@ -51,7 +51,7 @@
             <plainAuthEnabled>true</plainAuthEnabled>
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -98,8 +98,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
@@ -146,8 +145,7 @@
             -->
         </auth>
         <authorizedAddresses>127.0.0.0/8</authorizedAddresses>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
+        <verifyIdentity>true</verifyIdentity>
         <maxmessagesize>0</maxmessagesize>
         <addressBracketsEnforcement>true</addressBracketsEnforcement>
         <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>

--- a/server/apps/spring-app/src/main/resources/smtpserver.xml
+++ b/server/apps/spring-app/src/main/resources/smtpserver.xml
@@ -123,9 +123,7 @@
         <!--  the sender address matches the user who has authenticated. -->
         <!--  This prevents a user of your mail server from acting as someone else -->
         <!--  If unspecified, default value is true -->
-        <!--
         <verifyIdentity>true</verifyIdentity>
-         -->
 
         <!--  This sets the maximum allowed message size (in kilobytes) for this -->
         <!--  SMTP service. If unspecified, the value defaults to 0, which means no limit. -->

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -244,11 +244,6 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
             addressBracketsEnforcement = configuration.getBoolean("addressBracketsEnforcement", true);
 
             verifyIdentity = configuration.getBoolean("verifyIdentity", false);
-
-            if (authenticationConfiguration.getAuthenticationAnnounceMode() == NEVER && verifyIdentity) {
-                throw new ConfigurationException(
-                    "SMTP configuration: 'verifyIdentity' can't be set to true if 'authRequired' is set to false.");
-            }
         }
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServer.java
@@ -243,7 +243,7 @@ public class SMTPServer extends AbstractProtocolAsyncServer implements SMTPServe
 
             addressBracketsEnforcement = configuration.getBoolean("addressBracketsEnforcement", true);
 
-            verifyIdentity = configuration.getBoolean("verifyIdentity", false);
+            verifyIdentity = configuration.getBoolean("verifyIdentity", true);
         }
     }
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -2093,12 +2093,4 @@ public class SMTPServerTest {
         out.close();
         client.close();
     }
-
-    @Test
-    public void testRejectVerifyIdentityWhenAuthRequiredIsFalse() {
-        smtpConfiguration.setVerifyIdentity();
-
-        assertThatThrownBy(() -> init(smtpConfiguration))
-            .isInstanceOf(ConfigurationException.class);
-    }
 }


### PR DESCRIPTION
As this prevents spoofing