### PR TITLE
JAMES-3936 Webadmin: Avoid double decoding request param

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryIntegrationTest.java
@@ -88,6 +88,7 @@ class ToRepositoryIntegrationTest {
         webAdminAPI = WebAdminUtils.buildRequestSpecification(
             jamesServer.getProbe(WebAdminGuiceProbe.class)
                 .getWebAdminPort())
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationImmutableTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationImmutableTest.java
@@ -95,6 +95,7 @@ class RabbitMQWebAdminServerTaskSerializationIntegrationImmutableTest {
         WebAdminGuiceProbe webAdminGuiceProbe = guiceJamesServer.getProbe(WebAdminGuiceProbe.class);
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminGuiceProbe.getWebAdminPort())
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationTest.java
@@ -130,6 +130,7 @@ class RabbitMQWebAdminServerTaskSerializationIntegrationTest {
         mailboxProbe = guiceJamesServer.getProbe(MailboxProbeImpl.class);
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminGuiceProbe.getWebAdminPort())
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
@@ -111,6 +111,7 @@ public class WebAdminUtils {
     }
 
     public static RequestSpecification spec(Port port) {
-        return given().spec(buildRequestSpecification(port).build());
+        return given().spec(buildRequestSpecification(port).build())
+            .urlEncodingEnabled(false); // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
     }
 }

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainsRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainsRoutes.java
@@ -21,9 +21,6 @@ package org.apache.james.webadmin.routes;
 
 import static org.apache.james.webadmin.Constants.SEPARATOR;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -203,27 +200,13 @@ public class DomainsRoutes implements Routes {
     }
 
     private Domain checkValidDomain(String domainName) {
-        String urlDecodedDomainName = urlDecodeDomain(domainName);
         try {
-            return Domain.of(urlDecodedDomainName);
+            return Domain.of(domainName);
         } catch (IllegalArgumentException e) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
                 .type(ErrorType.INVALID_ARGUMENT)
-                .message("Invalid request for domain creation %s", urlDecodedDomainName)
-                .cause(e)
-                .haltError();
-        }
-    }
-
-    private String urlDecodeDomain(String domainName) {
-        try {
-            return URLDecoder.decode(domainName, StandardCharsets.UTF_8.toString());
-        } catch (IllegalArgumentException | UnsupportedEncodingException e) {
-            throw ErrorResponder.builder()
-                .statusCode(HttpStatus.BAD_REQUEST_400)
-                .type(ErrorType.INVALID_ARGUMENT)
-                .message("Invalid request for domain creation %s unable to url decode some characters", domainName)
+                .message("Invalid request for domain creation %s", domainName)
                 .cause(e)
                 .haltError();
         }

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/MailAddressParser.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/MailAddressParser.java
@@ -19,10 +19,6 @@
 
 package org.apache.james.webadmin.routes;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-
 import javax.mail.internet.AddressException;
 
 import org.apache.james.core.MailAddress;
@@ -37,22 +33,13 @@ class MailAddressParser {
 
     static MailAddress parseMailAddress(String address, String addressType) {
         try {
-            String decodedAddress = URLDecoder.decode(address, StandardCharsets.UTF_8.displayName());
-            return new MailAddress(decodedAddress);
+            return new MailAddress(address);
         } catch (AddressException e) {
             LOGGER.error("The {} {} is not an email address", addressType, address);
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
                 .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
                 .message("The %s is not an email address", addressType)
-                .cause(e)
-                .haltError();
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.error("UTF-8 should be a valid encoding");
-            throw ErrorResponder.builder()
-                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
-                .type(ErrorResponder.ErrorType.SERVER_ERROR)
-                .message("Internal server error - Something went bad on the server side.")
                 .cause(e)
                 .haltError();
         }

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/RegexMappingRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/RegexMappingRoutes.java
@@ -22,9 +22,6 @@ package org.apache.james.webadmin.routes;
 import static org.apache.james.webadmin.Constants.SEPARATOR;
 import static spark.Spark.halt;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-
 import javax.inject.Inject;
 
 import org.apache.james.core.Username;
@@ -75,7 +72,7 @@ public class RegexMappingRoutes implements Routes {
     private HaltException addRegexMapping(Request request, Response response) throws Exception {
         try {
             MappingSource mappingSource = extractMappingSource(request);
-            String regex = URLDecoder.decode(request.params(REGEX_PARAM), StandardCharsets.UTF_8.toString());
+            String regex = request.params(REGEX_PARAM);
             recipientRewriteTable.addRegexMapping(mappingSource, regex);
         } catch (InvalidRegexException e) {
             throw ErrorResponder.builder()
@@ -90,7 +87,7 @@ public class RegexMappingRoutes implements Routes {
     private HaltException removeRegexMapping(Request request, Response response) throws Exception {
         try {
             MappingSource mappingSource = MappingSource.parse(request.params(MAPPING_SOURCE_PARAM));
-            String regex = URLDecoder.decode(request.params(REGEX_PARAM), StandardCharsets.UTF_8.toString());
+            String regex = request.params(REGEX_PARAM);
             recipientRewriteTable.removeRegexMapping(mappingSource, regex);
         } catch (RecipientRewriteTableException e) {
             throw ErrorResponder.builder()

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AddressMappingRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AddressMappingRoutesTest.java
@@ -72,7 +72,7 @@ class AddressMappingRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath(AddressMappingRoutes.BASE_PATH)
-            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AddressMappingRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AddressMappingRoutesTest.java
@@ -46,9 +46,11 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 class AddressMappingRoutesTest {
-    private static String MAPPING_SOURCE = "source@domain.tld";
-    private static String ALICE_ADDRESS = "alice@domain.tld";
-    private static String BOB_ADDRESS = "bob@domain.tld";
+    private static final String MAPPING_SOURCE = "source@domain.tld";
+    private static final String ALICE_ADDRESS = "alice@domain.tld";
+    private static final String ALICE_WITH_SLASH = "alice/@domain.tld";
+    private static final String ALICE_WITH_ENCODED_SLASH = "alice%2F@domain.tld";
+    private static final String BOB_ADDRESS = "bob@domain.tld";
 
     private WebAdminServer webAdminServer;
     private MemoryRecipientRewriteTable recipientRewriteTable;
@@ -70,6 +72,7 @@ class AddressMappingRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath(AddressMappingRoutes.BASE_PATH)
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
             .build();
     }
 
@@ -85,6 +88,15 @@ class AddressMappingRoutesTest {
 
         assertThat(recipientRewriteTable.getStoredMappings(MappingSource.parse(MAPPING_SOURCE)))
             .containsAnyOf(Mapping.of(ALICE_ADDRESS));
+    }
+
+    @Test
+    void addAddressMappingShouldSupportOneTimeEncodedAddress() {
+        when()
+            .post(MAPPING_SOURCE + "/targets/" + ALICE_WITH_ENCODED_SLASH);
+
+        assertThat(recipientRewriteTable.getStoredMappings(MappingSource.parse(MAPPING_SOURCE)))
+            .containsAnyOf(Mapping.of(ALICE_WITH_SLASH));
     }
 
     @Test

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
@@ -90,7 +90,7 @@ class AliasRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath("address/aliases")
-            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
@@ -90,6 +90,7 @@ class AliasRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath("address/aliases")
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainsRoutesTest.java
@@ -117,6 +117,7 @@ class DomainsRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath(DomainsRoutes.DOMAINS)
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
             .build();
     }
 
@@ -332,7 +333,7 @@ class DomainsRoutesTest {
         }
 
         @Test
-        void putShouldReturnUserErrorWhenNameContainsUrlEncodedUrlOperator() {
+        void putWithDomainNameContainsSlashEncodedShouldDecodeAndReturnError() {
             Map<String, Object> errors = when()
                 .put(DOMAIN + "%2F" + DOMAIN)
             .then()
@@ -347,24 +348,6 @@ class DomainsRoutesTest {
                 .containsEntry("statusCode", HttpStatus.BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Invalid request for domain creation domain/domain");
-        }
-
-        @Test
-        void putShouldReturnUserErrorWhenNameContainsInvalidUrlEncodedCharacters() {
-            Map<String, Object> errors = when()
-                .put(DOMAIN + "%GG" + DOMAIN)
-            .then()
-                .statusCode(HttpStatus.BAD_REQUEST_400)
-                .contentType(ContentType.JSON)
-                .extract()
-                .body()
-                .jsonPath()
-                .getMap(".");
-
-            assertThat(errors)
-                .containsEntry("statusCode", HttpStatus.BAD_REQUEST_400)
-                .containsEntry("type", "InvalidArgument")
-                .containsEntry("message", "Invalid request for domain creation domain%GGdomain unable to url decode some characters");
         }
 
         @Test

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainsRoutesTest.java
@@ -117,7 +117,7 @@ class DomainsRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath(DomainsRoutes.DOMAINS)
-            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
@@ -88,6 +88,7 @@ class ForwardRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath("address/forwards")
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
             .build();
     }
 
@@ -404,6 +405,19 @@ class ForwardRoutesTest {
                 .containsEntry("statusCode", HttpStatus.NOT_FOUND_404)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Requested base forward address does not correspond to a user");
+        }
+
+        @Test
+        void addForwardWithOneTimeUrlEncodedAddressShouldSucceed() {
+            with()
+                .put(ALICE + SEPARATOR + "targets" + SEPARATOR + URLEncoder.encode("alice+tag@james.org", StandardCharsets.UTF_8));
+
+            when()
+                .get(ALICE)
+            .then()
+                .contentType(ContentType.JSON)
+                .statusCode(HttpStatus.OK_200)
+                .body("mailAddress", hasItems("alice+tag@james.org"));
         }
 
         @Test

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
@@ -88,7 +88,7 @@ class ForwardRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath("address/forwards")
-            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
@@ -88,7 +88,7 @@ class GroupsRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath("address/groups")
-            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
@@ -88,6 +88,7 @@ class GroupsRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath("address/groups")
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/RegexMappingRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/RegexMappingRoutesTest.java
@@ -63,7 +63,7 @@ class RegexMappingRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath(RegexMappingRoutes.BASE_PATH)
-            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/SieveScriptRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/SieveScriptRoutesTest.java
@@ -93,6 +93,7 @@ class SieveScriptRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils
             .buildRequestSpecification(webAdminServer)
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 
@@ -123,7 +124,7 @@ class SieveScriptRoutesTest {
             "}";
         String body = given()
             .pathParam("userName", "userA")
-            .pathParam("scriptName", " ")
+            .pathParam("scriptName", "%20")
             .body(sieveContent)
         .when()
             .put("sieve/{userName}/scripts/{scriptName}")
@@ -144,7 +145,7 @@ class SieveScriptRoutesTest {
             " \"details\":null" +
             "}";
         String body = given()
-            .pathParam("userName", " ")
+            .pathParam("userName", "%20")
             .pathParam("scriptName", "scriptA")
             .body(sieveContent)
         .when()

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/UserRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/UserRoutesTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -176,6 +177,7 @@ class UserRoutesTest {
 
             RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(server)
                 .setBasePath(UserRoutes.USERS)
+                .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
                 .build();
 
             return server;
@@ -607,20 +609,19 @@ class UserRoutesTest {
 
             default Stream<Arguments> illegalCharacters() {
                 return Stream.of(
-                    Arguments.of("\""),
-                    Arguments.of("("),
-                    Arguments.of(")"),
-                    Arguments.of(","),
-                    Arguments.of(":"),
-                    Arguments.of(";"),
-                    Arguments.of("<"),
-                    Arguments.of(">"),
-                    Arguments.of("@"),
-                    Arguments.of("["),
-                    Arguments.of("\\"),
-                    Arguments.of("]"),
-                    Arguments.of(" ")
-                );
+                    Arguments.of(URLEncoder.encode("\"")),
+                    Arguments.of(URLEncoder.encode("(")),
+                    Arguments.of(URLEncoder.encode(")")),
+                    Arguments.of(URLEncoder.encode(",")),
+                    Arguments.of(URLEncoder.encode(":")),
+                    Arguments.of(URLEncoder.encode(";")),
+                    Arguments.of(URLEncoder.encode("<")),
+                    Arguments.of(URLEncoder.encode(">")),
+                    Arguments.of(URLEncoder.encode("@")),
+                    Arguments.of(URLEncoder.encode("[")),
+                    Arguments.of(URLEncoder.encode("\\")),
+                    Arguments.of(URLEncoder.encode("]")),
+                    Arguments.of("%20"));
             }
 
             @ParameterizedTest

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/UserQuotaRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/UserQuotaRoutes.java
@@ -21,9 +21,6 @@ package org.apache.james.webadmin.routes;
 
 import static org.apache.james.webadmin.routes.MailboxesRoutes.TASK_PARAMETER;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -280,11 +277,8 @@ public class UserQuotaRoutes implements Routes {
         }, jsonTransformer);
     }
 
-    private Username checkUserExist(Request request) throws UsersRepositoryException, UnsupportedEncodingException {
-        String user = URLDecoder.decode(request.params(USER),
-            StandardCharsets.UTF_8.displayName());
-
-        Username username = Username.of(user);
+    private Username checkUserExist(Request request) throws UsersRepositoryException {
+        Username username = Username.of(request.params(USER));
 
         if (!usersRepository.contains(username)) {
             throw ErrorResponder.builder()

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -182,6 +183,7 @@ class UserMailboxesRoutesTest {
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath(USERS_BASE + SEPARATOR + USERNAME.asString() + SEPARATOR + UserMailboxesRoutes.MAILBOXES)
+            .setUrlEncodingEnabled(false) // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
             .build();
     }
 
@@ -331,7 +333,7 @@ class UserMailboxesRoutesTest {
             when(usersRepository.contains(USERNAME)).thenReturn(true);
 
             Map<String, Object> errors = when()
-                .put(INVALID_MAILBOX_NAME)
+                .put(URLEncoder.encode(INVALID_MAILBOX_NAME))
             .then()
                 .statusCode(BAD_REQUEST_400)
                 .contentType(JSON)
@@ -450,7 +452,7 @@ class UserMailboxesRoutesTest {
         @Test
         void getShouldReturnUserErrorWithInvalidPercentMailboxName() throws Exception {
             Map<String, Object> errors = when()
-                .get(MAILBOX_NAME + "%")
+                .get(URLEncoder.encode(MAILBOX_NAME + "%"))
             .then()
                 .statusCode(BAD_REQUEST_400)
                 .contentType(JSON)
@@ -469,7 +471,7 @@ class UserMailboxesRoutesTest {
         @Test
         void putShouldReturnUserErrorWithInvalidPercentMailboxName() throws Exception {
             Map<String, Object> errors = when()
-                .put(MAILBOX_NAME + "%")
+                .put(URLEncoder.encode(MAILBOX_NAME + "%"))
             .then()
                 .statusCode(BAD_REQUEST_400)
                 .contentType(JSON)
@@ -487,7 +489,7 @@ class UserMailboxesRoutesTest {
         @Test
         void deleteShouldReturnUserErrorWithInvalidPercentMailboxName() throws Exception {
             Map<String, Object> errors = when()
-                .put(MAILBOX_NAME + "%")
+                .put(URLEncoder.encode(MAILBOX_NAME + "%"))
             .then()
                 .statusCode(BAD_REQUEST_400)
                 .contentType(JSON)
@@ -505,7 +507,7 @@ class UserMailboxesRoutesTest {
         @Test
         void getShouldReturnUserErrorWithInvalidSharpMailboxName() throws Exception {
             Map<String, Object> errors = when()
-                .get("#" + MAILBOX_NAME)
+                .get(URLEncoder.encode("#" + MAILBOX_NAME))
             .then()
                 .statusCode(BAD_REQUEST_400)
                 .contentType(JSON)
@@ -535,7 +537,7 @@ class UserMailboxesRoutesTest {
         @Test
         void putShouldReturnUserErrorWithInvalidSharpMailboxName() throws Exception {
             Map<String, Object> errors = when()
-                .put("#" + MAILBOX_NAME)
+                .put(URLEncoder.encode("#" + MAILBOX_NAME))
             .then()
                 .statusCode(BAD_REQUEST_400)
                 .contentType(JSON)
@@ -561,7 +563,7 @@ class UserMailboxesRoutesTest {
         @Test
         void deleteShouldReturnUserErrorWithInvalidSharpMailboxName() throws Exception {
             Map<String, Object> errors = when()
-                .put("#" + MAILBOX_NAME)
+                .put(URLEncoder.encode("#" + MAILBOX_NAME))
             .then()
                 .statusCode(BAD_REQUEST_400)
                 .contentType(JSON)

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserQuotaRoutesTest.java
@@ -102,7 +102,8 @@ class UserQuotaRoutesTest {
         usersRepository.addUser(JACK, PASSWORD);
         usersRepository.addUser(GUY_WITH_STRANGE_DOMAIN, PASSWORD);
 
-        RestAssured.requestSpecification = testSystem.getRequestSpecification();
+        RestAssured.requestSpecification = testSystem.getRequestSpecification()
+            .urlEncodingEnabled(false); // no further automatically encoding by Rest Assured client. rf: https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3936
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 


### PR DESCRIPTION
Currently, we are doing 2 times URL decoding for request param: 1 by Spark and 1 by our own.
That leads to in some cases we need to encode 2 times which is not expected.

E.g we have a bug while creating forward with just 1-time encoding:
```
  Original forward address: `bob+tag@b.com`
  -> One-time encoded: `bob%2Btag%40b.com`
```
  James today decodes the address 2 times:
```
  1st decoding result: `bob+tag@b.com`
  2nd decoding result: `bob tag@b.com` => invalid Mail Address => Can not create the valid forward...
```