### PR TITLE
JAMES-3925 Enforce quota for JMAP uploads

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmap.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jmap.adoc
@@ -48,8 +48,12 @@ JMAP clients would use this property in order not to create too big emails.
 Default value: None. Supported units are B (bytes) K (KB) M (MB) G (GB).
 
 | upload.max.size
-| Optional. Configuration max size Upload in new JMAP-RFC-8621.
+| Optional. Configuration max size for each upload file in new JMAP-RFC-8621.
 Default value: 30M. Supported units are B (bytes) K (KB) M (MB) G (GB).
+
+| upload.quota.limit
+| Optional. Configure JMAP upload quota for total existing uploads' size per user. User exceeding the upload quota would result in old uploads being cleaned up.
+Default value: 200M. Supported units are B (bytes) K (KB) M (MB) G (GB).
 
 | view.email.query.enabled
 | Optional boolean. Defaults to false. Should simple Email/query be resolved against a Cassandra projection, or should we resolve them against OpenSearch?

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
@@ -36,6 +36,7 @@ import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.jmap.JMAPConfiguration;
 import org.apache.james.jmap.JMAPServer;
 import org.apache.james.jmap.Version;
+import org.apache.james.jmap.api.upload.JmapUploadQuotaConfiguration;
 import org.apache.james.jmap.core.CapabilityFactory;
 import org.apache.james.jmap.core.CoreCapabilityFactory;
 import org.apache.james.jmap.core.DelegationCapabilityFactory$;
@@ -184,6 +185,11 @@ public class JMAPModule extends AbstractModule {
     @Named("supportsDelaySends")
     boolean submissionCapability(JmapRfc8621Configuration configuration) {
         return configuration.supportsDelaySends();
+    }
+
+    @Provides
+    JmapUploadQuotaConfiguration jmapUploadQuotaConfiguration(JmapRfc8621Configuration configuration) {
+        return new JmapUploadQuotaConfiguration(configuration.jmapUploadQuotaLimit().asLong());
     }
 
     @ProvidesIntoSet

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/upload/CassandraUploadRepository.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/upload/CassandraUploadRepository.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import javax.inject.Inject;
 
@@ -65,7 +66,8 @@ public class CassandraUploadRepository implements UploadRepository {
 
         return Mono.fromCallable(() -> new CountingInputStream(data))
             .flatMap(countingInputStream -> Mono.from(blobStore.save(UPLOAD_BUCKET, countingInputStream, LOW_COST))
-                .map(blobId -> new UploadDAO.UploadRepresentation(uploadId, blobId, contentType, countingInputStream.getCount(), user, clock.instant()))
+                .map(blobId -> new UploadDAO.UploadRepresentation(uploadId, blobId, contentType, countingInputStream.getCount(), user,
+                    clock.instant().truncatedTo(ChronoUnit.MILLIS)))
                 .flatMap(upload -> uploadDAO.save(upload)
                     .thenReturn(upload.toUploadMetaData())));
     }

--- a/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraUploadServiceTest.java
+++ b/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraUploadServiceTest.java
@@ -1,0 +1,73 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.cassandra.upload;
+
+import java.time.Clock;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.apache.james.jmap.api.upload.UploadRepository;
+import org.apache.james.jmap.api.upload.UploadService;
+import org.apache.james.jmap.api.upload.UploadServiceContract;
+import org.apache.james.jmap.api.upload.UploadServiceDefaultImpl;
+import org.apache.james.jmap.api.upload.UploadUsageRepository;
+import org.apache.james.mailbox.cassandra.modules.CassandraQuotaModule;
+import org.apache.james.mailbox.cassandra.quota.CassandraQuotaCurrentValueDao;
+import org.apache.james.server.blob.deduplication.DeDuplicationBlobStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class CassandraUploadServiceTest implements UploadServiceContract {
+    @RegisterExtension
+    static CassandraClusterExtension cassandra = new CassandraClusterExtension(CassandraModule.aggregateModules(
+        UploadModule.MODULE, CassandraQuotaModule.MODULE));
+
+    private CassandraUploadRepository uploadRepository;
+    private CassandraUploadUsageRepository uploadUsageRepository;
+    private UploadService testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandraCluster) {
+        Clock clock = Clock.systemUTC();
+        uploadRepository = new CassandraUploadRepository(new UploadDAO(cassandraCluster.getConf(), new HashBlobId.Factory()), new DeDuplicationBlobStore(new MemoryBlobStoreDAO(),
+            BucketName.of("default"), new HashBlobId.Factory()), clock);
+        uploadUsageRepository = new CassandraUploadUsageRepository(new CassandraQuotaCurrentValueDao(cassandraCluster.getConf()));
+        testee = new UploadServiceDefaultImpl(uploadRepository, uploadUsageRepository, UploadServiceContract.TEST_CONFIGURATION());
+    }
+
+    @Override
+    public UploadRepository uploadRepository() {
+        return uploadRepository;
+    }
+
+    @Override
+    public UploadUsageRepository uploadUsageRepository() {
+        return uploadUsageRepository;
+    }
+
+    @Override
+    public UploadService testee() {
+        return testee;
+    }
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/upload/JmapUploadQuotaConfiguration.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/upload/JmapUploadQuotaConfiguration.java
@@ -19,17 +19,14 @@
 
 package org.apache.james.jmap.api.upload;
 
-import java.io.InputStream;
+public class JmapUploadQuotaConfiguration {
+    private final long uploadQuotaLimitInBytes;
 
-import org.apache.james.core.Username;
-import org.apache.james.jmap.api.model.Upload;
-import org.apache.james.jmap.api.model.UploadId;
-import org.apache.james.jmap.api.model.UploadMetaData;
-import org.apache.james.mailbox.model.ContentType;
-import org.reactivestreams.Publisher;
+    public JmapUploadQuotaConfiguration(long uploadQuotaLimitInBytes) {
+        this.uploadQuotaLimitInBytes = uploadQuotaLimitInBytes;
+    }
 
-public interface UploadService {
-    Publisher<UploadMetaData> upload(InputStream data, ContentType contentType, Username user);
-
-    Publisher<Upload> retrieve(UploadId id, Username user);
+    public long getUploadQuotaLimitInBytes() {
+        return uploadQuotaLimitInBytes;
+    }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/upload/UploadServiceDefaultImpl.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/upload/UploadServiceDefaultImpl.java
@@ -20,34 +20,92 @@
 package org.apache.james.jmap.api.upload;
 
 import java.io.InputStream;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.james.core.Username;
+import org.apache.james.core.quota.QuotaSizeUsage;
 import org.apache.james.jmap.api.model.Upload;
 import org.apache.james.jmap.api.model.UploadId;
 import org.apache.james.jmap.api.model.UploadMetaData;
 import org.apache.james.mailbox.model.ContentType;
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 
-public class UploadServiceDefaultImpl implements UploadService {
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-    private final UploadRepository repository;
+public class UploadServiceDefaultImpl implements UploadService {
+    private final UploadRepository uploadRepository;
+    private final UploadUsageRepository uploadUsageRepository;
+    private final JmapUploadQuotaConfiguration jmapUploadQuotaConfiguration;
 
     @Inject
     @Singleton
-    public UploadServiceDefaultImpl(UploadRepository repository) {
-        this.repository = repository;
+    public UploadServiceDefaultImpl(UploadRepository uploadRepository,
+                                    UploadUsageRepository uploadUsageRepository,
+                                    JmapUploadQuotaConfiguration jmapUploadQuotaConfiguration) {
+        this.uploadRepository = uploadRepository;
+        this.uploadUsageRepository = uploadUsageRepository;
+        this.jmapUploadQuotaConfiguration = jmapUploadQuotaConfiguration;
     }
 
     @Override
     public Publisher<UploadMetaData> upload(InputStream data, ContentType contentType, Username user) {
-        return repository.upload(data, contentType, user);
+        return Mono.from(uploadRepository.upload(data, contentType, user))
+            .flatMap(upload -> Mono.from(uploadUsageRepository.increaseSpace(user, QuotaSizeUsage.size(upload.sizeAsLong())))
+                .thenReturn(upload))
+            .doOnSuccess(uploaded -> cleanupUploadIfNeeded(user)
+                .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
+                .subscribe());
     }
 
     @Override
     public Publisher<Upload> retrieve(UploadId id, Username user) {
-        return repository.retrieve(id, user);
+        return uploadRepository.retrieve(id, user);
+    }
+
+    private Mono<Void> cleanupUploadIfNeeded(Username username) {
+        return Mono.from(uploadUsageRepository.getSpaceUsage(username))
+            .map(QuotaSizeUsage::asLong)
+            .filter(quotaExceededPredicate())
+            .switchIfEmpty(Mono.empty())
+            .flatMap(quotaExceeded -> cleanupUpload(username, quotaExceeded));
+    }
+
+    private Predicate<Long> quotaExceededPredicate() {
+        return currentUploadUsage -> currentUploadUsage > jmapUploadQuotaConfiguration.getUploadQuotaLimitInBytes();
+    }
+
+    private Mono<Void> cleanupUpload(Username username, long currentUploadUsage) {
+        long minimumSpaceToClean = currentUploadUsage - jmapUploadQuotaConfiguration.getUploadQuotaLimitInBytes() / 2;
+        AtomicLong cleanedSpace = new AtomicLong(0L);
+
+        return Flux.from(uploadRepository.listUploads(username))
+            .sort(Comparator.comparing(UploadMetaData::uploadDate))
+            .concatMap(deleteUpload(username, minimumSpaceToClean, cleanedSpace))
+            .map(UploadMetaData::sizeAsLong)
+            .reduce(Long::sum)
+            .filter(totalSpaceUsed -> totalSpaceUsed != currentUploadUsage)
+            .flatMap(totalSpaceUsed -> Mono.from(uploadUsageRepository.resetSpace(username, QuotaSizeUsage.size(totalSpaceUsed))))
+            .then();
+    }
+
+    private Function<UploadMetaData, Publisher<? extends UploadMetaData>> deleteUpload(Username username, long minimumSpaceToClean, AtomicLong cleanedSpace) {
+        return upload -> {
+            if (cleanedSpace.get() < minimumSpaceToClean) {
+                return Mono.from(uploadRepository.delete(upload.uploadId(), username))
+                    .then(Mono.from(uploadUsageRepository.decreaseSpace(username, QuotaSizeUsage.size(upload.sizeAsLong()))))
+                    .then(Mono.fromCallable(() -> cleanedSpace.addAndGet(upload.sizeAsLong())))
+                    .then(Mono.empty());
+            } else {
+                return Mono.fromCallable(() -> upload);
+            }
+        };
     }
 }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/upload/UploadRepositoryContract.scala
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/upload/UploadRepositoryContract.scala
@@ -30,9 +30,9 @@
  import org.apache.james.jmap.api.upload.UploadRepositoryContract.{CONTENT_TYPE, DATA_STRING, USER}
  import org.apache.james.mailbox.model.ContentType
  import org.assertj.core.api.Assertions.{assertThat, assertThatCode, assertThatThrownBy}
+ import org.assertj.core.groups.Tuple.tuple
  import org.junit.jupiter.api.Test
  import reactor.core.scala.publisher.{SFlux, SMono}
- import org.assertj.core.groups.Tuple.tuple
 
  import scala.jdk.CollectionConverters._
 
@@ -135,6 +135,19 @@
      assertThat(uploadMetaDataList.asJava)
        .extracting("blobId", "uploadDate")
        .doesNotContainNull()
+   }
+
+   @Test
+   def listUploadsShouldReturnTheSameUploadDateAsUpload(): Unit = {
+     val contentType1: ContentType = ContentType
+       .of("text/html")
+     val data1: InputStream = IOUtils.toInputStream("123321", StandardCharsets.UTF_8)
+
+     val upload: UploadMetaData = SMono.fromPublisher(testee.upload(data1, contentType1, USER)).block()
+
+     val listUploadsResult: UploadMetaData = SFlux.fromPublisher(testee.listUploads(USER)).blockFirst().get;
+
+     assertThat(upload.uploadDate).isEqualTo(listUploadsResult.uploadDate)
    }
 
    @Test

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryUploadServiceTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryUploadServiceTest.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory.upload;
+
+import java.time.Clock;
+
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.apache.james.jmap.api.upload.UploadRepository;
+import org.apache.james.jmap.api.upload.UploadService;
+import org.apache.james.jmap.api.upload.UploadServiceContract;
+import org.apache.james.jmap.api.upload.UploadServiceDefaultImpl;
+import org.apache.james.jmap.api.upload.UploadUsageRepository;
+import org.apache.james.server.blob.deduplication.DeDuplicationBlobStore;
+import org.junit.jupiter.api.BeforeEach;
+
+public class InMemoryUploadServiceTest implements UploadServiceContract {
+
+    private UploadRepository uploadRepository;
+    private UploadUsageRepository uploadUsageRepository;
+    private UploadService testee;
+
+    @BeforeEach
+    void setUp() {
+        BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, new HashBlobId.Factory());
+        uploadRepository = new InMemoryUploadRepository(blobStore, Clock.systemUTC());
+        uploadUsageRepository = new InMemoryUploadUsageRepository();
+        testee = new UploadServiceDefaultImpl(uploadRepository, uploadUsageRepository, UploadServiceContract.TEST_CONFIGURATION());
+    }
+
+    @Override
+    public UploadRepository uploadRepository() {
+        return uploadRepository;
+    }
+
+    @Override
+    public UploadUsageRepository uploadUsageRepository() {
+        return uploadUsageRepository;
+    }
+
+    @Override
+    public UploadService testee() {
+        return testee;
+    }
+}

--- a/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/upload/UploadServiceContract.scala
+++ b/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/upload/UploadServiceContract.scala
@@ -1,0 +1,189 @@
+ /***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.upload
+
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.time.{Duration, Instant}
+
+import org.apache.commons.io.IOUtils
+import org.apache.james.core.Username
+import org.apache.james.core.quota.QuotaSizeUsage
+import org.apache.james.jmap.api.model.UploadMetaData
+import org.apache.james.jmap.api.upload.UploadServiceContract.{BOB, CONTENT_TYPE, TEN_BYTES_DATA_STRING, UPLOAD_QUOTA_LIMIT, awaitAtMostTwoMinutes}
+import org.apache.james.mailbox.model.ContentType
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
+import org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS
+import org.junit.jupiter.api.Test
+import reactor.core.scala.publisher.{SFlux, SMono}
+
+object UploadServiceContract {
+  private lazy val UPLOAD_QUOTA_LIMIT: Long = 100L
+  lazy val TEST_CONFIGURATION: JmapUploadQuotaConfiguration = new JmapUploadQuotaConfiguration(UPLOAD_QUOTA_LIMIT)
+  private lazy val CONTENT_TYPE: ContentType = ContentType
+    .of("text/html")
+  private lazy val TEN_BYTES_DATA_STRING: String = "0123456789"
+  private lazy val BOB: Username = Username.of("Bob")
+
+  private lazy val awaitAtMostTwoMinutes = Awaitility.`with`
+    .pollInterval(ONE_HUNDRED_MILLISECONDS)
+    .and.`with`.pollDelay(ONE_HUNDRED_MILLISECONDS)
+    .atMost(Duration.ofMinutes(2))
+    .await
+}
+
+trait UploadServiceContract {
+
+  def uploadRepository: UploadRepository
+
+  def uploadUsageRepository: UploadUsageRepository
+
+  def testee: UploadService
+
+  def asInputStream(string: String): InputStream = IOUtils.toInputStream(string, StandardCharsets.UTF_8)
+
+  @Test
+  def uploadShouldIncreaseUsedSpace(): Unit = {
+    SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+      .block()
+
+    assertThat(SMono.fromPublisher(uploadUsageRepository.getSpaceUsage(BOB)).block().asLong())
+      .isEqualTo(10L)
+  }
+
+  @Test
+  def uploadShouldIncreaseUsedSpaceWhenMultipleUploads(): Unit = {
+    Range.inclusive(1, 9)
+      .foreach(_ => SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+        .block())
+
+    assertThat(SMono.fromPublisher(uploadUsageRepository.getSpaceUsage(BOB)).block().asLong())
+      .isEqualTo(90L)
+  }
+
+  @Test
+  def givenUploadQuotaExceededThenUploadShouldCleanAtLeast50PercentSpace(): Unit = {
+    Range.inclusive(1, 10)
+      .foreach(_ => SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+        .block())
+
+    // Exceed 100 bytes limit
+    SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+      .block()
+
+    awaitAtMostTwoMinutes.untilAsserted(() =>
+      assertThat(SFlux(uploadRepository.listUploads(BOB))
+        .map(_.size.value)
+        .sum
+        .block())
+        .isLessThanOrEqualTo(UPLOAD_QUOTA_LIMIT / 2))
+  }
+
+  @Test
+  def givenUploadQuotaExceededThenUploadShouldNotCleanAllSpace(): Unit = {
+    Range.inclusive(1, 10)
+      .foreach(_ => SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+        .block())
+
+    // Exceed 100 bytes limit
+    SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+      .block()
+
+    awaitAtMostTwoMinutes.untilAsserted(() =>
+      assertThat(SFlux(uploadRepository.listUploads(BOB))
+        .map(_.size.value)
+        .sum
+        .block())
+        .isGreaterThan(0L))
+  }
+
+  @Test
+  def givenUploadQuotaExceededThenUploadShouldCleanOldestUploads(): Unit = {
+    val uploads: Seq[UploadMetaData] = SFlux.fromIterable(Range.inclusive(1, 10))
+      .concatMap(_ => SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB)))
+      .sort(Ordering.by[UploadMetaData, Instant](upload => upload.uploadDate))
+      .collectSeq()
+      .block()
+
+    // Exceed 100 bytes limit
+    SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+      .block()
+
+    // let the upload cleanup finish first
+    awaitAtMostTwoMinutes.untilAsserted(() => {
+      assertThat(SFlux(uploadRepository.listUploads(BOB))
+        .map(_.size.value)
+        .sum
+        .block())
+        .isLessThanOrEqualTo(UPLOAD_QUOTA_LIMIT / 2)
+    })
+
+    val remainingUploads: Seq[UploadMetaData] = SFlux(uploadRepository.listUploads(BOB)).sort(Ordering.by[UploadMetaData, Instant](_.uploadDate)).collectSeq().block()
+    val oldestRemainingUpload: UploadMetaData = remainingUploads.head
+    val deletedUploads: Seq[UploadMetaData] = uploads.filter(!remainingUploads.contains(_)).sorted(Ordering.by[UploadMetaData, Instant](_.uploadDate))
+    val newestDeletedUpload: UploadMetaData = deletedUploads.last
+
+    assertThat(oldestRemainingUpload.uploadDate).isAfterOrEqualTo(newestDeletedUpload.uploadDate)
+  }
+
+  @Test
+  def uploadShouldUpdateCurrentStoredUsageUponCleaningUploadSpace(): Unit = {
+    Range.inclusive(1, 10)
+      .foreach(_ => SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+        .block())
+
+    // Exceed 100 bytes limit
+    SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+      .block()
+
+    awaitAtMostTwoMinutes.untilAsserted(() =>
+      assertThat(SMono.fromPublisher(uploadUsageRepository.getSpaceUsage(BOB)).block().asLong())
+        .isLessThanOrEqualTo(UPLOAD_QUOTA_LIMIT / 2))
+  }
+
+  @Test
+  def givenQuotaExceededThenUploadShouldRepairInconsistentCurrentUsage(): Unit = {
+    Range.inclusive(1, 10)
+      .foreach(_ => SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+        .block())
+
+    // Try to make the current stored usage inconsistent
+    SMono(uploadUsageRepository.resetSpace(BOB, QuotaSizeUsage.size(105L))).block()
+
+    // Exceed 100 bytes limit
+    SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB)).block()
+
+    // The current stored usage should be eventually consistent
+    awaitAtMostTwoMinutes.untilAsserted(() => {
+      val currentStoredUsage: Long = SMono(uploadUsageRepository.getSpaceUsage(BOB))
+        .block()
+        .asLong()
+
+      val totalCurrentUsage: Long = SFlux(uploadRepository.listUploads(BOB))
+        .map(_.size.value)
+        .sum
+        .block()
+
+      assertThat(currentStoredUsage).isEqualTo(totalCurrentUsage)
+    })
+  }
+
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capability.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capability.scala
@@ -233,6 +233,19 @@ case class MaxMailboxesPerEmail(value: Option[UnsignedInt])
 case class MaxMailboxDepth(value: Option[UnsignedInt])
 case class MaxSizeMailboxName(value: UnsignedInt)
 case class MaxSizeAttachmentsPerEmail(value: UnsignedInt)
+
+object JmapUploadQuotaLimit {
+  def of(size: Size): Try[JmapUploadQuotaLimit] = refined.refineV[UnsignedIntConstraint](size.asBytes()) match {
+    case Right(value) => Success(JmapUploadQuotaLimit(value))
+    case Left(error) => Failure(new NumberFormatException(error))
+  }
+}
+
+case class JmapUploadQuotaLimit(value: UnsignedInt) {
+  def asLong(): Long = value.value
+}
+
+case class JmapUploadQuotaReadRepairProbability(value: Float)
 case class MayCreateTopLevelMailbox(value: Boolean) extends AnyVal
 
 final case class MailCapabilityProperties(maxMailboxesPerEmail: MaxMailboxesPerEmail,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/JmapRfc8621Configuration.scala
@@ -23,7 +23,7 @@ import java.net.URI
 import java.util.Optional
 
 import org.apache.commons.configuration2.Configuration
-import org.apache.james.jmap.core.JmapRfc8621Configuration.{MAX_SIZE_ATTACHMENTS_PER_MAIL_DEFAULT, UPLOAD_LIMIT_DEFAULT}
+import org.apache.james.jmap.core.JmapRfc8621Configuration.{JMAP_UPLOAD_QUOTA_LIMIT_DEFAULT, MAX_SIZE_ATTACHMENTS_PER_MAIL_DEFAULT, UPLOAD_LIMIT_DEFAULT}
 import org.apache.james.jmap.pushsubscription.PushClientConfiguration
 import org.apache.james.util.Size
 
@@ -40,6 +40,7 @@ object JmapConfigProperties {
   val DYNAMIC_JMAP_PREFIX_RESOLUTION_ENABLED_PROPERTY: String = "dynamic.jmap.prefix.resolution.enabled"
   val DELAY_SENDS_ENABLED: String = "delay.sends.enabled"
   val AUTHENTICATION_STRATEGIES: String = "authentication.strategy.rfc8621"
+  val JMAP_UPLOAD_QUOTA_LIMIT_PROPERTY: String = "upload.quota.limit"
 }
 
 object JmapRfc8621Configuration {
@@ -48,6 +49,7 @@ object JmapRfc8621Configuration {
   val WEBSOCKET_URL_PREFIX_DEFAULT: String = "ws://localhost"
   val UPLOAD_LIMIT_DEFAULT: MaxSizeUpload = MaxSizeUpload.of(Size.of(30L, Size.Unit.M)).get
   val MAX_SIZE_ATTACHMENTS_PER_MAIL_DEFAULT: MaxSizeAttachmentsPerEmail = MaxSizeAttachmentsPerEmail.of(Size.of(20_000_000L, Size.Unit.B)).get
+  val JMAP_UPLOAD_QUOTA_LIMIT_DEFAULT: JmapUploadQuotaLimit = JmapUploadQuotaLimit.of(Size.of(200L, Size.Unit.M)).get
 
   val LOCALHOST_CONFIGURATION: JmapRfc8621Configuration = JmapRfc8621Configuration(
     urlPrefixString = URL_PREFIX_DEFAULT,
@@ -68,6 +70,10 @@ object JmapRfc8621Configuration {
         .map(Size.parse)
         .map(MaxSizeAttachmentsPerEmail.of(_).get)
         .getOrElse(MAX_SIZE_ATTACHMENTS_PER_MAIL_DEFAULT),
+      jmapUploadQuotaLimit = Option(configuration.getString(JMAP_UPLOAD_QUOTA_LIMIT_PROPERTY, null))
+        .map(Size.parse)
+        .map(JmapUploadQuotaLimit.of(_).get)
+        .getOrElse(JMAP_UPLOAD_QUOTA_LIMIT_DEFAULT),
       maxTimeoutSeconds = Optional.ofNullable(configuration.getInteger(WEB_PUSH_MAX_TIMEOUT_SECONDS_PROPERTY, null)).map(Integer2int).toScala,
       maxConnections = Optional.ofNullable(configuration.getInteger(WEB_PUSH_MAX_CONNECTIONS_PROPERTY, null)).map(Integer2int).toScala,
       preventServerSideRequestForgery = Optional.ofNullable(configuration.getBoolean(WEB_PUSH_PREVENT_SERVER_SIDE_REQUEST_FORGERY, null)).orElse(true),
@@ -80,6 +86,7 @@ case class JmapRfc8621Configuration(urlPrefixString: String,
                                     supportsDelaySends: Boolean = false,
                                     maxUploadSize: MaxSizeUpload = UPLOAD_LIMIT_DEFAULT,
                                     maxSizeAttachmentsPerEmail: MaxSizeAttachmentsPerEmail = MAX_SIZE_ATTACHMENTS_PER_MAIL_DEFAULT,
+                                    jmapUploadQuotaLimit: JmapUploadQuotaLimit = JMAP_UPLOAD_QUOTA_LIMIT_DEFAULT,
                                     maxTimeoutSeconds: Option[Int] = None,
                                     maxConnections: Option[Int] = None,
                                     authenticationStrategies: Option[java.util.List[String]] = None,

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -67,8 +67,12 @@
                     <dd>Default value: ws://localhost</dd>
 
                     <dt><strong>upload.max.size</strong></dt>
-                    <dd>Optional. Configuration max size Upload in new JMAP-RFC-8621.</dd>
+                    <dd>Optional. Configuration max size for each upload file in new JMAP-RFC-8621.</dd>
                     <dd>Default value: 30M. Supported units are B (bytes) K (KB) M (MB) G (GB).</dd>
+
+                    <dt><strong>upload.quota.limit</strong></dt>
+                    <dd>Optional. Configure JMAP upload quota for total existing uploads' size per user. User exceeding the upload quota would result in old uploads being cleaned up.</dd>
+                    <dd>Default value: 200M. Supported units are B (bytes) K (KB) M (MB) G (GB).</dd>
 
                     <dt><strong>email.send.max.size</strong></dt>
                     <dd>Optional. Configuration max size for message created in both JMAP Draft amd RFC-8621.</dd>


### PR DESCRIPTION
resolve https://github.com/linagora/james-project/issues/4848

TODO:
- Try to use `Flux.window` for batch sorting to avoid OOM upon large upload lists
- Documentation
- ...