### PR TITLE
[DOCUMENTATION] Update outdated link, not found link

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/blobstore.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/blobstore.adoc
@@ -205,7 +205,7 @@ Default: file://var/blobExporting
 
 === LinShare Blob Export Configuration
 
-Instead of exporting blobs in local file system, using https://www.linshare.org/en/index.html[LinShare]
+Instead of exporting blobs in local file system, using https://www.linshare.org[LinShare]
 helps you upload your blobs and people you have been shared to can access those blobs by accessing to
 LinShare server and download them.
 

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/index.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/index.adoc
@@ -33,7 +33,7 @@ Except specific documented cases, these files are required, at least to establis
 ** xref:configure/cassandra.adoc[*cassandra.properties*] allows to configure the Cassandra driver link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/cassandra.properties[example]
 ** xref:configure/opensearch.adoc[*opensearch.properties*] allows to configure OpenSearch driver link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/opensearch.properties[example]
 ** xref:configure/rabbitmq.adoc[*rabbitmq.properties*] allows configuration for the RabbitMQ driver link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/rabbitmq.properties[example]
-** xref:configure/redis.adoc[*redis.properties*] allows configuration for the Redis driver link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/redis.properties[example], that is used by optional
+** xref:configure/redis.adoc[*redis.properties*] allows configuration for the Redis driver link:https://github.com/apache/james-project/blob/fabfdf4874da3aebb04e6fe4a7277322a395536a/server/mailet/rate-limiter-redis/redis.properties[example], that is used by optional
 distributed rate limiting component.
 ** xref:configure/tika.adoc[*tika.properties*] allows configuring Tika as a backend for text extraction link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/tika.properties[example]
 

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/redis.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/redis.adoc
@@ -3,7 +3,7 @@
 
 This configuration helps you configure components using Redis. This so far only includes optional rate limiting component.
 
-Consult this link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/redis.properties[example]
+Consult this link:https://github.com/apache/james-project/blob/fabfdf4874da3aebb04e6fe4a7277322a395536a/server/mailet/rate-limiter-redis/redis.properties[example]
 to get some examples and hints.
 
 == Redis Configuration

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/operate/guide.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/operate/guide.adoc
@@ -51,9 +51,9 @@ xref:operate/webadmin.adoc#_removing_a_mail_from_a_mail_repository[delete
 a single mail of a mail repository].
 
 Performance of mail processing can be monitored via the
-https://github.com/apache/james-project/blob/master/grafana-reporting/MAILET-1490071694187-dashboard.json[mailet
+https://github.com/apache/james-project/blob/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting/es-datasource/MAILET-1490071694187-dashboard.json[mailet
 grafana board] and
-https://github.com/apache/james-project/blob/master/grafana-reporting/MATCHER-1490071813409-dashboard.json[matcher
+https://github.com/apache/james-project/blob/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting/es-datasource/MATCHER-1490071813409-dashboard.json[matcher
 grafana board].
 
 === Recipient rewriting
@@ -90,9 +90,9 @@ link:config-listeners.html[here].
 Currently, an administrator can monitor listeners failures through
 `ERROR` log review. Metrics regarding mailbox listeners can be monitored
 via
-https://github.com/apache/james-project/blob/master/grafana-reporting/MailboxListeners-1528958667486-dashboard.json[mailbox_listeners
+https://github.com/apache/james-project/blob/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting/es-datasource/MailboxListeners-1528958667486-dashboard.json[mailbox_listeners
 grafana board] and
-https://github.com/apache/james-project/blob/master/grafana-reporting/MailboxListeners%20rate-1552903378376.json[mailbox_listeners_rate
+https://github.com/apache/james-project/blob/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting/es-datasource/MailboxListeners%20rate-1552903378376.json[mailbox_listeners_rate
 grafana board].
 
 Upon exceptions, a bounded number of retries are performed (with

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/operate/metrics.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/operate/metrics.adoc
@@ -14,7 +14,7 @@ We also support displaying them via https://grafana.com/[Grafana]. Two methods c
  
 == Expose metrics for Prometheus collection
 
-To enable James metrics, add ``extensions.routes`` to https://github.com/apache/james-project/blob/master/docs/modules/servers/pages/distributed/configure/webadmin.adoc[webadmin.properties] file:
+To enable James metrics, add ``extensions.routes`` to https://github.com/apache/james-project/blob/master/server/apps/distributed-app/docs/modules/ROOT/pages/configure/webadmin.adoc[webadmin.properties] file:
 ```
 extensions.routes=org.apache.james.webadmin.dropwizard.MetricsRoutes
 ```
@@ -171,7 +171,7 @@ Import the different dashboards you want.
 You then need to enable reporting through ElasticSearch. Modify your
 James ElasticSearch configuration file accordingly. To help you doing
 this, you can take a look to
-link:https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/elasticsearch.properties[elasticsearch.properties].
+link:https://github.com/apache/james-project/blob/3.7.x/server/apps/distributed-app/sample-configuration/elasticsearch.properties[elasticsearch.properties].
 
 If some metrics seem abnormally slow despite in depth database
 performance tuning, feedback is appreciated as well on the bug tracker,

--- a/server/apps/jpa-smtp-app/README.adoc
+++ b/server/apps/jpa-smtp-app/README.adoc
@@ -13,7 +13,7 @@ This server acts as a Mail Transfer Agent and do not embed the mailbox component
 To run james, you have to create a directory containing required configuration files.
 
 James requires the configuration to be in a subfolder of working directory that is called
-**conf**. A [sample directory](https://github.com/apache/james-project/tree/master/server/container/guice/jpa-smtp/sample-configuration)
+**conf**. A [sample directory](https://github.com/apache/james-project/tree/master/server/apps/jpa-smtp-app/sample-configuration)
 is provided with some default values you may need to replace. You will need to update its content to match your needs.
 
 You also need to generate a keystore with the following command:

--- a/server/grafana-reporting/prometheus-datasource/README.md
+++ b/server/grafana-reporting/prometheus-datasource/README.md
@@ -11,7 +11,7 @@ This is a collection of Grafana dashboards to display James metrics.
 
 ## Expose metrics for Prometheus collection
 
-To enable James metrics, add ``extensions.routes`` to [webadmin.properties]( https://github.com/apache/james-project/blob/master/docs/modules/servers/pages/distributed/configure/webadmin.adoc) file:
+To enable James metrics, add ``extensions.routes`` to [webadmin.properties]( https://github.com/apache/james-project/blob/master/server/apps/distributed-app/docs/modules/ROOT/pages/configure/webadmin.adoc) file:
 ```
 extensions.routes=org.apache.james.webadmin.dropwizard.MetricsRoutes
 ```

--- a/src/homepage/_posts/2016-02-09-jmap.markdown
+++ b/src/homepage/_posts/2016-02-09-jmap.markdown
@@ -14,4 +14,4 @@ It allows to develop easily a mail client in a browser, without the pain of usin
 Feel free to help us, you can see our advancement on the specification implementation into [jmap/doc][doc]
 
 [JMAP]: http://jmap.io
-[doc]: https://github.com/apache/james-project/tree/master/server/protocols/jmap/doc/specs
+[doc]: https://github.com/apache/james-project/tree/3.3.x/server/protocols/jmap/doc/specs

--- a/src/homepage/howTo/custom-listeners.html
+++ b/src/homepage/howTo/custom-listeners.html
@@ -80,20 +80,20 @@ layout: howTo
                 </p>
 
                 <header class="major">
-                    <h3><b>Use the custom BigMessageListener in James</b></h3>
+                    <h3><b>Use the custom SetCustomFlagOnBigMessages in James</b></h3>
                 </header>
 
                 <p>
                     Once you have a custom Listener, it's very simple to setup James with that Listener.
                     In this example, we will use the
-                    <a href="https://github.com/apache/james-project/blob/master/examples/custom-mailets/src/main/java/org/apache/james/examples/custom/listeners/BigMessageListener.java">BigMessageListener</a>
+                    <a href="https://github.com/apache/james-project/blob/master/examples/custom-listeners/src/main/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessages.java">SetCustomFlagOnBigMessages</a>
                     which will listen events fired after emails are appended to users mailboxes,
                     then for each email added event, determine the size of added email by getting size information from the event.
-                    If the size of the email is greater than or equals 1 MB, then BigMessageListener will add a "BIG_MESSAGE" flag to that email
+                    If the size of the email is greater than or equals 1 MB, then SetCustomFlagOnBigMessages will add a "BIG_MESSAGE" flag to that email
                 </p>
 
                 <header class="major">
-                    <h3><b>Starting James with BigMessageListener</b></h3>
+                    <h3><b>Starting James with SetCustomFlagOnBigMessages</b></h3>
                 </header>
 
                 <p>We will take the simplest James product(JPA Guice) for the example</p>
@@ -110,7 +110,7 @@ $ keytool -genkey -alias james -keyalg RSA -keystore conf/keystore
                 </code></pre>
 
                 <p>
-                    Second, modify listener.xml configuration file in conf/ directory to use only BigMessageListener
+                    Second, modify listener.xml configuration file in conf/ directory to use only SetCustomFlagOnBigMessages
                     by specifying its full class name. We only need to use this Listener in our example.
                 </p>
                 <pre><code>
@@ -232,7 +232,7 @@ A1 UID SEARCH ALL
 A1 FETCH 1 (FLAGS)
                 </code></pre>
                 <p>
-                    That's it, we are now sure that our BigMessageListener worked !
+                    That's it, we are now sure that our SetCustomFlagOnBigMessages worked !
                     Now that you have learned how to set up a custom Listener, you can follow this setup to add your own !
                 </p>
             </div>

--- a/src/homepage/howTo/custom-smtp-commands.html
+++ b/src/homepage/howTo/custom-smtp-commands.html
@@ -36,7 +36,7 @@ layout: howTo
                 </p>
 
                 <p>
-                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-smtp-commands">GitHub</a>.
+                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-imap">GitHub</a>.
                 </p>
 
                 <p>

--- a/src/homepage/howTo/custom-webadmin-routes.html
+++ b/src/homepage/howTo/custom-webadmin-routes.html
@@ -38,7 +38,7 @@ layout: howTo
                 </p>
 
                 <p>
-                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-webadmin-routes">GitHub</a>.
+                    Find this example on <a href="https://github.com/apache/james-project/tree/master/examples/custom-webadmin-route">GitHub</a>.
                 </p>
 
                 <p>

--- a/src/homepage/howTo/deleted-messages-vault.html
+++ b/src/homepage/howTo/deleted-messages-vault.html
@@ -231,7 +231,7 @@ retentionPeriod=1y
                     </li>
                     <li>
                         <b>linshare</b>: Instead of exporting blobs to the local file system, using
-                        <a href="https://www.linshare.org/en/index.html">LinShare</a> helps you upload your blobs and people
+                        <a href="https://www.linshare.org">LinShare</a> helps you upload your blobs and people
                         you have been sharing to can access those blobs by accessing the LinShare server and download them.
                     </li>
                 </ul>

--- a/src/homepage/howTo/mail-processing.html
+++ b/src/homepage/howTo/mail-processing.html
@@ -47,7 +47,7 @@ layout: howTo
           <p> Read <a href="/server/feature-mailetcontainer.html">this</a> for more explanations of mailet container concepts.</p>
 
           <p>Once we define the mailet container content through the <a href="/server/config-mailetcontainer.html">mailetcontailer.xml</a> file.
-          Hence, we can arrange James standard components listed <a href="/server/dev-provided-mailets.html">here</a> to achieve basic logic. But what if our goals are more
+          Hence, we can arrange James standard components listed <a href="/server/3/dev-provided-mailets.html">here</a> to achieve basic logic. But what if our goals are more
           complex? What if we need our own processing components?</p>
 
           <p>This page will propose a 'hands on practice' how-to using James 3.7.3. We will implement a custom mailet and a custom matcher,

--- a/src/site/markdown/server/install/guice-jpa-smtp.md
+++ b/src/site/markdown/server/install/guice-jpa-smtp.md
@@ -22,7 +22,7 @@ two artifacts into server/container/guice/jpa-smtp/target directory :
 
  To run james, you have to create a directory containing required configuration files names **conf**.
 
- A [sample directory](https://github.com/apache/james-project/tree/master/server/container/guice/jpa-smtp/sample-configuration) is provided with some default value you may need to replace.
+ A [sample directory](https://github.com/apache/james-project/tree/master/server/apps/jpa-smtp-app/sample-configuration) is provided with some default value you may need to replace.
 
 
 ## Running

--- a/src/site/markdown/server/manage-guice-distributed-james.md
+++ b/src/site/markdown/server/manage-guice-distributed-james.md
@@ -71,7 +71,7 @@ James keeps tracks of various metrics and allow to easily visualize them.
 
 Read this page for [explanations on metrics](metrics.html).
 
-Here is a list of [available metric boards](https://github.com/apache/james-project/tree/master/grafana-reporting)
+Here is a list of [available metric boards](https://github.com/apache/james-project/tree/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting)
 
 Monitoring these graphs on a regular basis allows diagnosing early some performance issues. 
 
@@ -154,8 +154,8 @@ Also, one can decide to
 or [delete a single mail of a mail repository](manage-webadmin.html#Removing_a_mail_from_a_mail_repository).
 
 Performance of mail processing can be monitored via the 
-[mailet grafana board](https://github.com/apache/james-project/blob/master/grafana-reporting/MAILET-1490071694187-dashboard.json) 
-and [matcher grafana board](https://github.com/apache/james-project/blob/master/grafana-reporting/MATCHER-1490071813409-dashboard.json).
+[mailet grafana board](https://github.com/apache/james-project/blob/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting/es-datasource/MAILET-1490071694187-dashboard.json) 
+and [matcher grafana board](https://github.com/apache/james-project/blob/fabfdf4874da3aebb04e6fe4a7277322a395536a/server/mailet/rate-limiter-redis/redis.properties).
 
 ## Mailbox Event Bus
 
@@ -192,8 +192,8 @@ You can get more information about those [here](config-listeners.html).
 
 Currently, an administrator can monitor listeners failures through `ERROR` log review. 
 Metrics regarding mailbox listeners can be monitored via
-[mailbox_listeners grafana board](https://github.com/apache/james-project/blob/master/grafana-reporting/MailboxListeners-1528958667486-dashboard.json) 
-and [mailbox_listeners_rate grafana board](https://github.com/apache/james-project/blob/master/grafana-reporting/MailboxListeners%20rate-1552903378376.json).
+[mailbox_listeners grafana board](https://github.com/apache/james-project/blob/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting/es-datasource/MailboxListeners-1528958667486-dashboard.json) 
+and [mailbox_listeners_rate grafana board](https://github.com/apache/james-project/blob/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting/es-datasource/MailboxListeners%20rate-1552903378376.json).
 
 Upon exceptions, a bounded number of retries are performed (with exponential backoff delays). 
 If after those retries the listener is still failing to perform its operation, then the event will be stored in the 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -185,7 +185,6 @@
                 <item name="Crypto Mailets" href="/mailet/crypto/index.html"/>
                 <item name="Mailet AI" href="/mailet/ai/index.html"/>
                 <item name="MailetDocs" href="/mailet/mailetdocs-maven-plugin/index.html"/>
-                <item name="Mailing Lists" href="/mail.html#Mailet_API_List" />
                 <item name="Release Notes" href="/mailet/release-notes.html"/>
                 <item name="Java Docs" href="/mailet/apidocs"/>
                 <item name="Issue Tracker" href="https://issues.apache.org/jira/browse/MAILET" />

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -164,7 +164,7 @@
                             <item name="SMTP Hook" href="/server/dev-extend-smtp-hook.html" />
                         </item>
                         <item name="Provided Extensions" href="/server/dev-provided.html" collapse="true" >
-                            <item name="Mailets" href="/server/dev-provided-mailets.html" />
+                            <item name="Mailets" href="/server/3/dev-provided-mailets.html" />
                             <item name="SMTP Hooks" href="/server/dev-provided-smtp-hooks.html" />
                         </item>
                     </item>

--- a/src/site/xdoc/server/config-blob-export.xml
+++ b/src/site/xdoc/server/config-blob-export.xml
@@ -62,7 +62,7 @@
       </subsection>
       <subsection name="LinShare Blob Export Configuration">
           <p>
-              Instead of exporting blobs in local file system, using <a href="https://www.linshare.org/en/index.html">LinShare</a> helps you upload your blobs and people
+              Instead of exporting blobs in local file system, using <a href="https://www.linshare.org">LinShare</a> helps you upload your blobs and people
               you have been shared to can access those blobs by accessing to LinShare server and download them.
 
               This way helps you to share via whole network as long as they can access to LinShare server.

--- a/src/site/xdoc/server/config-guice.xml
+++ b/src/site/xdoc/server/config-guice.xml
@@ -72,7 +72,7 @@
         <td></td>
       </tr>
       <tr>
-        <td><a href="https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/elasticsearch.properties">elasticsearch.properties</a></td>
+        <td><a href="https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/opensearch.properties">opensearch.properties</a></td>
         <td><a href="config-opensearch.html">OpenSearch Configuration</a></td>
         <td></td>
       </tr>

--- a/src/site/xdoc/server/config-redis.xml
+++ b/src/site/xdoc/server/config-redis.xml
@@ -33,7 +33,7 @@
           And it is only applicable with Guice products.
       </p>
       <p>
-          Consult <a href="https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration/redis.properties">redis.properties</a>
+          Consult <a href="https://github.com/apache/james-project/blob/fabfdf4874da3aebb04e6fe4a7277322a395536a/server/mailet/rate-limiter-redis/redis.properties">redis.properties</a>
           in GIT to get some examples and hints.
       </p>
 

--- a/src/site/xdoc/server/config.xml
+++ b/src/site/xdoc/server/config.xml
@@ -169,7 +169,7 @@
         <td></td>
       </tr>
       <tr>
-        <td><a href="https://github.com/apache/james-project/tree/master/server/apps/spring-app/src/main/resources/log4j.properties">log4j.properties</a></td>
+        <td><a href="https://github.com/apache/james-project/blob/087e8e13e13f868280e19b74b6a8f14f55c997d1/mailbox/spring/src/main/resources/log4j.properties">log4j.properties</a></td>
         <td>See <a href="monitor-logging.html">monitoring with log4j</a> section.</td>
         <td></td>
       </tr>

--- a/src/site/xdoc/server/dev-extend-matcher.xml
+++ b/src/site/xdoc/server/dev-extend-matcher.xml
@@ -149,7 +149,7 @@ After that restart james.
         <p>Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
             In order to do that:</p>
         <p> 1. Place the jar containing the guice module that should be used to instantiate your extensions within the /extensions-jars folder</p>
-        <p> 2. Register your module fully qualified class name within <a href="https://github.com/apache/james-project/blob/master/server/container/guice/memory-guice/sample-configuration/extensions.properties">
+        <p> 2. Register your module fully qualified class name within <a href="https://github.com/apache/james-project/blob/3.6.x/server/container/guice/memory-guice/sample-configuration/extensions.properties">
             extensions.properties</a> under the <code>guice.extension.module</code> key.</p>
     </subsection>
 

--- a/src/site/xdoc/server/dev-extend.xml
+++ b/src/site/xdoc/server/dev-extend.xml
@@ -81,7 +81,7 @@
         <ul>
             <li><a href="https://github.com/apache/james-project/blob/master/mailet/api/src/main/java/org/apache/mailet/Mailet.java">Mailets</a></li>
             <li><a href="https://github.com/apache/james-project/blob/master/mailet/api/src/main/java/org/apache/mailet/Matcher.java">Matchers</a></li>
-            <li><a href="https://github.com/apache/james-project/blob/master/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java">Mailbox Listeners</a></li>
+            <li><a href="https://github.com/apache/james-project/blob/master/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxEvents.java">Mailbox Events</a></li>
             <li><a href="https://github.com/apache/james-project/blob/master/mailbox/api/src/main/java/org/apache/james/mailbox/extension/PreDeletionHook.java">PreDeletion hooks</a></li>
             <li><a href="https://github.com/apache/james-project/blob/master/protocols/api/src/main/java/org/apache/james/protocols/api/handler/ProtocolHandler.java">Protocol handlers</a> (SMTP/LMTP/POP3)</li>
             <li><a href="https://github.com/apache/james-project/blob/master/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/Routes.java">Additional webAdmin routes</a></li>

--- a/src/site/xdoc/server/feature-performance.xml
+++ b/src/site/xdoc/server/feature-performance.xml
@@ -39,7 +39,7 @@
       <ul>
         <li>Testing main <a href="https://github.com/linagora/james-gatling">JMAP</a> commands</li>
         <li>Testing main <a href="https://github.com/linagora/gatling-imap">IMAP</a> commands</li>
-        <li>Testing basic <a href="https://github.com/linagora/james-gatling/tree/master/src/main/scala-2.11/org/apache/james/gatling/smtp">SMTP</a> scenarios</li>
+        <li>Testing basic <a href="https://github.com/linagora/james-gatling/tree/master/src/main/scala-2.13/org/apache/james/gatling/smtp">SMTP</a> scenarios</li>
       </ul>
 
       <img src="images/performances/gatling_2.png"/>
@@ -56,7 +56,7 @@
       <p> Additionally, we added metrics a bit everywhere in James using the brand new metrics API. We collect and export
         everything in OpenSearch using <a href="http://metrics.dropwizard.io/3.2.1/">Dropwizard metrics</a>. Then we
         graph it all using <a href="http://grafana.com/">Grafana</a>. This allows us to collect all statistics and percentiles.
-        Boards can be downloaded <a href="https://github.com/apache/james-project/tree/master/grafana-reporting">here</a>.</p>
+        Boards can be downloaded <a href="https://github.com/apache/james-project/tree/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting">here</a>.</p>
 
       <img src="images/performances/metrics.png"/>
 

--- a/src/site/xdoc/server/feature-security.xml
+++ b/src/site/xdoc/server/feature-security.xml
@@ -31,7 +31,7 @@
     
     <p>SMTP Auth and "Verify Identity" options are enabled when you install James (<a href="config-smtp-lmtp.html">read more</a>).</p>
 
-    <p>SMTP outgoing traffic can be transmitted via SSL by default. Check <a href="http://james.apache.org/server/dev-provided-mailets.html#RemoteDelivery">RemoteDelivery</a> documentation for
+    <p>SMTP outgoing traffic can be transmitted via SSL by default. Check <a href="https://james.apache.org/server/3/dev-provided-mailets.html#RemoteDelivery">RemoteDelivery</a> documentation for
     further explanations.</p>
 
   </section>

--- a/src/site/xdoc/server/metrics.xml
+++ b/src/site/xdoc/server/metrics.xml
@@ -51,7 +51,7 @@
         </section>
 
         <section name="Expose metrics for Prometheus collection">
-            <p>To enable James metrics, add <code>extensions.routes</code> to <a href="https://github.com/apache/james-project/blob/master/docs/modules/servers/pages/distributed/configure/webadmin.adoc">webadmin.properties</a> file:</p>
+            <p>To enable James metrics, add <code>extensions.routes</code> to <a href="https://github.com/apache/james-project/blob/master/server/apps/distributed-app/docs/modules/ROOT/pages/configure/webadmin.adoc">webadmin.properties</a> file:</p>
             <pre><code>extensions.routes=org.apache.james.webadmin.dropwizard.MetricsRoutes</code></pre>
 
             <p>Connect to james-admin url to test the result:</p>
@@ -90,7 +90,7 @@
                     <li>Pre-deletion hooks execution statistics time percentiles</li>
                 </ul>
 
-                Retrieve <a href="https://github.com/apache/james-project/tree/master/grafana-reporting">available boards</a> for Grafana.
+                Retrieve <a href="https://github.com/apache/james-project/tree/d2cf7c8e229d9ed30125871b3de5af3cb1553649/server/grafana-reporting">available boards</a> for Grafana.
             </p>
 
             <img src="images/performances/metrics.png"/>

--- a/src/site/xdoc/server/monitor-logging.xml
+++ b/src/site/xdoc/server/monitor-logging.xml
@@ -87,7 +87,7 @@ drwxrwxrwx. 7 root root   4096 2010-11-06 09:01 ../
 -rw-r--r--. 1 root root     71 2010-11-06 09:24 usersrepository.log
 </source>
 
-      <p>Consult <a href="https://github.com/apache/james-project/tree/master/server/apps/spring-app/src/main/resources/log4j.properties">log4j.properties</a> in GIT to get some examples and hints.</p>
+      <p>Consult <a href="https://github.com/apache/james-project/blob/087e8e13e13f868280e19b74b6a8f14f55c997d1/mailbox/spring/src/main/resources/log4j.properties">log4j.properties</a> in GIT to get some examples and hints.</p>
 
       <p>You can rise the logging level on protocols.</p>
       <p>Set log4j.logger.james.smtpserver=DEBUG, SMTPSERVER</p>

--- a/src/site/xdoc/server/packaging.xml
+++ b/src/site/xdoc/server/packaging.xml
@@ -37,15 +37,15 @@
             <p>Thus, one must carefully choose his packaging.</p>
 
             <ul>To help you doing this, here is a list of available packages:
-                <li><a href="https://github.com/apache/james-project/tree/master/server/app">Spring</a>: Allows you to
+                <li><a href="https://github.com/apache/james-project/tree/master/server/apps/spring-app">Spring</a>: Allows you to
                     choose across various available implementations for each component. Requires more configuration effort.</li>
-                <li><a href="https://github.com/apache/james-project/tree/master/server/container/guice/cassandra-guice">
+                <li><a href="https://github.com/apache/james-project/tree/master/server/apps/cassandra-app">
                     Cassandra-guice</a>: Ships a James server storing emails in Cassandra and index them in OpenSearch targeting single server deployment. Optional support for LDAP authentication.</li>
-                <li><a href="https://github.com/apache/james-project/tree/master/server/container/guice/cassandra-rabbitmq-guice">
+                <li><a href="https://github.com/apache/james-project/tree/master/server/apps/distributed-app">
                     Distributed: cassandra-rabbitmq-guice</a>: Ships a James server storing emails in Cassandra and index them in OpenSearch targeting multi node deployments. S3 is used to store blobs. RabbitMQ is used for inter-node messaging. Optional support for LDAP authentication.</li>
-                <li><a href="https://github.com/apache/james-project/tree/master/server/container/guice/jpa-guice">
+                <li><a href="https://github.com/apache/james-project/tree/master/server/apps/jpa-app">
                     Jpa-Guice</a>: Ships a James server storing emails in a SQL database (derby by default) accessed with JPA and Lucene to index emails and targets single node deployment.</li>
-                <li><a href="https://github.com/apache/james-project/tree/master/server/container/guice/jpa-smtp">
+                <li><a href="https://github.com/apache/james-project/tree/master/server/apps/jpa-smtp-app">
                     Jpa-Smtp</a>: A tiny SMTP server shiped without mailbox, using SQL database to store data, accessed by JPA.</li>
             </ul>
 


### PR DESCRIPTION
When I use [siteinspector](https://github.com/siteinspector/siteinspector) to scan dead links of https://james.apache.org/, I get a lot of results. A lot of them were published a long time ago (since 2009...)
In this PR, I just updated the link that I found a new

Here is a full not-found link list
[notFound.csv](https://github.com/apache/james-project/files/12557244/notFound.csv)
