### PR TITLE
JAMES-3135 blob_cache table needs to use STCS

### DIFF
--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CassandraBlobCacheModule.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CassandraBlobCacheModule.java
@@ -27,7 +27,6 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
-import com.datastax.oss.driver.api.querybuilder.schema.compaction.TimeWindowCompactionStrategy;
 
 public interface CassandraBlobCacheModule {
 
@@ -35,9 +34,8 @@ public interface CassandraBlobCacheModule {
         .builder()
         .table(TABLE_NAME)
         .options(options -> options
-            .withCompaction(SchemaBuilder.timeWindowCompactionStrategy()
-                .withCompactionWindow(1, TimeWindowCompactionStrategy.CompactionWindowUnit.HOURS))
-            .withCompression("LZ4Compressor", 8, 1.0)) // todo check
+            .withCompaction(SchemaBuilder.sizeTieredCompactionStrategy())
+            .withCompression("LZ4Compressor", 8, 1.0))
         .comment("Write through cache for small blobs stored in a slower blob store implementation.")
         .statement(statement ->  types -> statement
             .withPartitionKey(ID, DataTypes.TEXT)

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -23,6 +23,18 @@ Change list:
  - [Drop Legacy Cassandra migrations](#drop-legacy-cassandra-migrations)
  - [Improve CassandraThreadIdGuessingAlgorithm](#improve-cassandrathreadidguessingalgorithm)
  - [Set up TTL on the mailbox_change and email_change tables](#set-up-ttl-on-the-mailboxchange-and-emailchange-tables)
+ - [Change compaction strategy of blob_cache table](#change-compaction-strategy-of-blobcache-table)
+
+
+### Change compaction strategy of blob_cache table
+Date: 18/09/2023
+
+To decrease the pressure on the Cassandra server.
+The`blob_cache` table needs to use STCS instead of TWCS compaction strategy.
+
+```
+ALTER TABLE james_keyspace.blob_cache WITH compaction = { 'class' :  'SizeTieredCompactionStrategy'  };
+```
 
 ### Set up TTL on the mailbox_change and email_change tables
 Date: 15/09/2023


### PR DESCRIPTION
- The use of TWCS creates MANY small SSTABLE and puts a lot of pressure on the Cassandra server.