### PR TITLE
[JAMES-3943] fix package pulsar smtp docker image with jib

### DIFF
--- a/server/apps/scaling-pulsar-smtp/pom.xml
+++ b/server/apps/scaling-pulsar-smtp/pom.xml
@@ -323,10 +323,6 @@
                                 <into>/root/conf</into>
                             </path>
                             <path>
-                                <from>docker-configuration</from>
-                                <into>/root/conf</into>
-                            </path>
-                            <path>
                                 <from>src/main/scripts</from>
                                 <into>/usr/bin</into>
                             </path>


### PR DESCRIPTION
docker-configuration folder does not exists, was making the docker build with Jib failing for pulsar smtp module.

cc @jeantil :)