### PR TITLE
JAMES-3925 Enforce quota for JMAP uploads - fix the unstable test

### DIFF
--- a/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/upload/UploadServiceContract.scala
+++ b/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/upload/UploadServiceContract.scala
@@ -35,6 +35,8 @@ import org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS
 import org.junit.jupiter.api.Test
 import reactor.core.scala.publisher.{SFlux, SMono}
 
+import scala.concurrent.duration.MICROSECONDS
+
 object UploadServiceContract {
   private lazy val UPLOAD_QUOTA_LIMIT: Long = 100L
   lazy val TEST_CONFIGURATION: JmapUploadQuotaConfiguration = new JmapUploadQuotaConfiguration(UPLOAD_QUOTA_LIMIT)
@@ -183,6 +185,7 @@ trait UploadServiceContract {
   def givenQuotaExceededThenUploadShouldRepairInconsistentCurrentUsage(): Unit = {
     Range.inclusive(1, 10)
       .foreach(_ => SMono.fromPublisher(testee.upload(asInputStream(TEN_BYTES_DATA_STRING), CONTENT_TYPE, BOB))
+        .delayElement(scala.concurrent.duration.Duration(200, MICROSECONDS))
         .block())
 
     // Try to make the current stored usage inconsistent


### PR DESCRIPTION
Fix CI unstable 
```
givenQuotaExceededThenUploadShouldRepairInconsistentCurrentUsage – org.apache.james.jmap.memory.upload.InMemoryUploadServiceTest

Assertion condition defined as a lambda expression in org.apache.james.jmap.api.upload.UploadServiceContract 
expected: 50L
 but was: 40L within 2 minutes.
```

before
![image](https://github.com/apache/james-project/assets/81145350/2f12f7e9-ae11-45dc-9490-e103aa47a47a)

after
![image](https://github.com/apache/james-project/assets/81145350/ca2a60aa-aa40-4977-9332-567cfddd42ca)
