### PR TITLE
JAMES-3948 FIX virtual users should not be listed

### DIFF
--- a/server/container/guice/data-cassandra/src/main/java/org/apache/james/modules/data/CassandraDelegationStoreModule.java
+++ b/server/container/guice/data-cassandra/src/main/java/org/apache/james/modules/data/CassandraDelegationStoreModule.java
@@ -41,6 +41,7 @@ public class CassandraDelegationStoreModule extends AbstractModule {
     @Override
     public void configure() {
         bind(DelegationStore.class).to(CassandraDelegationStore.class);
+        bind(CassandraDelegationStore.UserExistencePredicate.class).to(CassandraDelegationStore.UserExistencePredicateImplementation.class);
         bind(Authorizator.class).to(DelegationStoreAuthorizator.class);
         Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
         cassandraDataDefinitions.addBinding().toInstance(org.apache.james.user.cassandra.CassandraUsersRepositoryModule.MODULE);

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraDelegationStore.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraDelegationStore.java
@@ -20,12 +20,13 @@
 package org.apache.james.user.cassandra;
 
 import javax.inject.Inject;
-import reactor.core.publisher.Mono;
 
 import org.apache.james.core.Username;
 import org.apache.james.user.api.DelegationStore;
 import org.apache.james.user.api.UsersRepository;
 import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
 
 public class CassandraDelegationStore implements DelegationStore {
     public interface UserExistencePredicate {

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
@@ -52,7 +52,6 @@ import org.reactivestreams.Publisher;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.BatchType;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
@@ -199,21 +199,18 @@ public class CassandraUsersDAO implements UsersDAO {
         }
     }
 
-    public Mono<Void> addAuthorizedUsers(Username baseUser, Username userWithAccess) {
-        return exist(userWithAccess)
-            .flatMap(targetUserExists -> {
-                BatchStatementBuilder batchBuilder = new BatchStatementBuilder(BatchType.LOGGED);
-                batchBuilder.addStatement(addAuthorizedUsersStatement.bind()
-                    .setString(NAME, baseUser.asString())
-                    .setSet(AUTHORIZED_USERS, ImmutableSet.of(userWithAccess.asString()), String.class));
-                if (targetUserExists) {
-                    batchBuilder.addStatement(addDelegatedToUsersStatement.bind()
-                        .setString(NAME, userWithAccess.asString())
-                        .setSet(DELEGATED_USERS, ImmutableSet.of(baseUser.asString()), String.class));
-                }
+    public Mono<Void> addAuthorizedUsers(Username baseUser, Username userWithAccess, boolean targetUserExists) {
+        BatchStatementBuilder batchBuilder = new BatchStatementBuilder(BatchType.LOGGED);
+        batchBuilder.addStatement(addAuthorizedUsersStatement.bind()
+            .setString(NAME, baseUser.asString())
+            .setSet(AUTHORIZED_USERS, ImmutableSet.of(userWithAccess.asString()), String.class));
+        if (targetUserExists) {
+            batchBuilder.addStatement(addDelegatedToUsersStatement.bind()
+                .setString(NAME, userWithAccess.asString())
+                .setSet(DELEGATED_USERS, ImmutableSet.of(baseUser.asString()), String.class));
+        }
 
-                return executor.executeVoid(batchBuilder.build());
-            });
+        return executor.executeVoid(batchBuilder.build());
     }
 
     public Mono<Void> removeAuthorizedUser(Username baseUser, Username userWithAccess) {

--- a/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/user/cassandra/CassandraUsersDAO.java
@@ -201,16 +201,20 @@ public class CassandraUsersDAO implements UsersDAO {
     }
 
     public Mono<Void> addAuthorizedUsers(Username baseUser, Username userWithAccess) {
-        BatchStatementBuilder batchBuilder = new BatchStatementBuilder(BatchType.LOGGED);
-        BoundStatement addAuthorizedStatement = addAuthorizedUsersStatement.bind()
-            .setString(NAME, baseUser.asString())
-            .setSet(AUTHORIZED_USERS, ImmutableSet.of(userWithAccess.asString()), String.class);
-        batchBuilder.addStatement(addAuthorizedStatement);
-        batchBuilder.addStatement(addDelegatedToUsersStatement.bind()
-            .setString(NAME, userWithAccess.asString())
-            .setSet(DELEGATED_USERS, ImmutableSet.of(baseUser.asString()), String.class));
+        return exist(userWithAccess)
+            .flatMap(targetUserExists -> {
+                BatchStatementBuilder batchBuilder = new BatchStatementBuilder(BatchType.LOGGED);
+                batchBuilder.addStatement(addAuthorizedUsersStatement.bind()
+                    .setString(NAME, baseUser.asString())
+                    .setSet(AUTHORIZED_USERS, ImmutableSet.of(userWithAccess.asString()), String.class));
+                if (targetUserExists) {
+                    batchBuilder.addStatement(addDelegatedToUsersStatement.bind()
+                        .setString(NAME, userWithAccess.asString())
+                        .setSet(DELEGATED_USERS, ImmutableSet.of(baseUser.asString()), String.class));
+                }
 
-        return executor.executeVoid(batchBuilder.build());
+                return executor.executeVoid(batchBuilder.build());
+            });
     }
 
     public Mono<Void> removeAuthorizedUser(Username baseUser, Username userWithAccess) {

--- a/server/data/data-cassandra/src/test/java/org/apache/james/user/cassandra/CassandraDelegationStoreTest.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/user/cassandra/CassandraDelegationStoreTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class CassandraDelegationStoreTest implements DelegationStoreContract {
@@ -43,7 +42,7 @@ public class CassandraDelegationStoreTest implements DelegationStoreContract {
     @BeforeEach
     void setUp() {
         cassandraUsersDAO = new CassandraUsersDAO(cassandraCluster.getCassandraCluster().getConf());
-        testee = new CassandraDelegationStore(cassandraUsersDAO);
+        testee = new CassandraDelegationStore(cassandraUsersDAO, any -> Mono.just(true));
     }
 
     @Override
@@ -62,6 +61,7 @@ public class CassandraDelegationStoreTest implements DelegationStoreContract {
 
     @Test
     void virtualUsersShouldNotBeListed() {
+        testee = new CassandraDelegationStore(cassandraUsersDAO, any -> Mono.just(false));
         addUser(BOB);
 
         Mono.from(testee().addAuthorizedUser(ALICE).forUser(BOB)).block();


### PR DESCRIPTION
Those are only authorizedAccesses,
authenticated through other means (OIDC,
certificates) that do not correspond to an
actual user (no mails of their own). They
only access mails of others.

Cassandra partial row for keeping track
which users we have access to causes James
to mistakenly list those entries into local
users.