### PR TITLE
JAMES-3944 FILTER: forward loop issue

### DIFF
--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/mailet/api/src/main/java/org/apache/mailet/LoopPrevention.java
+++ b/mailet/api/src/main/java/org/apache/mailet/LoopPrevention.java
@@ -1,0 +1,109 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.apache.james.core.MailAddress;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+public class LoopPrevention {
+    public static class RecordedRecipients {
+        public static final RecordedRecipients NO_RECORDED_RECIPIENTS = new RecordedRecipients(ImmutableSet.of());
+
+        public static RecordedRecipients fromMail(Mail mail) {
+            return mail.getAttribute(RECORDED_RECIPIENTS_ATTRIBUTE_NAME)
+                .map(RecordedRecipients::fromAttribute)
+                .orElse(NO_RECORDED_RECIPIENTS);
+        }
+
+        public static RecordedRecipients fromAttribute(Attribute attribute) {
+            Collection<AttributeValue> attributeValues = (Collection<AttributeValue>) attribute.getValue().getValue();
+            return new RecordedRecipients(attributeValues
+                .stream()
+                .map(Throwing.function(attributeValue -> new MailAddress((String) attributeValue.getValue())))
+                .collect(ImmutableSet.toImmutableSet()));
+        }
+
+        private final Set<MailAddress> recipients;
+
+        public RecordedRecipients(Set<MailAddress> recipients) {
+            this.recipients = recipients;
+        }
+
+        public RecordedRecipients(MailAddress... recipients) {
+            this.recipients = ImmutableSet.copyOf(recipients);
+        }
+
+        public Set<MailAddress> getRecipients() {
+            return recipients;
+        }
+
+        public Set<MailAddress> nonRecordedRecipients(Collection<MailAddress> recipients) {
+            return Sets.difference(ImmutableSet.copyOf(recipients), this.recipients);
+        }
+
+        public Set<MailAddress> nonRecordedRecipients(MailAddress... recipients) {
+            return Sets.difference(ImmutableSet.copyOf(recipients), this.recipients);
+        }
+
+        public RecordedRecipients merge(RecordedRecipients other) {
+            return new RecordedRecipients(ImmutableSet.<MailAddress>builder()
+                .addAll(recipients)
+                .addAll(other.recipients)
+                .build());
+        }
+
+        public RecordedRecipients merge(Collection<MailAddress> other) {
+            return merge(new RecordedRecipients(ImmutableSet.copyOf(other)));
+        }
+
+        public RecordedRecipients merge(MailAddress... other) {
+            return merge(ImmutableSet.copyOf(other));
+        }
+
+        public RecordedRecipients mergeIfEmpty(MailAddress... other) {
+            if (recipients.isEmpty()) {
+                return merge(ImmutableSet.copyOf(other));
+            } else {
+                return this;
+            }
+        }
+
+        public Attribute asAttribute() {
+            return new Attribute(RECORDED_RECIPIENTS_ATTRIBUTE_NAME,
+                AttributeValue.of(recipients.stream()
+                    .map(mailAddress -> AttributeValue.of(mailAddress.asString()))
+                    .collect(ImmutableList.toImmutableList())));
+        }
+
+        public void recordOn(Mail mail) {
+            mail.setAttribute(asAttribute());
+        }
+    }
+
+    public static final AttributeName RECORDED_RECIPIENTS_ATTRIBUTE_NAME = AttributeName.of("loop.prevention.recorded.recipients");
+
+}

--- a/mailet/api/src/test/java/org/apache/mailet/LoopPreventionTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/LoopPreventionTest.java
@@ -1,0 +1,90 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import static org.apache.mailet.LoopPrevention.RECORDED_RECIPIENTS_ATTRIBUTE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class LoopPreventionTest {
+
+    public static final String DEFAULT_DOMAIN = "james.org";
+    private static final Username ALICE = Username.of("alice@" + DEFAULT_DOMAIN);
+    private static final Username BOB = Username.of("bob@" + DEFAULT_DOMAIN);
+    private static final Username CEDRIC = Username.of("cedric@" + DEFAULT_DOMAIN);
+
+    @Test
+    void nonRecordedRecipientsShouldWork() throws Exception {
+        assertThat(new LoopPrevention.RecordedRecipients(BOB.asMailAddress())
+            .nonRecordedRecipients(ALICE.asMailAddress(), BOB.asMailAddress()))
+            .containsOnly(ALICE.asMailAddress());
+    }
+
+    @Test
+    void recordedRecipientsShouldWork() throws Exception {
+        Mail mail = mock(Mail.class);
+
+        new LoopPrevention.RecordedRecipients(ALICE.asMailAddress(), BOB.asMailAddress())
+            .merge(CEDRIC.asMailAddress())
+            .recordOn(mail);
+
+        Attribute attribute = new Attribute(RECORDED_RECIPIENTS_ATTRIBUTE_NAME,
+            AttributeValue.of(ImmutableList.of(AttributeValue.of(ALICE.asString()),
+                AttributeValue.of(BOB.asString()),
+                AttributeValue.of(CEDRIC.asString()))));
+
+        verify(mail).setAttribute(attribute);
+    }
+
+    @Test
+    void fromMailShouldRetrieveRecordedRecipients() throws Exception {
+        Mail mail = mock(Mail.class);
+
+        Attribute attribute = new Attribute(RECORDED_RECIPIENTS_ATTRIBUTE_NAME,
+            AttributeValue.of(ImmutableList.of(AttributeValue.of(ALICE.asString()))));
+
+        when(mail.getAttribute(RECORDED_RECIPIENTS_ATTRIBUTE_NAME))
+            .thenReturn(Optional.of(attribute));
+
+        assertThat(LoopPrevention.RecordedRecipients.fromMail(mail).getRecipients())
+            .containsOnly(ALICE.asMailAddress());
+    }
+
+    @Test
+    void retrieveRecordedRecipientsShouldReturnEmptyWhenTheAttributeDoesNotExist() {
+        Mail mail =  mock(Mail.class);
+
+        when(mail.getAttribute(RECORDED_RECIPIENTS_ATTRIBUTE_NAME))
+            .thenReturn(Optional.empty());
+
+        assertThat(LoopPrevention.RecordedRecipients.fromMail(mail).getRecipients())
+            .isEmpty();
+    }
+
+}

--- a/server/container/guice/common/src/main/java/org/apache/james/utils/FilteringManagementProbeImpl.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/FilteringManagementProbeImpl.java
@@ -20,6 +20,7 @@
 package org.apache.james.utils;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
@@ -27,6 +28,8 @@ import org.apache.james.core.Username;
 import org.apache.james.jmap.api.filtering.FilteringManagement;
 import org.apache.james.jmap.api.filtering.Rule;
 import org.apache.james.jmap.api.filtering.Version;
+
+import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 
@@ -41,5 +44,12 @@ public class FilteringManagementProbeImpl implements GuiceProbe {
 
     public void defineRulesForUser(Username username, Optional<Version> ifInState, Rule... rules) {
         Mono.from(filteringManagement.defineRulesForUser(username, ifInState, rules)).block();
+    }
+
+    public void defineRulesForUser(Username username, Rule.Builder... rules) {
+        Optional<Version> noVersion = Optional.empty();
+        Mono.from(filteringManagement.defineRulesForUser(username, Stream.of(rules)
+            .map(Rule.Builder::build)
+            .collect(ImmutableList.toImmutableList()), noVersion)).block();
     }
 }

--- a/server/container/guice/common/src/main/java/org/apache/james/utils/MailRepositoryProbeImpl.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/MailRepositoryProbeImpl.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
+import org.apache.james.core.MailAddress;
 import org.apache.james.mailrepository.api.MailKey;
 import org.apache.james.mailrepository.api.MailRepositoryStore;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
@@ -62,6 +63,11 @@ public class MailRepositoryProbeImpl implements GuiceProbe {
         return listMailKeys(url)
             .stream()
             .map(Throwing.function(key -> getMail(url, key)));
+    }
+
+    public List<Mail> listMails(MailRepositoryUrl url, MailAddress recipient) throws Exception {
+        return listMails(url).filter(Throwing.predicate(mail -> mail.getRecipients().contains(recipient)))
+            .collect(ImmutableList.toImmutableList());
     }
 
     public Mail getMail(MailRepositoryUrl url, MailKey key) throws Exception {

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/RuleDTO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/filtering/RuleDTO.java
@@ -200,10 +200,10 @@ public class RuleDTO {
             }
 
             public Rule.Action.Forward toForward() {
-                return Rule.Action.Forward.of(addresses.stream()
-                        .map(Throwing.function(MailAddress::new))
-                        .collect(ImmutableList.toImmutableList()),
-                    keepACopy);
+                return Rule.Action.Forward.to(addresses.stream()
+                    .map(Throwing.function(MailAddress::new))
+                    .collect(ImmutableList.toImmutableList()))
+                    .keepACopy(keepACopy);
             }
 
             @Override

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
@@ -41,11 +41,11 @@ public interface RuleFixture {
         true,
         true,
         ImmutableList.of("abc"),
-        Optional.of(Rule.Action.Forward.of(ImmutableList.of("abc@example.com")
+        Optional.of(Rule.Action.Forward.to(ImmutableList.of("abc@example.com")
                 .stream()
                 .map(Throwing.function(MailAddress::new))
-                .collect(ImmutableList.toImmutableList()),
-            true)));
+                .collect(ImmutableList.toImmutableList()))
+            .keepACopy()));
     Rule.Builder RULE_BUILDER = Rule.builder().name(NAME).conditionGroup(CONDITION).action(ACTION);
     Rule RULE_1 = RULE_BUILDER.id(Rule.Id.of("1")).build();
     Rule RULE_1_MODIFIED = Rule.builder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/ForwardLoopIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/ForwardLoopIntegrationTest.java
@@ -1,0 +1,238 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets;
+
+import static org.apache.james.jmap.api.filtering.Rule.Condition.Comparator.NOT_CONTAINS;
+import static org.apache.james.jmap.api.filtering.Rule.Condition.Field.FROM;
+import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
+import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
+import static org.apache.james.mailets.configuration.Constants.PASSWORD;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.james.core.Username;
+import org.apache.james.jmap.api.filtering.Rule;
+import org.apache.james.jmap.api.filtering.Rule.Action;
+import org.apache.james.jmap.api.filtering.Rule.Action.Forward;
+import org.apache.james.jmap.mailet.filter.JMAPFiltering;
+import org.apache.james.mailets.configuration.CommonProcessors;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.MailetContainer;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.rrt.lib.Mapping;
+import org.apache.james.rrt.lib.MappingSource;
+import org.apache.james.transport.mailets.RecipientRewriteTable;
+import org.apache.james.transport.mailets.ToRepository;
+import org.apache.james.transport.matchers.All;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.FilteringManagementProbeImpl;
+import org.apache.james.utils.GuiceProbe;
+import org.apache.james.utils.MailRepositoryProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.SpoolerProbe;
+import org.apache.mailet.Mail;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.multibindings.Multibinder;
+
+public class ForwardLoopIntegrationTest {
+
+    private static final Username SENDER = Username.of("sender@" + DEFAULT_DOMAIN);
+    private static final Username ALICE = Username.of("alice@" + DEFAULT_DOMAIN);
+    private static final Username BOB = Username.of("bob@" + DEFAULT_DOMAIN);
+    private static final Username CEDRIC = Username.of("cedric@" + DEFAULT_DOMAIN);
+    private static final MailRepositoryUrl CUSTOM_REPOSITORY = MailRepositoryUrl.from("memory://var/mail/custom/");
+    public static final Rule.ConditionGroup CONDITION_GROUP = Rule.ConditionGroup.of(Rule.ConditionCombiner.AND, Rule.Condition.of(FROM, NOT_CONTAINS, "AAA"));
+
+    private static Rule.Builder asRule(Action.Forward forward) {
+        return Rule.builder()
+            .id(Rule.Id.of("1"))
+            .name("rule 1")
+            .conditionGroup(CONDITION_GROUP)
+            .action(Action.builder().setForward(forward));
+    }
+
+    private TemporaryJamesServer jamesServer;
+    private FilteringManagementProbeImpl filteringManagementProbe;
+    private MailRepositoryProbeImpl mailRepositoryProbe;
+
+    @RegisterExtension
+    public SMTPMessageSender messageSender = new SMTPMessageSender(DEFAULT_DOMAIN);
+    private DataProbeImpl dataProbe;
+
+    @BeforeEach
+    void setup(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withOverrides(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class).addBinding().to(FilteringManagementProbeImpl.class))
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(ProcessorConfiguration.root()
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(RecipientRewriteTable.class))
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(JMAPFiltering.class))
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(ToRepository.class)
+                        .addProperty("repositoryPath", CUSTOM_REPOSITORY.asString())))
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(CommonProcessors.transport())
+                .putProcessor(CommonProcessors.bounces()))
+            .build(temporaryFolder);
+
+        jamesServer.start();
+
+        dataProbe = jamesServer.getProbe(DataProbeImpl.class);
+        dataProbe.addDomain(DEFAULT_DOMAIN);
+
+        dataProbe.addUser(SENDER.asString(), PASSWORD);
+        dataProbe.addUser(ALICE.asString(), PASSWORD);
+        dataProbe.addUser(BOB.asString(), PASSWORD);
+        dataProbe.addUser(CEDRIC.asString(), PASSWORD);
+
+        mailRepositoryProbe = jamesServer.getProbe(MailRepositoryProbeImpl.class);
+
+        filteringManagementProbe = jamesServer.getProbe(FilteringManagementProbeImpl.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jamesServer.shutdown();
+    }
+
+    @Test
+    void filterForwardShouldNotCreateLoopError() throws Exception {
+        filteringManagementProbe.defineRulesForUser(ALICE, asRule(Forward.to(BOB.asMailAddress()).withoutACopy()));
+        filteringManagementProbe.defineRulesForUser(BOB, asRule(Forward.to(CEDRIC.asMailAddress()).withoutACopy()));
+        filteringManagementProbe.defineRulesForUser(CEDRIC, asRule(Forward.to(ALICE.asMailAddress()).withoutACopy()));
+
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER.asString(), PASSWORD)
+            .sendMessage(SENDER.asString(), ALICE.asString());
+
+        Awaitility.await().until(() -> jamesServer.getProbe(SpoolerProbe.class).processingFinished());
+        Awaitility.await().until(() -> mailRepositoryProbe.getRepositoryMailCount(CUSTOM_REPOSITORY) == 1L);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            List<Mail> mails = mailRepositoryProbe.listMails(CUSTOM_REPOSITORY)
+                .collect(ImmutableList.toImmutableList());
+
+            softly.assertThat(mails.get(0).getRecipients()).containsOnly(CEDRIC.asMailAddress());
+        }));
+    }
+
+    @Test
+    void filterForwardShouldNotCreateLoopErrorAndKeepEmailForUserWhoWantToKeepACopy() throws Exception {
+        filteringManagementProbe.defineRulesForUser(ALICE, asRule(Forward.to(BOB.asMailAddress()).keepACopy()));
+        filteringManagementProbe.defineRulesForUser(BOB, asRule(Forward.to(CEDRIC.asMailAddress()).withoutACopy()));
+        filteringManagementProbe.defineRulesForUser(CEDRIC, asRule(Forward.to(ALICE.asMailAddress()).withoutACopy()));
+
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER.asString(), PASSWORD)
+            .sendMessage(SENDER.asString(), ALICE.asString());
+
+        Awaitility.await().until(() -> jamesServer.getProbe(SpoolerProbe.class).processingFinished());
+        Awaitility.await().until(() -> mailRepositoryProbe.getRepositoryMailCount(CUSTOM_REPOSITORY) == 2L);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            List<Mail> mailListOne = mailRepositoryProbe.listMails(CUSTOM_REPOSITORY, ALICE.asMailAddress());
+            softly.assertThat(mailListOne.get(0).getRecipients()).containsOnly(ALICE.asMailAddress());
+
+            List<Mail> mailListTwo = mailRepositoryProbe.listMails(CUSTOM_REPOSITORY, CEDRIC.asMailAddress());
+            softly.assertThat(mailListTwo.get(0).getRecipients()).containsOnly(CEDRIC.asMailAddress());
+        }));
+    }
+
+    @Test
+    void regularForwardShouldNotCreateLoopError() throws Exception {
+        dataProbe.addMapping(MappingSource.fromUser(ALICE), Mapping.forward(BOB.asString()));
+        dataProbe.addMapping(MappingSource.fromUser(BOB), Mapping.forward(CEDRIC.asString()));
+        dataProbe.addMapping(MappingSource.fromUser(CEDRIC), Mapping.forward(ALICE.asString()));
+
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER.asString(), PASSWORD)
+            .sendMessage(SENDER.asString(), ALICE.asString());
+
+        Awaitility.await().until(() -> jamesServer.getProbe(SpoolerProbe.class).processingFinished());
+        Awaitility.await().until(() -> mailRepositoryProbe.getRepositoryMailCount(CUSTOM_REPOSITORY) == 1L);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            List<Mail> mails = mailRepositoryProbe.listMails(CUSTOM_REPOSITORY)
+                .collect(ImmutableList.toImmutableList());
+
+            softly.assertThat(mails.get(0).getRecipients()).containsOnly(CEDRIC.asMailAddress());
+        }));
+    }
+
+    @Test
+    void regularForwardShouldNotCreateLoopErrorAndSendEmailToAppropriateReceivers() throws Exception {
+        dataProbe.addMapping(MappingSource.fromUser(ALICE), Mapping.forward(BOB.asString()));
+        dataProbe.addMapping(MappingSource.fromUser(BOB), Mapping.forward(CEDRIC.asString()));
+        dataProbe.addMapping(MappingSource.fromUser(CEDRIC), Mapping.forward(ALICE.asString()));
+        dataProbe.addMapping(MappingSource.fromUser(CEDRIC), Mapping.forward(SENDER.asString()));
+
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER.asString(), PASSWORD)
+            .sendMessage(SENDER.asString(), ALICE.asString());
+
+        Awaitility.await().until(() -> jamesServer.getProbe(SpoolerProbe.class).processingFinished());
+        Awaitility.await().until(() -> mailRepositoryProbe.getRepositoryMailCount(CUSTOM_REPOSITORY) == 1L);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            List<Mail> mails = mailRepositoryProbe.listMails(CUSTOM_REPOSITORY)
+                .collect(ImmutableList.toImmutableList());
+
+            softly.assertThat(mails.get(0).getRecipients()).containsOnly(SENDER.asMailAddress());
+        }));
+    }
+
+    @Test
+    void forwardShouldNotCreateLoopErrorWhenFilterForwardAndRegularForwardWorkTogether() throws Exception {
+        filteringManagementProbe.defineRulesForUser(ALICE, asRule(Forward.to(BOB.asMailAddress()).withoutACopy()));
+        dataProbe.addMapping(MappingSource.fromUser(BOB), Mapping.forward(CEDRIC.asString()));
+        filteringManagementProbe.defineRulesForUser(CEDRIC, asRule(Forward.to(ALICE.asMailAddress()).withoutACopy()));
+
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(SENDER.asString(), PASSWORD)
+            .sendMessage(SENDER.asString(), ALICE.asString());
+
+        Awaitility.await().until(() -> jamesServer.getProbe(SpoolerProbe.class).processingFinished());
+        Awaitility.await().until(() -> mailRepositoryProbe.getRepositoryMailCount(CUSTOM_REPOSITORY) == 1L);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            List<Mail> mails = mailRepositoryProbe.listMails(CUSTOM_REPOSITORY)
+                .collect(ImmutableList.toImmutableList());
+
+            softly.assertThat(mails.get(0).getRecipients()).containsOnly(CEDRIC.asMailAddress());
+        }));
+    }
+}


### PR DESCRIPTION
Prevents infinite email loop with forwards by tracking for which users the forwards where applied.

Tracks both regular forwards and JMAP filters forwards.

CF https://github.com/apache/james-project/pull/1758