### PR TITLE
JAMES-3949 Prevent usage of JMX file auto configuration on Windows

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -47,7 +47,7 @@ config.file=conf/cassandra-driver.conf
 sun.rmi.dgc.server.gcInterval=3600000000
 sun.rmi.dgc.client.gcInterval=3600000000
 
-# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password. Not supported on windows.
 james.jmx.credential.generation=true
 
 # Disable Remote Code Execution feature from JMX

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -47,7 +47,7 @@ config.file=conf/cassandra-driver.conf
 sun.rmi.dgc.server.gcInterval=3600000000
 sun.rmi.dgc.client.gcInterval=3600000000
 
-# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password. Not supported on windows.
 james.jmx.credential.generation=true
 
 # Disable Remote Code Execution feature from JMX

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -47,7 +47,7 @@ config.file=conf/cassandra-driver.conf
 sun.rmi.dgc.server.gcInterval=3600000000
 sun.rmi.dgc.client.gcInterval=3600000000
 
-# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password. Not supported on windows.
 james.jmx.credential.generation=true
 
 # Disable Remote Code Execution feature from JMX

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -44,7 +44,7 @@
 sun.rmi.dgc.server.gcInterval=3600000000
 sun.rmi.dgc.client.gcInterval=3600000000
 
-# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password. Not supported on windows.
 james.jmx.credential.generation=true
 
 # Disable Remote Code Execution feature from JMX

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -44,7 +44,7 @@
 sun.rmi.dgc.server.gcInterval=3600000000
 sun.rmi.dgc.client.gcInterval=3600000000
 
-# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password. Not supported on windows.
 james.jmx.credential.generation=true
 
 # Disable Remote Code Execution feature from JMX

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -44,7 +44,7 @@
 sun.rmi.dgc.server.gcInterval=3600000000
 sun.rmi.dgc.client.gcInterval=3600000000
 
-# Automatically generate a JMX password upon start. CLI is able to retrieve this password.
+# Automatically generate a JMX password upon start. CLI is able to retrieve this password. Not supported on windows.
 james.jmx.credential.generation=true
 
 # Disable Remote Code Execution feature from JMX

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.google.common.base.Preconditions;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.management.MBeanServer;
@@ -60,6 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 public class JMXServer implements Startable {

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.google.common.base.Preconditions;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.management.MBeanServer;
@@ -50,6 +51,7 @@ import javax.management.remote.JMXServiceURL;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.james.filesystem.api.JamesDirectoriesProvider;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.util.FunctionalUtils;
@@ -159,8 +161,8 @@ public class JMXServer implements Startable {
     }
 
     private void generateJMXPasswordFileIfNeed() {
-        if (Boolean.parseBoolean(System.getProperty(JMX_CREDENTIAL_GENERATION_ENABLE_PROPERTY_KEY, JMX_CREDENTIAL_GENERATION_ENABLE_DEFAULT_VALUE))
-            && !existJmxPasswordFile()) {
+        boolean shouldCreateJMXPasswordFile = Boolean.parseBoolean(System.getProperty(JMX_CREDENTIAL_GENERATION_ENABLE_PROPERTY_KEY, JMX_CREDENTIAL_GENERATION_ENABLE_DEFAULT_VALUE));
+        if (shouldCreateJMXPasswordFile && !existJmxPasswordFile()) {
             generateJMXPasswordFile();
         }
     }
@@ -170,6 +172,7 @@ public class JMXServer implements Startable {
     }
 
     private void generateJMXPasswordFile() {
+        Preconditions.checkState(!SystemUtils.IS_OS_WINDOWS, "Generating JMX password file is not supported on Windows");
         try {
             File passwordFile = new File(jmxPasswordFilePath);
             if (!passwordFile.exists()) {

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.james.util.Host;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -35,7 +36,7 @@ public class JmxConfiguration {
     public static final int DEFAULT_PORT = 9999;
     public static final boolean ENABLED = true;
     public static final String JMX_CREDENTIAL_GENERATION_ENABLE_PROPERTY_KEY = "james.jmx.credential.generation";
-    public static final String JMX_CREDENTIAL_GENERATION_ENABLE_DEFAULT_VALUE = "true";
+    public static final String JMX_CREDENTIAL_GENERATION_ENABLE_DEFAULT_VALUE = Boolean.valueOf(!SystemUtils.IS_OS_WINDOWS).toString();
     public static final String PASSWORD_FILE_NAME = "jmxremote.password";
     public static final String ACCESS_FILE_NAME = "jmxremote.access";
     public static final String JAMES_ADMIN_USER_DEFAULT = "james-admin";


### PR DESCRIPTION
Non POSIX compliant systems can't manage permissions the right way.