### PR TITLE
[Build] Few stability improvements...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3304,8 +3304,8 @@
                             -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                             -Xms512m -Xmx1024m</argLine>
                         <reuseForks>true</reuseForks>
-                        <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                        <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                        <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                        <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                         <excludedGroups>unstable</excludedGroups>
                     </configuration>
                 </plugin>

--- a/server/apps/distributed-app/pom.xml
+++ b/server/apps/distributed-app/pom.xml
@@ -499,8 +499,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <excludedGroups>unstable</excludedGroups>
                 </configuration>
             </plugin>

--- a/server/apps/distributed-pop3-app/pom.xml
+++ b/server/apps/distributed-pop3-app/pom.xml
@@ -468,8 +468,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <excludedGroups>unstable</excludedGroups>
                 </configuration>
             </plugin>

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CachedBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CachedBlobStoreTest.java
@@ -544,7 +544,7 @@ public class CachedBlobStoreTest implements BlobStoreContract {
         void readBytesShouldRecordDistinctTimingsWhenRepeatAndBackendRead() {
             BlobId blobId = Mono.from(testee.save(DEFAULT_BUCKETNAME, ELEVEN_KILOBYTES, SIZE_BASED)).block();
 
-            Duration delay = Duration.ofMillis(500);
+            Duration delay = Duration.ofMillis(1000);
             Mono.from(testee.readBytes(DEFAULT_BUCKETNAME, blobId, HIGH_PERFORMANCE))
                 .then(Mono.delay(delay))
                 .repeat(2)
@@ -559,7 +559,7 @@ public class CachedBlobStoreTest implements BlobStoreContract {
         void readBytesShouldRecordDistinctTimingsWhenRepeat() {
             BlobId blobId = Mono.from(testee.save(DEFAULT_BUCKETNAME, APPROXIMATELY_FIVE_KILOBYTES, SIZE_BASED)).block();
 
-            Duration delay = Duration.ofMillis(500);
+            Duration delay = Duration.ofMillis(1000);
             Mono.from(testee.readBytes(DEFAULT_BUCKETNAME, blobId, HIGH_PERFORMANCE))
                 .then(Mono.delay(delay))
                 .repeat(2)

--- a/server/blob/blob-file/pom.xml
+++ b/server/blob/blob-file/pom.xml
@@ -109,7 +109,7 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms1024m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>
         </plugins>

--- a/server/blob/blob-memory/pom.xml
+++ b/server/blob/blob-memory/pom.xml
@@ -101,7 +101,7 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms1024m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>
         </plugins>

--- a/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
+++ b/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
@@ -74,7 +74,7 @@ public class MailImplTest extends ContractMailTest {
         assertThat(mail.getName()).isEqualTo("mail-id");
         assertThat(mail.hasAttributes()).describedAs("no initial attributes").isFalse();
         assertThat(mail.getErrorMessage()).describedAs("no initial error").isNull();
-        assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(1));
+        assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(2));
         assertThat(mail.getRecipients()).describedAs("no initial recipient").isNullOrEmpty();
         assertThat(mail.getRemoteAddr()).describedAs("initial remote address is localhost ip").isEqualTo("127.0.0.1");
         assertThat(mail.getRemoteHost()).describedAs("initial remote host is localhost").isEqualTo("localhost");
@@ -102,7 +102,7 @@ public class MailImplTest extends ContractMailTest {
             .usingRecursiveComparison()
             .ignoringFields("sender", "name", "recipients", "lastUpdated")
             .isEqualTo(expected);
-        assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(1));
+        assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(2));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class MailImplTest extends ContractMailTest {
             .usingRecursiveComparison()
             .ignoringFields("message", "lastUpdated")
             .isEqualTo(expected);
-        assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(1));
+        assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(2));
     }
 
     @Test

--- a/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/pom.xml
@@ -136,8 +136,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <!-- Junit 5 move from Category to Tag, and it need tag's name as parameter -->
                     <groups combine.self="override">BasicFeature</groups>
                     <excludedGroups>unstable</excludedGroups>

--- a/server/protocols/protocols-imap4/pom.xml
+++ b/server/protocols/protocols-imap4/pom.xml
@@ -190,8 +190,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx1024m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <excludedGroups>unstable</excludedGroups>
                 </configuration>
             </plugin>

--- a/server/protocols/protocols-lmtp/pom.xml
+++ b/server/protocols/protocols-lmtp/pom.xml
@@ -197,8 +197,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx1024m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <excludedGroups>unstable</excludedGroups>
                 </configuration>
             </plugin>

--- a/server/protocols/protocols-pop3/pom.xml
+++ b/server/protocols/protocols-pop3/pom.xml
@@ -186,8 +186,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx1024m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <excludedGroups>unstable</excludedGroups>
                 </configuration>
             </plugin>

--- a/server/protocols/protocols-smtp/pom.xml
+++ b/server/protocols/protocols-smtp/pom.xml
@@ -228,8 +228,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx1024m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <excludedGroups>unstable</excludedGroups>
                 </configuration>
             </plugin>

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/pom.xml
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/pom.xml
@@ -101,8 +101,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms1024m -Xmx4096m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <!-- Junit 5 move from Category to Tag, and it needs tag's name as parameter -->
                     <groups combine.self="override">BasicFeature</groups>
                     <excludedGroups>unstable</excludedGroups>

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/pom.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/pom.xml
@@ -61,7 +61,7 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <forkCount>4</forkCount>
                 </configuration>
             </plugin>

--- a/server/protocols/webadmin/webadmin-mailbox/pom.xml
+++ b/server/protocols/webadmin/webadmin-mailbox/pom.xml
@@ -248,8 +248,8 @@
                         -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
                         -Xms512m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
-                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
-                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                    <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                     <excludedGroups>unstable</excludedGroups>
                 </configuration>
             </plugin>


### PR DESCRIPTION
I keep seeing from time to time some builds failing because a module spent 25 minutes to test instead of less than 20. I think we can relax it to 30 minutes.

Also sometimes I saw some builds failing because in MailImplTest we test that we gate the last updated date of created email close to 1s to the now Date. A bit flacky, with all the heavy tests we run in parallel. So increased it to 2s