### PR TITLE
[Build] Do not build on ephemeral nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@
  *
  */
 
-def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
+def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu && !ephemeral'
 def JDK_NAME = env.JDK_NAME ?: 'jdk_11_latest'
 
 pipeline {


### PR DESCRIPTION
Infra team put some extra nodes called ephemeral are just overflow nodes, kicking in when no buildsxx nodes are available for new builds.

We can't run on those as there is less resources on those than buildsxx, which is not enough for James heavy builds.