### PR TITLE
JAMES-2586 Add an `addAdditionalAlterQueries` option when declaring Postgres table

### DIFF
--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/quota/PostgresQuotaModule.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/quota/PostgresQuotaModule.java
@@ -50,7 +50,8 @@ public interface PostgresQuotaModule {
                 .column(CURRENT_VALUE)
                 .constraint(DSL.constraint(PRIMARY_KEY_CONSTRAINT_NAME)
                     .primaryKey(IDENTIFIER, COMPONENT, TYPE))))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
     }
 
     interface PostgresQuotaLimitTable {
@@ -72,7 +73,8 @@ public interface PostgresQuotaModule {
                 .column(QUOTA_TYPE)
                 .column(QUOTA_LIMIT)
                 .constraint(DSL.constraint(PK_CONSTRAINT_NAME).primaryKey(QUOTA_SCOPE, IDENTIFIER, QUOTA_COMPONENT, QUOTA_TYPE))))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
     }
 
     PostgresModule MODULE = PostgresModule.builder()

--- a/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresExtensionTest.java
+++ b/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresExtensionTest.java
@@ -38,7 +38,8 @@ class PostgresExtensionTest {
             .column("column1", SQLDataType.UUID.notNull())
             .column("column2", SQLDataType.INTEGER)
             .column("column3", SQLDataType.VARCHAR(255).notNull()))
-        .disableRowLevelSecurity();
+        .disableRowLevelSecurity()
+        .build();
 
     static PostgresIndex INDEX_1 = PostgresIndex.name("index1")
         .createIndexStep((dslContext, indexName) -> dslContext.createIndex(indexName)
@@ -47,7 +48,8 @@ class PostgresExtensionTest {
     static PostgresTable TABLE_2 = PostgresTable.name("table2")
         .createTableStep((dslContext, tableName) -> dslContext.createTable(tableName)
             .column("column1", SQLDataType.INTEGER))
-        .disableRowLevelSecurity();
+        .disableRowLevelSecurity()
+        .build();
 
     static PostgresIndex INDEX_2 = PostgresIndex.name("index2")
         .createIndexStep((dslContext, indexName) -> dslContext.createIndex(indexName)

--- a/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresTableManagerTest.java
+++ b/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresTableManagerTest.java
@@ -52,7 +52,8 @@ class PostgresTableManagerTest {
                 .column("colum1", SQLDataType.UUID.notNull())
                 .column("colum2", SQLDataType.INTEGER)
                 .column("colum3", SQLDataType.VARCHAR(255).notNull()))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
 
         PostgresModule module = PostgresModule.table(table);
 
@@ -74,12 +75,14 @@ class PostgresTableManagerTest {
 
         PostgresTable table1 = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
-                .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity();
+                .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity()
+            .build();
 
         String tableName2 = "tableName2";
         PostgresTable table2 = PostgresTable.name(tableName2)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
-                .column("columB", SQLDataType.INTEGER)).disableRowLevelSecurity();
+                .column("columB", SQLDataType.INTEGER)).disableRowLevelSecurity()
+            .build();
 
         PostgresTableManager testee = tableManagerFactory.apply(PostgresModule.table(table1, table2));
 
@@ -100,7 +103,8 @@ class PostgresTableManagerTest {
 
         PostgresTable table1 = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
-                .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity();
+                .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity()
+            .build();
 
         PostgresTableManager testee = tableManagerFactory.apply(PostgresModule.table(table1));
 
@@ -116,7 +120,8 @@ class PostgresTableManagerTest {
         String tableName1 = "tableName1";
         PostgresTable table1 = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
-                .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity();
+                .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity()
+            .build();
 
         tableManagerFactory.apply(PostgresModule.table(table1))
             .initializeTables()
@@ -124,7 +129,8 @@ class PostgresTableManagerTest {
 
         PostgresTable table1Changed = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
-                .column("columB", SQLDataType.INTEGER)).disableRowLevelSecurity();
+                .column("columB", SQLDataType.INTEGER)).disableRowLevelSecurity()
+            .build();
 
         tableManagerFactory.apply(PostgresModule.table(table1Changed))
             .initializeTables()
@@ -144,7 +150,8 @@ class PostgresTableManagerTest {
                 .column("colum1", SQLDataType.UUID.notNull())
                 .column("colum2", SQLDataType.INTEGER)
                 .column("colum3", SQLDataType.VARCHAR(255).notNull()))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
 
         String indexName = "idx_test_1";
         PostgresIndex index = PostgresIndex.name(indexName)
@@ -177,7 +184,8 @@ class PostgresTableManagerTest {
                 .column("colum1", SQLDataType.UUID.notNull())
                 .column("colum2", SQLDataType.INTEGER)
                 .column("colum3", SQLDataType.VARCHAR(255).notNull()))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
 
         String indexName1 = "idx_test_1";
         PostgresIndex index1 = PostgresIndex.name(indexName1)
@@ -215,7 +223,8 @@ class PostgresTableManagerTest {
                 .column("colum1", SQLDataType.UUID.notNull())
                 .column("colum2", SQLDataType.INTEGER)
                 .column("colum3", SQLDataType.VARCHAR(255).notNull()))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
 
         String indexName = "idx_test_1";
         PostgresIndex index = PostgresIndex.name(indexName)
@@ -243,7 +252,8 @@ class PostgresTableManagerTest {
         String tableName1 = "tbn1";
         PostgresTable table1 = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
-                .column("column1", SQLDataType.INTEGER.notNull())).disableRowLevelSecurity();
+                .column("column1", SQLDataType.INTEGER.notNull())).disableRowLevelSecurity()
+            .build();
 
         PostgresTableManager testee = tableManagerFactory.apply(PostgresModule.table(table1));
         testee.initializeTables()
@@ -285,7 +295,8 @@ class PostgresTableManagerTest {
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
                 .column("clm1", SQLDataType.UUID.notNull())
                 .column("clm2", SQLDataType.VARCHAR(255).notNull()))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
 
         PostgresModule module = PostgresModule.table(table);
 
@@ -325,7 +336,8 @@ class PostgresTableManagerTest {
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
                 .column("clm1", SQLDataType.UUID.notNull())
                 .column("clm2", SQLDataType.VARCHAR(255).notNull()))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
 
         PostgresModule module = PostgresModule.table(table);
         boolean disabledRLS = false;
@@ -348,11 +360,57 @@ class PostgresTableManagerTest {
         PostgresTable rlsTable = PostgresTable.name(tableName)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
                 .column("colum1", SQLDataType.UUID.notNull()))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
 
         PostgresModule module = PostgresModule.table(rlsTable);
 
         PostgresTableManager testee = tableManagerFactory.apply(module);
+        testee.initializeTables().block();
+
+        assertThatCode(() -> testee.initializeTables().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void additionalAlterQueryToCreateConstraintShouldSucceed() {
+        String constraintName = "exclude_constraint";
+        PostgresTable table = PostgresTable.name("tbn1")
+            .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
+                .column("clm1", SQLDataType.UUID.notNull())
+                .column("clm2", SQLDataType.VARCHAR(255).notNull()))
+            .disableRowLevelSecurity()
+            .addAdditionalAlterQueries("ALTER TABLE tbn1 ADD CONSTRAINT " + constraintName + " EXCLUDE (clm2 WITH =)")
+            .build();
+        PostgresModule module = PostgresModule.table(table);
+        PostgresTableManager testee = new PostgresTableManager(postgresExtension.getPostgresExecutor(), module, false);
+
+        testee.initializeTables().block();
+
+        boolean constraintExists = postgresExtension.getConnection()
+            .flatMapMany(connection -> connection.createStatement("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_constraint WHERE conname = $1) AS constraint_exists;")
+                .bind("$1", constraintName)
+                    .execute())
+            .flatMap(result -> result.map((row, rowMetaData) -> row.get("constraint_exists", Boolean.class)))
+            .single()
+            .block();
+
+        assertThat(constraintExists).isTrue();
+    }
+
+    @Test
+    void additionalAlterQueryToReCreateConstraintShouldNotThrow() {
+        String constraintName = "exclude_constraint";
+        PostgresTable table = PostgresTable.name("tbn1")
+            .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
+                .column("clm1", SQLDataType.UUID.notNull())
+                .column("clm2", SQLDataType.VARCHAR(255).notNull()))
+            .disableRowLevelSecurity()
+            .addAdditionalAlterQueries("ALTER TABLE tbn1 ADD CONSTRAINT " + constraintName + " EXCLUDE (clm2 WITH =)")
+            .build();
+        PostgresModule module = PostgresModule.table(table);
+        PostgresTableManager testee = new PostgresTableManager(postgresExtension.getPostgresExecutor(), module, false);
+
         testee.initializeTables().block();
 
         assertThatCode(() -> testee.initializeTables().block())

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/PostgresMailboxAnnotationModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/PostgresMailboxAnnotationModule.java
@@ -47,7 +47,8 @@ public interface PostgresMailboxAnnotationModule {
                 .column(ANNOTATIONS)
                 .primaryKey(MAILBOX_ID)
                 .constraints(DSL.constraint().foreignKey(MAILBOX_ID).references(PostgresMailboxTable.TABLE_NAME, PostgresMailboxTable.MAILBOX_ID).onDeleteCascade())))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
     }
 
     PostgresModule MODULE = PostgresModule.builder()

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
@@ -58,7 +58,8 @@ public interface PostgresMailboxModule {
                 .column(MAILBOX_ACL)
                 .constraint(DSL.primaryKey(MAILBOX_ID))
                 .constraint(DSL.unique(MAILBOX_NAME, USER_NAME, MAILBOX_NAMESPACE))))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
     }
 
     PostgresModule MODULE = PostgresModule.builder()

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageModule.java
@@ -85,7 +85,8 @@ public interface PostgresMessageModule {
                 .column(CONTENT_DISPOSITION_PARAMETERS)
                 .constraint(DSL.primaryKey(MESSAGE_ID))
                 .comment("Holds the metadata of a mail")))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
     }
 
     interface MessageToMailboxTable {
@@ -128,7 +129,8 @@ public interface PostgresMessageModule {
                 .constraints(DSL.primaryKey(MAILBOX_ID, MESSAGE_UID),
                     foreignKey(MESSAGE_ID).references(MessageTable.TABLE_NAME, MessageTable.MESSAGE_ID))
                 .comment("Holds mailbox and flags for each message")))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
 
         PostgresIndex MESSAGE_ID_INDEX = PostgresIndex.name("message_mailbox_message_id_index")
             .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/user/PostgresSubscriptionModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/user/PostgresSubscriptionModule.java
@@ -43,7 +43,8 @@ public interface PostgresSubscriptionModule {
             .column(MAILBOX)
             .column(USER)
             .constraint(DSL.unique(MAILBOX, USER))))
-        .supportsRowLevelSecurity();
+        .supportsRowLevelSecurity()
+        .build();
     PostgresIndex INDEX = PostgresIndex.name("subscription_user_index")
         .createIndexStep((dsl, indexName) -> dsl.createIndex(indexName)
             .on(TABLE_NAME, USER));

--- a/server/data/data-postgres/src/main/java/org/apache/james/domainlist/postgres/PostgresDomainModule.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/domainlist/postgres/PostgresDomainModule.java
@@ -37,7 +37,8 @@ public interface PostgresDomainModule {
             .createTableStep(((dsl, tableName) -> dsl.createTableIfNotExists(tableName)
                 .column(DOMAIN)
                 .primaryKey(DOMAIN)))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
     }
 
     PostgresModule MODULE = PostgresModule.builder()

--- a/server/data/data-postgres/src/main/java/org/apache/james/mailrepository/postgres/PostgresMailRepositoryModule.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/mailrepository/postgres/PostgresMailRepositoryModule.java
@@ -37,7 +37,8 @@ public interface PostgresMailRepositoryModule {
             .createTableStep(((dsl, tableName) -> dsl.createTableIfNotExists(tableName)
                 .column(URL)
                 .primaryKey(URL)))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
     }
 
     PostgresModule MODULE = PostgresModule.builder()

--- a/server/data/data-postgres/src/main/java/org/apache/james/rrt/postgres/PostgresRecipientRewriteTableModule.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/rrt/postgres/PostgresRecipientRewriteTableModule.java
@@ -45,7 +45,8 @@ public interface PostgresRecipientRewriteTableModule {
                 .column(DOMAIN_NAME)
                 .column(TARGET_ADDRESS)
                 .constraint(DSL.constraint(PK_CONSTRAINT_NAME).primaryKey(USERNAME, DOMAIN_NAME, TARGET_ADDRESS))))
-            .supportsRowLevelSecurity();
+            .supportsRowLevelSecurity()
+            .build();
 
         PostgresIndex INDEX = PostgresIndex.name("idx_rrt_target_address")
             .createIndexStep((dslContext, indexName) -> dslContext.createIndex(indexName)

--- a/server/data/data-postgres/src/main/java/org/apache/james/user/postgres/PostgresUserModule.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/user/postgres/PostgresUserModule.java
@@ -45,7 +45,8 @@ public interface PostgresUserModule {
                 .column(AUTHORIZED_USERS)
                 .column(DELEGATED_USERS)
                 .constraint(DSL.primaryKey(USERNAME))))
-            .disableRowLevelSecurity();
+            .disableRowLevelSecurity()
+            .build();
     }
 
     PostgresModule MODULE = PostgresModule.builder()


### PR DESCRIPTION
Would be useful in case jOOQ DSL does not provide support for some queries e.g. create an EXCLUDE constraint.