### PR TITLE
JAMES-2586 Fix [PGSQL] Concurrency control for flags updates

### DIFF
--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresCommons.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresCommons.java
@@ -66,4 +66,6 @@ public class PostgresCommons {
 
     public static final int IN_CLAUSE_MAX_SIZE = 32;
 
+    public static final Field<String[]> EMPTY_STRING_ARRAY_FIELD =  DSL.array("");
+
 }

--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresCommons.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresCommons.java
@@ -66,6 +66,4 @@ public class PostgresCommons {
 
     public static final int IN_CLAUSE_MAX_SIZE = 32;
 
-    public static final Field<String[]> EMPTY_STRING_ARRAY_FIELD =  DSL.array("");
-
 }

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
@@ -321,27 +321,40 @@ public class PostgresMessageMapper implements MessageMapper {
     }
 
     private Mono<UpdatedFlags> updateFlags(ComposedMessageIdWithMetaData currentMetaData,
-                                           FlagsUpdateCalculator flagsUpdateCalculator,
-                                           ModSeq newModSeq) {
+                                            FlagsUpdateCalculator flagsUpdateCalculator,
+                                            ModSeq newModSeq) {
         Flags oldFlags = currentMetaData.getFlags();
-        Flags newFlags = flagsUpdateCalculator.buildNewFlags(oldFlags);
-
         ComposedMessageId composedMessageId = currentMetaData.getComposedMessageId();
 
-        return Mono.just(UpdatedFlags.builder()
+        if (oldFlags.equals(flagsUpdateCalculator.buildNewFlags(oldFlags))) {
+            return Mono.just(UpdatedFlags.builder()
                 .messageId(composedMessageId.getMessageId())
                 .oldFlags(oldFlags)
-                .newFlags(newFlags)
-                .uid(composedMessageId.getUid()))
-            .flatMap(builder -> {
-                if (oldFlags.equals(newFlags)) {
-                    return Mono.just(builder.modSeq(currentMetaData.getModSeq())
-                        .build());
-                }
-                return Mono.fromCallable(() -> builder.modSeq(newModSeq).build())
-                    .flatMap(updatedFlags -> mailboxMessageDAO.updateFlag((PostgresMailboxId) composedMessageId.getMailboxId(), composedMessageId.getUid(), updatedFlags)
-                        .thenReturn(updatedFlags));
-            });
+                .newFlags(oldFlags)
+                .uid(composedMessageId.getUid())
+                .modSeq(currentMetaData.getModSeq())
+                .build());
+        } else {
+            return Mono.just(flagsUpdateCalculator.getMode())
+                .flatMap(mode -> {
+                    switch (mode) {
+                        case ADD:
+                            return mailboxMessageDAO.addFlags((PostgresMailboxId) composedMessageId.getMailboxId(), composedMessageId.getUid(), flagsUpdateCalculator.providedFlags(), newModSeq);
+                        case REMOVE:
+                            return mailboxMessageDAO.removeFlags((PostgresMailboxId) composedMessageId.getMailboxId(), composedMessageId.getUid(), flagsUpdateCalculator.providedFlags(), newModSeq);
+                        case REPLACE:
+                            return mailboxMessageDAO.replaceFlags((PostgresMailboxId) composedMessageId.getMailboxId(), composedMessageId.getUid(), flagsUpdateCalculator.providedFlags(), newModSeq);
+                        default:
+                            throw new RuntimeException("Unknown MessageRange type " + mode);
+                    }
+                }).map(updatedFlags -> UpdatedFlags.builder()
+                    .messageId(composedMessageId.getMessageId())
+                    .oldFlags(oldFlags)
+                    .newFlags(updatedFlags)
+                    .uid(composedMessageId.getUid())
+                    .modSeq(newModSeq)
+                    .build());
+        }
     }
 
     @Override

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
@@ -321,8 +321,8 @@ public class PostgresMessageMapper implements MessageMapper {
     }
 
     private Mono<UpdatedFlags> updateFlags(ComposedMessageIdWithMetaData currentMetaData,
-                                            FlagsUpdateCalculator flagsUpdateCalculator,
-                                            ModSeq newModSeq) {
+                                           FlagsUpdateCalculator flagsUpdateCalculator,
+                                           ModSeq newModSeq) {
         Flags oldFlags = currentMetaData.getFlags();
         ComposedMessageId composedMessageId = currentMetaData.getComposedMessageId();
 

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageModule.java
@@ -111,19 +111,19 @@ public interface PostgresMessageModule {
         String ARRAY_REMOVE_JAMES_FUNCTION_NAME = "array_remove_james";
         String CREATE_ARRAY_REMOVE_JAMES_FUNCTION =
             "CREATE OR REPLACE FUNCTION " + ARRAY_REMOVE_JAMES_FUNCTION_NAME + "(\n" +
-                "    p_remove_flags_1 text[],\n" +
-                "    p_remove_flags_2 text[])\n" +
+                "    source text[],\n" +
+                "    elements_to_remove text[])\n" +
                 "    RETURNS text[]\n" +
                 "AS\n" +
                 "$$\n" +
                 "DECLARE\n" +
-                "    merged_flags text[];\n" +
+                "    result text[];\n" +
                 "BEGIN\n" +
-                "    select array_agg(elements) INTO merged_flags\n" +
-                "    from (select unnest(p_remove_flags_1)\n" +
+                "    select array_agg(elements) INTO result\n" +
+                "    from (select unnest(source)\n" +
                 "          except\n" +
-                "          select unnest(p_remove_flags_2)) t (elements);\n" +
-                "    RETURN merged_flags;\n" +
+                "          select unnest(elements_to_remove)) t (elements);\n" +
+                "    RETURN result;\n" +
                 "END;\n" +
                 "$$ LANGUAGE plpgsql;";
 

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageModule.java
@@ -108,9 +108,9 @@ public interface PostgresMessageModule {
         Field<String[]> USER_FLAGS = DSL.field("user_flags", DataTypes.STRING_ARRAY);
         Field<LocalDateTime> SAVE_DATE = DSL.field("save_date", DataTypes.TIMESTAMP);
 
-        String ARRAY_REMOVE_JAMES_FUNCTION_NAME = "array_remove_james";
+        String REMOVE_ELEMENTS_FROM_ARRAY_FUNCTION_NAME = "remove_elements_from_array";
         String CREATE_ARRAY_REMOVE_JAMES_FUNCTION =
-            "CREATE OR REPLACE FUNCTION " + ARRAY_REMOVE_JAMES_FUNCTION_NAME + "(\n" +
+            "CREATE OR REPLACE FUNCTION " + REMOVE_ELEMENTS_FROM_ARRAY_FUNCTION_NAME + "(\n" +
                 "    source text[],\n" +
                 "    elements_to_remove text[])\n" +
                 "    RETURNS text[]\n" +

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
@@ -27,7 +27,6 @@ import static org.apache.james.backends.postgres.PostgresCommons.tableField;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageTable.BLOB_ID;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageTable.INTERNAL_DATE;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageTable.SIZE;
-import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.ARRAY_REMOVE_JAMES_FUNCTION_NAME;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.IS_ANSWERED;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.IS_DELETED;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.IS_DRAFT;
@@ -38,6 +37,7 @@ import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.Messa
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.MESSAGE_ID;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.MESSAGE_UID;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.MOD_SEQ;
+import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.REMOVE_ELEMENTS_FROM_ARRAY_FUNCTION_NAME;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.SAVE_DATE;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.TABLE_NAME;
 import static org.apache.james.mailbox.postgres.mail.PostgresMessageModule.MessageToMailboxTable.THREAD_ID;
@@ -385,7 +385,7 @@ public class PostgresMailboxMessageDAO {
             if (removeFlags.getUserFlags().length == 1) {
                 updateStatement.getAndUpdate(currentStatement -> currentStatement.set(USER_FLAGS, PostgresDSL.arrayRemove(USER_FLAGS, removeFlags.getUserFlags()[0])));
             } else {
-                updateStatement.getAndUpdate(currentStatement -> currentStatement.set(USER_FLAGS, DSL.function(ARRAY_REMOVE_JAMES_FUNCTION_NAME, String[].class,
+                updateStatement.getAndUpdate(currentStatement -> currentStatement.set(USER_FLAGS, DSL.function(REMOVE_ELEMENTS_FROM_ARRAY_FUNCTION_NAME, String[].class,
                     USER_FLAGS,
                     DSL.array(removeFlags.getUserFlags()))));
             }

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
@@ -353,7 +353,7 @@ public class PostgresMailboxMessageDAO {
     }
 
     private UpdateConditionStep<Record> buildReplaceFlagsStatement(DSLContext dslContext, Flags newFlags,
-                                                               PostgresMailboxId mailboxId, MessageUid uid, ModSeq newModSeq) {
+                                                                   PostgresMailboxId mailboxId, MessageUid uid, ModSeq newModSeq) {
         AtomicReference<UpdateSetStep<Record>> updateStatement = new AtomicReference<>(dslContext.update(TABLE_NAME));
 
         BOOLEAN_FLAGS_MAPPING.forEach((flagColumn, flagMapped) -> {
@@ -368,7 +368,7 @@ public class PostgresMailboxMessageDAO {
     }
 
     private UpdateConditionStep<Record> buildRemoveFlagsStatement(DSLContext dslContext, Flags removeFlags,
-                                                               PostgresMailboxId mailboxId, MessageUid uid, ModSeq newModSeq) {
+                                                                  PostgresMailboxId mailboxId, MessageUid uid, ModSeq newModSeq) {
         AtomicReference<UpdateSetStep<Record>> updateStatement = new AtomicReference<>(dslContext.update(TABLE_NAME));
 
         BOOLEAN_FLAGS_MAPPING.forEach((flagColumn, flagMapped) -> {

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMapperProvider.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMapperProvider.java
@@ -65,7 +65,7 @@ public class PostgresMapperProvider implements MapperProvider {
 
     @Override
     public List<Capabilities> getSupportedCapabilities() {
-        return ImmutableList.of(Capabilities.ANNOTATION, Capabilities.MAILBOX, Capabilities.MESSAGE, Capabilities.MOVE, Capabilities.ATTACHMENT);
+        return ImmutableList.of(Capabilities.ANNOTATION, Capabilities.MAILBOX, Capabilities.MESSAGE, Capabilities.MOVE, Capabilities.ATTACHMENT, Capabilities.THREAD_SAFE_FLAGS_UPDATE);
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/FlagsUpdateCalculator.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/FlagsUpdateCalculator.java
@@ -48,4 +48,11 @@ public class FlagsUpdateCalculator {
         return updatedFlags;
     }
 
+    public Flags providedFlags() {
+        return providedFlags;
+    }
+
+    public MessageManager.FlagsUpdateMode getMode() {
+        return mode;
+    }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -216,11 +216,11 @@ public abstract class MessageMapperTest {
     void messagesCanBeRetrievedInMailboxWithRangeTypeRange() throws MailboxException, IOException {
         saveMessages();
         Iterator<MailboxMessage> retrievedMessageIterator = messageMapper
-                .findInMailbox(benwaInboxMailbox, MessageRange.range(message1.getUid(), message4.getUid()), MessageMapper.FetchType.FULL, LIMIT);
+            .findInMailbox(benwaInboxMailbox, MessageRange.range(message1.getUid(), message4.getUid()), MessageMapper.FetchType.FULL, LIMIT);
 
         assertMessages(Lists.newArrayList(retrievedMessageIterator)).containOnly(message1, message2, message3, message4);
     }
-    
+
     @Test
     void messagesCanBeRetrievedInMailboxWithRangeTypeRangeContainingAHole() throws MailboxException, IOException {
         saveMessages();
@@ -234,7 +234,7 @@ public abstract class MessageMapperTest {
     void messagesCanBeRetrievedInMailboxWithRangeTypeFrom() throws MailboxException, IOException {
         saveMessages();
         Iterator<MailboxMessage> retrievedMessageIterator = messageMapper
-                .findInMailbox(benwaInboxMailbox, MessageRange.from(message3.getUid()), MessageMapper.FetchType.FULL, LIMIT);
+            .findInMailbox(benwaInboxMailbox, MessageRange.from(message3.getUid()), MessageMapper.FetchType.FULL, LIMIT);
         assertMessages(Lists.newArrayList(retrievedMessageIterator)).containOnly(message3, message4, message5);
     }
 
@@ -243,7 +243,7 @@ public abstract class MessageMapperTest {
         saveMessages();
         messageMapper.delete(benwaInboxMailbox, message4);
         Iterator<MailboxMessage> retrievedMessageIterator = messageMapper
-                .findInMailbox(benwaInboxMailbox, MessageRange.from(message3.getUid()), MessageMapper.FetchType.FULL, LIMIT);
+            .findInMailbox(benwaInboxMailbox, MessageRange.from(message3.getUid()), MessageMapper.FetchType.FULL, LIMIT);
         assertMessages(Lists.newArrayList(retrievedMessageIterator)).containOnly(message3, message5);
     }
 
@@ -259,7 +259,7 @@ public abstract class MessageMapperTest {
         saveMessages();
         messageMapper.delete(benwaInboxMailbox, message1);
         Iterator<MailboxMessage> retrievedMessageIterator = messageMapper
-                .findInMailbox(benwaInboxMailbox, MessageRange.all(), MessageMapper.FetchType.FULL, LIMIT);
+            .findInMailbox(benwaInboxMailbox, MessageRange.all(), MessageMapper.FetchType.FULL, LIMIT);
         assertMessages(Lists.newArrayList(retrievedMessageIterator)).containOnly(message2, message3, message4, message5);
     }
 
@@ -631,9 +631,9 @@ public abstract class MessageMapperTest {
         assertThat(messageMapper.getLastUid(benwaInboxMailbox).get()).isGreaterThan(message6.getUid());
 
         MailboxMessage result = messageMapper.findInMailbox(benwaInboxMailbox,
-            MessageRange.one(messageMapper.getLastUid(benwaInboxMailbox).get()),
-            MessageMapper.FetchType.FULL,
-            LIMIT)
+                MessageRange.one(messageMapper.getLastUid(benwaInboxMailbox).get()),
+                MessageMapper.FetchType.FULL,
+                LIMIT)
             .next();
 
         assertThat(result).isEqualToWithoutUidAndAttachment(message7, MessageMapper.FetchType.FULL);
@@ -659,11 +659,11 @@ public abstract class MessageMapperTest {
         MessageMetaData metaData = messageMapper.copy(benwaInboxMailbox, message);
         assertThat(
             messageMapper.findInMailbox(benwaInboxMailbox,
-                MessageRange.one(metaData.getUid()),
-                MessageMapper.FetchType.METADATA,
-                LIMIT
-            ).next()
-            .isRecent()
+                    MessageRange.one(metaData.getUid()),
+                    MessageMapper.FetchType.METADATA,
+                    LIMIT
+                ).next()
+                .isRecent()
         ).isTrue();
     }
 
@@ -675,10 +675,10 @@ public abstract class MessageMapperTest {
         MessageMetaData metaData = messageMapper.copy(benwaInboxMailbox, message);
         assertThat(
             messageMapper.findInMailbox(benwaInboxMailbox,
-                MessageRange.one(metaData.getUid()),
-                MessageMapper.FetchType.METADATA,
-                LIMIT
-            ).next()
+                    MessageRange.one(metaData.getUid()),
+                    MessageMapper.FetchType.METADATA,
+                    LIMIT
+                ).next()
                 .isRecent()
         ).isTrue();
     }
@@ -690,11 +690,11 @@ public abstract class MessageMapperTest {
         messageMapper.copy(benwaInboxMailbox, message);
         assertThat(
             messageMapper.findInMailbox(benwaWorkMailbox,
-                MessageRange.one(message6.getUid()),
-                MessageMapper.FetchType.METADATA,
-                LIMIT
-            ).next()
-            .isRecent()
+                    MessageRange.one(message6.getUid()),
+                    MessageMapper.FetchType.METADATA,
+                    LIMIT
+                ).next()
+                .isRecent()
         ).isFalse();
     }
 
@@ -710,7 +710,7 @@ public abstract class MessageMapperTest {
         saveMessages();
         ModSeq modSeq = messageMapper.getHighestModSeq(benwaInboxMailbox);
         Optional<UpdatedFlags> updatedFlags = messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(),
-                new FlagsUpdateCalculator(new Flags(Flags.Flag.FLAGGED), FlagsUpdateMode.REPLACE));
+            new FlagsUpdateCalculator(new Flags(Flags.Flag.FLAGGED), FlagsUpdateMode.REPLACE));
         assertThat(updatedFlags)
             .contains(UpdatedFlags.builder()
                 .uid(message1.getUid())
@@ -728,12 +728,12 @@ public abstract class MessageMapperTest {
         ModSeq modSeq = messageMapper.getHighestModSeq(benwaInboxMailbox);
         assertThat(messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(), new FlagsUpdateCalculator(new Flags(Flags.Flag.SEEN), FlagsUpdateMode.ADD)))
             .contains(UpdatedFlags.builder()
-                    .uid(message1.getUid())
-                    .messageId(message1.getMessageId())
-                    .modSeq(modSeq.next())
-                    .oldFlags(new Flags(Flags.Flag.FLAGGED))
-                    .newFlags(new FlagsBuilder().add(Flags.Flag.SEEN, Flags.Flag.FLAGGED).build())
-                    .build());
+                .uid(message1.getUid())
+                .messageId(message1.getMessageId())
+                .modSeq(modSeq.next())
+                .oldFlags(new Flags(Flags.Flag.FLAGGED))
+                .newFlags(new FlagsBuilder().add(Flags.Flag.SEEN, Flags.Flag.FLAGGED).build())
+                .build());
     }
 
     @Test
@@ -817,7 +817,7 @@ public abstract class MessageMapperTest {
 
         assertProperties(message.getProperties().toProperties()).containsOnly(propBuilder.toProperties());
     }
-    
+
     @Test
     void messagePropertiesShouldBeStoredWhenDuplicateEntries() throws Exception {
         PropertyBuilder propBuilder = new PropertyBuilder();
@@ -901,7 +901,7 @@ public abstract class MessageMapperTest {
         saveMessages();
 
         assertThat(
-            messageMapper.updateFlags(benwaInboxMailbox,message1.getUid(),
+            messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(),
                 new FlagsUpdateCalculator(new Flags(USER_FLAG), FlagsUpdateMode.REMOVE)))
             .contains(
                 UpdatedFlags.builder()
@@ -943,7 +943,7 @@ public abstract class MessageMapperTest {
         int updateCount = 40;
         ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> {
-                if (step  < updateCount / 2) {
+                if (step < updateCount / 2) {
                     messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(),
                         new FlagsUpdateCalculator(new Flags("custom-" + threadNumber + "-" + step), FlagsUpdateMode.ADD));
                 } else {
@@ -1123,7 +1123,7 @@ public abstract class MessageMapperTest {
 
     @Test
     void getApplicableFlagShouldHaveNotEffectWhenUnsetMessageFlagThenIncrementalApplicableFlags() throws Exception {
-        Assume.assumeTrue(mapperProvider.getSupportedCapabilities().contains(MapperProvider.Capabilities.THREAD_SAFE_FLAGS_UPDATE));
+        Assume.assumeTrue(mapperProvider.getSupportedCapabilities().contains(MapperProvider.Capabilities.INCREMENTAL_APPLICABLE_FLAGS));
         String customFlag1 = "custom1";
         String customFlag2 = "custom2";
         message1.setFlags(new Flags(customFlag1));
@@ -1217,7 +1217,8 @@ public abstract class MessageMapperTest {
 
         messageMapper.updateFlags(benwaInboxMailbox,
             new FlagsUpdateCalculator(new Flags(Flag.DELETED), FlagsUpdateMode.ADD),
-            MessageRange.range(message2.getUid(), message4.getUid())).forEachRemaining(any -> {});
+            MessageRange.range(message2.getUid(), message4.getUid())).forEachRemaining(any -> {
+        });
         List<MessageUid> uids = messageMapper.retrieveMessagesMarkedForDeletion(benwaInboxMailbox, MessageRange.all());
         messageMapper.deleteMessages(benwaInboxMailbox, uids);
 
@@ -1349,7 +1350,7 @@ public abstract class MessageMapperTest {
     private MailboxMessage retrieveMessageFromStorage(MailboxMessage message) throws MailboxException {
         return messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message.getUid()), MessageMapper.FetchType.METADATA, LIMIT).next();
     }
-    
+
     private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
         return new SimpleMailboxMessage(messageId, ThreadId.fromBaseMessageId(messageId), new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
     }


### PR DESCRIPTION
## The before way:
- James will fetch current flags from the database -> evaluate the new updatedFlag based on request -> update the new flags to the database 

## The after way
- Based on the update flags mode (append, remove, replace) then will directly update to flags in the database (without fetching before)