### PR TITLE
JAMES-2586 Implement Postgresql search overrides

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
@@ -298,7 +298,7 @@ public class PostgresMailboxMessageDAO {
 
     public Flux<MessageUid> findDeletedMessagesByMailboxId(PostgresMailboxId mailboxId) {
         return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(MESSAGE_UID)
-                .from(MESSAGES_JOIN_MAILBOX_MESSAGES_CONDITION_STEP)
+                .from(TABLE_NAME)
                 .where(MAILBOX_ID.eq(mailboxId.asUuid()))
                 .and(IS_DELETED.eq(true))
                 .orderBy(DEFAULT_SORT_ORDER_BY)))
@@ -307,7 +307,7 @@ public class PostgresMailboxMessageDAO {
 
     public Flux<MessageUid> findDeletedMessagesByMailboxIdAndBetweenUIDs(PostgresMailboxId mailboxId, MessageUid from, MessageUid to) {
         return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(MESSAGE_UID)
-                .from(MESSAGES_JOIN_MAILBOX_MESSAGES_CONDITION_STEP)
+                .from(TABLE_NAME)
                 .where(MAILBOX_ID.eq(mailboxId.asUuid()))
                 .and(IS_DELETED.eq(true))
                 .and(MESSAGE_UID.greaterOrEqual(from.asLong()))
@@ -318,7 +318,7 @@ public class PostgresMailboxMessageDAO {
 
     public Flux<MessageUid> findDeletedMessagesByMailboxIdAndAfterUID(PostgresMailboxId mailboxId, MessageUid from) {
         return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(MESSAGE_UID)
-                .from(MESSAGES_JOIN_MAILBOX_MESSAGES_CONDITION_STEP)
+                .from(TABLE_NAME)
                 .where(MAILBOX_ID.eq(mailboxId.asUuid()))
                 .and(IS_DELETED.eq(true))
                 .and(MESSAGE_UID.greaterOrEqual(from.asLong()))
@@ -328,7 +328,7 @@ public class PostgresMailboxMessageDAO {
 
     public Mono<MessageUid> findDeletedMessageByMailboxIdAndUid(PostgresMailboxId mailboxId, MessageUid uid) {
         return postgresExecutor.executeRow(dslContext -> Mono.from(dslContext.select(MESSAGE_UID)
-                .from(MESSAGES_JOIN_MAILBOX_MESSAGES_CONDITION_STEP)
+                .from(TABLE_NAME)
                 .where(MAILBOX_ID.eq(mailboxId.asUuid()))
                 .and(IS_DELETED.eq(true))
                 .and(MESSAGE_UID.eq(uid.asLong()))))

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
@@ -278,6 +278,17 @@ public class PostgresMailboxMessageDAO {
             .map(RECORD_TO_MESSAGE_UID_FUNCTION);
     }
 
+    public Flux<MessageUid> listNotDeletedUids(PostgresMailboxId mailboxId, MessageRange range) {
+        return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(MESSAGE_UID, IS_DELETED)
+                .from(TABLE_NAME)
+                .where(MAILBOX_ID.eq(mailboxId.asUuid()))
+                .and(MESSAGE_UID.greaterOrEqual(range.getUidFrom().asLong()))
+                .and(MESSAGE_UID.lessOrEqual(range.getUidTo().asLong()))
+                .orderBy(DEFAULT_SORT_ORDER_BY)))
+            .filter(record -> !record.get(IS_DELETED))
+            .map(RECORD_TO_MESSAGE_UID_FUNCTION);
+    }
+
     public Flux<ComposedMessageIdWithMetaData> findMessagesMetadata(PostgresMailboxId mailboxId, MessageRange range) {
         return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select()
                 .from(TABLE_NAME)

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/AllSearchOverride.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/AllSearchOverride.java
@@ -1,0 +1,70 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class AllSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final PostgresMailboxMessageDAO dao;
+
+    @Inject
+    public AllSearchOverride(PostgresMailboxMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return isAll(searchQuery)
+            || isFromOne(searchQuery)
+            || isEmpty(searchQuery);
+    }
+
+    private boolean isAll(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0).equals(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isFromOne(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0).equals(SearchQuery.all())
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isEmpty(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().isEmpty()
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        return dao.listAllMessageUid((PostgresMailboxId) mailbox.getMailboxId());
+    }
+}

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/DeletedSearchOverride.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/DeletedSearchOverride.java
@@ -1,0 +1,54 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class DeletedSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final PostgresMailboxMessageDAO dao;
+
+    @Inject
+    public DeletedSearchOverride(PostgresMailboxMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0).equals(SearchQuery.flagIsSet(Flags.Flag.DELETED))
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        return dao.findDeletedMessagesByMailboxId((PostgresMailboxId) mailbox.getMailboxId());
+    }
+}

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/DeletedWithRangeSearchOverride.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/DeletedWithRangeSearchOverride.java
@@ -1,0 +1,68 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+
+public class DeletedWithRangeSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final PostgresMailboxMessageDAO dao;
+
+    @Inject
+    public DeletedWithRangeSearchOverride(PostgresMailboxMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return searchQuery.getCriteria().size() == 2
+            && searchQuery.getCriteria().contains(SearchQuery.flagIsSet(Flags.Flag.DELETED))
+            && searchQuery.getCriteria().stream()
+            .anyMatch(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        SearchQuery.UidCriterion uidArgument = searchQuery.getCriteria().stream()
+            .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            .map(SearchQuery.UidCriterion.class::cast)
+            .findAny()
+            .orElseThrow(() -> new RuntimeException("Missing Uid argument"));
+
+        SearchQuery.UidRange[] uidRanges = uidArgument.getOperator().getRange();
+
+        return Flux.fromIterable(ImmutableList.copyOf(uidRanges))
+            .concatMap(range -> dao.findDeletedMessagesByMailboxIdAndBetweenUIDs((PostgresMailboxId) mailbox.getMailboxId(),
+                range.getLowValue(), range.getHighValue()));
+    }
+}

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/NotDeletedWithRangeSearchOverride.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/NotDeletedWithRangeSearchOverride.java
@@ -1,0 +1,79 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import reactor.core.publisher.Flux;
+
+public class NotDeletedWithRangeSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final PostgresMailboxMessageDAO dao;
+
+    @Inject
+    public NotDeletedWithRangeSearchOverride(PostgresMailboxMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return isDeletedUnset(searchQuery) || isDeletedNotSet(searchQuery);
+    }
+
+    private boolean isDeletedUnset(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 2
+            && searchQuery.getCriteria().contains(SearchQuery.flagIsUnSet(Flags.Flag.DELETED))
+            && searchQuery.getCriteria().stream()
+            .anyMatch(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isDeletedNotSet(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().size() == 2
+            && searchQuery.getCriteria().contains(SearchQuery.not(SearchQuery.flagIsSet(Flags.Flag.DELETED)))
+            && searchQuery.getCriteria().stream()
+            .anyMatch(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        SearchQuery.UidCriterion uidArgument = searchQuery.getCriteria().stream()
+            .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            .map(SearchQuery.UidCriterion.class::cast)
+            .findAny()
+            .orElseThrow(() -> new RuntimeException("Missing Uid argument"));
+
+        SearchQuery.UidRange[] uidRanges = uidArgument.getOperator().getRange();
+
+        return Flux.fromArray(uidRanges)
+            .concatMap(range -> dao.listNotDeletedUids((PostgresMailboxId) mailbox.getMailboxId(),
+                MessageRange.range(range.getLowValue(), range.getHighValue())));
+    }
+}

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/UidSearchOverride.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/UidSearchOverride.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+
+public class UidSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final PostgresMailboxMessageDAO dao;
+
+    @Inject
+    public UidSearchOverride(PostgresMailboxMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return searchQuery.getCriteria().size() == 1
+            && searchQuery.getCriteria().get(0) instanceof SearchQuery.UidCriterion
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        SearchQuery.UidCriterion uidArgument = searchQuery.getCriteria().stream()
+            .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            .map(SearchQuery.UidCriterion.class::cast)
+            .findAny()
+            .orElseThrow(() -> new RuntimeException("Missing Uid argument"));
+
+        SearchQuery.UidRange[] uidRanges = uidArgument.getOperator().getRange();
+
+        return Flux.fromIterable(ImmutableList.copyOf(uidRanges))
+            .concatMap(range -> dao.listUids((PostgresMailboxId) mailbox.getMailboxId(),
+                MessageRange.range(range.getLowValue(), range.getHighValue())));
+    }
+}

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/UnseenSearchOverride.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/search/UnseenSearchOverride.java
@@ -1,0 +1,93 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+
+public class UnseenSearchOverride implements ListeningMessageSearchIndex.SearchOverride {
+    private final PostgresMailboxMessageDAO dao;
+
+    @Inject
+    public UnseenSearchOverride(PostgresMailboxMessageDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public boolean applicable(SearchQuery searchQuery, MailboxSession session) {
+        return isUnseenWithAll(searchQuery)
+            || isNotSeenWithAll(searchQuery);
+    }
+
+    private boolean isUnseenWithAll(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().contains(SearchQuery.flagIsUnSet(Flags.Flag.SEEN))
+            && allMessages(searchQuery)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean isNotSeenWithAll(SearchQuery searchQuery) {
+        return searchQuery.getCriteria().contains(SearchQuery.not(SearchQuery.flagIsSet(Flags.Flag.SEEN)))
+            && allMessages(searchQuery)
+            && searchQuery.getSorts().equals(SearchQuery.DEFAULT_SORTS);
+    }
+
+    private boolean allMessages(SearchQuery searchQuery) {
+        if (searchQuery.getCriteria().size() == 1) {
+            // Only the unseen critrion
+            return true;
+        }
+        if (searchQuery.getCriteria().size() == 2) {
+            return searchQuery.getCriteria().stream()
+                .anyMatch(criterion -> criterion instanceof SearchQuery.UidCriterion) ||
+                searchQuery.getCriteria().stream()
+                    .anyMatch(criterion -> criterion instanceof SearchQuery.AllCriterion);
+        }
+        return false;
+    }
+
+    @Override
+    public Flux<MessageUid> search(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) {
+        final Optional<SearchQuery.UidCriterion> maybeUidCriterion = searchQuery.getCriteria().stream()
+            .filter(criterion -> criterion instanceof SearchQuery.UidCriterion)
+            .map(SearchQuery.UidCriterion.class::cast)
+            .findFirst();
+
+        return maybeUidCriterion
+            .map(uidCriterion -> Flux.fromIterable(ImmutableList.copyOf(uidCriterion.getOperator().getRange()))
+                .concatMap(range -> dao.listUnseen((PostgresMailboxId) mailbox.getMailboxId(),
+                    MessageRange.range(range.getLowValue(), range.getHighValue()))))
+            .orElseGet(() -> dao.listUnseen((PostgresMailboxId) mailbox.getMailboxId()));
+    }
+}

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/AllSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/AllSearchOverrideTest.java
@@ -1,0 +1,188 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.PostgresMessageId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class AllSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
+    private static final String BLOB_ID = "abc";
+    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
+    private static final String MESSAGE_CONTENT = "Simple message content";
+    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
+    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
+    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
+
+    private PostgresMailboxMessageDAO postgresMailboxMessageDAO;
+    private PostgresMessageDAO postgresMessageDAO;
+    private AllSearchOverride testee;
+
+    @BeforeEach
+    void setUp() {
+        postgresMessageDAO = new PostgresMessageDAO(postgresExtension.getPostgresExecutor());
+        postgresMailboxMessageDAO = new PostgresMailboxMessageDAO(postgresExtension.getPostgresExecutor());
+        testee = new AllSearchOverride(postgresMailboxMessageDAO);
+    }
+
+    @Test
+    void emptyQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void allQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.all())
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void fromOneQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.all())
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
+        MailboxMessage message1 = SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .uid(messageUid)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags())
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message1, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message1).block();
+
+        MessageUid messageUid2 = MessageUid.of(2);
+        PostgresMessageId messageId2 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message2 = SimpleMailboxMessage.builder()
+            .messageId(messageId2)
+            .threadId(ThreadId.fromBaseMessageId(messageId2))
+            .uid(messageUid2)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags())
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message2, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message2).block();
+
+        MessageUid messageUid3 = MessageUid.of(3);
+        PostgresMessageId messageId3 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message3 = SimpleMailboxMessage.builder()
+            .messageId(messageId3)
+            .threadId(ThreadId.fromBaseMessageId(messageId3))
+            .uid(messageUid3)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags())
+            .properties(new PropertyBuilder())
+            .mailboxId(PostgresMailboxId.generate())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message3, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message3).block();
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.all())
+                .build()).collectList().block())
+            .containsOnly(messageUid, messageUid2);
+    }
+}

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedSearchOverrideTest.java
@@ -1,0 +1,171 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import static javax.mail.Flags.Flag.DELETED;
+import static javax.mail.Flags.Flag.SEEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.PostgresMessageId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class DeletedSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
+    private static final String BLOB_ID = "abc";
+    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
+    private static final String MESSAGE_CONTENT = "Simple message content";
+    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
+    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
+    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
+
+    private PostgresMailboxMessageDAO postgresMailboxMessageDAO;
+    private PostgresMessageDAO postgresMessageDAO;
+    private DeletedSearchOverride testee;
+
+    @BeforeEach
+    void setUp() {
+        postgresMessageDAO = new PostgresMessageDAO(postgresExtension.getPostgresExecutor());
+        postgresMailboxMessageDAO = new PostgresMailboxMessageDAO(postgresExtension.getPostgresExecutor());
+        testee = new DeletedSearchOverride(postgresMailboxMessageDAO);
+    }
+
+    @Test
+    void deletedQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
+        MailboxMessage message1 = SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .uid(messageUid)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags(DELETED))
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message1, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message1).block();
+
+        MessageUid messageUid2 = MessageUid.of(2);
+        PostgresMessageId messageId2 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message2 = SimpleMailboxMessage.builder()
+            .messageId(messageId2)
+            .threadId(ThreadId.fromBaseMessageId(messageId2))
+            .uid(messageUid2)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags(DELETED))
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message2, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message2).block();
+
+        MessageUid messageUid3 = MessageUid.of(3);
+        PostgresMessageId messageId3 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message3 = SimpleMailboxMessage.builder()
+            .messageId(messageId3)
+            .threadId(ThreadId.fromBaseMessageId(messageId3))
+            .uid(messageUid3)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags())
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message3, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message3).block();
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .build()).collectList().block())
+            .containsOnly(messageUid, messageUid2);
+    }
+}

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedSearchOverrideTest.java
@@ -21,48 +21,26 @@ package org.apache.james.mailbox.postgres.search;
 
 import static javax.mail.Flags.Flag.DELETED;
 import static javax.mail.Flags.Flag.SEEN;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.BLOB_ID;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX_SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
 
 import javax.mail.Flags;
 
 import org.apache.james.backends.postgres.PostgresExtension;
-import org.apache.james.core.Username;
-import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageUid;
-import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.model.ByteContent;
-import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.SearchQuery;
-import org.apache.james.mailbox.model.ThreadId;
-import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
-import org.apache.james.mailbox.postgres.PostgresMailboxId;
-import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
-import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DeletedSearchOverrideTest {
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
-    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
-    private static final String BLOB_ID = "abc";
-    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
-    private static final String MESSAGE_CONTENT = "Simple message content";
-    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
-    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
-    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
-
     @RegisterExtension
     static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
 
@@ -109,63 +87,24 @@ public class DeletedSearchOverrideTest {
     @Test
     void searchShouldReturnMailboxEntries() {
         MessageUid messageUid = MessageUid.of(1);
-        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
-        MailboxMessage message1 = SimpleMailboxMessage.builder()
-            .messageId(messageId)
-            .threadId(ThreadId.fromBaseMessageId(messageId))
-            .uid(messageUid)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags(DELETED))
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message1, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message1).block();
+        insert(messageUid, MAILBOX.getMailboxId(), new Flags(DELETED));
 
         MessageUid messageUid2 = MessageUid.of(2);
-        PostgresMessageId messageId2 = new PostgresMessageId.Factory().generate();
-        MailboxMessage message2 = SimpleMailboxMessage.builder()
-            .messageId(messageId2)
-            .threadId(ThreadId.fromBaseMessageId(messageId2))
-            .uid(messageUid2)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags(DELETED))
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message2, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message2).block();
+        insert(messageUid2, MAILBOX.getMailboxId(), new Flags(DELETED));
 
         MessageUid messageUid3 = MessageUid.of(3);
-        PostgresMessageId messageId3 = new PostgresMessageId.Factory().generate();
-        MailboxMessage message3 = SimpleMailboxMessage.builder()
-            .messageId(messageId3)
-            .threadId(ThreadId.fromBaseMessageId(messageId3))
-            .uid(messageUid3)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags())
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message3, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message3).block();
+        insert(messageUid3, MAILBOX.getMailboxId(), new Flags());
 
         assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
             SearchQuery.builder()
                 .andCriteria(SearchQuery.flagIsSet(DELETED))
                 .build()).collectList().block())
             .containsOnly(messageUid, messageUid2);
+    }
+
+    private void insert(MessageUid messageUid, MailboxId mailboxId, Flags flags) {
+        MailboxMessage message = SearchOverrideFixture.createMessage(messageUid, mailboxId, flags);
+        postgresMessageDAO.insert(message, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message).block();
     }
 }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedWithRangeSearchOverrideTest.java
@@ -1,0 +1,220 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import static javax.mail.Flags.Flag.DELETED;
+import static javax.mail.Flags.Flag.SEEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.PostgresMessageId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class DeletedWithRangeSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
+    private static final String BLOB_ID = "abc";
+    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
+    private static final String MESSAGE_CONTENT = "Simple message content";
+    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
+    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
+    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
+
+    private PostgresMailboxMessageDAO postgresMailboxMessageDAO;
+    private PostgresMessageDAO postgresMessageDAO;
+    private DeletedWithRangeSearchOverride testee;
+
+    @BeforeEach
+    void setUp() {
+        postgresMessageDAO = new PostgresMessageDAO(postgresExtension.getPostgresExecutor());
+        postgresMailboxMessageDAO = new PostgresMailboxMessageDAO(postgresExtension.getPostgresExecutor());
+        testee = new DeletedWithRangeSearchOverride(postgresMailboxMessageDAO);
+    }
+
+    @Test
+    void deletedWithRangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void deletedQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.of(45))))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
+        MailboxMessage message1 = SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .uid(messageUid)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags(DELETED))
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message1, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message1).block();
+
+        MessageUid messageUid2 = MessageUid.of(2);
+        PostgresMessageId messageId2 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message2 = SimpleMailboxMessage.builder()
+            .messageId(messageId2)
+            .threadId(ThreadId.fromBaseMessageId(messageId2))
+            .uid(messageUid2)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags(DELETED))
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message2, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message2).block();
+
+        MessageUid messageUid3 = MessageUid.of(3);
+        PostgresMessageId messageId3 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message3 = SimpleMailboxMessage.builder()
+            .messageId(messageId3)
+            .threadId(ThreadId.fromBaseMessageId(messageId3))
+            .uid(messageUid3)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags(DELETED))
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message3, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message3).block();
+
+        MessageUid messageUid4 = MessageUid.of(4);
+        PostgresMessageId messageId4 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message4 = SimpleMailboxMessage.builder()
+            .messageId(messageId4)
+            .threadId(ThreadId.fromBaseMessageId(messageId4))
+            .uid(messageUid4)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags(DELETED))
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message4, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message4).block();
+
+        MessageUid messageUid5 = MessageUid.of(5);
+        PostgresMessageId messageId5 = new PostgresMessageId.Factory().generate();
+        MailboxMessage message5 = SimpleMailboxMessage.builder()
+            .messageId(messageId5)
+            .threadId(ThreadId.fromBaseMessageId(messageId5))
+            .uid(messageUid5)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags(DELETED))
+            .properties(new PropertyBuilder())
+            .mailboxId(MAILBOX.getMailboxId())
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message5, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message5).block();
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsSet(DELETED))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(messageUid2, messageUid4)))
+                .build()).collectList().block())
+            .containsOnly(messageUid2, messageUid3, messageUid4);
+    }
+}

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/DeletedWithRangeSearchOverrideTest.java
@@ -21,48 +21,26 @@ package org.apache.james.mailbox.postgres.search;
 
 import static javax.mail.Flags.Flag.DELETED;
 import static javax.mail.Flags.Flag.SEEN;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.BLOB_ID;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX_SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
 
 import javax.mail.Flags;
 
 import org.apache.james.backends.postgres.PostgresExtension;
-import org.apache.james.core.Username;
-import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageUid;
-import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.model.ByteContent;
-import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.SearchQuery;
-import org.apache.james.mailbox.model.ThreadId;
-import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
-import org.apache.james.mailbox.postgres.PostgresMailboxId;
-import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
-import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DeletedWithRangeSearchOverrideTest {
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
-    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
-    private static final String BLOB_ID = "abc";
-    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
-    private static final String MESSAGE_CONTENT = "Simple message content";
-    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
-    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
-    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
-
     @RegisterExtension
     static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
 
@@ -121,100 +99,31 @@ public class DeletedWithRangeSearchOverrideTest {
     @Test
     void searchShouldReturnMailboxEntries() {
         MessageUid messageUid = MessageUid.of(1);
-        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
-        MailboxMessage message1 = SimpleMailboxMessage.builder()
-            .messageId(messageId)
-            .threadId(ThreadId.fromBaseMessageId(messageId))
-            .uid(messageUid)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags(DELETED))
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message1, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message1).block();
+        insert(messageUid, MAILBOX.getMailboxId(), new Flags(DELETED));
 
         MessageUid messageUid2 = MessageUid.of(2);
-        PostgresMessageId messageId2 = new PostgresMessageId.Factory().generate();
-        MailboxMessage message2 = SimpleMailboxMessage.builder()
-            .messageId(messageId2)
-            .threadId(ThreadId.fromBaseMessageId(messageId2))
-            .uid(messageUid2)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags(DELETED))
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message2, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message2).block();
+        insert(messageUid2, MAILBOX.getMailboxId(), new Flags(DELETED));
 
         MessageUid messageUid3 = MessageUid.of(3);
-        PostgresMessageId messageId3 = new PostgresMessageId.Factory().generate();
-        MailboxMessage message3 = SimpleMailboxMessage.builder()
-            .messageId(messageId3)
-            .threadId(ThreadId.fromBaseMessageId(messageId3))
-            .uid(messageUid3)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags(DELETED))
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message3, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message3).block();
+        insert(messageUid3, MAILBOX.getMailboxId(), new Flags());
 
         MessageUid messageUid4 = MessageUid.of(4);
-        PostgresMessageId messageId4 = new PostgresMessageId.Factory().generate();
-        MailboxMessage message4 = SimpleMailboxMessage.builder()
-            .messageId(messageId4)
-            .threadId(ThreadId.fromBaseMessageId(messageId4))
-            .uid(messageUid4)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags(DELETED))
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message4, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message4).block();
+        insert(messageUid4, MAILBOX.getMailboxId(), new Flags(DELETED));
 
         MessageUid messageUid5 = MessageUid.of(5);
-        PostgresMessageId messageId5 = new PostgresMessageId.Factory().generate();
-        MailboxMessage message5 = SimpleMailboxMessage.builder()
-            .messageId(messageId5)
-            .threadId(ThreadId.fromBaseMessageId(messageId5))
-            .uid(messageUid5)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags(DELETED))
-            .properties(new PropertyBuilder())
-            .mailboxId(MAILBOX.getMailboxId())
-            .modseq(ModSeq.of(1))
-            .build();
-        postgresMessageDAO.insert(message5, BLOB_ID).block();
-        postgresMailboxMessageDAO.insert(message5).block();
+        insert(messageUid5, MAILBOX.getMailboxId(), new Flags(DELETED));
 
         assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
             SearchQuery.builder()
                 .andCriteria(SearchQuery.flagIsSet(DELETED))
                 .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(messageUid2, messageUid4)))
                 .build()).collectList().block())
-            .containsOnly(messageUid2, messageUid3, messageUid4);
+            .containsOnly(messageUid2, messageUid4);
+    }
+
+    private void insert(MessageUid messageUid, MailboxId mailboxId, Flags flags) {
+        MailboxMessage message = SearchOverrideFixture.createMessage(messageUid, mailboxId, flags);
+        postgresMessageDAO.insert(message, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message).block();
     }
 }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/NotDeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/NotDeletedWithRangeSearchOverrideTest.java
@@ -20,49 +20,27 @@
 package org.apache.james.mailbox.postgres.search;
 
 import static javax.mail.Flags.Flag.DELETED;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.BLOB_ID;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX_SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
 
 import javax.mail.Flags;
 
 import org.apache.james.backends.postgres.PostgresExtension;
-import org.apache.james.core.Username;
-import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageUid;
-import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.model.ByteContent;
-import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
-import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SearchQuery;
-import org.apache.james.mailbox.model.ThreadId;
-import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
 import org.apache.james.mailbox.postgres.PostgresMailboxId;
-import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
-import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class NotDeletedWithRangeSearchOverrideTest {
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
-    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
-    private static final String BLOB_ID = "abc";
-    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
-    private static final String MESSAGE_CONTENT = "Simple message content";
-    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
-    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
-    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
-
     @RegisterExtension
     static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
 
@@ -123,14 +101,19 @@ public class NotDeletedWithRangeSearchOverrideTest {
     void searchShouldReturnMailboxEntries() {
         MessageUid messageUid = MessageUid.of(1);
         insert(messageUid, MAILBOX.getMailboxId(), new Flags());
+
         MessageUid messageUid2 = MessageUid.of(2);
         insert(messageUid2, MAILBOX.getMailboxId(), new Flags());
+
         MessageUid messageUid3 = MessageUid.of(3);
         insert(messageUid3, MAILBOX.getMailboxId(), new Flags(DELETED));
+
         MessageUid messageUid4 = MessageUid.of(4);
         insert(messageUid4, MAILBOX.getMailboxId(), new Flags());
+
         MessageUid messageUid5 = MessageUid.of(5);
         insert(messageUid5, MAILBOX.getMailboxId(), new Flags());
+
         MessageUid messageUid6 = MessageUid.of(6);
         insert(messageUid6, PostgresMailboxId.generate(), new Flags(DELETED));
 
@@ -143,20 +126,7 @@ public class NotDeletedWithRangeSearchOverrideTest {
     }
 
     private void insert(MessageUid messageUid, MailboxId mailboxId, Flags flags) {
-        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
-        MailboxMessage message = SimpleMailboxMessage.builder()
-            .messageId(messageId)
-            .threadId(ThreadId.fromBaseMessageId(messageId))
-            .uid(messageUid)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(flags)
-            .properties(new PropertyBuilder())
-            .mailboxId(mailboxId)
-            .modseq(ModSeq.of(1))
-            .build();
+        MailboxMessage message = SearchOverrideFixture.createMessage(messageUid, mailboxId, flags);
         postgresMessageDAO.insert(message, BLOB_ID).block();
         postgresMailboxMessageDAO.insert(message).block();
     }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/NotDeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/NotDeletedWithRangeSearchOverrideTest.java
@@ -1,0 +1,163 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import static javax.mail.Flags.Flag.DELETED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.PostgresMessageId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class NotDeletedWithRangeSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
+    private static final String BLOB_ID = "abc";
+    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
+    private static final String MESSAGE_CONTENT = "Simple message content";
+    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
+    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
+    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
+
+    private PostgresMailboxMessageDAO postgresMailboxMessageDAO;
+    private PostgresMessageDAO postgresMessageDAO;
+    private NotDeletedWithRangeSearchOverride testee;
+
+    @BeforeEach
+    void setUp() {
+        postgresMessageDAO = new PostgresMessageDAO(postgresExtension.getPostgresExecutor());
+        postgresMailboxMessageDAO = new PostgresMailboxMessageDAO(postgresExtension.getPostgresExecutor());
+        testee = new NotDeletedWithRangeSearchOverride(postgresMailboxMessageDAO);
+    }
+
+    @Test
+    void undeletedRangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(DELETED))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notDeletedRangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(DELETED)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(DELETED)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(34), MessageUid.of(345))))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        insert(messageUid, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid2 = MessageUid.of(2);
+        insert(messageUid2, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid3 = MessageUid.of(3);
+        insert(messageUid3, MAILBOX.getMailboxId(), new Flags(DELETED));
+        MessageUid messageUid4 = MessageUid.of(4);
+        insert(messageUid4, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid5 = MessageUid.of(5);
+        insert(messageUid5, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid6 = MessageUid.of(6);
+        insert(messageUid6, PostgresMailboxId.generate(), new Flags(DELETED));
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(DELETED)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(messageUid2, messageUid4)))
+                .build()).collectList().block())
+            .containsOnly(messageUid2, messageUid4);
+    }
+
+    private void insert(MessageUid messageUid, MailboxId mailboxId, Flags flags) {
+        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
+        MailboxMessage message = SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .uid(messageUid)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(flags)
+            .properties(new PropertyBuilder())
+            .mailboxId(mailboxId)
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message).block();
+    }
+}

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/SearchOverrideFixture.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/SearchOverrideFixture.java
@@ -1,0 +1,71 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.PostgresMessageId;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+
+interface SearchOverrideFixture {
+    MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
+    String BLOB_ID = "abc";
+    Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
+    String MESSAGE_CONTENT = "Simple message content";
+    byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
+    ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
+    long SIZE = MESSAGE_CONTENT_BYTES.length;
+
+    static MailboxMessage createMessage(MessageUid messageUid, MailboxId mailboxId, Flags flags) {
+        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
+        return SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .uid(messageUid)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(flags)
+            .properties(new PropertyBuilder())
+            .mailboxId(mailboxId)
+            .modseq(ModSeq.of(1))
+            .build();
+    }
+}

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UidSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UidSearchOverrideTest.java
@@ -19,49 +19,27 @@
 
 package org.apache.james.mailbox.postgres.search;
 
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.BLOB_ID;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX_SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
 
 import javax.mail.Flags;
 
 import org.apache.james.backends.postgres.PostgresExtension;
-import org.apache.james.core.Username;
-import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageUid;
-import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.model.ByteContent;
-import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
-import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SearchQuery;
-import org.apache.james.mailbox.model.ThreadId;
-import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
 import org.apache.james.mailbox.postgres.PostgresMailboxId;
-import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
-import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class UidSearchOverrideTest {
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
-    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
-    private static final String BLOB_ID = "abc";
-    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
-    private static final String MESSAGE_CONTENT = "Simple message content";
-    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
-    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
-    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
-
     @RegisterExtension
     static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
 
@@ -109,14 +87,19 @@ public class UidSearchOverrideTest {
     void searchShouldReturnMailboxEntries() {
         MessageUid messageUid = MessageUid.of(1);
         insert(messageUid, MAILBOX.getMailboxId());
+
         MessageUid messageUid2 = MessageUid.of(2);
         insert(messageUid2, MAILBOX.getMailboxId());
+
         MessageUid messageUid3 = MessageUid.of(3);
         insert(messageUid3, MAILBOX.getMailboxId());
+
         MessageUid messageUid4 = MessageUid.of(4);
         insert(messageUid4, MAILBOX.getMailboxId());
+
         MessageUid messageUid5 = MessageUid.of(5);
         insert(messageUid5, MAILBOX.getMailboxId());
+
         MessageUid messageUid6 = MessageUid.of(6);
         insert(messageUid6, PostgresMailboxId.generate());
 
@@ -128,20 +111,7 @@ public class UidSearchOverrideTest {
     }
 
     private void insert(MessageUid messageUid, MailboxId mailboxId) {
-        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
-        MailboxMessage message = SimpleMailboxMessage.builder()
-            .messageId(messageId)
-            .threadId(ThreadId.fromBaseMessageId(messageId))
-            .uid(messageUid)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(new Flags())
-            .properties(new PropertyBuilder())
-            .mailboxId(mailboxId)
-            .modseq(ModSeq.of(1))
-            .build();
+        MailboxMessage message = SearchOverrideFixture.createMessage(messageUid, mailboxId, new Flags());
         postgresMessageDAO.insert(message, BLOB_ID).block();
         postgresMailboxMessageDAO.insert(message).block();
     }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UidSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UidSearchOverrideTest.java
@@ -1,0 +1,148 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.PostgresMessageId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class UidSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
+    private static final String BLOB_ID = "abc";
+    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
+    private static final String MESSAGE_CONTENT = "Simple message content";
+    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
+    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
+    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
+
+    private PostgresMailboxMessageDAO postgresMailboxMessageDAO;
+    private PostgresMessageDAO postgresMessageDAO;
+    private UidSearchOverride testee;
+
+    @BeforeEach
+    void setUp() {
+        postgresMessageDAO = new PostgresMessageDAO(postgresExtension.getPostgresExecutor());
+        postgresMailboxMessageDAO = new PostgresMailboxMessageDAO(postgresExtension.getPostgresExecutor());
+        testee = new UidSearchOverride(postgresMailboxMessageDAO);
+    }
+
+    @Test
+    void rangeQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(4), MessageUid.of(45))))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(34), MessageUid.of(345))))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        insert(messageUid, MAILBOX.getMailboxId());
+        MessageUid messageUid2 = MessageUid.of(2);
+        insert(messageUid2, MAILBOX.getMailboxId());
+        MessageUid messageUid3 = MessageUid.of(3);
+        insert(messageUid3, MAILBOX.getMailboxId());
+        MessageUid messageUid4 = MessageUid.of(4);
+        insert(messageUid4, MAILBOX.getMailboxId());
+        MessageUid messageUid5 = MessageUid.of(5);
+        insert(messageUid5, MAILBOX.getMailboxId());
+        MessageUid messageUid6 = MessageUid.of(6);
+        insert(messageUid6, PostgresMailboxId.generate());
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(messageUid2, messageUid4)))
+                .build()).collectList().block())
+            .containsOnly(messageUid2, messageUid3, messageUid4);
+    }
+
+    private void insert(MessageUid messageUid, MailboxId mailboxId) {
+        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
+        MailboxMessage message = SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .uid(messageUid)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(new Flags())
+            .properties(new PropertyBuilder())
+            .mailboxId(mailboxId)
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message).block();
+    }
+}

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UnseenSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UnseenSearchOverrideTest.java
@@ -20,49 +20,26 @@
 package org.apache.james.mailbox.postgres.search;
 
 import static javax.mail.Flags.Flag.SEEN;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.BLOB_ID;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX;
+import static org.apache.james.mailbox.postgres.search.SearchOverrideFixture.MAILBOX_SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
 
 import javax.mail.Flags;
 
 import org.apache.james.backends.postgres.PostgresExtension;
-import org.apache.james.core.Username;
-import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageUid;
-import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.model.ByteContent;
-import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
-import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SearchQuery;
-import org.apache.james.mailbox.model.ThreadId;
-import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
-import org.apache.james.mailbox.postgres.PostgresMailboxId;
-import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
-import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class UnseenSearchOverrideTest {
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
-    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
-    private static final String BLOB_ID = "abc";
-    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
-    private static final String MESSAGE_CONTENT = "Simple message content";
-    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
-    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
-    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
-
     @RegisterExtension
     static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
 
@@ -180,10 +157,13 @@ public class UnseenSearchOverrideTest {
     void searchShouldSupportRanges() {
         MessageUid messageUid = MessageUid.of(1);
         insert(messageUid, MAILBOX.getMailboxId(), new Flags());
+
         MessageUid messageUid2 = MessageUid.of(2);
         insert(messageUid2, MAILBOX.getMailboxId(), new Flags());
+
         MessageUid messageUid3 = MessageUid.of(3);
         insert(messageUid3, MAILBOX.getMailboxId(), new Flags(SEEN));
+
         MessageUid messageUid4 = MessageUid.of(4);
         insert(messageUid4, MAILBOX.getMailboxId(), new Flags());
 
@@ -196,20 +176,7 @@ public class UnseenSearchOverrideTest {
     }
 
     private void insert(MessageUid messageUid, MailboxId mailboxId, Flags flags) {
-        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
-        MailboxMessage message = SimpleMailboxMessage.builder()
-            .messageId(messageId)
-            .threadId(ThreadId.fromBaseMessageId(messageId))
-            .uid(messageUid)
-            .content(CONTENT_STREAM)
-            .size(SIZE)
-            .internalDate(new Date())
-            .bodyStartOctet(18)
-            .flags(flags)
-            .properties(new PropertyBuilder())
-            .mailboxId(mailboxId)
-            .modseq(ModSeq.of(1))
-            .build();
+        MailboxMessage message = SearchOverrideFixture.createMessage(messageUid, mailboxId, flags);
         postgresMessageDAO.insert(message, BLOB_ID).block();
         postgresMailboxMessageDAO.insert(message).block();
     }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UnseenSearchOverrideTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/search/UnseenSearchOverrideTest.java
@@ -1,0 +1,216 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.search;
+
+import static javax.mail.Flags.Flag.SEEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.model.ThreadId;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.PostgresMessageId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class UnseenSearchOverrideTest {
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), PostgresMailboxId.generate());
+    private static final String BLOB_ID = "abc";
+    private static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
+    private static final String MESSAGE_CONTENT = "Simple message content";
+    private static final byte[] MESSAGE_CONTENT_BYTES = MESSAGE_CONTENT.getBytes(MESSAGE_CHARSET);
+    private static final ByteContent CONTENT_STREAM = new ByteContent(MESSAGE_CONTENT_BYTES);
+    private final static long SIZE = MESSAGE_CONTENT_BYTES.length;
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateModule.MODULE);
+
+    private PostgresMailboxMessageDAO postgresMailboxMessageDAO;
+    private PostgresMessageDAO postgresMessageDAO;
+    private UnseenSearchOverride testee;
+
+    @BeforeEach
+    void setUp() {
+        postgresMessageDAO = new PostgresMessageDAO(postgresExtension.getPostgresExecutor());
+        postgresMailboxMessageDAO = new PostgresMailboxMessageDAO(postgresExtension.getPostgresExecutor());
+        testee = new UnseenSearchOverride(postgresMailboxMessageDAO);
+    }
+
+    @Test
+    void unseenQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notSeenQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(SEEN)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void unseenAndAllQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .andCriteria(SearchQuery.all())
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notSeenAndAllQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(SEEN)))
+                .andCriteria(SearchQuery.all())
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void unseenAndFromOneQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void notSeenFromOneQueryShouldBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.not(SearchQuery.flagIsSet(SEEN)))
+                .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)))
+                .build(),
+            MAILBOX_SESSION))
+            .isTrue();
+    }
+
+    @Test
+    void sizeQueryShouldNotBeApplicable() {
+        assertThat(testee.applicable(
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.sizeEquals(12))
+                .build(),
+            MAILBOX_SESSION))
+            .isFalse();
+    }
+
+    @Test
+    void searchShouldReturnEmptyByDefault() {
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnMailboxEntries() {
+        MessageUid messageUid = MessageUid.of(1);
+        insert(messageUid, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid2 = MessageUid.of(2);
+        insert(messageUid2, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid3 = MessageUid.of(3);
+        insert(messageUid3, MAILBOX.getMailboxId(), new Flags(SEEN));
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .build()).collectList().block())
+            .containsOnly(messageUid, messageUid2);
+    }
+
+    @Test
+    void searchShouldSupportRanges() {
+        MessageUid messageUid = MessageUid.of(1);
+        insert(messageUid, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid2 = MessageUid.of(2);
+        insert(messageUid2, MAILBOX.getMailboxId(), new Flags());
+        MessageUid messageUid3 = MessageUid.of(3);
+        insert(messageUid3, MAILBOX.getMailboxId(), new Flags(SEEN));
+        MessageUid messageUid4 = MessageUid.of(4);
+        insert(messageUid4, MAILBOX.getMailboxId(), new Flags());
+
+        assertThat(testee.search(MAILBOX_SESSION, MAILBOX,
+            SearchQuery.builder()
+                .andCriteria(SearchQuery.flagIsUnSet(SEEN))
+                .andCriterion(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(2), MessageUid.of(4))))
+                .build()).collectList().block())
+            .containsOnly(messageUid2, messageUid4);
+    }
+
+    private void insert(MessageUid messageUid, MailboxId mailboxId, Flags flags) {
+        PostgresMessageId messageId = new PostgresMessageId.Factory().generate();
+        MailboxMessage message = SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .threadId(ThreadId.fromBaseMessageId(messageId))
+            .uid(messageUid)
+            .content(CONTENT_STREAM)
+            .size(SIZE)
+            .internalDate(new Date())
+            .bodyStartOctet(18)
+            .flags(flags)
+            .properties(new PropertyBuilder())
+            .mailboxId(mailboxId)
+            .modseq(ModSeq.of(1))
+            .build();
+        postgresMessageDAO.insert(message, BLOB_ID).block();
+        postgresMailboxMessageDAO.insert(message).block();
+    }
+}

--- a/server/apps/postgres-app/sample-configuration-distributed/opensearch.properties
+++ b/server/apps/postgres-app/sample-configuration-distributed/opensearch.properties
@@ -80,23 +80,21 @@ opensearch.indexAttachments=false
 # are simple enough to be resolved against Cassandra.
 #
 # Possible values are:
-#  - `org.apache.james.mailbox.cassandra.search.AllSearchOverride` Some IMAP clients uses SEARCH ALL to fully list messages in
+#  - `org.apache.james.mailbox.postgres.search.AllSearchOverride` Some IMAP clients uses SEARCH ALL to fully list messages in
 # a mailbox and detect deletions. This is typically done by clients not supporting QRESYNC and from an IMAP perspective
 # is considered an optimisation as less data is transmitted compared to a FETCH command. Resolving such requests against
-# Cassandra is enabled by this search override and likely desirable.
-#  - `org.apache.james.mailbox.cassandra.search.UidSearchOverride`. Same as above but restricted by ranges.
-#  - `org.apache.james.mailbox.cassandra.search.DeletedSearchOverride`. Find deleted messages by looking up in the relevant Cassandra
+# Postgresql is enabled by this search override and likely desirable.
+#  - `org.apache.james.mailbox.postgres.search.UidSearchOverride`. Same as above but restricted by ranges.
+#  - `org.apache.james.mailbox.postgres.search.DeletedSearchOverride`. Find deleted messages by looking up in the relevant Postgresql
 # table.
-#  - `org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride`. Same as above but limited by ranges.
-#  - `org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride`. List non deleted messages in a given range.
+#  - `org.apache.james.mailbox.postgres.search.DeletedWithRangeSearchOverride`. Same as above but limited by ranges.
+#  - `org.apache.james.mailbox.postgres.search.NotDeletedWithRangeSearchOverride`. List non deleted messages in a given range.
 # Lists all messages and filters out deleted message thus this is based on the following heuristic: most messages are not marked as deleted.
-#  - `org.apache.james.mailbox.cassandra.search.UnseenSearchOverride`. List unseen messages in the corresponding cassandra projection.
+#  - `org.apache.james.mailbox.postgres.search.UnseenSearchOverride`. List unseen messages in the corresponding Postgresql index.
 #
 # Please note that custom overrides can be defined here.
 #
-# Note: Search overrides not implemented yet for postgresql.
-#
-# opensearch.search.overrides=org.apache.james.mailbox.cassandra.search.AllSearchOverride,org.apache.james.mailbox.cassandra.search.DeletedSearchOverride, org.apache.james.mailbox.cassandra.search.DeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.NotDeletedWithRangeSearchOverride,org.apache.james.mailbox.cassandra.search.UidSearchOverride,org.apache.james.mailbox.cassandra.search.UnseenSearchOverride
+# opensearch.search.overrides=org.apache.james.mailbox.postgres.search.AllSearchOverride,org.apache.james.mailbox.postgres.search.DeletedSearchOverride, org.apache.james.mailbox.postgres.search.DeletedWithRangeSearchOverride,org.apache.james.mailbox.postgres.search.NotDeletedWithRangeSearchOverride,org.apache.james.mailbox.postgres.search.UidSearchOverride,org.apache.james.mailbox.postgres.search.UnseenSearchOverride
 
 # Optional. Default is `false`
 # When set to true, James will attempt to reindex from the indexed message when moved. If the message is not found, it will fall back to the old behavior (The message will be indexed from the blobStore source)


### PR DESCRIPTION
Todo:

- [x] AllSearchOverride
- [x] DeletedSearchOverride
- [x] DeletedWithRangeSearchOverride
- [x] NotDeletedWithRangeSearchOverride
- [x] UidSearchOverride
- [x] UnseenSearchOverride

Technically, if I'm not wrong, with the searchModuleChooser integrated, the conf is already there, and there is no need to care about bindings?