### PR TITLE
JAMES-2586 Refactor the way initPostgres of PostgresTableManager

### DIFF
--- a/server/container/guice/common/src/main/java/org/apache/james/utils/InitializationOperations.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/InitializationOperations.java
@@ -47,6 +47,7 @@ public class InitializationOperations {
         return startables.get().stream()
             .flatMap(this::configurationPerformerFor)
             .distinct()
+            .sorted((a, b) -> Integer.compare(b.priority(), a.priority()))
             .peek(Throwing.consumer(InitializationOperation::initModule).sneakyThrow())
             .collect(Collectors.toSet());
     }

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/InitializationOperation.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/InitializationOperation.java
@@ -27,6 +27,8 @@ import com.google.common.collect.ImmutableList;
 
 public interface InitializationOperation {
 
+    int DEFAULT_PRIORITY = 0;
+
     void initModule() throws Exception;
 
     /**
@@ -41,4 +43,9 @@ public interface InitializationOperation {
     default List<Class<?>> requires() {
         return ImmutableList.of();
     }
+
+    default int priority() {
+        return DEFAULT_PRIORITY;
+    }
+
 }

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/InitilizationOperationBuilder.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/InitilizationOperationBuilder.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.utils;
 
+import static org.apache.james.utils.InitializationOperation.DEFAULT_PRIORITY;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -41,7 +43,11 @@ public class InitilizationOperationBuilder {
     }
 
     public static RequireInit forClass(Class<? extends Startable> type) {
-        return init -> new PrivateImpl(init, type);
+        return init -> new PrivateImpl(init, type, DEFAULT_PRIORITY);
+    }
+
+    public static RequireInit forClass(Class<? extends Startable> type, int priority) {
+        return init -> new PrivateImpl(init, type, priority);
     }
 
     public static class PrivateImpl implements InitializationOperation {
@@ -49,9 +55,12 @@ public class InitilizationOperationBuilder {
         private final Class<? extends Startable> type;
         private List<Class<?>> requires;
 
-        private PrivateImpl(Init init, Class<? extends Startable> type) {
+        private final int priority;
+
+        private PrivateImpl(Init init, Class<? extends Startable> type, int priority) {
             this.init = init;
             this.type = type;
+            this.priority = priority;
             /*
             Class requirements are by default infered from the parameters of the first @Inject annotated constructor.
 
@@ -84,6 +93,11 @@ public class InitilizationOperationBuilder {
         @Override
         public List<Class<?>> requires() {
             return requires;
+        }
+
+        @Override
+        public int priority() {
+            return priority;
         }
     }
 }


### PR DESCRIPTION
## Context
- Because using `InitializationOperation` for init postgres does not ensure the sort order. 
Hence James will throw an exception at DomainList init when starting. 
More detail: https://github.com/apache/james-project/pull/1807#issuecomment-1835691054
- Currently, we bypass it by moving `initPostgres()` inside the constructor of `PostgresTableManager` => when Guice loads inject constructor, it will also run `initPostgres()`

It works, but we can refactor it by adding the "priority" in `InitializationOperation`, then we can sort the list before running the init method. 
In this way, not only `PostgresTableManger`, we can get the benefit in the future when similar cases

