### PR TITLE
[UPDATE] jooq and r2dbc-postgresql version

### DIFF
--- a/backends-common/postgres/pom.xml
+++ b/backends-common/postgres/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <jooq.version>3.16.23</jooq.version>
-        <r2dbc.postgresql.version>1.0.2.RELEASE</r2dbc.postgresql.version>
+        <r2dbc.postgresql.version>1.0.3.RELEASE</r2dbc.postgresql.version>
     </properties>
 
     <dependencies>

--- a/backends-common/postgres/pom.xml
+++ b/backends-common/postgres/pom.xml
@@ -29,7 +29,7 @@
     <name>Apache James :: Backends Common :: Postgres</name>
 
     <properties>
-        <jooq.version>3.16.22</jooq.version>
+        <jooq.version>3.16.23</jooq.version>
         <r2dbc.postgresql.version>1.0.2.RELEASE</r2dbc.postgresql.version>
     </properties>
 


### PR DESCRIPTION
jooq 3.16 (latest version for JDK 11 support) is in the end-of-life stage. We may need to consider pushing James to JDK 17 soon...