### PR TITLE
JAMES-3968 Fix mail loss due to RabbitMQ ack failure (3.7.x)

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
@@ -91,7 +91,7 @@ class Enqueuer {
         return (Throwable e) -> {
             DeleteCondition.WithEnqueueId deleteCondition = DeleteCondition.withEnqueueId(enqueueId, mailReference.getPartsId());
             return Mono.from(mailQueueView.delete(deleteCondition))
-                    .thenReturn(Mono.<Void>error(e));
+                    .then(Mono.<Void>error(e));
         };
     }
 


### PR DESCRIPTION
One-liner to correctly propagate the exception up the chain. 3.7.x backport.
