### PR TITLE
Fix for GUICE configuration and wiring the SPFHandler (DNSService)

### DIFF
--- a/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/JSPFModule.java
+++ b/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/JSPFModule.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.modules.protocols;
 
+import org.apache.james.jspf.core.DNSService;
 import org.apache.james.jspf.impl.DNSServiceXBillImpl;
 
 import com.google.inject.AbstractModule;
@@ -29,7 +30,7 @@ public class JSPFModule extends AbstractModule {
 
     @Override
     protected void configure() {
-
+        bind(DNSService.class).to(DNSServiceXBillImpl.class);
     }
 
     @Singleton


### PR DESCRIPTION
… DNSService isn't properly registered resulting in an error when wiring up the SPFHandler.

This one-liner solves the issue.