### PR TITLE
[boyscout] fixes missing mdc values in smtp audit logs

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
@@ -168,7 +168,9 @@ public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter imp
         }
         ChannelInboundHandlerAdapter override = behaviourOverrides.peekFirst();
         if (override != null) {
-            override.channelRead(ctx, msg);
+            try (Closeable closeable = mdc(ctx).build()) {
+                override.channelRead(ctx, msg);
+            }
             return;
         }
 


### PR DESCRIPTION
Both the HA proxy path and the non behaviour overrides do build the mdc. unfortunately unless behind an HA proxy, SMTP server will go the behaviour overrides path and lose its MDC in the process.

I discovered this while attempting to configure crowdsec on my SMTP server instance and noticed we lacked the remote IP in the logs.

I could not find a sane way to write tests for this patch.