### PR TITLE
JAMES-2586 Disable row-level security by default in postgres.properties

### DIFF
--- a/server/apps/postgres-app/sample-configuration/postgres.properties
+++ b/server/apps/postgres-app/sample-configuration/postgres.properties
@@ -16,11 +16,11 @@ database.username=james
 # String. Required. Database password of the user.
 database.password=secret1
 
+# Boolean. Optional, default to false. Whether to enable row level security.
+row.level.security.enabled=false
+
 # String. It is required when row.level.security.enabled is true. Database username with the permission of bypassing RLS.
-database.non-rls.username=nonrlsjames
+#database.non-rls.username=nonrlsjames
 
 # String. It is required when row.level.security.enabled is true. Database password of non-rls user.
-database.non-rls.password=secret1
-
-# Boolean. Optional, default to false. Whether to enable row level security.
-row.level.security.enabled=true
+#database.non-rls.password=secret1


### PR DESCRIPTION
- Fix the startup docker-compose not work