### PR TITLE
[IMPROVEMENT] SPF mailet: add missing private network "192.168.0.0/16…

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SPF.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SPF.java
@@ -79,7 +79,7 @@ public class SPF extends GenericMailet {
     private org.apache.james.jspf.impl.SPF spf;
     public static final AttributeName EXPLANATION_ATTRIBUTE = AttributeName.of("org.apache.james.transport.mailets.spf.explanation");
     public static final AttributeName RESULT_ATTRIBUTE = AttributeName.of("org.apache.james.transport.mailets.spf.result");
-    private static final String privateNetworks = "127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/16, 172.17.0.0/16, 172.18.0.0/16, 172.19.0.0/16, 172.20.0.0/16, 172.21.0.0/16, 172.22.0.0/16, 172.23.0.0/16, 172.24.0.0/16, 172.25.0.0/16, 172.26.0.0/16, 172.27.0.0/16, 172.28.0.0/16, 172.29.0.0/16, 172.30.0.0/16, 172.31.0.0/16";
+    private static final String privateNetworks = "127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16";
 
     private final DNSService dnsService;
     private NetMatcher netMatcher;


### PR DESCRIPTION
…" and use correct CIDR for private range "172.16.0.0/12"