### PR TITLE
[JAMES-3978] initial setup of develocity for james build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dockerfiles/run/**/glowroot
 .m2
 test-run.log
 build
+.mvn/.gradle-enterprise

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,22 @@
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <!--
+      provides develocity related services such as
+      - build scans
+      - local and remote cache
+      build scans capture information see https://docs.gradle.com/enterprise/gradle-plugin/#captured_information
+    -->
+    <artifactId>gradle-enterprise-maven-extension</artifactId>
+    <version>1.20</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <!--
+      adds common env and build information as tags for build scans
+      see https://github.com/gradle/common-custom-user-data-gradle-plugin
+    -->
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>1.12.5</version>
+  </extension>
+</extensions>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,60 @@
+<gradleEnterprise>
+  <server>
+    <url>https://ge.apache.org</url>
+    <allowUntrusted>false</allowUntrusted>
+    <!--
+    credentials provided by jenkins exposing GRADLE_ENTERPRISE_ACCESS_KEY
+    apache members can create their own on the server
+    -->
+  </server>
+  <!-- options are documented at https://docs.gradle.com/enterprise/maven-extension/#configuring_background_uploading -->
+  <!-- chosen values align with https://cwiki.apache.org/confluence/display/INFRA/Project+Onboarding+Instructions+for+Develocity -->
+  <buildScan>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+    <publish>ALWAYS</publish>
+    <publishIfAuthenticated>true</publishIfAuthenticated>
+    <!-- Always publish build scans for CI, only if requested locally -->
+    <publish>#{env['CI'] == null ? 'ON_DEMAND' : 'ALWAYS'}</publish>
+    <capture>
+      <goalInputFiles>true</goalInputFiles> <!-- To be enabled locally when debugging goal caching or if we want to enable predictive test selection -->
+      <buildLogging>false</buildLogging> <!-- disabled by default for privacy and performance, to be discussed -->
+      <testLogging>false</testLogging> <!-- disabled by default for privacy and performance, to be discussed -->
+    </capture>
+    <links>
+      <link>
+        <name>Apache James github</name>
+        <url>https://github.com/apache/james-project/</url>
+      </link>
+      <link>
+        <name>Apache James project website</name>
+        <url>https://github.com/apache/james-project/</url>
+      </link>
+    </links>
+    <obfuscation>
+      <!-- Use Spring Expression Language. -->
+      <!-- <hostname>#{isTrue(env['CI']) ? hostname : 'Local agent'}</hostname> -->
+      <hostname>#{isTrue(env['CI']) ? 'jenkins' : 'Local agent'}</hostname>
+      <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+    </obfuscation>
+  </buildScan>
+  <buildCache>
+    <local>
+      <!-- disabling build cache on CI as it seems to affect
+      MemoryLdapLocalPartLoginIntegrationTest and DistributedTaskManagerTest -->
+      <enabled>#{isFalse(env['CI'])}</enabled>
+      <cleanup>
+    <!-- materialize default settings -->
+        <retention>P7D</retention>
+        <interval>P1D</interval>
+      </cleanup>
+    </local>
+    <remote>
+      <storeEnabled>false</storeEnabled>
+      <!--
+      the next step is this
+      <storeEnabled>#{isTrue(env['CI'])</storeEnabled>
+      but it requires requesting a cache node to infra project
+      -->
+    </remote>
+  </buildCache>
+</gradleEnterprise>

--- a/pom.xml
+++ b/pom.xml
@@ -3265,6 +3265,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
+                    <configuration>
+                        <!-- avoid double buildscan during forked builds -->
+                        <arguments>-Dgradle.scan.disabled=true</arguments>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/JAMES-3978 this PR configure the basics dor develocity integration. 

This brings : 
- build scans at https://ge.apache.org
  - automatic build scan upload for CI 
  - manual build scan upload for local dev
  - build metrics from the accumulated build scans 
- automatic local caching for maven goals that are known by the extension 
  - can bring speed up gains for both local and ci builds as long as you remember to include the clean goal 

https://issues.apache.org/jira/browse/JAMES-3978?focusedCommentId=17813731&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17813731