### PR TITLE
[FIX] Prevent creation of multiline mailbox names

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -94,7 +94,7 @@ public class MailboxPath {
         return Username.of(USERNAME_UNESCAPER.translate(parts.get(1)));
     }
 
-    private static final String INVALID_CHARS = "%*";
+    private static final String INVALID_CHARS = "%*\r\n";
     private static final CharMatcher INVALID_CHARS_MATCHER = CharMatcher.anyOf(INVALID_CHARS);
     // This is the size that all mailbox backend should support
     public  static final int MAX_MAILBOX_NAME_LENGTH = 200;

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -148,6 +148,12 @@ class MailboxPathTest {
     }
 
     @Test
+    void shouldThrowWhenLineBreak() {
+        assertThatThrownBy(() -> MailboxPath.forUser(USER, "a\r\n [ALERT] that's bad").assertAcceptable('.'))
+            .isInstanceOf(MailboxNameException.class);
+    }
+
+    @Test
     void childShouldThrowWhenBlank() {
         MailboxPath path = MailboxPath.forUser(USER, "folder");
         assertThatThrownBy(() -> path.child(" ", '.'))

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -348,7 +348,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to create an invalid mailbox")
-                .containsEntry("details", "#private:username:#myMailboxName contains one of the forbidden characters %* or starts with #");
+                .containsEntry("details", "#private:username:#myMailboxName contains one of the forbidden characters %*\r\n or starts with #");
         }
 
         @Test
@@ -412,7 +412,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to test existence of an invalid mailbox")
-                .containsEntry("details", "#private:username:myMailboxName* contains one of the forbidden characters %* or starts with #");
+                .containsEntry("details", "#private:username:myMailboxName* contains one of the forbidden characters %*\r\n or starts with #");
         }
 
         @Test
@@ -467,7 +467,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to test existence of an invalid mailbox")
-                .containsEntry("details", "#private:username:myMailboxName% contains one of the forbidden characters %* or starts with #");
+                .containsEntry("details", "#private:username:myMailboxName% contains one of the forbidden characters %*\r\n or starts with #");
         }
 
         @Test
@@ -522,7 +522,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to test existence of an invalid mailbox")
-                .containsEntry("details", "#private:username:#myMailboxName contains one of the forbidden characters %* or starts with #");
+                .containsEntry("details", "#private:username:#myMailboxName contains one of the forbidden characters %*\r\n or starts with #");
         }
 
         @Test


### PR DESCRIPTION
Multiline mailbox names could be created through JMAP.

As '*' character is forbidden in mailbox name so
injection of IMAP untagged commands was not possible but this could still be used to inject lines onto
unspecting IMAO clients eg with an hypothetic team mailbox.

Better disactivate.