### PR TITLE
[Build][Fix] Fix tag for Minio testing image

### DIFF
--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
@@ -51,11 +51,14 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 @Testcontainers
 public class S3MinioTest implements BlobStoreDAOContract {
 
+    private static final String MINIO_IMAGE = "quay.io/minio/minio";
+    private static final String MINIO_TAG = "RELEASE.2024-01-29T03-56-32Z";
+    private static final String MINIO_IMAGE_FULL = MINIO_IMAGE + ":" + MINIO_TAG;
     private static final int MINIO_PORT = 9000;
     private static S3BlobStoreDAO testee;
 
     @Container
-    private static final GenericContainer<?> minioContainer = new GenericContainer<>("quay.io/minio/minio")
+    private static final GenericContainer<?> minioContainer = new GenericContainer<>(MINIO_IMAGE_FULL)
         .withExposedPorts(MINIO_PORT)
         .withEnv("MINIO_ROOT_USER", ACCESS_KEY_ID)
         .withEnv("MINIO_ROOT_PASSWORD", SECRET_ACCESS_KEY)


### PR DESCRIPTION
I saw lots of builds failing on Minio today. decided to investigate and yeah locally it was very unstable on latest minio image.

Not the first time it happens, so I went back on the latest stable tag that I could get when testing locally and pushed this PR. IDK if the image is buggy or if something slightly changed in minio behavior, but not the issue here.