### PR TITLE
[FIX] Apply RFC-5321 syntax validation for EHLO

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyServer.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyServer.java
@@ -88,6 +88,8 @@ public class NettyServer extends AbstractAsyncServer {
         this.secure = secure;
         this.proxyRequired = proxyRequired;
         this.frameHandlerFactory = frameHandlerFactory;
+
+        this.setGracefulShutdown(false);
     }
     
     public void setMaxConcurrentConnections(int maxCurConnections) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/HeloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/HeloCmdHandler.java
@@ -87,7 +87,11 @@ public class HeloCmdHandler extends AbstractHookableCmdHandler<HeloHook> {
 
     private boolean isValid(String argument) {
         String hostname = unquote(argument);
+
+        // Without [] Guava attempt to parse IPV4
         return InetAddresses.isUriInetAddress(hostname)
+            // Guava tries parsing IPv6 if and only if wrapped by []
+            || InetAddresses.isUriInetAddress("[" + hostname + "]")
             || InternetDomainName.isValid(hostname);
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
@@ -96,7 +96,11 @@ public class EhloCmdHandler extends AbstractHookableCmdHandler<HeloHook> impleme
 
     private boolean isValid(String argument) {
         String hostname = unquote(argument);
+
+        // Without [] Guava attempt to parse IPV4
         return InetAddresses.isUriInetAddress(hostname)
+            // Guava tries parsing IPv6 if and only if wrapped by []
+            || InetAddresses.isUriInetAddress("[" + hostname + "]")
             || InternetDomainName.isValid(hostname);
     }
 

--- a/server/apps/memory-app/src/test/java/org/apache/james/LmtpIntegrationTest.java
+++ b/server/apps/memory-app/src/test/java/org/apache/james/LmtpIntegrationTest.java
@@ -63,7 +63,7 @@ public class LmtpIntegrationTest {
         server.connect(new InetSocketAddress(LOCALHOST_IP, guiceJamesServer.getProbe(LmtpGuiceProbe.class).getLmtpPort()));
         readBytes(server);
 
-        server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+        server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
         readBytes(server);
         server.write(ByteBuffer.wrap(("MAIL FROM: <user@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
         readBytes(server);
@@ -91,7 +91,7 @@ public class LmtpIntegrationTest {
         server.connect(new InetSocketAddress(LOCALHOST_IP, guiceJamesServer.getProbe(LmtpGuiceProbe.class).getLmtpPort()));
         readBytes(server);
 
-        server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+        server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
         readBytes(server);
         server.write(ByteBuffer.wrap(("MAIL FROM: <user@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
         readBytes(server);

--- a/server/protocols/protocols-lmtp/src/test/java/org/apache/james/lmtpserver/LmtpServerTest.java
+++ b/server/protocols/protocols-lmtp/src/test/java/org/apache/james/lmtpserver/LmtpServerTest.java
@@ -190,7 +190,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -215,7 +215,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -255,7 +255,7 @@ class LmtpServerTest {
             SocketChannel server = SocketChannel.open();
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + "> RET=HDRS ENVID=QQ314159\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -288,7 +288,7 @@ class LmtpServerTest {
             SocketChannel server = SocketChannel.open();
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
 
             assertThat(new String(readBytes(server), StandardCharsets.UTF_8)).contains("250 DSN\r\n");
         }
@@ -312,7 +312,7 @@ class LmtpServerTest {
             SocketChannel server = SocketChannel.open();
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + "> RET=HDRS ENVID=QQ314159\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -355,7 +355,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -381,7 +381,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -433,7 +433,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -475,7 +475,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -514,7 +514,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("LHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("LHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
             server.write(ByteBuffer.wrap(("MAIL FROM: <bob@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
             readBytes(server);
@@ -542,7 +542,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("EHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("EHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             assertThat(new String(readBytes(server), StandardCharsets.UTF_8))
                 .contains("500 Unable to process request: the command is unknown");
         }
@@ -553,7 +553,7 @@ class LmtpServerTest {
             server.connect(new InetSocketAddress(LOCALHOST_IP, getLmtpPort(lmtpServerFactory)));
             readBytes(server);
 
-            server.write(ByteBuffer.wrap(("HELO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+            server.write(ByteBuffer.wrap(("HELO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
             assertThat(new String(readBytes(server), StandardCharsets.UTF_8))
                 .contains("500 Unable to process request: the command is unknown");
         }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPProxyProtocolTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPProxyProtocolTest.java
@@ -67,7 +67,7 @@ class SMTPProxyProtocolTest {
 
         String proxyMessage = String.format("PROXY %s %s %s %d %d\r\n", protocol, source, destination, 65535, 65535);
         server.write(ByteBuffer.wrap((proxyMessage).getBytes(StandardCharsets.UTF_8)));
-        server.write(ByteBuffer.wrap(("EHLO <" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
+        server.write(ByteBuffer.wrap(("EHLO " + DOMAIN + "\r\n").getBytes(StandardCharsets.UTF_8)));
         readBytes(server);
         server.write(ByteBuffer.wrap(("MAIL FROM: <user@" + DOMAIN + ">\r\n").getBytes(StandardCharsets.UTF_8)));
         readBytes(server);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -353,7 +353,7 @@ public class SMTPServerTest {
         SMTPClient smtpProtocol = new SMTPClient();
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
-        smtpProtocol.sendCommand("EHLO lcoalhost");
+        smtpProtocol.sendCommand("EHLO localhost");
         smtpProtocol.setSender("mail@localhost");
         smtpProtocol.addRecipient("mail@localhost");
         // Create a 1K+ message
@@ -495,7 +495,9 @@ public class SMTPServerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"good", "adomain.com", "sub.domain.com",  "127.0.0.1",  "[127.0.0.1]"})
+    @ValueSource(strings = {"good", "adomain.com", "sub.domain.com",  "127.0.0.1",  "[127.0.0.1]",
+        "fe80::1ff:fe23:4567:890a", "[fe80::1ff:fe23:4567:890a]",
+        "2001:db8:85a3:8d3:1319:8a2e:370:7348", "[2001:db8:85a3:8d3:1319:8a2e:370:7348]"})
     public void testValidHELO(String helo) throws Exception {
         init(smtpConfiguration);
 
@@ -531,9 +533,10 @@ public class SMTPServerTest {
             .startsWith("501");
     }
 
-
     @ParameterizedTest
-    @ValueSource(strings = {"good", "127.0.0.1", "adomain.com", "sub.domain.com", "[abc.def]", "[124.54.67.43]"})
+    @ValueSource(strings = {"good", "127.0.0.1", "adomain.com", "sub.domain.com", "[abc.def]", "[124.54.67.43]",
+        "fe80::1ff:fe23:4567:890a", "[fe80::1ff:fe23:4567:890a]",
+        "2001:db8:85a3:8d3:1319:8a2e:370:7348", "[2001:db8:85a3:8d3:1319:8a2e:370:7348]"})
     public void testValidEHLO(String helo) throws Exception {
         init(smtpConfiguration);
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -55,6 +55,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -273,7 +275,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol.sendCommand("EHLO " + InetAddress.getLocalHost());
+        smtpProtocol.sendCommand("EHLO localhost");
         String[] capabilityRes = smtpProtocol.getReplyStrings();
 
         List<String> capabilitieslist = new ArrayList<>();
@@ -351,7 +353,7 @@ public class SMTPServerTest {
         SMTPClient smtpProtocol = new SMTPClient();
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
-        smtpProtocol.sendCommand("EHLO " + InetAddress.getLocalHost());
+        smtpProtocol.sendCommand("EHLO lcoalhost");
         smtpProtocol.setSender("mail@localhost");
         smtpProtocol.addRecipient("mail@localhost");
         // Create a 1K+ message
@@ -385,7 +387,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol.sendCommand("EHLO " + InetAddress.getLocalHost());
+        smtpProtocol.sendCommand("EHLO localhost");
         String[] capabilityRes = smtpProtocol.getReplyStrings();
 
         List<String> capabilitieslist = new ArrayList<>();
@@ -479,7 +481,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtp.helo(InetAddress.getLocalHost().toString());
+        smtp.helo("localhost");
         smtp.setSender("mail@localhost");
         smtp.addRecipient("mail@localhost");
         smtp.sendShortMessageData("Subject: test\r\n\r\n");
@@ -490,6 +492,80 @@ public class SMTPServerTest {
         assertThat(testSystem.queue.getLastMail().getMessage().getHeader("Received"))
             .as("spooled mail has Received header")
             .isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"good", "adomain.com", "sub.domain.com",  "127.0.0.1",  "[127.0.0.1]"})
+    public void testValidHELO(String helo) throws Exception {
+        init(smtpConfiguration);
+
+        SMTPClient smtp = newSMTPClient();
+
+        // no message there, yet
+        assertThat(testSystem.queue.getLastMail())
+            .as("no mail received by mail server")
+            .isNull();
+
+        smtp.helo(helo);
+
+        assertThat(smtp.getReplyString())
+            .startsWith("250");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"bad value", "localhost) (spoofed into received header", "localhost)", "127.0.0.1/24",
+        "sub..bad", "[]", ""})
+    public void testInvalidHELO(String helo) throws Exception {
+        init(smtpConfiguration);
+
+        SMTPClient smtp = newSMTPClient();
+
+        // no message there, yet
+        assertThat(testSystem.queue.getLastMail())
+            .as("no mail received by mail server")
+            .isNull();
+
+        smtp.helo(helo);
+
+        assertThat(smtp.getReplyString())
+            .startsWith("501");
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"good", "127.0.0.1", "adomain.com", "sub.domain.com", "[abc.def]", "[124.54.67.43]"})
+    public void testValidEHLO(String helo) throws Exception {
+        init(smtpConfiguration);
+
+        SMTPClient smtp = newSMTPClient();
+
+        // no message there, yet
+        assertThat(testSystem.queue.getLastMail())
+            .as("no mail received by mail server")
+            .isNull();
+
+        smtp.sendCommand("EHLO " + helo);
+
+        assertThat(smtp.getReplyString())
+            .startsWith("250");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"bad value", "localhost) (spoofed into received header", "localhost)", "127.0.0.1/24", "sub..bad", "[]"})
+    public void testInvalidEHLO(String helo) throws Exception {
+        init(smtpConfiguration);
+
+        SMTPClient smtp = newSMTPClient();
+
+        // no message there, yet
+        assertThat(testSystem.queue.getLastMail())
+            .as("no mail received by mail server")
+            .isNull();
+
+        smtp.sendCommand("EHLO " + helo);
+
+        assertThat(smtp.getReplyString())
+            .startsWith("501 5.5.2 Invalid domain name or ip supplied as HELO argument");
     }
 
     // FIXME
@@ -532,7 +608,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol.helo(InetAddress.getLocalHost().toString());
+        smtpProtocol.helo("localhost");
 
         smtpProtocol.setSender("mail@localhost");
 
@@ -571,8 +647,8 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol1.helo(InetAddress.getLocalHost().toString());
-        smtpProtocol2.helo(InetAddress.getLocalHost().toString());
+        smtpProtocol1.helo("localhost");
+        smtpProtocol2.helo("localhost");
 
         String sender1 = "mail_sender1@localhost";
         String recipient1 = "mail_recipient1@localhost";
@@ -614,7 +690,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol1.helo(InetAddress.getLocalHost().toString());
+        smtpProtocol1.helo("localhost");
 
         String sender1 = "mail_sender1@localhost";
         String recipient1 = "mail_recipient1@localhost";
@@ -778,7 +854,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol1.helo(InetAddress.getLocalHost().toString());
+        smtpProtocol1.helo("localhost");
 
         String sender1 = "mail_sender1@xfwrqqfgfe.de";
 
@@ -860,7 +936,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol1.helo(InetAddress.getLocalHost().toString());
+        smtpProtocol1.helo("localhost");
 
         String sender1 = "mail_sender1@xfwrqqfgfe.de";
         String sender2 = "mail_sender2@james.apache.org";
@@ -894,7 +970,7 @@ public class SMTPServerTest {
             .as("no mail received by mail server")
             .isNull();
 
-        smtpProtocol1.helo(InetAddress.getLocalHost().toString());
+        smtpProtocol1.helo("localhost");
 
         String sender1 = "mail_sender1@james.apache.org";
         String rcpt1 = "test@localhost";
@@ -1130,7 +1206,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
         String[] capabilityRes = smtpProtocol.getReplyStrings();
 
         List<String> capabilitieslist = new ArrayList<>();
@@ -1212,7 +1288,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
         String[] capabilityRes = smtpProtocol.getReplyStrings();
 
         List<String> capabilitieslist = new ArrayList<>();
@@ -1296,7 +1372,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
         String[] capabilityRes = smtpProtocol.getReplyStrings();
 
         List<String> capabilitieslist = new ArrayList<>();
@@ -1338,7 +1414,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
         String[] capabilityRes = smtpProtocol.getReplyStrings();
 
         List<String> capabilitieslist = new ArrayList<>();
@@ -1507,7 +1583,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo " + InetAddress.getLocalHost());
+        smtpProtocol.sendCommand("ehlo localhost");
 
         smtpProtocol.setSender("mail@sample.com");
 
@@ -1526,7 +1602,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo " + InetAddress.getLocalHost());
+        smtpProtocol.sendCommand("ehlo localhost");
 
         smtpProtocol.sendCommand("MAIL FROM:<mail@localhost> SIZE=1025", null);
         assertThat(smtpProtocol.getReplyCode())
@@ -1548,7 +1624,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo " + InetAddress.getLocalHost());
+        smtpProtocol.sendCommand("ehlo localhost");
 
         smtpProtocol.setSender("mail@localhost");
         smtpProtocol.addRecipient("mail@localhost");
@@ -1588,7 +1664,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo " + InetAddress.getLocalHost());
+        smtpProtocol.sendCommand("ehlo localhost");
 
         smtpProtocol.setSender("mail@localhost");
         smtpProtocol.addRecipient("mail@localhost");
@@ -1631,7 +1707,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
         String[] capabilityRes = smtpProtocol.getReplyStrings();
 
         List<String> capabilitieslist = new ArrayList<>();
@@ -1690,7 +1766,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
 
         String sender = USER_LOCALHOST;
 
@@ -1717,7 +1793,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
 
         smtpProtocol.sendCommand("mail from:", "test@localhost");
         assertThat(smtpProtocol.getReplyCode())
@@ -1733,7 +1809,7 @@ public class SMTPServerTest {
 
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
 
         smtpProtocol.sendCommand("mail from:", "<test@localhost>");
         assertThat(smtpProtocol.getReplyCode())
@@ -1755,7 +1831,7 @@ public class SMTPServerTest {
         InetSocketAddress bindedAddress = testSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
 
-        smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
+        smtpProtocol.sendCommand("ehlo", "localhost");
 
         smtpProtocol.sendCommand("mail from:", "test@localhost");
         assertThat(smtpProtocol.getReplyCode())

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPTestConfiguration.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPTestConfiguration.java
@@ -137,6 +137,7 @@ public class SMTPTestConfiguration extends BaseHierarchicalConfiguration {
         addProperty("tls.secret", "jamestest");
         addProperty("auth.requireSSL", false);
         addProperty("verifyIdentity", verifyIdentity);
+        addProperty("gracefulShutdown", false);
 
         // add the rbl handler
         if (useRBL) {


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.1.1

   Syntax:
   ehlo           = "EHLO" SP ( Domain / address-literal ) CRLF
   helo           = "HELO" SP Domain CRLF

Failing to do so could lead to vulnerabilities eg value injection
in received headers that could lead to arbitrary Received header
crafting and might allow eg to bypass some anti-virus checks.
This is a simple exploit that the non security-expert I am could put together in
2 minutes but other scenarii could leverage this as well.

Tests demanded substancial adaptations to be syntax compliant.