### PR TITLE
JAMES-2586 Handle case when Postgres index/constraint already exists

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/user/PostgresSubscriptionModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/user/PostgresSubscriptionModule.java
@@ -46,7 +46,7 @@ public interface PostgresSubscriptionModule {
         .supportsRowLevelSecurity()
         .build();
     PostgresIndex INDEX = PostgresIndex.name("subscription_user_index")
-        .createIndexStep((dsl, indexName) -> dsl.createIndex(indexName)
+        .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
             .on(TABLE_NAME, USER));
     PostgresModule MODULE = PostgresModule.builder()
         .addTable(TABLE)

--- a/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresEmailChangeModule.java
+++ b/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresEmailChangeModule.java
@@ -60,7 +60,7 @@ public interface PostgresEmailChangeModule {
             .build();
 
         PostgresIndex INDEX = PostgresIndex.name("idx_email_change_date")
-            .createIndexStep((dslContext, indexName) -> dslContext.createIndex(indexName)
+            .createIndexStep((dslContext, indexName) -> dslContext.createIndexIfNotExists(indexName)
                 .on(TABLE_NAME, DATE));
     }
 

--- a/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresMailboxChangeModule.java
+++ b/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresMailboxChangeModule.java
@@ -62,7 +62,7 @@ public interface PostgresMailboxChangeModule {
             .build();
 
         PostgresIndex INDEX = PostgresIndex.name("index_mailbox_change_date")
-            .createIndexStep((dslContext, indexName) -> dslContext.createIndex(indexName)
+            .createIndexStep((dslContext, indexName) -> dslContext.createIndexIfNotExists(indexName)
                 .on(TABLE_NAME, DATE));
     }
 

--- a/server/data/data-postgres/src/main/java/org/apache/james/mailrepository/postgres/PostgresMailRepositoryUrlStore.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/mailrepository/postgres/PostgresMailRepositoryUrlStore.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.james.backends.postgres.utils.PostgresExecutor;
-import org.apache.james.backends.postgres.utils.PostgresUtils;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.mailrepository.api.MailRepositoryUrlStore;
 
@@ -47,8 +46,9 @@ public class PostgresMailRepositoryUrlStore implements MailRepositoryUrlStore {
     @Override
     public void add(MailRepositoryUrl url) {
         postgresExecutor.executeVoid(context -> Mono.from(context.insertInto(TABLE_NAME, URL)
-            .values(url.asString())))
-            .onErrorResume(PostgresUtils.UNIQUE_CONSTRAINT_VIOLATION_PREDICATE, e -> Mono.empty())
+                .values(url.asString())
+                .onConflict(URL)
+                .doNothing()))
             .block();
     }
 

--- a/server/data/data-postgres/src/main/java/org/apache/james/rrt/postgres/PostgresRecipientRewriteTableModule.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/rrt/postgres/PostgresRecipientRewriteTableModule.java
@@ -49,7 +49,7 @@ public interface PostgresRecipientRewriteTableModule {
             .build();
 
         PostgresIndex INDEX = PostgresIndex.name("idx_rrt_target_address")
-            .createIndexStep((dslContext, indexName) -> dslContext.createIndex(indexName)
+            .createIndexStep((dslContext, indexName) -> dslContext.createIndexIfNotExists(indexName)
                 .on(TABLE_NAME, TARGET_ADDRESS));
     }
 


### PR DESCRIPTION
Fix error log from postgres when james startup

```
2024-02-06 09:07:22.373 UTC [41] ERROR:  relation "subscription_user_index" already exists
2024-02-06T09:07:22.373765269Z 2024-02-06 09:07:22.373 UTC [41] STATEMENT:  create index "subscription_user_index" on subscription(user_name)
2024-02-06T09:07:22.381077149Z 2024-02-06 09:07:22.381 UTC [41] ERROR:  relation "idx_rrt_target_address" already exists
2024-02-06T09:07:22.381086477Z 2024-02-06 09:07:22.381 UTC [41] STATEMENT:  create index "idx_rrt_target_address" on rrt(target_address)
2024-02-06T09:07:22.385200689Z 2024-02-06 09:07:22.385 UTC [41] ERROR:  relation "idx_email_change_date" already exists
2024-02-06T09:07:22.385207101Z 2024-02-06 09:07:22.385 UTC [41] STATEMENT:  create index "idx_email_change_date" on email_change(date)
2024-02-06T09:07:22.385617231Z 2024-02-06 09:07:22.385 UTC [41] ERROR:  relation "index_mailbox_change_date" already exists
2024-02-06T09:07:22.385624785Z 2024-02-06 09:07:22.385 UTC [41] STATEMENT:  create index "index_mailbox_change_date" on mailbox_change(date)
2024-02-06T09:07:22.645716708Z 2024-02-06 09:07:22.645 UTC [41] ERROR:  duplicate key value violates unique constraint "mail_repository_url_pkey"
2024-02-06T09:07:22.645734952Z 2024-02-06 09:07:22.645 UTC [41] DETAIL:  Key (url)=(postgres://var/mail/relay-limit-exceeded) already exists.
2024-02-06T09:07:22.645738058Z 2024-02-06 09:07:22.645 UTC [41] STATEMENT:  insert into mail_repository_url (url)
```
