### PR TITLE
JAMES-2586 Optimize some postgres query

### DIFF
--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/quota/PostgresQuotaCurrentValueDAO.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/quota/PostgresQuotaCurrentValueDAO.java
@@ -22,7 +22,6 @@ package org.apache.james.backends.postgres.quota;
 import static org.apache.james.backends.postgres.quota.PostgresQuotaModule.PostgresQuotaCurrentValueTable.COMPONENT;
 import static org.apache.james.backends.postgres.quota.PostgresQuotaModule.PostgresQuotaCurrentValueTable.CURRENT_VALUE;
 import static org.apache.james.backends.postgres.quota.PostgresQuotaModule.PostgresQuotaCurrentValueTable.IDENTIFIER;
-import static org.apache.james.backends.postgres.quota.PostgresQuotaModule.PostgresQuotaCurrentValueTable.PRIMARY_KEY_CONSTRAINT_NAME;
 import static org.apache.james.backends.postgres.quota.PostgresQuotaModule.PostgresQuotaCurrentValueTable.TABLE_NAME;
 import static org.apache.james.backends.postgres.quota.PostgresQuotaModule.PostgresQuotaCurrentValueTable.TYPE;
 import static org.apache.james.backends.postgres.utils.PostgresExecutor.DEFAULT_INJECT;
@@ -36,15 +35,14 @@ import org.apache.james.backends.postgres.utils.PostgresExecutor;
 import org.apache.james.core.quota.QuotaComponent;
 import org.apache.james.core.quota.QuotaCurrentValue;
 import org.apache.james.core.quota.QuotaType;
+import org.jooq.Field;
 import org.jooq.Record;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class PostgresQuotaCurrentValueDAO {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresQuotaCurrentValueDAO.class);
+    private static final boolean IS_INCREASE = true;
 
     private final PostgresExecutor postgresExecutor;
 
@@ -54,35 +52,49 @@ public class PostgresQuotaCurrentValueDAO {
     }
 
     public Mono<Void> increase(QuotaCurrentValue.Key quotaKey, long amount) {
-        return postgresExecutor.executeVoid(dslContext -> Mono.from(dslContext.insertInto(TABLE_NAME)
-            .set(IDENTIFIER, quotaKey.getIdentifier())
-            .set(COMPONENT, quotaKey.getQuotaComponent().getValue())
-            .set(TYPE, quotaKey.getQuotaType().getValue())
-            .set(CURRENT_VALUE, amount)
-            .onConflictOnConstraint(PRIMARY_KEY_CONSTRAINT_NAME)
-            .doUpdate()
-            .set(CURRENT_VALUE, CURRENT_VALUE.plus(amount))))
-            .onErrorResume(ex -> {
-                LOGGER.warn("Failure when increasing {} {} quota for {}. Quota current value is thus not updated and needs re-computation",
-                    quotaKey.getQuotaComponent().getValue(), quotaKey.getQuotaType().getValue(), quotaKey.getIdentifier(), ex);
-                return Mono.empty();
-            });
+        return updateCurrentValue(quotaKey, amount, IS_INCREASE)
+            .switchIfEmpty(Mono.defer(() -> insert(quotaKey, amount, IS_INCREASE)))
+            .then();
+    }
+
+    public Mono<Long> updateCurrentValue(QuotaCurrentValue.Key quotaKey, long amount, boolean isIncrease) {
+        return postgresExecutor.executeRow(dslContext -> Mono.from(dslContext.update(TABLE_NAME)
+                .set(CURRENT_VALUE, getCurrentValueOperator(isIncrease, amount))
+                .where(IDENTIFIER.eq(quotaKey.getIdentifier()),
+                    COMPONENT.eq(quotaKey.getQuotaComponent().getValue()),
+                    TYPE.eq(quotaKey.getQuotaType().getValue()))
+                .returning(CURRENT_VALUE)))
+            .map(record -> record.get(CURRENT_VALUE));
+    }
+
+    private Field<Long> getCurrentValueOperator(boolean isIncrease, long amount) {
+        if (isIncrease) {
+            return CURRENT_VALUE.plus(amount);
+        }
+        return CURRENT_VALUE.minus(amount);
+    }
+
+    public Mono<Long> insert(QuotaCurrentValue.Key quotaKey, long amount, boolean isIncrease) {
+        return postgresExecutor.executeRow(dslContext -> Mono.from(dslContext.insertInto(TABLE_NAME)
+                .set(IDENTIFIER, quotaKey.getIdentifier())
+                .set(COMPONENT, quotaKey.getQuotaComponent().getValue())
+                .set(TYPE, quotaKey.getQuotaType().getValue())
+                .set(CURRENT_VALUE, newCurrentValue(amount, isIncrease))
+                .returning(CURRENT_VALUE)))
+            .map(record -> record.get(CURRENT_VALUE));
+    }
+
+    private Long newCurrentValue(long amount, boolean isIncrease) {
+        if (isIncrease) {
+            return amount;
+        }
+        return -amount;
     }
 
     public Mono<Void> decrease(QuotaCurrentValue.Key quotaKey, long amount) {
-        return postgresExecutor.executeVoid(dslContext -> Mono.from(dslContext.insertInto(TABLE_NAME)
-            .set(IDENTIFIER, quotaKey.getIdentifier())
-            .set(COMPONENT, quotaKey.getQuotaComponent().getValue())
-            .set(TYPE, quotaKey.getQuotaType().getValue())
-            .set(CURRENT_VALUE, -amount)
-            .onConflictOnConstraint(PRIMARY_KEY_CONSTRAINT_NAME)
-            .doUpdate()
-            .set(CURRENT_VALUE, CURRENT_VALUE.minus(amount))))
-            .onErrorResume(ex -> {
-                LOGGER.warn("Failure when decreasing {} {} quota for {}. Quota current value is thus not updated and needs re-computation",
-                    quotaKey.getQuotaComponent().getValue(), quotaKey.getQuotaType().getValue(), quotaKey.getIdentifier(), ex);
-                return Mono.empty();
-            });
+        return updateCurrentValue(quotaKey, amount, !IS_INCREASE)
+            .switchIfEmpty(Mono.defer(() -> insert(quotaKey, amount, !IS_INCREASE)))
+            .then();
     }
 
     public Mono<QuotaCurrentValue> getQuotaCurrentValue(QuotaCurrentValue.Key quotaKey) {

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
@@ -23,6 +23,7 @@ import static org.jooq.impl.SQLDataType.BIGINT;
 
 import java.util.UUID;
 
+import org.apache.james.backends.postgres.PostgresIndex;
 import org.apache.james.backends.postgres.PostgresModule;
 import org.apache.james.backends.postgres.PostgresTable;
 import org.jooq.Field;
@@ -60,9 +61,13 @@ public interface PostgresMailboxModule {
                 .constraint(DSL.unique(MAILBOX_NAME, USER_NAME, MAILBOX_NAMESPACE))))
             .supportsRowLevelSecurity()
             .build();
+        PostgresIndex MAILBOX_USERNAME_NAMESPACE_INDEX = PostgresIndex.name("mailbox_username_namespace_index")
+            .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
+                .on(TABLE_NAME, USER_NAME, MAILBOX_NAMESPACE));
     }
 
     PostgresModule MODULE = PostgresModule.builder()
         .addTable(PostgresMailboxTable.TABLE)
+        .addIndex(PostgresMailboxTable.MAILBOX_USERNAME_NAMESPACE_INDEX)
         .build();
 }


### PR DESCRIPTION
1. [JAMES-2586 Optimize query increase/decrease for Quota Current Value](https://github.com/apache/james-project/commit/721f9c0bfc80974a798b0c45df1498fe0bd0fb95)

The query to increase the current value of the quota is frequently executed. The current SQL query is as follows:

```sql
insert into quota_current_value (
  identifier,
  component,
  type,
  "current_value"
)
values (
  '$1',
  '$2',
  '$3',
  '$4'
)
on conflict on constraint "quota_current_value_primary_key"
do update
set
  "current_value" = ("quota_current_value"."current_value" + $5);
```

This query is verbose and incurs overhead due to constraint checking.

=> The reality is the INSERT statement should be executed only once during initialization, and subsequent operations should use the UPDATE statement.
=> James can handle the INSERT and UPDATE cases appropriately.
___________________

2. [JAMES-2586 Add Index for Postgres Mailbox table](https://github.com/apache/james-project/commit/721f9c0bfc80974a798b0c45df1498fe0bd0fb95)

The query searches for `mailbox.mailbox_name `using `LIKE`: : https://github.com/apache/james-project/blob/542e4956312bf4d136d75f93d077b2f246c90774/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxDAO.java#L186
```sql
select *
from mailbox
where (
  mailbox_name like '$1'
  and user_name = '$2'
  and mailbox_namespace = '$3'
);
```
Although the mailbox table already has an index for the trio `(MAILBOX_NAME, USER_NAME, MAILBOX_NAMESPACE)`, the `LIKE "prefix%"` query slows it down.

=> Create one more index for the composite `(USER_NAME, MAILBOX_NAMESPACE)`

**result:**
before
![image](https://github.com/apache/james-project/assets/81145350/5ee8d60b-aa9d-4a12-901a-e5f695c4cc78)

after
![image](https://github.com/apache/james-project/assets/81145350/3521b288-402d-423b-be27-b4606429fe17)

