### PR TITLE
[JAMES-3978] avoid forked javadoc goals and associated build scans

### DIFF
--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -11,14 +11,13 @@
   <!-- chosen values align with https://cwiki.apache.org/confluence/display/INFRA/Project+Onboarding+Instructions+for+Develocity -->
   <buildScan>
     <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
-    <publish>ALWAYS</publish>
     <publishIfAuthenticated>true</publishIfAuthenticated>
-    <!-- Always publish build scans for CI, only if requested locally -->
+    <!-- Always publish build scans for CI, only if requested locally differs from onboarding instructions -->
     <publish>#{env['CI'] == null ? 'ON_DEMAND' : 'ALWAYS'}</publish>
     <capture>
-      <goalInputFiles>true</goalInputFiles> <!-- To be enabled locally when debugging goal caching or if we want to enable predictive test selection -->
-      <buildLogging>false</buildLogging> <!-- disabled by default for privacy and performance, to be discussed -->
-      <testLogging>false</testLogging> <!-- disabled by default for privacy and performance, to be discussed -->
+      <goalInputFiles>true</goalInputFiles>
+      <buildLogging>true</buildLogging>
+      <testLogging>true</testLogging>
     </capture>
     <links>
       <link>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -38,6 +38,7 @@
     <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
     <maven.compiler.target>1.11</maven.compiler.target>
     <maven.compiler.source>1.11</maven.compiler.source>
+    <jacoco-maven-plugin.version>0.8.9</jacoco-maven-plugin.version>
   </properties>
 
   <modules>
@@ -57,6 +58,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>jacoco-report</id>

--- a/mpt/core/pom.xml
+++ b/mpt/core/pom.xml
@@ -87,7 +87,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
+                <artifactId>maven-bundle-plugin </artifactId>
                 <version>${felix.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>

--- a/mpt/core/pom.xml
+++ b/mpt/core/pom.xml
@@ -64,7 +64,6 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         <manifestEntries>
                             <Specification-Title>Apache James MPT</Specification-Title>
                             <Specification-Version>${project.version}</Specification-Version>
@@ -73,6 +72,9 @@
                             <Implementation-Version>${project.version}</Implementation-Version>
                             <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
                             <Implementation-Vendor-Id>org.apache</Implementation-Vendor-Id>
+                            <Implementation-Url>${project.url}</Implementation-Url>
+                            <Embed-Dependency>*;scope=runtime</Embed-Dependency>
+                            <Export-Package>org.apache.james.mpt;version="${project.version}"</Export-Package>
                             <url>${project.url}</url>
                         </manifestEntries>
                     </archive>
@@ -85,27 +87,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin </artifactId>
-                <version>${felix.plugin.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.apache.james.mpt</Export-Package>
-                        <Embed-Dependency>*;scope=runtime</Embed-Dependency>
-                    </instructions>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <phase>process-classes</phase>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3216,8 +3216,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.6.3</version>
                     <configuration>
+                        <!-- The javadoc plugin only runs in the javadoc modules. But with the default configuration it tries
+                              to run a new maven instance in every dependency, in order to generate the apidocs there as well.
+                              I haven't found a way to control the forked instances to disable the build scans and this comes up in many projects
+                              as slowing the build.
+                              {@link https://maven.apache.org/plugins-archives/maven-javadoc-plugin-3.1.1/javadoc-mojo.html#detectOfflineLinks}
+                              {@link https://github.com/apache/bookkeeper/issues/1514}
+                              {@link https://issues.redhat.com/browse/ISPN-8629}
+                        -->
+                        <detectOfflineLinks>false</detectOfflineLinks>
                         <linksource>true</linksource>
                         <maxmemory>1g</maxmemory>
                         <minmemory>256m</minmemory>

--- a/server/apps/scaling-pulsar-smtp/pom.xml
+++ b/server/apps/scaling-pulsar-smtp/pom.xml
@@ -187,11 +187,6 @@
             <version>42.3.8</version>
         </dependency>
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.3.8</version>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <version>1.17.2</version>


### PR DESCRIPTION
After enabling the build scans  quickly noticed that each full clean install generates extra build scans for mpt-core and testing
![image](https://github.com/apache/james-project/assets/22979/7f792c67-b070-493d-8838-cc1850fc27e0)
I tracked it to a behavior of the javadoc plugin which forks maven goals for dependencies
symptoms are 
```
[INFO] --- javadoc:3.1.1:javadoc (create-javadocs) @ apache-james-mpt-app ---
[INFO] The goal 'org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:javadoc' has not been previously called for the module: 'org.apache.james:testing-base:jar:3.9.0-SNAPSHOT'. Trying to invoke it...
[INFO] The goal 'org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:javadoc' has not been previously called for the module: 'org.apache.james:apache-james-mpt-core:jar:3.9.0-SNAPSHOT'. Trying to invoke it...
[INFO]
```
and 
```
[INFO] --- javadoc:3.1.1:jar (create-javadocs) @ apache-james-mpt-app ---
[INFO] The goal 'org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:javadoc' has not been previously called for the module: 'org.apache.james:testing-base:jar:3.9.0-SNAPSHOT'. Trying to invoke it...
[WARNING] Creating fake javadoc directory to prevent repeated invocations: /home/jean/perso/dev/secretjames/develocity/testing/base/target/apidocs
[INFO] The goal 'org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:javadoc' has not been previously called for the module: 'org.apache.james:apache-james-mpt-core:jar:3.9.0-SNAPSHOT'. Trying to invoke it...
[WARNING] Creating fake javadoc directory to prevent repeated invocations: /home/jean/perso/dev/secretjames/develocity/mpt/core/target/apidocs
[ERROR] Error fetching link: /home/jean/perso/dev/secretjames/develocity/testing/base/target/apidocs. Ignored it.
[ERROR] Error fetching link: /home/jean/perso/dev/secretjames/develocity/mpt/core/target/apidocs. Ignored it.
[INFO]
```
in the logs

Investigating led me to an apache bookkeeper issue that ended up disabling the `<detectOfflineLinks>false</detectOfflineLinks>` option but for performance reasons.

I haven't found another way to avoid the forks or to prevent the forks to emit build scans and it doesn´t  seem to be a problem for bookkeeper. So I propose to follow them and disable that feature.

I added a few cleanup commits that
- solve the toplevel maven warnings 
- remove the felix bundle plugin despite it not being the root cause for the forks as benoit seemed to feel it was a good thing :D