### PR TITLE
[JAMES-3978] activate flaky tests detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3969,9 +3969,15 @@
                                 </execution>
                             </executions>
                         </plugin>
-
                         <plugin>
-                            <groupId>pl.project13.maven</groupId>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                        <groupId>pl.project13.maven</groupId>
                             <artifactId>git-commit-id-plugin</artifactId>
                             <executions>
                                 <execution>


### PR DESCRIPTION
Flaky test detection in develocity requires allowing test retry at least once. While this will probably make our test suite even longer than it already is, it could help prioritize the tests to be fixed to enabled test result remote caching