### PR TITLE
Upgrade activemq to address CVE-2023-46604

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
 
         <james.groupId>org.apache.james</james.groupId>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
-        <activemq.version>5.18.3</activemq.version>
+        <activemq.version>5.18.2</activemq.version>
         <apache-mime4j.version>0.8.9</apache-mime4j.version>
         <apache.openjpa.version>3.2.0</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
 
         <james.groupId>org.apache.james</james.groupId>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
-        <activemq.version>5.18.2</activemq.version>
+        <activemq.version>5.18.3</activemq.version>
         <apache-mime4j.version>0.8.9</apache-mime4j.version>
         <apache.openjpa.version>3.2.0</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>


### PR DESCRIPTION
Upgraded activemq from 5.18.2 to 5.18.3 to address CVE-2023-46604