### PR TITLE
Use io.netty.tryReflectionSetAccessible=true JVM option

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -59,3 +59,7 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # improving JMAP filter storage efficiency. Snapshots enable to only build the aggregate from the last few events.
 # james.jmap.filters.eventsource.increments.enabled=true
 # james.jmap.filters.eventsource.snapshots.enabled=true
+
+# On Java >= 9 Netty requires the io.netty.tryReflectionSetAccessible system property to be set to true to enable
+# This setting was taken from Cassandra jvm11-server.option
+io.netty.tryReflectionSetAccessible=true

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -62,3 +62,7 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # Default charset to use in JMAP to present text body parts
 # james.jmap.default.charset=US-ASCII
+
+# On Java >= 9 Netty requires the io.netty.tryReflectionSetAccessible system property to be set to true to enable
+# This setting was taken from Cassandra jvm11-server.option
+io.netty.tryReflectionSetAccessible=true

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -53,3 +53,7 @@ james.jmx.credential.generation=true
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
+
+# On Java >= 9 Netty requires the io.netty.tryReflectionSetAccessible system property to be set to true to enable
+# This setting was taken from Cassandra jvm11-server.option
+io.netty.tryReflectionSetAccessible=true

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -51,3 +51,7 @@ james.jmx.credential.generation=true
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
 openjpa.Multithreaded=true
+
+# On Java >= 9 Netty requires the io.netty.tryReflectionSetAccessible system property to be set to true to enable
+# This setting was taken from Cassandra jvm11-server.option
+io.netty.tryReflectionSetAccessible=true

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -51,3 +51,7 @@ james.jmx.credential.generation=true
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
 openjpa.Multithreaded=true
+
+# On Java >= 9 Netty requires the io.netty.tryReflectionSetAccessible system property to be set to true to enable
+# This setting was taken from Cassandra jvm11-server.option
+io.netty.tryReflectionSetAccessible=true

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -53,3 +53,7 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # Default charset to use in JMAP to present text body parts
 # james.jmap.default.charset=US-ASCII
+
+# On Java >= 9 Netty requires the io.netty.tryReflectionSetAccessible system property to be set to true to enable
+# This setting was taken from Cassandra jvm11-server.option
+io.netty.tryReflectionSetAccessible=true

--- a/server/apps/scaling-pulsar-smtp/sample-configuration/jvm.properties
+++ b/server/apps/scaling-pulsar-smtp/sample-configuration/jvm.properties
@@ -43,3 +43,7 @@
 # JMX, when enable causes RMI to plan System.gc every hour. Set this instead to once every 1000h.
 #sun.rmi.dgc.server.gcInterval=3600000000
 #sun.rmi.dgc.client.gcInterval=3600000000
+
+# On Java >= 9 Netty requires the io.netty.tryReflectionSetAccessible system property to be set to true to enable
+# This setting was taken from Cassandra jvm11-server.option
+io.netty.tryReflectionSetAccessible=true

--- a/server/apps/spring-app/pom.xml
+++ b/server/apps/spring-app/pom.xml
@@ -50,11 +50,12 @@
         <javamail.system-property10>-Dmail.mime.address.strict=false</javamail.system-property10>
         <javamail.system-property11>-Djmx.remote.x.mlet.allow.getMBeansFromURL=false</javamail.system-property11>
         <javamail.system-property12>-Djames.jmx.unregister.log4j.mbeans=true</javamail.system-property12>
+        <javamail.system-property13>-Dio.netty.tryReflectionSetAccessible=true</javamail.system-property13>
         <javamail.system-properties>${javamail.system-property1} ${javamail.system-property2}
             ${javamail.system-property3} ${javamail.system-property4} ${javamail.system-property5}
             ${javamail.system-property6} ${javamail.system-property7} ${javamail.system-property8}
             ${javamail.system-property9} ${javamail.system-property10} ${javamail.system-property11}
-            ${javamail.system-property12}
+            ${javamail.system-property12} ${javamail.system-property13}
         </javamail.system-properties>
 
         <!-- JMX system properties -->


### PR DESCRIPTION
 On Java >= 9 Netty requires the
 io.netty.tryReflectionSetAccessible system property to be
 set to true to enable

 This setting was taken from Cassandra jvm11-server.option