### PR TITLE
[FIX] Lower log level of SSL handshake exceptions

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
@@ -51,10 +51,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.util.AttributeKey;
+import javax.net.ssl.SSLHandshakeException;
 
 /**
  * {@link ChannelInboundHandlerAdapter} which is used by the SMTPServer and other line based protocols
@@ -270,12 +272,19 @@ public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter imp
                 }
                 if (cause instanceof SocketException) {
                     LOGGER.info("Socket exception encountered: {}", cause.getMessage());
+                } else if (isSslHandshkeException(cause)) {
+                    LOGGER.info("SSH handshake rejected {}", cause.getMessage());
                 } else if (!(cause instanceof ClosedChannelException)) {
                     LOGGER.error("Unable to process request", cause);
                 }
                 ctx.close();
             }
         }
+    }
+
+    private boolean isSslHandshkeException(Throwable cause) {
+        return cause instanceof DecoderException &&
+            cause.getCause() instanceof SSLHandshakeException;
     }
 
     @Override

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import org.apache.james.protocols.api.CommandDetectionSession;
 import org.apache.james.protocols.api.Protocol;
 import org.apache.james.protocols.api.ProtocolSession;
@@ -56,7 +58,6 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.util.AttributeKey;
-import javax.net.ssl.SSLHandshakeException;
 
 /**
  * {@link ChannelInboundHandlerAdapter} which is used by the SMTPServer and other line based protocols

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -59,8 +59,10 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.Attribute;
+import javax.net.ssl.SSLHandshakeException;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -274,6 +276,8 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
         try (Closeable closeable = mdc(ctx).build()) {
             if (cause instanceof SocketException) {
                 LOGGER.info("Socket exception encountered: {}", cause.getMessage());
+            } else if (isSslHandshkeException(cause)) {
+                LOGGER.info("SSH handshake rejected {}", cause.getMessage());
             } else if (!(cause instanceof ClosedChannelException)) {
                 LOGGER.warn("Error while processing imap request", cause);
             }
@@ -305,6 +309,11 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                 manageUnknownError(ctx);
             }
         }
+    }
+
+    private boolean isSslHandshkeException(Throwable cause) {
+        return cause instanceof DecoderException &&
+            cause.getCause() instanceof SSLHandshakeException;
     }
 
     private void manageRejectedException(ChannelHandlerContext ctx, ReactiveThrottler.RejectedException cause) throws IOException {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -312,8 +312,8 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
     }
 
     private boolean isSslHandshkeException(Throwable cause) {
-        return cause instanceof DecoderException &&
-            cause.getCause() instanceof SSLHandshakeException;
+        return cause instanceof DecoderException
+            && cause.getCause() instanceof SSLHandshakeException;
     }
 
     private void manageRejectedException(ChannelHandlerContext ctx, ReactiveThrottler.RejectedException cause) throws IOException {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -30,6 +30,8 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import org.apache.james.imap.api.ConnectionCheck;
 import org.apache.james.imap.api.ImapConstants;
 import org.apache.james.imap.api.ImapMessage;
@@ -62,7 +64,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.Attribute;
-import javax.net.ssl.SSLHandshakeException;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;


### PR DESCRIPTION
Client requested protocol TLSv1.1 is not enabled or supported in server context

This benign event should likely not lead to an error log.