### PR TITLE
Feature/fixing tupo truststoretype

### DIFF
--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
@@ -91,7 +91,7 @@ public class LegacyJavaEncryptionFactory implements Encryption.Factory {
                 Throwing.runnable(() -> sslFactoryBuilder.withTrustMaterial(
                         fileSystem.getFile(sslConfig.getTruststore()).toPath(),
                         sslConfig.getTruststoreSecret(),
-                        sslConfig.getKeystoreType())));
+                        sslConfig.getTruststoreType())));
         }
 
         SSLContext context = sslFactoryBuilder.build().getSslContext();

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
@@ -85,7 +85,7 @@ public class LegacyJavaEncryptionFactory implements Encryption.Factory {
             maybeTrustOptions.ifPresentOrElse(Throwing.<TrustStoreTrustOptions<? extends CertPathTrustManagerParameters>>consumer(trustOptions ->
             sslFactoryBuilder.withTrustMaterial(
                     fileSystem.getFile(sslConfig.getTruststore()).toPath(),
-                    sslConfig.getTruststoreSecret(),
+                    sslConfig.getSecret().toCharArray(),
                     sslConfig.getKeystoreType(),
                     trustOptions)).sneakyThrow(),
                 Throwing.runnable(() -> sslFactoryBuilder.withTrustMaterial(

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
@@ -85,8 +85,8 @@ public class LegacyJavaEncryptionFactory implements Encryption.Factory {
             maybeTrustOptions.ifPresentOrElse(Throwing.<TrustStoreTrustOptions<? extends CertPathTrustManagerParameters>>consumer(trustOptions ->
             sslFactoryBuilder.withTrustMaterial(
                     fileSystem.getFile(sslConfig.getTruststore()).toPath(),
-                    sslConfig.getSecret().toCharArray(),
-                    sslConfig.getKeystoreType(),
+                    sslConfig.getTruststoreSecret(),
+                    sslConfig.getTruststoreType(),
                     trustOptions)).sneakyThrow(),
                 Throwing.runnable(() -> sslFactoryBuilder.withTrustMaterial(
                         fileSystem.getFile(sslConfig.getTruststore()).toPath(),


### PR DESCRIPTION
It looks if something is  wrong with the current code. I  think it should be like this, but please correct me if I'm wrong.
After looking in the code, I noticed that the `getTruststoreType()` is never actually used, which can't be correct.

But I might be wrong.