### PR TITLE
JAMES-3991 Vacation handling should be case insensitive (3.8.x)

### DIFF
--- a/server/data/data-api/src/main/java/org/apache/james/vacation/api/AccountId.java
+++ b/server/data/data-api/src/main/java/org/apache/james/vacation/api/AccountId.java
@@ -40,7 +40,7 @@ public class AccountId {
     private final String identifier;
 
     private AccountId(String identifier) {
-        this.identifier = identifier;
+        this.identifier = identifier.toLowerCase();
     }
 
     public String getIdentifier() {

--- a/server/data/data-api/src/test/java/org/apache/james/vacation/api/NotificationRegistryContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/vacation/api/NotificationRegistryContract.java
@@ -100,4 +100,31 @@ public interface NotificationRegistryContract {
 
         assertThat(notificationRegistry().isRegistered(ACCOUNT_ID, recipientId()).block()).isTrue();
     }
+
+    @Test
+    default void isRegisteredShouldIgnoreCase() {
+        notificationRegistry().register(ACCOUNT_ID, recipientId(), Optional.empty()).block();
+
+        AccountId upperCaseAccount = AccountId.fromString(ACCOUNT_ID.getIdentifier().toUpperCase());
+        assertThat(notificationRegistry().isRegistered(upperCaseAccount, recipientId()).block()).isTrue();
+    }
+
+    @Test
+    default void registerShouldIgnoreCase() {
+        AccountId upperCaseAccount = AccountId.fromString(ACCOUNT_ID.getIdentifier().toUpperCase());
+        notificationRegistry().register(upperCaseAccount, recipientId(), Optional.empty()).block();
+
+        assertThat(notificationRegistry().isRegistered(ACCOUNT_ID, recipientId()).block()).isTrue();
+    }
+
+    @Test
+    default void flushShouldIgnoreCase() {
+        when(zonedDateTimeProvider.get()).thenReturn(ZONED_DATE_TIME);
+        notificationRegistry().register(ACCOUNT_ID, recipientId(), Optional.empty()).block();
+
+        AccountId upperCaseAccount = AccountId.fromString(ACCOUNT_ID.getIdentifier().toUpperCase());
+        notificationRegistry().flush(upperCaseAccount).block();
+
+        assertThat(notificationRegistry().isRegistered(ACCOUNT_ID, recipientId()).block()).isFalse();
+    }
 }

--- a/server/data/data-api/src/test/java/org/apache/james/vacation/api/VacationRepositoryContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/vacation/api/VacationRepositoryContract.java
@@ -337,4 +337,27 @@ public interface VacationRepositoryContract {
             .isInstanceOf(NullPointerException.class);
     }
 
+    @Test
+    default void retrieveVacationShouldIgnoreCase() {
+        vacationRepository().modifyVacation(ACCOUNT_ID,
+                VacationPatch.builderFrom(VACATION)
+                    .build())
+            .block();
+
+        AccountId upperCaseAccount = AccountId.fromString(ACCOUNT_ID.getIdentifier().toUpperCase());
+        Vacation vacation = vacationRepository().retrieveVacation(upperCaseAccount).block();
+        assertThat(vacation).isNotNull();
+    }
+
+    @Test
+    default void modifiyVacationShouldIgnoreCase() {
+        AccountId upperCaseAccount = AccountId.fromString(ACCOUNT_ID.getIdentifier().toUpperCase());
+        vacationRepository().modifyVacation(upperCaseAccount,
+                VacationPatch.builderFrom(VACATION)
+                    .build())
+            .block();
+
+        Vacation vacation = vacationRepository().retrieveVacation(ACCOUNT_ID).block();
+        assertThat(vacation).isNotNull();
+    }
 }


### PR DESCRIPTION
Cherry-Pick from master.
While this is not strictly a bugfix, it solves an inconsistent behavior, so IMO makes sense to have it on the stable branch as well.