### PR TITLE
[FIX] Mime parsing on parallel scheduler

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -174,7 +174,6 @@ public class StoreMessageIdManager implements MessageIdManager {
 
     @Override
     public Flux<MessageResult> getMessagesReactive(Collection<MessageId> messageIds, FetchGroup fetchGroup, MailboxSession mailboxSession) {
-        // Here
         MessageIdMapper messageIdMapper = mailboxSessionMapperFactory.getMessageIdMapper(mailboxSession);
 
         MessageMapper.FetchType fetchType = FetchGroupConverter.getFetchType(fetchGroup);

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailBodyPart.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailBodyPart.scala
@@ -287,7 +287,6 @@ case class EmailBodyPart(partId: PartId,
 
   def bodyContent: Try[Option[EmailBodyValue]] = entity.getBody match {
     case textBody: Mime4JTextBody =>
-      new Exception("" + textBody.getCharset).printStackTrace()
       for {
         value <- Try(IOUtils.toString(textBody.getInputStream, Option(textBody.getCharset).getOrElse(ISO_8859_1)))
       } yield {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailImport.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailImport.scala
@@ -20,10 +20,10 @@
 package org.apache.james.jmap.mail
 
 import java.time.ZonedDateTime
-
 import org.apache.james.jmap.core.{AccountId, SetError, UTCDate, UuidState}
 import org.apache.james.jmap.method.WithAccountId
 import org.apache.james.mailbox.model.MailboxId
+import reactor.core.scala.publisher.SMono
 
 case class EmailImportRequest(accountId: AccountId,
                               emails: Map[EmailCreationId, EmailImport]) extends WithAccountId
@@ -32,10 +32,10 @@ case class EmailImport(blobId: BlobId,
                        mailboxIds: MailboxIds,
                        keywords: Option[Keywords],
                        receivedAt: Option[UTCDate]) {
-  def validate: Either[IllegalArgumentException, ValidatedEmailImport] = mailboxIds match {
-    case MailboxIds(List(mailboxId)) => scala.Right(ValidatedEmailImport(blobId, mailboxId, keywords.getOrElse(Keywords(Set())),
+  def validate: SMono[ValidatedEmailImport] = mailboxIds match {
+    case MailboxIds(List(mailboxId)) => SMono.just(ValidatedEmailImport(blobId, mailboxId, keywords.getOrElse(Keywords(Set())),
       receivedAt.getOrElse(UTCDate(ZonedDateTime.now()))))
-    case _ => Left(new IllegalArgumentException("Email/import so far only supports a single mailboxId"))
+    case _ => SMono.error(new IllegalArgumentException("Email/import so far only supports a single mailboxId"))
   }
 }
 


### PR DESCRIPTION
For 20MB + files this takes time.
This approach avoids over-switching by doing it
only after fetching items...