### PR TITLE
JAMES-4003 [FIX] Avoid forwarding bounces as it might create infinite loops

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/partials/RecipientRewriteTable.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/partials/RecipientRewriteTable.adoc
@@ -17,3 +17,6 @@ The *rewriteSenderUponForward* option (default to true) can be used to prevent s
 (JAMES 3.8.0 default behaviour). *WARNING*: Please note that not rewriting the sender will cause issues forwarding emails
 from external senders to external addresses as the DKIM and SPF records will not be matching the ones of the sending
 domain.
+
+The *forwardAutoSubmittedEmails* option (default to false) can be used to prevent forwarding bounces as such a scenario
+can lead to an infinite loop if the forward recipient bounces the email.

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
@@ -50,10 +50,13 @@ import com.google.common.collect.ImmutableList;
  * </code>
  * </pre>
  *
- * The <b>rewriteSenderUponForward</b> option (fault to true) can be used to prevent senders to be rewritten upon forwards in the transport enveloppe
+ * The <b>rewriteSenderUponForward</b> option (default to true) can be used to prevent senders to be rewritten upon forwards in the transport enveloppe
  * (JAMES 3.8.0 default behaviour). <b>WARNING</b>: Please note that not rewriting the sender will cause issues forwarding emails
  * from external senders to external addresses as the DKIM and SPF records will not be matching the ones of the sending
  * domain.
+ *
+ * The <b>forwardAutoSubmittedEmails</b> option (default to false) can be used to prevent forwarding bounces as such a scenario
+ * can lead to an infinite loop if the forward recipient bounces the email.
  */
 public class RecipientRewriteTable extends GenericMailet {
     public static final String ERROR_PROCESSOR = "errorProcessor";
@@ -63,6 +66,7 @@ public class RecipientRewriteTable extends GenericMailet {
     private RecipientRewriteTableProcessor processor;
     private ProcessingState errorProcessor;
     private boolean rewriteSenderUponForward = true;
+    private boolean forwardAutoSubmittedEmails = false;
 
     @Inject
     public RecipientRewriteTable(org.apache.james.rrt.api.RecipientRewriteTable virtualTableStore, DomainList domainList) {
@@ -74,8 +78,9 @@ public class RecipientRewriteTable extends GenericMailet {
     public void init() throws MessagingException {
         errorProcessor = new ProcessingState(getInitParameter(ERROR_PROCESSOR, Mail.ERROR));
         rewriteSenderUponForward = getBooleanParameter("rewriteSenderUponForward", true);
+        forwardAutoSubmittedEmails = getBooleanParameter("forwardAutoSubmittedEmails", false);
         processor = new RecipientRewriteTableProcessor(virtualTableStore, domainList, getMailetContext(), errorProcessor,
-            rewriteSenderUponForward);
+            rewriteSenderUponForward, forwardAutoSubmittedEmails);
     }
 
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -187,7 +187,7 @@ public class RecipientRewriteTableProcessor {
 
     public RecipientRewriteTableProcessor(RecipientRewriteTable virtualTableStore, DomainList domainList, MailetContext mailetContext) {
         this(virtualTableStore, domainList, mailetContext, new ProcessingState(Mail.ERROR), !REWRITE_SENDER_UPON_FORWARD,
-            false);
+            !FORWARD_AUTOMATED_EMAILS);
     }
 
     private Domain getDefaultDomain(DomainList domainList) throws MessagingException {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -278,7 +278,12 @@ public class RecipientRewriteTableProcessor {
         void apply(Mail mail) throws Exception;
     }
 
-    public void processForwards(Mail mail) {
+    public void processForwards(Mail mail) throws MessagingException {
+        if (Optional.ofNullable(mail.getMessage().getHeader("Auto-Submitted")).map(ImmutableList::copyOf).orElse(ImmutableList.of())
+            .stream()
+            .anyMatch(value -> value.startsWith("auto-replied"))) {
+            return;
+        }
         if (rewriteSenderUponForward) {
             mail.getRecipients()
                 .stream()


### PR DESCRIPTION
**Why** Destination service might consider Header from do not match sender envelop and reject with a bounce.

This creates an infinite loop.

=> This is **DIRTY FIXING**

Real fix: do like outlook...

- For local domains: like today.
- For remote domains: Wrap the forwarded message ina nested mime part, set subject to the value of the mail.