### PR TITLE
JAMES-2586 Document jvm option to prevent reactor R2dbc error (queue limit is exceeded)

### DIFF
--- a/server/apps/postgres-app/README.adoc
+++ b/server/apps/postgres-app/README.adoc
@@ -134,6 +134,15 @@ The never used data are:
 - email_change
 - vacation_notification_registry
 
+=== Optimizing R2DBC Performance
+
+==== Enhancing with reactor.bufferSize.small adjustment
+
+Adjusting `reactor.bufferSize.small` JVM argument helps prevent R2DBC errors due to request queue limits.
+The error "Cannot exchange messages because the request queue limit is exceeded".
+
+It's acceptable to configure this argument in the jvm.properties file.
+
 ## Development
 
 ### How to track the stats of the statement execution


### PR DESCRIPTION
Document note the jvm argument, 
that help prevent Reactor R2dbc error:
```
10:25:47.463 [ERROR] o.a.j.i.p.AbstractMailboxProcessor - Unexpected error during IMAP processing
2023-12-19T10:25:47.463747215Z io.r2dbc.postgresql.client.ReactorNettyClient$RequestQueueException: Cannot exchange messages because the request queue limit is exceeded
2023-12-19T10:25:47.463750862Z 	... 152 common frames omitted
...........
; Cannot exchange messages because the request queue limit is exceeded
```