### PR TITLE
JAMES-3997 Netty backpressure for IMAP FETCH

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
@@ -103,6 +103,19 @@ public interface ImapSession extends CommandDetectionSession {
     Mono<Void> logout();
 
     /**
+     * Allows implementation to apply back pressure on heavy senders.
+     *
+     * Return true if the sender needs to be throttled.
+     * Return false if backpressure do not need to be applied.
+     * @param restoreBackpressure will be called to restore backpressure to its current state when backpressure
+     *                            is no longer needed.
+     */
+    default boolean backpressureNeeded(Runnable restoreBackpressure) {
+        // Naive implementation: never backpressure
+        return false;
+    }
+
+    /**
      * Gets the current client state.
      * 
      * @return Returns the current state of this session.

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -218,7 +218,14 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
             response.flush();
             super.channelActive(ctx);
         }
+    }
 
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) {
+        if (ctx.channel().isWritable()) {
+            Optional.ofNullable(ctx.channel().attr(BACKPRESSURE_CALLBACK).get())
+                .ifPresent(Runnable::run);
+        }
     }
 
     private void performConnectionCheck(InetSocketAddress clientIp) {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyConstants.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyConstants.java
@@ -43,6 +43,7 @@ public interface NettyConstants {
     AttributeKey<ImapSession> IMAP_SESSION_ATTRIBUTE_KEY = AttributeKey.valueOf("ImapSession");
     AttributeKey<Linearalizer> LINEARALIZER_ATTRIBUTE_KEY = AttributeKey.valueOf("Linearalizer");
     AttributeKey<Disposable> REQUEST_IN_FLIGHT_ATTRIBUTE_KEY = AttributeKey.valueOf("requestInFlight");
+    AttributeKey<Runnable> BACKPRESSURE_CALLBACK = AttributeKey.valueOf("BACKPRESSURE_CALLBACK");
     AttributeKey<Map<String, Object>> FRAME_DECODE_ATTACHMENT_ATTRIBUTE_KEY  = AttributeKey.valueOf("FrameDecoderMap");
 
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -313,4 +313,14 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     public void schedule(Runnable runnable, Duration waitDelay) {
         channel.eventLoop().schedule(runnable, waitDelay.toMillis(), TimeUnit.MILLISECONDS);
     }
+
+    @Override
+    public boolean backpressureNeeded(Runnable restoreBackpressure) {
+        boolean writable = channel.isWritable();
+        if (!writable) {
+            channel.attr(BACKPRESSURE_CALLBACK).set(restoreBackpressure);
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Channel writability is the netty trick for backpressure: as a server you shall avoid writing to a channel that is not writable.

In order to apply this Netty best practice to Apache James we relied on:
 - The ImapSession as a mean to communicate between the processor and the channel.
 - A sink to bridge the gap from a push oriented architecture (our IMAP stack) to a pull one (netty writability).

In order for it to be merged I would like:

 - [ ] A performance test (IMAP0. Please Linagora team help!
 - [ ] To deploy it cowboy style on imap.linagora.com (hotpatch on top of current image) and see what happens.
 
 (Cowboy style -> avoid unecessary administrative friction in the validation of that patch that would definitively make me sleep better!)