### PR TITLE
Fixed issue with incorrect JPA properties values

### DIFF
--- a/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
+++ b/server/container/guice/jpa-common/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
@@ -67,14 +67,11 @@ public class JPAEntityManagerModule extends AbstractModule {
         properties.putAll(jpaConfiguration.getCustomOpenjpaProperties());
 
         jpaConfiguration.isMultithreaded()
-            .ifPresent(isMultiThread ->
-                properties.put(JPAConfiguration.JPA_MULTITHREADED, jpaConfiguration.isMultithreaded().toString())
-            );
-
+                .map(Object::toString)
+                .ifPresent(value -> properties.put(JPAConfiguration.JPA_MULTITHREADED, value));
         jpaConfiguration.isAttachmentStorageEnabled()
-            .ifPresent(isMultiThread ->
-                properties.put(JPAConfiguration.ATTACHMENT_STORAGE, jpaConfiguration.isAttachmentStorageEnabled().toString())
-            );
+                .map(Object::toString)
+                .ifPresent(value -> properties.put(JPAConfiguration.ATTACHMENT_STORAGE, value));
 
         return Persistence.createEntityManagerFactory("Global", properties);
     }


### PR DESCRIPTION
Due to changes introduced with "JAMES-2156 Add configuration option to enable attachment storage for JPA", values for keys `openjpa.Multithreaded` and `attachmentStorage.enabled` set in properties passed to `Persistence.createEntityManagerFactory()` method have incorrect values.

Due to usage of `toString()` method on `Optional<Boolean>` instead of calling it directly on `Boolean`, values are set as `Optional[true]` if they had value `true` causing it to evaluate inside persistence to `false`.

This change fixes this regression restoring ability to set  `openjpa.Multithreaded` and `attachmentStorage.enabled` to values other than `false`.