### PR TITLE
Revert git commit id maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3497,9 +3497,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>io.github.git-commit-id</groupId>
-                    <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>7.0.0</version>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>4.9.10</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -3636,30 +3636,29 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.github.git-commit-id</groupId>
-                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                    <injectAllReactorProjects>true</injectAllReactorProjects>
+                    <prefix>git</prefix>
+                    <verbose>false</verbose>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <format>json</format>
-                    <gitDescribe>
-                        <skip>false</skip>
-                        <always>true</always>
-                        <dirty>-dirty</dirty>
-                    </gitDescribe>
                     <includeOnlyProperties>
                         <includeOnlyProperty>git.commit.id</includeOnlyProperty>
                         <includeOnlyProperty>git.commit.id.describe</includeOnlyProperty>
                         <includeOnlyProperty>git.commit.message.short</includeOnlyProperty>
                         <includeOnlyProperty>git.dirty</includeOnlyProperty>
                     </includeOnlyProperties>
-                    <prefix>git</prefix>
                     <skip>false</skip>
                     <useNativeGit>true</useNativeGit>
-                    <verbose>false</verbose>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <gitDescribe>
+                        <skip>false</skip>
+                        <always>true</always>
+                        <dirty>-dirty</dirty>
+                    </gitDescribe>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3640,6 +3640,7 @@
                 <artifactId>git-commit-id-plugin</artifactId>
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <injectAllReactorProjects>true</injectAllReactorProjects>
                     <prefix>git</prefix>
                     <verbose>false</verbose>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>


### PR DESCRIPTION
@jeantil I'm sorry to ask for this, but do you mind if we revert the upgrade of the git-commit-id-maven-plugin for now?

It seems tocreate issues with projects using James as a submodule (like TMail-backend) and makes the build impossible.

I opened an issue on the plugin backlog if you want to have a look for more context/details: https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/701

But for now this is a blocker for us unfortunately^^'

Mind that I still put back for `injectAllReactorProjects` to true after the revert, hoping it keeps similar gain in build performance :)