### PR TITLE
[UPDATE] commons-compress 1.24.0 -> 1.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2565,7 +2565,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
+                <version>1.26.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Fixes:
 - CVE-2024-25710: Denial of service caused by an infinite loop for a corrupted DUMP file
 - CVE-2024-26308: OutOfMemoryError unpacking broken Pack200 file