### PR TITLE
[UPGRADE] MIME4J 0.8.9 -> 0.8.10

### DIFF
--- a/mailbox/store/src/test/resources/eml/james-3901.json
+++ b/mailbox/store/src/test/resources/eml/james-3901.json
@@ -1,4 +1,11 @@
-{"attachments":[],
+{"attachments":[{
+    "mediaType":"application",
+    "subtype":"octet-stream",
+    "fileName":"4%P001!.DOC4%P001!.DOC",
+    "fileExtension":"DOC",
+    "contentDisposition":"attachment",
+    "textContent":null}
+  ],
   "bcc":[],
   "htmlBody":null,
   "textBody":"---------------------- Forwarded by Drew Fossum/ET&S/Enron on 04/04/2001 \n01:19 PM ---------------------------\n\n\n\"Hirasuna, Robert\" <rhirasuna@AkinGump.com> on 04/04/2001 10:18:00 AM\nTo: \"Drew Fossum (E-mail)\" <dfossum@enron.com>\ncc:  \n\nSubject: Revised Draft\n\n\n <<4%P001!.DOC>> Use this draft instead.  I missed a couple of delted dashes \non the first page.\n\nThe information contained in this e-mail message is intended only for the \npersonal and confidential use of the recipient(s) named above. This message \nmay be an attorney-client communication and/or work product and as such is \nprivileged and confidential. If the reader of this message is not the \nintended recipient or an agent responsible for delivering it to the intended \nrecipient, you are hereby notified that you have received this document in \nerror and that any review, dissemination, distribution, or copying of this \nmessage is strictly prohibited. If you have received this communication in \nerror, please notify us immediately by e-mail, and delete the original \nmessage.\n\n\n - 4%P001!.DOC\n\n\n***********\nEDRM Enron Email Data Set has been produced in EML, PST and NSF format by ZL Technologies, Inc. This Data Set is licensed under a Creative Commons Attribution 3.0 United States License <http://creativecommons.org/licenses/by/3.0/us/> . To provide attribution, please cite to \"ZL Technologies, Inc. (http://www.zlti.com).\"\n***********\n",

--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,7 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
         <activemq.version>5.18.3</activemq.version>
-        <apache-mime4j.version>0.8.9</apache-mime4j.version>
+        <apache-mime4j.version>0.8.10</apache-mime4j.version>
         <apache.openjpa.version>3.2.0</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/MIMEMessageConverterTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/MIMEMessageConverterTest.java
@@ -801,7 +801,6 @@ class MIMEMessageConverterTest {
             String expectedMimeType = "image/png";
             String text = "123456";
             String name = "ديناصور.png";
-            String expectedName = EncoderUtil.encodeEncodedWord(name, Usage.TEXT_TOKEN);
             AttachmentId blodId = AttachmentId.from("blodId");
 
             Attachment.WithBlob attachment = new Attachment.WithBlob(
@@ -829,7 +828,7 @@ class MIMEMessageConverterTest {
                 .hasSize(1)
                 .extracting(entity -> (Multipart) entity.getBody())
                 .flatExtracting(Multipart::getBodyParts)
-                .anySatisfy(part -> assertThat(getNameParameterValue(part)).isEqualTo(expectedName));
+                .anySatisfy(part -> assertThat(getNameParameterValue(part)).isEqualTo(name));
         }
 
 


### PR DESCRIPTION
Solves https://github.com/linagora/james-project/issues/5080

```
java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern
	at java.base/java.net.URLDecoder.decode(Unknown Source)
	at java.base/java.net.URLDecoder.decode(Unknown Source)
	at org.apache.james.mime4j.util.MimeParameterMapping.decodeParameterValue(MimeParameterMapping.java:55)
	at org.apache.james.mime4j.util.MimeParameterMapping.addParameter(MimeParameterMapping.java:39)
	at org.apache.james.mime4j.field.ContentDispositionFieldLenientImpl.parse(ContentDispositionFieldLenientImpl.java:165)
	at org.apache.james.mime4j.field.ContentDispositionFieldLenientImpl.getDispositionType(ContentDispositionFieldLenientImpl.java:72)
	at org.apache.james.mime4j.message.MaximalBodyDescriptor.getContentDispositionType(MaximalBodyDescriptor.java:183)
	at org.apache.james.mailbox.store.MimeDescriptorImpl.createDescriptor(MimeDescriptorImpl.java:187)
```