### PR TITLE
Upgrade git-commit-id-maven-plugin to 8.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3499,7 +3499,7 @@
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>7.0.0</version>
+                    <version>8.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
The issue with submodules has been fixed. What was bothering some of us on other projects using James as a submodule has been fixed and released in this new version, among other things, cf: https://github.com/git-commit-id/git-commit-id-maven-plugin/releases/tag/v8.0.0

I think that should content everybody :)

cc @chibenwa , @jeantil 