### PR TITLE
[FIX] IMAP execution management 

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapSession.java
@@ -102,6 +102,10 @@ public interface ImapSession extends CommandDetectionSession {
      */
     Mono<Void> logout();
 
+    default void cancelOngoingProcessing() {
+
+    }
+
     /**
      * Allows implementation to apply back pressure on heavy senders.
      *

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -34,6 +34,8 @@ import org.apache.james.imap.decode.ImapRequestLineReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import reactor.core.scheduler.Schedulers;
+
 /**
  * {@link ImapDecoder} implementation which parse the data via lookup the right
  * {@link ImapCommandParser} via an {@link ImapCommandParserFactory}. The
@@ -78,7 +80,7 @@ public class DefaultImapDecoder implements ImapDecoder {
             String commandName = request.atom();
             return decodeCommandNamed(request, tag, commandName, session);
         } catch (DecodingException e) {
-            LOGGER.debug("Error during initial request parsing", e);
+            LOGGER.info("Error during initial request parsing", e);
             return unknownCommand(tag, session);
         }
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -90,7 +90,10 @@ public class DefaultImapDecoder implements ImapDecoder {
 
         if (count > maxInvalidCommands || session.getState() == ImapSessionState.NON_AUTHENTICATED) {
             ImapMessage message = responseFactory.bye(HumanReadableText.BYE_UNKNOWN_COMMAND);
-            session.logout().block();
+            session.cancelOngoingProcessing();
+            session.logout()
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(); // Avoid synchronously calling this onto the event loop
             return message;
         }
         session.setAttribute(INVALID_COMMAND_COUNT, count);

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -338,10 +338,8 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
 
     private void manageUnknownError(ChannelHandlerContext ctx) {
         // logout on error not sure if that is the best way to handle it
-        final ImapSession imapSession = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
-
-        Optional.ofNullable(ctx.channel().attr(REQUEST_IN_FLIGHT_ATTRIBUTE_KEY).getAndSet(null))
-            .ifPresent(Disposable::dispose);
+        ImapSession imapSession = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
+        Optional.ofNullable(imapSession).ifPresent(ImapSession::cancelOngoingProcessing);
 
         Optional.ofNullable(imapSession)
             .map(ImapSession::logout)

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -263,8 +263,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
             InetSocketAddress address = (InetSocketAddress) ctx.channel().remoteAddress();
             LOGGER.info("Connection closed for {}", address.getAddress().getHostAddress());
 
-            Disposable disposableAttribute = ctx.channel().attr(REQUEST_IN_FLIGHT_ATTRIBUTE_KEY).getAndSet(null);
-
+            Optional.ofNullable(imapSession).ifPresent(ImapSession::cancelOngoingProcessing);
             Optional.ofNullable(imapSession)
                 .map(ImapSession::logout)
                 .orElse(Mono.empty())
@@ -275,7 +274,6 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                 .subscribe(any -> {
 
                 }, ctx::fireExceptionCaught);
-            Optional.ofNullable(disposableAttribute).ifPresent(Disposable::dispose);
         }
     }
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapIdleStateHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapIdleStateHandler.java
@@ -60,7 +60,7 @@ public class ImapIdleStateHandler extends IdleStateHandler implements NettyConst
             LOGGER.info("Logout client {} ({}) because it idled for too long...",
                 address.getHostName(),
                 address.getAddress().getHostAddress());
-
+            session.cancelOngoingProcessing();
             // logout the client
             session.logout()
                 // close the channel

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -49,6 +49,7 @@ import io.netty.handler.codec.compression.ZlibDecoder;
 import io.netty.handler.codec.compression.ZlibEncoder;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.ssl.SslHandler;
+import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 
 public class NettyImapSession implements ImapSession, NettyConstants {
@@ -114,6 +115,12 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     public Mono<Void> logout() {
         return closeMailbox()
             .then(Mono.fromRunnable(() -> state = ImapSessionState.LOGOUT));
+    }
+
+    @Override
+    public void cancelOngoingProcessing() {
+        Disposable disposableAttribute = channel.attr(REQUEST_IN_FLIGHT_ATTRIBUTE_KEY).getAndSet(null);
+        Optional.ofNullable(disposableAttribute).ifPresent(Disposable::dispose);
     }
 
     @Override


### PR DESCRIPTION
That is my best shot at explaining:

```
java.lang.NullPointerException: Cannot invoke "org.apache.james.imap.api.process.SelectedMailbox.existsCount()" because "selected" is null
```

CF https://github.com/linagora/james-project/issues/4688 which was mostly fixed incorrectly...

The Netty stack enforce linearisability of operation conducted on the event loop for a single channel, including command decoding.

For command execution, we trigger the processing only reactor. We rely on a linarizer to enforce sequential IMAP execution.

So in theory we do never execute two IMAP commands of a given connection at the same time.

However no mechanism prevents decoding at the same time than command execution - and that is fine - however the channel operations (inactive, idle, parsing failures) MAY interfere with command execution by deciding a logout eventually deselecting the current mailbox and resulting in the NPE.

Lessons learned: always cancel current command execution before deciding to log out!

That, and we were executing blocking code onto the netty event loop which IS BAD.