### PR TITLE
JAMES-3419 JMAP EmailBodyPart individual headers - Fix test cases

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailGetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailGetMethodContract.scala
@@ -3831,7 +3831,7 @@ trait EmailGetMethodContract {
          |    "charset": "UTF-8",
          |    "size": 8,
          |    "partId": "1",
-         |    "blobId": "1_1",
+         |    "blobId": "${messageId.serialize}_1",
          |    "type": "text/plain"
          |  }
          |}""".stripMargin)


### PR DESCRIPTION
Fix test cases `bodyStructureShouldSupportSpecificHeaders`

![image](https://github.com/apache/james-project/assets/81145350/0625587b-c6f5-4fab-b44e-93a3fcba191e)
it fails when run with Distributed test

How to fix:
Replace `"blobId": "1_1"` -> `"blobId": "${messageId.serialize}_1"`

Reference: https://github.com/apache/james-project/blob/aee6550277db4e31099867e1d29c7598f9a4dad9/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailBodyPart.scala#L136