### PR TITLE
[FIX] RSpamD should not fail when reporting empty body

### DIFF
--- a/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdHttpClient.java
+++ b/third-party/rspamd/src/main/java/org/apache/james/rspamd/client/RspamdHttpClient.java
@@ -248,6 +248,10 @@ public class RspamdHttpClient {
                             LOGGER.debug(responseBody);
                             return Mono.empty();
                         }
+                        if (responseBody.contains("Empty body is not permitted")) {
+                            LOGGER.debug(responseBody);
+                            return Mono.empty();
+                        }
                         return Mono.error(() -> new RspamdUnexpectedException(responseBody));
                     });
         }

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RspamdHttpClientTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/client/RspamdHttpClientTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Optional;
 
@@ -315,6 +316,15 @@ class RspamdHttpClientTest {
         RspamdHttpClient client = new RspamdHttpClient(configuration);
 
         assertThat(client.ping().block().status()).isEqualTo(HttpResponseStatus.OK);
+    }
+
+    @Test
+    void shouldNotFailOnEmptyContent() {
+        RspamdClientConfiguration configuration = new RspamdClientConfiguration(rspamdExtension.getBaseUrl(), PASSWORD, Optional.empty());
+        RspamdHttpClient client = new RspamdHttpClient(configuration);
+
+        client.reportAsSpam(ReactorUtils.toChunks(new ByteArrayInputStream("".getBytes()),
+            BUFFER_SIZE), RspamdHttpClient.Options.forUser(BOB)).block();
     }
 
     private void reportAsSpam(RspamdHttpClient client, InputStream inputStream) {


### PR DESCRIPTION
Technicly this can be caused by buggy IMAP clients

When that happens then this causes a cascade of failures with dead letter as this gets retried.

Better ignore...