### PR TITLE
[ENHANCEMENT] Decrease log level for "NotSslRecordException"

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
@@ -57,6 +57,7 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
+import io.netty.handler.ssl.NotSslRecordException;
 import io.netty.util.AttributeKey;
 
 /**
@@ -275,6 +276,8 @@ public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter imp
                     LOGGER.info("Socket exception encountered: {}", cause.getMessage());
                 } else if (isSslHandshkeException(cause)) {
                     LOGGER.info("SSH handshake rejected {}", cause.getMessage());
+                } else if (isNotSslRecordException(cause)) {
+                    LOGGER.info("Not an SSL record {}", cause.getMessage());
                 } else if (!(cause instanceof ClosedChannelException)) {
                     LOGGER.error("Unable to process request", cause);
                 }
@@ -286,6 +289,11 @@ public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter imp
     private boolean isSslHandshkeException(Throwable cause) {
         return cause instanceof DecoderException &&
             cause.getCause() instanceof SSLHandshakeException;
+    }
+
+    private boolean isNotSslRecordException(Throwable cause) {
+        return cause instanceof DecoderException &&
+            cause.getCause() instanceof NotSslRecordException;
     }
 
     @Override

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -63,6 +63,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.ssl.NotSslRecordException;
 import io.netty.util.Attribute;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -284,6 +285,8 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                 LOGGER.info("Socket exception encountered: {}", cause.getMessage());
             } else if (isSslHandshkeException(cause)) {
                 LOGGER.info("SSH handshake rejected {}", cause.getMessage());
+            } else if (isNotSslRecordException(cause)) {
+                LOGGER.info("Not an SSL record {}", cause.getMessage());
             } else if (!(cause instanceof ClosedChannelException)) {
                 LOGGER.warn("Error while processing imap request", cause);
             }
@@ -320,6 +323,11 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
     private boolean isSslHandshkeException(Throwable cause) {
         return cause instanceof DecoderException
             && cause.getCause() instanceof SSLHandshakeException;
+    }
+
+    private boolean isNotSslRecordException(Throwable cause) {
+        return cause instanceof DecoderException &&
+            cause.getCause() instanceof NotSslRecordException;
     }
 
     private void manageRejectedException(ChannelHandlerContext ctx, ReactiveThrottler.RejectedException cause) throws IOException {


### PR DESCRIPTION
This pollutes the logs.

ERROR logs are for really bad thing needing immediate admin attention, ideally triggering an alarm.

Those are not to be triggered when a guy try telnet on a SMTPS endpoint.

Reducing the log level to info would help making james easier to monitor