### PR TITLE
JAMES-2586 [Postgres] FIXUP when query with IN - should pre-check collection size

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxMessageDAO.java
@@ -217,6 +217,9 @@ public class PostgresMailboxMessageDAO {
     }
 
     public Flux<MessageMetaData> deleteByMailboxIdAndMessageUids(PostgresMailboxId mailboxId, List<MessageUid> uids) {
+        if (uids.isEmpty()) {
+            return Flux.empty();
+        }
         Function<List<MessageUid>, Flux<MessageMetaData>> deletePublisherFunction = uidsToDelete -> postgresExecutor.executeDeleteAndReturnList(dslContext -> dslContext.deleteFrom(TABLE_NAME)
                 .where(MAILBOX_ID.eq(mailboxId.asUuid()))
                 .and(MESSAGE_UID.in(uidsToDelete.stream().map(MessageUid::asLong).toArray(Long[]::new)))
@@ -239,6 +242,9 @@ public class PostgresMailboxMessageDAO {
     }
 
     public Mono<Void> deleteByMessageIdAndMailboxIds(PostgresMessageId messageId, Collection<PostgresMailboxId> mailboxIds) {
+        if (mailboxIds.isEmpty()) {
+            return Mono.empty();
+        }
         return postgresExecutor.executeVoid(dslContext -> Mono.from(dslContext.deleteFrom(TABLE_NAME)
             .where(MESSAGE_ID.eq(messageId.asUuid()))
             .and(MAILBOX_ID.in(mailboxIds.stream().map(PostgresMailboxId::asUuid).collect(ImmutableList.toImmutableList())))));
@@ -318,6 +324,9 @@ public class PostgresMailboxMessageDAO {
     }
 
     public Flux<SimpleMailboxMessage.Builder> findMessagesByMailboxIdAndUIDs(PostgresMailboxId mailboxId, List<MessageUid> uids) {
+        if (uids.isEmpty()) {
+            return Flux.empty();
+        }
         PostgresMailboxMessageFetchStrategy fetchStrategy = PostgresMailboxMessageFetchStrategy.METADATA;
         Function<List<MessageUid>, Flux<SimpleMailboxMessage.Builder>> queryPublisherFunction =
             uidsToFetch -> postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(fetchStrategy.fetchFields())
@@ -507,6 +516,9 @@ public class PostgresMailboxMessageDAO {
     }
 
     public Flux<MessageMetaData> resetRecentFlag(PostgresMailboxId mailboxId, List<MessageUid> uids, ModSeq newModSeq) {
+        if (uids.isEmpty()) {
+            return Flux.empty();
+        }
         Function<List<MessageUid>, Flux<MessageMetaData>> queryPublisherFunction = uidsMatching -> postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.update(TABLE_NAME)
                 .set(IS_RECENT, false)
                 .set(MOD_SEQ, newModSeq.asLong())
@@ -554,6 +566,9 @@ public class PostgresMailboxMessageDAO {
     }
 
     public Flux<Pair<SimpleMailboxMessage.Builder, Record>> findMessagesByMessageIds(Collection<PostgresMessageId> messageIds, MessageMapper.FetchType fetchType) {
+        if (messageIds.isEmpty()) {
+            return Flux.empty();
+        }
         PostgresMailboxMessageFetchStrategy fetchStrategy = FETCH_TYPE_TO_FETCH_STRATEGY.apply(fetchType);
 
         return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(fetchStrategy.fetchFields())

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresThreadDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresThreadDAO.java
@@ -83,6 +83,9 @@ public class PostgresThreadDAO {
     }
 
     public Flux<Pair<Optional<Integer>, ThreadId>> findThreads(Username username, Set<Integer> hashMimeMessageIds) {
+        if (hashMimeMessageIds.isEmpty()) {
+            return Flux.empty();
+        }
         Function<Collection<Integer>, Flux<Pair<Optional<Integer>, ThreadId>>> function = hashMimeMessageIdSubSet ->
             postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(THREAD_ID, HASH_BASE_SUBJECT)
                     .from(TABLE_NAME)

--- a/server/blob/blob-postgres/src/main/java/org/apache/james/blob/postgres/PostgresBlobStoreDAO.java
+++ b/server/blob/blob-postgres/src/main/java/org/apache/james/blob/postgres/PostgresBlobStoreDAO.java
@@ -128,6 +128,9 @@ public class PostgresBlobStoreDAO implements BlobStoreDAO {
 
     @Override
     public Mono<Void> delete(BucketName bucketName, Collection<BlobId> blobIds) {
+        if (blobIds.isEmpty()) {
+            return Mono.empty();
+        }
         return postgresExecutor.executeVoid(dsl -> Mono.from(dsl.deleteFrom(TABLE_NAME)
             .where(BUCKET_NAME.eq(bucketName.asString()))
             .and(BLOB_ID.in(blobIds.stream().map(BlobId::asString).collect(ImmutableList.toImmutableList())))));

--- a/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/identity/PostgresCustomIdentityDAO.java
+++ b/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/identity/PostgresCustomIdentityDAO.java
@@ -167,6 +167,9 @@ public class PostgresCustomIdentityDAO implements CustomIdentityDAO {
 
     @Override
     public Publisher<BoxedUnit> delete(Username username, Seq<IdentityId> ids) {
+        if (ids.isEmpty()) {
+            return Mono.empty();
+        }
         return executorFactory.create(username.getDomainPart())
             .executeVoid(dslContext -> Mono.from(dslContext.deleteFrom(TABLE_NAME)
                 .where(USERNAME.eq(username.asString()))

--- a/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/pushsubscription/PostgresPushSubscriptionDAO.java
+++ b/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/pushsubscription/PostgresPushSubscriptionDAO.java
@@ -89,6 +89,9 @@ public class PostgresPushSubscriptionDAO {
     }
 
     public Flux<PushSubscription> getByUsernameAndIds(Username username, Collection<PushSubscriptionId> ids) {
+        if (ids.isEmpty()) {
+            return Flux.empty();
+        }
         Function<Collection<PushSubscriptionId>, Flux<PushSubscription>> queryPublisherFunction = idsMatching -> postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.selectFrom(PushSubscriptionTable.TABLE_NAME)
                 .where(PushSubscriptionTable.USER.eq(username.asString()))
                 .and(PushSubscriptionTable.ID.in(idsMatching.stream().map(PushSubscriptionId::value).collect(Collectors.toList())))))


### PR DESCRIPTION
When debugging why CI failed at https://github.com/apache/james-project/pull/2048#issuecomment-1987593874
I realized that Jooq will hang when the input to `IN` clause is empty.
=> 
We should check the collection size before the query 