### PR TITLE
Add sslMode to require in PostgresqlConnectionConfiguration

### DIFF
--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresConfiguration.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresConfiguration.java
@@ -43,7 +43,7 @@ public class PostgresConfiguration {
     public static final String NON_RLS_PASSWORD = "database.non-rls.password";
     public static final String RLS_ENABLED = "row.level.security.enabled";
     public static final String SSL_MODE = "ssl.mode";
-    public static final String SSL_MODE_DEFAULT_VALUE = "disable";
+    public static final String SSL_MODE_DEFAULT_VALUE = "allow";
 
     public static class Credential {
         private final String username;

--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresConfiguration.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresConfiguration.java
@@ -26,6 +26,8 @@ import org.apache.commons.configuration2.Configuration;
 
 import com.google.common.base.Preconditions;
 
+import io.r2dbc.postgresql.client.SSLMode;
+
 public class PostgresConfiguration {
     public static final String DATABASE_NAME = "database.name";
     public static final String DATABASE_NAME_DEFAULT_VALUE = "postgres";
@@ -40,6 +42,8 @@ public class PostgresConfiguration {
     public static final String NON_RLS_USERNAME = "database.non-rls.username";
     public static final String NON_RLS_PASSWORD = "database.non-rls.password";
     public static final String RLS_ENABLED = "row.level.security.enabled";
+    public static final String SSL_MODE = "ssl.mode";
+    public static final String SSL_MODE_DEFAULT_VALUE = "disable";
 
     public static class Credential {
         private final String username;
@@ -70,6 +74,7 @@ public class PostgresConfiguration {
         private Optional<String> nonRLSUser = Optional.empty();
         private Optional<String> nonRLSPassword = Optional.empty();
         private Optional<Boolean> rowLevelSecurityEnabled = Optional.empty();
+        private Optional<String> sslMode = Optional.empty();
 
         public Builder databaseName(String databaseName) {
             this.databaseName = Optional.of(databaseName);
@@ -161,6 +166,16 @@ public class PostgresConfiguration {
             return this;
         }
 
+        public Builder sslMode(Optional<String> sslMode) {
+            this.sslMode = sslMode;
+            return this;
+        }
+
+        public Builder sslMode(String sslMode) {
+            this.sslMode = Optional.of(sslMode);
+            return this;
+        }
+
         public PostgresConfiguration build() {
             Preconditions.checkArgument(username.isPresent() && !username.get().isBlank(), "You need to specify username");
             Preconditions.checkArgument(password.isPresent() && !password.get().isBlank(), "You need to specify password");
@@ -176,7 +191,8 @@ public class PostgresConfiguration {
                 databaseSchema.orElse(DATABASE_SCHEMA_DEFAULT_VALUE),
                 new Credential(username.get(), password.get()),
                 new Credential(nonRLSUser.orElse(username.get()), nonRLSPassword.orElse(password.get())),
-                rowLevelSecurityEnabled.orElse(false));
+                rowLevelSecurityEnabled.orElse(false),
+                SSLMode.fromValue(sslMode.orElse(SSL_MODE_DEFAULT_VALUE)));
         }
     }
 
@@ -195,6 +211,7 @@ public class PostgresConfiguration {
             .nonRLSUser(Optional.ofNullable(propertiesConfiguration.getString(NON_RLS_USERNAME)))
             .nonRLSPassword(Optional.ofNullable(propertiesConfiguration.getString(NON_RLS_PASSWORD)))
             .rowLevelSecurityEnabled(propertiesConfiguration.getBoolean(RLS_ENABLED, false))
+            .sslMode(Optional.ofNullable(propertiesConfiguration.getString(SSL_MODE)))
             .build();
     }
 
@@ -205,9 +222,11 @@ public class PostgresConfiguration {
     private final Credential credential;
     private final Credential nonRLSCredential;
     private final boolean rowLevelSecurityEnabled;
+    private final SSLMode sslMode;
 
     private PostgresConfiguration(String host, int port, String databaseName, String databaseSchema,
-                                  Credential credential, Credential nonRLSCredential, boolean rowLevelSecurityEnabled) {
+                                  Credential credential, Credential nonRLSCredential, boolean rowLevelSecurityEnabled,
+                                  SSLMode sslMode) {
         this.host = host;
         this.port = port;
         this.databaseName = databaseName;
@@ -215,6 +234,7 @@ public class PostgresConfiguration {
         this.credential = credential;
         this.nonRLSCredential = nonRLSCredential;
         this.rowLevelSecurityEnabled = rowLevelSecurityEnabled;
+        this.sslMode = sslMode;
     }
 
     public String getHost() {
@@ -245,9 +265,13 @@ public class PostgresConfiguration {
         return rowLevelSecurityEnabled;
     }
 
+    public SSLMode getSslMode() {
+        return sslMode;
+    }
+
     @Override
     public final int hashCode() {
-        return Objects.hash(host, port, databaseName, databaseSchema, credential, nonRLSCredential, rowLevelSecurityEnabled);
+        return Objects.hash(host, port, databaseName, databaseSchema, credential, nonRLSCredential, rowLevelSecurityEnabled, sslMode);
     }
 
     @Override
@@ -261,7 +285,8 @@ public class PostgresConfiguration {
                 && Objects.equals(this.credential, that.credential)
                 && Objects.equals(this.nonRLSCredential, that.nonRLSCredential)
                 && Objects.equals(this.databaseName, that.databaseName)
-                && Objects.equals(this.databaseSchema, that.databaseSchema);
+                && Objects.equals(this.databaseSchema, that.databaseSchema)
+                && Objects.equals(this.sslMode, that.sslMode);
         }
         return false;
     }

--- a/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresConfigurationTest.java
+++ b/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresConfigurationTest.java
@@ -69,7 +69,7 @@ class PostgresConfigurationTest {
         assertThat(configuration.getNonRLSCredential().getUsername()).isEqualTo("james");
         assertThat(configuration.getNonRLSCredential().getPassword()).isEqualTo("1");
         assertThat(configuration.rowLevelSecurityEnabled()).isEqualTo(false);
-        assertThat(configuration.getSslMode()).isEqualTo(SSLMode.DISABLE);
+        assertThat(configuration.getSslMode()).isEqualTo(SSLMode.ALLOW);
     }
 
     @Test

--- a/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresConfigurationTest.java
+++ b/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresConfigurationTest.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
+import io.r2dbc.postgresql.client.SSLMode;
+
 class PostgresConfigurationTest {
 
     @Test
@@ -38,6 +40,7 @@ class PostgresConfigurationTest {
             .nonRLSUser("nonrlsjames")
             .nonRLSPassword("2")
             .rowLevelSecurityEnabled()
+            .sslMode("require")
             .build();
 
         assertThat(configuration.getHost()).isEqualTo("1.1.1.1");
@@ -49,6 +52,7 @@ class PostgresConfigurationTest {
         assertThat(configuration.getNonRLSCredential().getUsername()).isEqualTo("nonrlsjames");
         assertThat(configuration.getNonRLSCredential().getPassword()).isEqualTo("2");
         assertThat(configuration.rowLevelSecurityEnabled()).isEqualTo(true);
+        assertThat(configuration.getSslMode()).isEqualTo(SSLMode.REQUIRE);
     }
 
     @Test
@@ -65,6 +69,7 @@ class PostgresConfigurationTest {
         assertThat(configuration.getNonRLSCredential().getUsername()).isEqualTo("james");
         assertThat(configuration.getNonRLSCredential().getPassword()).isEqualTo("1");
         assertThat(configuration.rowLevelSecurityEnabled()).isEqualTo(false);
+        assertThat(configuration.getSslMode()).isEqualTo(SSLMode.DISABLE);
     }
 
     @Test
@@ -108,12 +113,13 @@ class PostgresConfigurationTest {
     }
 
     @Test
-    void rowLevelSecurityShouldBeDisabledByDefault() {
-        PostgresConfiguration configuration = PostgresConfiguration.builder()
+    void shouldThrowWhenInvalidSslMode() {
+        assertThatThrownBy(() -> PostgresConfiguration.builder()
             .username("james")
             .password("1")
-            .build();
-
-        assertThat(configuration.rowLevelSecurityEnabled()).isFalse();
+            .sslMode("invalid")
+            .build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid ssl mode value: invalid");
     }
 }

--- a/server/apps/postgres-app/sample-configuration/postgres.properties
+++ b/server/apps/postgres-app/sample-configuration/postgres.properties
@@ -25,6 +25,6 @@ row.level.security.enabled=false
 # String. It is required when row.level.security.enabled is true. Database password of non-rls user.
 #database.non-rls.password=secret1
 
-# String. Optional, defaults to disable. SSLMode required to connect to the Postgresql db server.
+# String. Optional, defaults to allow. SSLMode required to connect to the Postgresql db server.
 # Check https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION for a list of supported SSLModes.
-ssl.mode=disable
+ssl.mode=allow

--- a/server/apps/postgres-app/sample-configuration/postgres.properties
+++ b/server/apps/postgres-app/sample-configuration/postgres.properties
@@ -24,3 +24,7 @@ row.level.security.enabled=false
 
 # String. It is required when row.level.security.enabled is true. Database password of non-rls user.
 #database.non-rls.password=secret1
+
+# String. Optional, defaults to disable. SSLMode required to connect to the Postgresql db server.
+# Check https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION for a list of supported SSLModes.
+ssl.mode=disable

--- a/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresCommonModule.java
+++ b/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresCommonModule.java
@@ -104,6 +104,7 @@ public class PostgresCommonModule extends AbstractModule {
             .password(postgresConfiguration.getCredential().getPassword())
             .database(postgresConfiguration.getDatabaseName())
             .schema(postgresConfiguration.getDatabaseSchema())
+            .sslMode(postgresConfiguration.getSslMode())
             .build());
     }
 
@@ -118,6 +119,7 @@ public class PostgresCommonModule extends AbstractModule {
             .password(postgresConfiguration.getNonRLSCredential().getPassword())
             .database(postgresConfiguration.getDatabaseName())
             .schema(postgresConfiguration.getDatabaseSchema())
+            .sslMode(postgresConfiguration.getSslMode())
             .build());
     }
 


### PR DESCRIPTION
Default is disabled in rd2bc conf, which is an issue when trying to connect to a postgresql db using ssl.

Yes it's dirty, it was to be able to test quickly if I could connect to a postgresql db backed up by ovh service or not. 

Result is yes it works :) 

Will work on making the sslMode configurable at least.

Would probably be beneficial to make the all ssl configurable in case James is backed by a postgres db hosted internally with specific ssl certs, but we can probably do that later/have a ticket for it.