### PR TITLE
JAMES 2586 Increase timeout to for postgres-jmap-integration-test module

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/postgres-jmap-rfc-8621-integration-tests/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/postgres-jmap-rfc-8621-integration-tests/pom.xml
@@ -94,4 +94,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/server/protocols/jmap-rfc-8621-integration-tests/postgres-jmap-rfc-8621-integration-tests/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/postgres-jmap-rfc-8621-integration-tests/pom.xml
@@ -102,6 +102,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
+                    <reuseForks>true</reuseForks>
+                    <forkCount>2</forkCount>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The module keeps being timeout. Let's ease the timeout for now before investigating if any test takes too much time (may take the develocity work on master to have metrics on the tests runtime)

Or maybe the JMAP postgres ITs are just really slow (I suspect the same for Distributed JMAP IT on master but we likely skipped tests using the `BasicFeature` tag).

