### PR TITLE
JAMES-2586 Reduce repeat count for some JMAP integration tests

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -6314,7 +6314,7 @@ trait MailboxSetMethodContract {
          |}""".stripMargin)
   }
 
-  @RepeatedTest(100)
+  @RepeatedTest(20)
   def concurrencyChecksUponParentIdUpdate(server: GuiceJamesServer): Unit = {
     val mailboxId1: MailboxId = server.getProbe(classOf[MailboxProbeImpl])
       .createMailbox(MailboxPath.forUser(BOB, "mailbox1"))

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
@@ -58,7 +58,7 @@ trait UploadContract {
       .build
   }
 
-  @RepeatedTest(50)
+  @RepeatedTest(20)
   def shouldUploadFileAndAllowToDownloadIt(): Unit = {
     val uploadResponse: String = `given`
       .basePath("")


### PR DESCRIPTION
These are the tests that took a lot of time to fully repeat. 
cf: https://ge.apache.org/s/dqudut5akzxr6/tests/goal/org.apache.james:postgres-jmap-rfc-8621-integration-tests:surefire:test@default-test/details/org.apache.james.jmap.rfc8621.postgres.PostgresUploadTest?top-execution=1 

cf: https://ge.apache.org/s/dqudut5akzxr6/tests/goal/org.apache.james:postgres-jmap-rfc-8621-integration-tests:surefire:test@default-test/details/org.apache.james.jmap.rfc8621.postgres.PostgresMailboxSetMethodTest?top-execution=1

Likely overkill to repeat that much, we can reduce the repeat count to save some test runtime...