### PR TITLE
[FIX] AbstractValidRcptHandler fix error handling on invalid username

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -47,12 +47,12 @@ public abstract class AbstractValidRcptHandler implements RcptHook {
                 return reject(rcpt);
             }
             return HookResult.DECLINED;
-        } catch (IllegalAccessException e) {
-            LOGGER.warn("Encounter an error upon RCPT validation ({}), deny-soft", rcpt.asString());
+        } catch (IllegalArgumentException e) {
+            LOGGER.info("Encounter an error upon RCPT validation ({}), deny", rcpt.asString());
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.deny())
-                .smtpReturnCode(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS)
-                .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_SYNTAX) + " Unexpected error for " + rcpt.asString())
+                .smtpReturnCode(SMTPRetCode.MAILBOX_PERM_UNAVAILABLE)
+                .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.ADDRESS_MAILBOX) + " Unknown user: " + rcpt.asString())
                 .build();
         } catch (Exception e) {
             LOGGER.error("Encounter an error upon RCPT validation ({}), deny-soft", rcpt.asString(), e);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -236,4 +236,12 @@ class ValidRcptHandlerTest {
         assertThat(rCode).isEqualTo(HookReturnCode.denySoft());
     }
 
+    @Test
+    void doRcptShouldReturnDeclineWhenInvalidUsername() throws Exception {
+        SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
+
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, new MailAddress("\"abc@\"@localhost")).getResult();
+
+        assertThat(rCode).isEqualTo(HookReturnCode.deny());
+    }
 }


### PR DESCRIPTION
Syntactically valid email address but invalid username. The best is to advertise "no such person here".

Deny soft in such case causes numerous retires:
 - log noise!
 - And delayed feedback for the sender