### PR TITLE
[LOGGING] Aborting JMAP upload is too verbose

### DIFF
--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/ProblemDetails.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/ProblemDetails.scala
@@ -25,6 +25,7 @@ import org.apache.james.jmap.core.RequestLevelErrorType.{DEFAULT_ERROR_TYPE, Err
 import org.apache.james.jmap.exceptions.UnauthorizedException
 import org.apache.james.jmap.routes.UnsupportedCapabilitiesException
 import org.slf4j.{Logger, LoggerFactory}
+import reactor.netty.channel.AbortedException
 
 /**
  * Problem Details for HTTP APIs within the JMAP context
@@ -40,6 +41,9 @@ object ProblemDetails {
   val LOGGER: Logger = LoggerFactory.getLogger(classOf[ProblemDetails])
 
   def forThrowable(throwable: Throwable): ProblemDetails = throwable match {
+    case exception: AbortedException =>
+      LOGGER.info("The connection was aborted: {}", exception.getMessage)
+      ProblemDetails(status = INTERNAL_SERVER_ERROR, detail = exception.getMessage)
     case exception: IllegalArgumentException =>
       LOGGER.info("The request was successfully parsed as JSON but did not match the type signature of the Request object: {}", exception.getMessage)
       notRequestProblem(

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetCreatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetCreatePerformer.scala
@@ -40,7 +40,7 @@ import reactor.core.scala.publisher.{SFlux, SMono}
 import scala.util.Try
 
 object MailboxSetCreatePerformer {
-  private val LOGGER = LoggerFactory.getLogger(classOf[EmailSetCreatePerformer])
+  private val LOGGER = LoggerFactory.getLogger(classOf[MailboxSetCreatePerformer])
   sealed trait MailboxCreationResult {
     def mailboxCreationId: MailboxCreationId
   }


### PR DESCRIPTION
ERROR level logs:

```
reactor.netty.channel.AbortedException: Connection has been closed
	at reactor.netty.http.server.HttpServerOperations.onInboundClose(HttpServerOperations.java:699)
	at reactor.netty.channel.ChannelOperationsHandler.channelInactive(ChannelOperationsHandler.java:73)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:305)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:274)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelInactive(CombinedChannelDuplexHandler.java:418)
	at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:411)
	at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:376)
	at io.netty.channel.CombinedChannelDuplexHandler.channelInactive(CombinedChannelDuplexHandler.java:221)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:303)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:274)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1405)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:301)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:901)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$7.run(AbstractChannel.java:813)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:413)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```