### PR TITLE
JAMES-2586 [REFACTORING] - PostgresTableManager - fix incorrect log...

### DIFF
--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresIndex.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresIndex.java
@@ -40,8 +40,9 @@ public class PostgresIndex {
 
     public static RequireCreateIndexStep name(String indexName) {
         Preconditions.checkNotNull(indexName);
+        String strategyIndexName = indexName.toLowerCase();
 
-        return createIndexFunction -> new PostgresIndex(indexName, dsl -> createIndexFunction.createIndex(dsl, indexName));
+        return createIndexFunction -> new PostgresIndex(strategyIndexName, dsl -> createIndexFunction.createIndex(dsl, strategyIndexName));
     }
 
     private final String name;

--- a/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresTable.java
+++ b/backends-common/postgres/src/main/java/org/apache/james/backends/postgres/PostgresTable.java
@@ -80,8 +80,9 @@ public class PostgresTable {
 
     public static RequireCreateTableStep name(String tableName) {
         Preconditions.checkNotNull(tableName);
+        String strategyName = tableName.toLowerCase();
 
-        return createTableFunction -> supportsRowLevelSecurity -> new FinalStage(tableName, supportsRowLevelSecurity, dsl -> createTableFunction.createTable(dsl, tableName));
+        return createTableFunction -> supportsRowLevelSecurity -> new FinalStage(strategyName, supportsRowLevelSecurity, dsl -> createTableFunction.createTable(dsl, strategyName));
     }
 
     private final String name;

--- a/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresTableManagerTest.java
+++ b/backends-common/postgres/src/test/java/org/apache/james/backends/postgres/PostgresTableManagerTest.java
@@ -45,7 +45,7 @@ class PostgresTableManagerTest {
 
     @Test
     void initializeTableShouldSuccessWhenModuleHasSingleTable() {
-        String tableName = "tableName1";
+        String tableName = "tablename1";
 
         PostgresTable table = PostgresTable.name(tableName)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
@@ -71,14 +71,14 @@ class PostgresTableManagerTest {
 
     @Test
     void initializeTableShouldSuccessWhenModuleHasMultiTables() {
-        String tableName1 = "tableName1";
+        String tableName1 = "tablename1";
 
         PostgresTable table1 = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
                 .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity()
             .build();
 
-        String tableName2 = "tableName2";
+        String tableName2 = "tablename2";
         PostgresTable table2 = PostgresTable.name(tableName2)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
                 .column("columB", SQLDataType.INTEGER)).disableRowLevelSecurity()
@@ -99,7 +99,7 @@ class PostgresTableManagerTest {
 
     @Test
     void initializeTableShouldNotThrowWhenTableExists() {
-        String tableName1 = "tableName1";
+        String tableName1 = "tablename1";
 
         PostgresTable table1 = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
@@ -117,7 +117,7 @@ class PostgresTableManagerTest {
 
     @Test
     void initializeTableShouldNotChangeTableStructureOfExistTable() {
-        String tableName1 = "tableName1";
+        String tableName1 = "tablename1";
         PostgresTable table1 = PostgresTable.name(tableName1)
             .createTableStep((dsl, tbn) -> dsl.createTable(tbn)
                 .column("columA", SQLDataType.UUID.notNull())).disableRowLevelSecurity()

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
@@ -27,6 +27,7 @@ import org.apache.james.backends.postgres.PostgresIndex;
 import org.apache.james.backends.postgres.PostgresModule;
 import org.apache.james.backends.postgres.PostgresTable;
 import org.jooq.Field;
+import org.jooq.Name;
 import org.jooq.Record;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
@@ -47,6 +48,8 @@ public interface PostgresMailboxModule {
         Field<Long> MAILBOX_HIGHEST_MODSEQ = DSL.field("mailbox_highest_modseq", BIGINT);
         Field<Hstore> MAILBOX_ACL = DSL.field("mailbox_acl", org.jooq.impl.DefaultDataType.getDefaultDataType("hstore").asConvertedDataType(new HstoreBinding()));
 
+        Name MAILBOX_NAME_USER_NAME_NAMESPACE_UNIQUE_CONSTRAINT = DSL.name("mailbox_mailbox_name_user_name_mailbox_namespace_key");
+
         PostgresTable TABLE = PostgresTable.name(TABLE_NAME.getName())
             .createTableStep(((dsl, tableName) -> dsl.createTableIfNotExists(tableName)
                 .column(MAILBOX_ID, SQLDataType.UUID)
@@ -58,7 +61,7 @@ public interface PostgresMailboxModule {
                 .column(MAILBOX_HIGHEST_MODSEQ)
                 .column(MAILBOX_ACL)
                 .constraint(DSL.primaryKey(MAILBOX_ID))
-                .constraint(DSL.unique(MAILBOX_NAME, USER_NAME, MAILBOX_NAMESPACE))))
+                .constraint(DSL.constraint(MAILBOX_NAME_USER_NAME_NAMESPACE_UNIQUE_CONSTRAINT).unique(MAILBOX_NAME, USER_NAME, MAILBOX_NAMESPACE))))
             .supportsRowLevelSecurity()
             .build();
         PostgresIndex MAILBOX_USERNAME_NAMESPACE_INDEX = PostgresIndex.name("mailbox_username_namespace_index")

--- a/server/data/data-postgres/src/main/java/org/apache/james/user/postgres/PostgresUserModule.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/user/postgres/PostgresUserModule.java
@@ -22,6 +22,7 @@ package org.apache.james.user.postgres;
 import org.apache.james.backends.postgres.PostgresModule;
 import org.apache.james.backends.postgres.PostgresTable;
 import org.jooq.Field;
+import org.jooq.Name;
 import org.jooq.Record;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
@@ -37,6 +38,8 @@ public interface PostgresUserModule {
         Field<String[]> AUTHORIZED_USERS = DSL.field("authorized_users", SQLDataType.VARCHAR.getArrayDataType());
         Field<String[]> DELEGATED_USERS = DSL.field("delegated_users", SQLDataType.VARCHAR.getArrayDataType());
 
+        Name USERNAME_PRIMARY_KEY = DSL.name("users_username_pk");
+
         PostgresTable TABLE = PostgresTable.name(TABLE_NAME.getName())
             .createTableStep(((dsl, tableName) -> dsl.createTableIfNotExists(tableName)
                 .column(USERNAME)
@@ -44,7 +47,7 @@ public interface PostgresUserModule {
                 .column(ALGORITHM)
                 .column(AUTHORIZED_USERS)
                 .column(DELEGATED_USERS)
-                .constraint(DSL.primaryKey(USERNAME))))
+                .constraint(DSL.constraint(USERNAME_PRIMARY_KEY).primaryKey(USERNAME))))
             .disableRowLevelSecurity()
             .build();
     }

--- a/server/data/data-postgres/src/main/java/org/apache/james/vacation/postgres/PostgresVacationModule.java
+++ b/server/data/data-postgres/src/main/java/org/apache/james/vacation/postgres/PostgresVacationModule.java
@@ -74,11 +74,11 @@ public interface PostgresVacationModule {
             .supportsRowLevelSecurity()
             .build();
 
-        PostgresIndex ACCOUNT_ID_INDEX = PostgresIndex.name("vacation_notification_registry_accountId_index")
+        PostgresIndex ACCOUNT_ID_INDEX = PostgresIndex.name("vacation_notification_registry_accountid_index")
             .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
                 .on(TABLE_NAME, ACCOUNT_ID));
 
-        PostgresIndex FULL_COMPOSITE_INDEX = PostgresIndex.name("vacation_notification_registry_accountId_recipientId_expiryDate_index")
+        PostgresIndex FULL_COMPOSITE_INDEX = PostgresIndex.name("vnr_accountid_recipientid_expirydate_index")
             .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
                 .on(TABLE_NAME, ACCOUNT_ID, RECIPIENT_ID, EXPIRY_DATE));
     }


### PR DESCRIPTION
**JAMES-2586 [REFACTORING] - PostgresTableManager - fix incorrect log**

To avoid incorrect logs for each startup James. The fact is James does nothing when the table, index already exist
```
o.a.j.b.p.PostgresTableManager - Table users created
o.a.j.b.p.PostgresTableManager - Table blob_storage created
o.a.j.b.p.PostgresTableManager - Table mailbox created
...
o.a.j.b.p.PostgresTableManager - Index push_subscription_username_index created
o.a.j.b.p.PostgresTableManager - Index push_subscription_username_id_index created
o.a.j.b.p.PostgresTableManager - Index custom_identity_username_index created
...
```

**JAMES-2586 Refactor the handle way duplicate value on constraint index to avoid noise log (Mailbox and User table)** 

To avoid noise log from JOOQ library

