### PR TITLE
POC IMAP FETCH with large body should not rely on in-memory buffering

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -87,7 +87,9 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
         Namespace,
         UserFlag,
         ACL,
-        Quota
+        Quota,
+        // Reads at level HeaderWithAttachementsMetadata allows to also lazy load the body
+        MessageContentStreaming
     }
 
     EnumSet<MailboxCapabilities> getSupportedMailboxCapabilities();

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageResult.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageResult.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.model;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -30,6 +31,7 @@ import jakarta.mail.Flags;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.reactivestreams.Publisher;
 
 
 /**
@@ -168,4 +170,5 @@ public interface MessageResult extends Comparable<MessageResult> {
      */
     List<MessageAttachmentMetadata> getLoadedAttachments() throws MailboxException;
 
+    Publisher<InputStream> lazyLoadedFullContent();
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
@@ -54,7 +54,8 @@ public class CassandraMailboxManager extends StoreMailboxManager {
         MailboxCapabilities.Namespace,
         MailboxCapabilities.Annotation,
         MailboxCapabilities.ACL,
-        MailboxCapabilities.Quota);
+        MailboxCapabilities.Quota,
+        MailboxCapabilities.MessageContentStreaming);
     public static final EnumSet<MessageCapabilities> MESSAGE_CAPABILITIES = EnumSet.of(MessageCapabilities.UniqueID);
 
     private final MailboxPathLocker locker;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMetadata.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMetadata.java
@@ -43,6 +43,7 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.Properties;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.reactivestreams.Publisher;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -295,6 +296,11 @@ public class CassandraMessageMetadata {
         @Override
         public MailboxMessage copy(Mailbox mailbox) throws MailboxException {
             return new CassandraMailboxMessage(delegate.copy(mailbox), headerBlobId);
+        }
+
+        @Override
+        public Publisher<InputStream> lazyLoadedFullContent() {
+            return delegate.lazyLoadedFullContent();
         }
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
+import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +31,7 @@ import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.mail.model.impl.Properties;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.reactivestreams.Publisher;
 
 public class MessageRepresentation {
     private final MessageId messageId;
@@ -41,9 +43,11 @@ public class MessageRepresentation {
     private final List<MessageAttachmentRepresentation> attachments;
     private final BlobId headerId;
     private final BlobId bodyId;
+    private final Publisher<InputStream> lazyLoadedFullContent;
 
     public MessageRepresentation(MessageId messageId, Date internalDate, Long size, Integer bodyStartOctet, Content content,
-                                 Properties properties, List<MessageAttachmentRepresentation> attachments, BlobId headerId, BlobId bodyId) {
+                                 Properties properties, List<MessageAttachmentRepresentation> attachments, BlobId headerId, BlobId bodyId,
+                                 Publisher<InputStream> lazyLoadedFullContent) {
         this.messageId = messageId;
         this.internalDate = internalDate;
         this.size = size;
@@ -53,6 +57,7 @@ public class MessageRepresentation {
         this.attachments = attachments;
         this.headerId = headerId;
         this.bodyId = bodyId;
+        this.lazyLoadedFullContent = lazyLoadedFullContent;
     }
 
     public SimpleMailboxMessage toMailboxMessage(ComposedMessageIdWithMetaData metadata, List<MessageAttachmentMetadata> attachments, Optional<Date> saveDate) {
@@ -70,6 +75,7 @@ public class MessageRepresentation {
             .flags(metadata.getFlags())
             .properties(properties)
             .addAttachments(attachments)
+            .lazyLoadedFullContent(lazyLoadedFullContent)
             .build();
     }
 
@@ -107,5 +113,9 @@ public class MessageRepresentation {
 
     public BlobId getBodyId() {
         return bodyId;
+    }
+
+    public Publisher<InputStream> getLazyLoadedFullContent() {
+        return lazyLoadedFullContent;
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 
 import jakarta.mail.Flags;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.StatementRecorder;
@@ -73,6 +74,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
+import reactor.core.publisher.Mono;
 
 class CassandraMessageMapperTest extends MessageMapperTest {
     @RegisterExtension
@@ -451,7 +453,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
         List<MessageAttachmentMetadata> messageAttachments = attachmentMapper.storeAttachments(ImmutableList.of(attachment1), messageId);
         MailboxMessage message = new SimpleMailboxMessage(messageId, ThreadId.fromBaseMessageId(messageId), new Date(), content.length(), 16,
             new ByteContent(content.getBytes()), new Flags(), new PropertyBuilder().build(), benwaInboxMailbox.getMailboxId(),
-            messageAttachments, Optional.empty());
+            messageAttachments, Mono.error(new NotImplementedException()), Optional.empty());
         messageMapper.add(benwaInboxMailbox, message);
         message.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
 

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -68,10 +68,13 @@ import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.openjpa.persistence.jdbc.ElementJoinColumn;
 import org.apache.openjpa.persistence.jdbc.ElementJoinColumns;
 import org.apache.openjpa.persistence.jdbc.Index;
+import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Mono;
 
 /**
  * Abstract base class for JPA based implementations of
@@ -576,5 +579,10 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
 
     private AttachmentId generateFixedAttachmentId(int position) {
         return AttachmentId.from(getMailboxId().serialize() + "-" + getUid().asLong() + "-" + position);
+    }
+
+    @Override
+    public Publisher<InputStream> lazyLoadedFullContent() {
+        return Mono.fromCallable(this::getFullContent);
     }
 }

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManager.java
@@ -49,7 +49,8 @@ public class InMemoryMailboxManager extends StoreMailboxManager {
         MailboxCapabilities.Namespace,
         MailboxCapabilities.Annotation,
         MailboxCapabilities.ACL,
-        MailboxCapabilities.Quota);
+        MailboxCapabilities.Quota,
+        MailboxCapabilities.MessageContentStreaming);
     public static final EnumSet<MessageCapabilities> MESSAGE_CAPABILITIES = EnumSet.of(MessageCapabilities.UniqueID);
 
     @Inject

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
@@ -35,6 +35,8 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 
+import reactor.core.publisher.Mono;
+
 public interface MessageFactory<T extends MailboxMessage> {
     T createMessage(MessageId messageId, ThreadId threadId, Mailbox mailbox, Date internalDate, Date saveDate, int size, int bodyStartOctet,
                     Content content, Flags flags, PropertyBuilder propertyBuilder,
@@ -46,7 +48,7 @@ public interface MessageFactory<T extends MailboxMessage> {
                                                   int bodyStartOctet, Content content, Flags flags,
                                                   PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
             return new SimpleMailboxMessage(messageId, threadId, internalDate, size, bodyStartOctet, content, flags, propertyBuilder.build(),
-                mailbox.getMailboxId(), attachments, Optional.of(saveDate));
+                mailbox.getMailboxId(), attachments, Mono.fromCallable(content::getInputStream), Optional.of(saveDate));
         }
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
@@ -376,4 +376,9 @@ public class MessageResultImpl implements MessageResult {
             return headers.iterator();
         }
     }
+
+    @Override
+    public Publisher<InputStream> lazyLoadedFullContent() {
+        return message.lazyLoadedFullContent();
+    }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageResultIterator.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageResultIterator.java
@@ -20,6 +20,7 @@ package org.apache.james.mailbox.store;
 
 import static org.apache.james.mailbox.store.mail.FetchGroupConverter.getFetchType;
 
+import java.io.InputStream;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -51,8 +52,11 @@ import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
 
 public class StoreMessageResultIterator implements MessageResultIterator {
     private static final Logger LOGGER = LoggerFactory.getLogger(StoreMessageResultIterator.class);
@@ -290,6 +294,10 @@ public class StoreMessageResultIterator implements MessageResultIterator {
             throw exception;
         }
 
+        @Override
+        public Publisher<InputStream> lazyLoadedFullContent() {
+            return Mono.error(exception);
+        }
     }
 
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/MailboxMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/MailboxMessage.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.store.mail.model;
 
+import java.io.InputStream;
 import java.util.Date;
 import java.util.Optional;
 
@@ -31,6 +32,7 @@ import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.ThreadId;
+import org.reactivestreams.Publisher;
 
 /**
  * A MIME message, consisting of meta-data (including MIME headers)
@@ -129,4 +131,6 @@ public interface MailboxMessage extends Message, Comparable<MailboxMessage> {
     MailboxMessage copy(Mailbox mailbox) throws MailboxException;
 
     Optional<Date> getSaveDate();
+
+    Publisher<InputStream> lazyLoadedFullContent();
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageBuilder.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageBuilder.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import jakarta.mail.Flags;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
@@ -43,6 +44,7 @@ import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
+import reactor.core.publisher.Mono;
 
 public class MessageBuilder {
     private static final char[] NEW_LINE = { 0x0D, 0x0A };
@@ -85,7 +87,7 @@ public class MessageBuilder {
         byte[] headerContent = getHeaderContent();
         ThreadId threadId = ThreadId.fromBaseMessageId(messageId);
         SimpleMailboxMessage mailboxMessage = new SimpleMailboxMessage(messageId, threadId, internalDate, size, headerContent.length,
-            new ByteContent(Bytes.concat(headerContent, body)), flags, new PropertyBuilder().build(), mailboxId, NO_ATTACHMENTS, saveDate);
+            new ByteContent(Bytes.concat(headerContent, body)), flags, new PropertyBuilder().build(), mailboxId, NO_ATTACHMENTS, Mono.error(new NotImplementedException()), saveDate);
         mailboxMessage.setUid(uid);
         return mailboxMessage;
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import jakarta.mail.Flags;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.ByteContent;
@@ -54,6 +55,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
+import reactor.core.publisher.Mono;
 
 public abstract class MessageWithAttachmentMapperTest {
 
@@ -186,7 +188,7 @@ public abstract class MessageWithAttachmentMapperTest {
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, ThreadId threadId, String content, int bodyStart, PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
-        return new SimpleMailboxMessage(messageId, threadId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId(), attachments, EMPTY_SAVE_DATE);
+        return new SimpleMailboxMessage(messageId, threadId, new Date(), content.length(), bodyStart, new ByteContent(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId(), attachments, Mono.error(new NotImplementedException()), EMPTY_SAVE_DATE);
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, ThreadId threadId, String content, int bodyStart, PropertyBuilder propertyBuilder) {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
@@ -134,7 +134,7 @@ class SimpleMailboxMessageTest {
 
         assertThat((Object)copy).isEqualToIgnoringGivenFields(original, "message", "mailboxId").isNotSameAs(original);
         assertThat(copy.getMessage())
-            .isEqualToIgnoringGivenFields(original.getMessage(), "content")
+            .isEqualToIgnoringGivenFields(original.getMessage(), "content", "lazyLoadedFullContent")
             .isNotSameAs(original.getMessage());
         assertThat(IOUtils.toString(copy.getMessage().getFullContent(), StandardCharsets.UTF_8))
             .isEqualTo(IOUtils.toString(original.getMessage().getFullContent(), StandardCharsets.UTF_8));

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
@@ -34,6 +34,7 @@ import jakarta.mail.Flags;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import reactor.core.publisher.Mono;
 
 class SimpleMailboxMessageTest {
     static final Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
@@ -125,7 +127,7 @@ class SimpleMailboxMessageTest {
             new Flags(),
             propertyBuilder.build(),
             TEST_ID,
-            List.of(),
+            List.of(), Mono.error(new NotImplementedException()),
             saveDate);
 
         SimpleMailboxMessage copy = SimpleMailboxMessage.copy(TestId.of(1337), original);

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/FetchData.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/FetchData.java
@@ -173,6 +173,26 @@ public class FetchData {
             .isEmpty();
     }
 
+    public boolean singleBodyRead() {
+        if (getBodyElements().size() != 1) {
+            return false;
+        }
+        if (itemToFetch.contains(Item.BODY) || itemToFetch.contains(Item.BODY_STRUCTURE)) {
+            return false;
+        }
+        BodyFetchElement bodyFetchElement = getBodyElements().stream().findAny().get();
+        if (bodyFetchElement.getPath() != null) {
+            return false;
+        }
+        if (bodyFetchElement.getSectionType() != SectionType.CONTENT) {
+            return false;
+        }
+        if (bodyFetchElement.getFieldNames() != null && !bodyFetchElement.getFieldNames().isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public final int hashCode() {
         return Objects.hash(itemToFetch, bodyElements, setSeen, changedSince);


### PR DESCRIPTION
 - [x] Runned the Distributed AES tests successfully, S3 too

Real question on non-aes tests and I think `Flux<ButeBuffer> -> InputStream` needs to be improved in order not to be blocking