### PR TITLE
POC Potentially non blocking Flux<ByteBuffer> => InputStream implementation

### DIFF
--- a/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
@@ -21,6 +21,7 @@ package org.apache.james.util;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Iterator;
@@ -146,6 +147,11 @@ public class ReactorUtils {
                     return toRead;
                 })
                 .orElse(NO_MORE_DATA);
+        }
+
+        @Override
+        public int available() {
+            return currentItemByteStream.map(Buffer::remaining).orElse(0);
         }
 
         @Override


### PR DESCRIPTION
The ChunkStream Netty abstraction makes it clear it needs a reliable implementation of `available()` method which is not the case today: always return 0 and needlessly block most of the time.

This attempt tries to enhance the overall working of this class.

Note: Unit test passes but the Distributed integration tests randomly fails. 5% of the time part of the message is missing causing failures. I suspect a data race between the subscription and consumption which happens on distinct threads.