### PR TITLE
[Netty] Size estimator for ChunkedStream

### DIFF
--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
@@ -34,7 +34,6 @@ import io.netty.channel.DefaultFileRegion;
 import io.netty.handler.codec.compression.ZlibEncoder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedNioFile;
-import io.netty.handler.stream.ChunkedStream;
 
 /**
  * {@link ImapResponseWriter} implementation which writes the data to a
@@ -90,7 +89,7 @@ public class ChannelImapResponseWriter implements ImapResponseWriter {
                     channel.writeAndFlush(new ChunkedNioFile(fc, 8192));
                 }
             } else {
-                channel.writeAndFlush(new ChunkedStream(in));
+                channel.writeAndFlush(new ChunkedStreamWithSize(in));
             }
         }
     }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChunkedStreamWithSize.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChunkedStreamWithSize.java
@@ -1,0 +1,150 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imapserver.netty;
+
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.stream.ChunkedInput;
+import io.netty.util.internal.ObjectUtil;
+
+/**
+ * A clone of io.netty.handler.stream.ChunkedStream class, with getChunkSize method added
+ */
+public class ChunkedStreamWithSize implements ChunkedInput<ByteBuf> {
+
+    static final int DEFAULT_CHUNK_SIZE = 8192;
+
+    private final PushbackInputStream in;
+    private final int chunkSize;
+    private long offset;
+    private boolean closed;
+
+    /**
+     * Creates a new instance that fetches data from the specified stream.
+     */
+    public ChunkedStreamWithSize(InputStream in) {
+        this(in, DEFAULT_CHUNK_SIZE);
+    }
+
+    /**
+     * Creates a new instance that fetches data from the specified stream.
+     *
+     * @param chunkSize the number of bytes to fetch on each
+     *                  {@link #readChunk(ChannelHandlerContext)} call
+     */
+    public ChunkedStreamWithSize(InputStream in, int chunkSize) {
+        ObjectUtil.checkNotNull(in, "in");
+        ObjectUtil.checkPositive(chunkSize, "chunkSize");
+
+        if (in instanceof PushbackInputStream) {
+            this.in = (PushbackInputStream) in;
+        } else {
+            this.in = new PushbackInputStream(in);
+        }
+        this.chunkSize = chunkSize;
+    }
+
+    /**
+     * Returns the number of transferred bytes.
+     */
+    public long transferredBytes() {
+        return offset;
+    }
+
+    @Override
+    public boolean isEndOfInput() throws Exception {
+        if (closed) {
+            return true;
+        }
+        if (in.available() > 0) {
+            return false;
+        }
+
+        int b = in.read();
+        if (b < 0) {
+            return true;
+        } else {
+            in.unread(b);
+            return false;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        closed = true;
+        in.close();
+    }
+
+    @Deprecated
+    @Override
+    public ByteBuf readChunk(ChannelHandlerContext ctx) throws Exception {
+        return readChunk(ctx.alloc());
+    }
+
+    @Override
+    public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
+        if (isEndOfInput()) {
+            return null;
+        }
+
+        final int availableBytes = in.available();
+        final int chunkSize;
+        if (availableBytes <= 0) {
+            chunkSize = this.chunkSize;
+        } else {
+            chunkSize = Math.min(this.chunkSize, in.available());
+        }
+
+        boolean release = true;
+        ByteBuf buffer = allocator.buffer(chunkSize);
+        try {
+            // transfer to buffer
+            int written = buffer.writeBytes(in, chunkSize);
+            if (written < 0) {
+                return null;
+            }
+            offset += written;
+            release = false;
+            return buffer;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
+    }
+
+    @Override
+    public long length() {
+        return -1;
+    }
+
+    @Override
+    public long progress() {
+        return offset;
+    }
+
+    public int getChunkSize() {
+        return chunkSize;
+    }
+}

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/DefaultMessageSizeEstimatorSupportingChunkedStream.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/DefaultMessageSizeEstimatorSupportingChunkedStream.java
@@ -1,0 +1,81 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imapserver.netty;
+
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.FileRegion;
+import io.netty.channel.MessageSizeEstimator;
+
+/**
+ * Default {@link MessageSizeEstimator} implementation which supports the estimation of the size of
+ * {@link ByteBuf}, {@link ByteBufHolder} and {@link FileRegion}.
+ */
+public final class DefaultMessageSizeEstimatorSupportingChunkedStream implements MessageSizeEstimator {
+
+    private static final class HandleImpl implements Handle {
+        private final int unknownSize;
+
+        private HandleImpl(int unknownSize) {
+            this.unknownSize = unknownSize;
+        }
+
+        @Override
+        public int size(Object msg) {
+            if (msg instanceof ByteBuf) {
+                return ((ByteBuf) msg).readableBytes();
+            }
+            if (msg instanceof ByteBufHolder) {
+                return ((ByteBufHolder) msg).content().readableBytes();
+            }
+            if (msg instanceof FileRegion) {
+                return 0;
+            }
+            if (msg instanceof ChunkedStreamWithSize) {
+                return ((ChunkedStreamWithSize) msg).getChunkSize();
+            }
+            return unknownSize;
+        }
+    }
+
+    /**
+     * Return the default implementation which returns {@code 8} for unknown messages.
+     */
+    public static final MessageSizeEstimator DEFAULT = new DefaultMessageSizeEstimatorSupportingChunkedStream(8);
+
+    private final Handle handle;
+
+    /**
+     * Create a new instance
+     *
+     * @param unknownSize       The size which is returned for unknown messages.
+     */
+    public DefaultMessageSizeEstimatorSupportingChunkedStream(int unknownSize) {
+        checkPositiveOrZero(unknownSize, "unknownSize");
+        handle = new HandleImpl(unknownSize);
+    }
+
+    @Override
+    public Handle newHandle() {
+        return handle;
+    }
+}

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -62,6 +62,7 @@ import io.netty.handler.stream.ChunkedWriteHandler;
  */
 public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapConstants, IMAPServerMBean, NettyConstants {
     private static final Logger LOG = LoggerFactory.getLogger(IMAPServer.class);
+    private static final DefaultMessageSizeEstimatorSupportingChunkedStream SIZE_ESTIMATOR_SUPPORTING_CHUNKED_STREAM = new DefaultMessageSizeEstimatorSupportingChunkedStream(8);
 
     public static class AuthenticationConfiguration {
         private static final boolean PLAIN_AUTH_DISALLOWED_DEFAULT = true;
@@ -273,6 +274,9 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
                     literalSizeLimit, maxLineLength));
 
                 pipeline.addLast(CORE_HANDLER, createCoreHandler());
+
+                // A ChunkedStream supported MessageSizeEstimator is needed to back Netty backpressure
+                channel.config().setMessageSizeEstimator(SIZE_ESTIMATOR_SUPPORTING_CHUNKED_STREAM);
             }
 
         };


### PR DESCRIPTION
Rationale: `DefaultMessageSizeEstimator` does not support estimating size for `ChunkedStream` (the wrapper type JAMES IMAP is using to wrap ByteBuf over Netty channel), therefore Netty can not know if it should delay writing this message yet (e.g. IMAP server memory is full and the message size is big then Netty would delay the write).

Implementing a `MessageSizeEstimator` support `ChunkedStream` would help.

Before: the back-pressure is triggered at minimum (1-2 times over transferring 500 **big** messages)
cf: [without chunked stream size estimator.txt](https://github.com/apache/james-project/files/14692758/without.chunked.stream.size.estimator.txt)

After: the back-pressure is triggered more often (over 20 times over transferring 500 **big** messages)
cf: [with chunked stream size estimator.txt](https://github.com/apache/james-project/files/14692764/with.chunked.stream.size.estimator.txt)


cc @vttranlina @chibenwa 
