### PR TITLE
JAMES-3961 data-file RRT test should not fail unstable test phase

### DIFF
--- a/server/data/data-file/src/test/java/org/apache/james/rrt/file/RewriteTablesTest.java
+++ b/server/data/data-file/src/test/java/org/apache/james/rrt/file/RewriteTablesTest.java
@@ -26,7 +26,7 @@ import org.junit.platform.suite.api.IncludeTags;
 import org.junit.platform.suite.api.SelectClasspathResource;
 import org.junit.platform.suite.api.Suite;
 
-@Suite
+@Suite(failIfNoTests = false)
 @IncludeEngines("cucumber")
 @SelectClasspathResource("cucumber")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "org.apache.james.rrt.lib,org.apache.james.rrt.file")


### PR DESCRIPTION
Somehow I missed that in https://github.com/apache/james-project/pull/1963/commits/c6f2462a8d8cf7b90c1509ca9c13ae16ecc74ba5 

This commit is to add it back.