### PR TITLE
JAMES-3977 Accurate backpressure for IMAP FETCH

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/ByteContent.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/ByteContent.java
@@ -25,6 +25,7 @@ package org.apache.james.mailbox.model;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 import org.reactivestreams.Publisher;
 
@@ -55,5 +56,12 @@ public final class ByteContent implements Content {
     public Publisher<ByteBuffer> reactiveBytes() {
         return Flux.just(contents)
             .map(ByteBuffer::wrap);
+    }
+
+    @Override
+    public Optional<byte[][]> asBytesSequence() {
+        byte[][] answer = new byte[1][];
+        answer[0] = contents;
+        return Optional.of(answer);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Content.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Content.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.model;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.util.ReactorUtils;
@@ -41,7 +42,11 @@ public interface Content {
      * Return the content as {@link InputStream}
      */
     InputStream getInputStream() throws IOException;
-    
+
+    default Optional<byte[][]> asBytesSequence() {
+        return Optional.empty();
+    }
+
     /**
      * Size (in octets) of the content.
      * 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/HeaderAndBodyByteContent.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/HeaderAndBodyByteContent.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 import org.reactivestreams.Publisher;
 
@@ -51,6 +52,14 @@ public final class HeaderAndBodyByteContent implements Content {
         return new SequenceInputStream(
             new ByteArrayInputStream(headers),
             new ByteArrayInputStream(body));
+    }
+
+    @Override
+    public Optional<byte[][]> asBytesSequence() {
+        byte[][] answer = new byte[2][];
+        answer[0] = headers;
+        answer[1] = body;
+        return Optional.of(answer);
     }
 
     @Override

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/JPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/JPAMailboxMessage.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
+import java.util.Optional;
 
 import javax.persistence.Basic;
 import javax.persistence.Column;
@@ -123,5 +124,27 @@ public class JPAMailboxMessage extends AbstractJPAMailboxMessage {
     @Override
     public MailboxMessage copy(Mailbox mailbox) throws MailboxException {
         return new JPAMailboxMessage(JPAMailbox.from(mailbox), getUid(), getModSeq(), this);
+    }
+
+    @Override
+    public Optional<byte[][]> getBodyBytes() {
+        byte[][] answer = new byte[1][];
+        answer[0] = body;
+        return Optional.of(answer);
+    }
+
+    @Override
+    public Optional<byte[][]> getFullBytes() {
+        byte[][] answer = new byte[2][];
+        answer[0] = header;
+        answer[1] = body;
+        return Optional.of(answer);
+    }
+
+    @Override
+    public Optional<byte[][]> getHeadersBytes() {
+        byte[][] answer = new byte[1][];
+        answer[0] = header;
+        return Optional.of(answer);
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageResultImpl.java
@@ -365,6 +365,11 @@ public class MessageResultImpl implements MessageResult {
         }
 
         @Override
+        public Optional<byte[][]> asBytesSequence() {
+            return msg.getHeadersBytes();
+        }
+
+        @Override
         public Iterator<Header> headers() throws MailboxException {
             if (headers == null) {
                 try {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/DelegatingMailboxMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/DelegatingMailboxMessage.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.mail.Flags;
 
@@ -125,5 +126,10 @@ public abstract class DelegatingMailboxMessage implements MailboxMessage {
     @Override
     public List<MessageAttachmentMetadata> getAttachments() {
         return message.getAttachments();
+    }
+
+    @Override
+    public Optional<byte[][]> getFullBytes() {
+        return message.getFullBytes();
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Message.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Message.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
@@ -49,6 +50,10 @@ public interface Message {
      * @return body, not null
      */
     InputStream getBodyContent() throws IOException;
+
+    default Optional<byte[][]> getBodyBytes() {
+        return Optional.empty();
+    }
 
     default Publisher<ByteBuffer> getBodyContentReactive() {
         try {
@@ -103,6 +108,10 @@ public interface Message {
      */
     InputStream getHeaderContent() throws IOException;
 
+    default Optional<byte[][]> getHeadersBytes() {
+        return Optional.empty();
+    }
+
 
     default Publisher<ByteBuffer> getHeaderContentReactive() {
         try {
@@ -121,6 +130,9 @@ public interface Message {
      */
     InputStream getFullContent() throws IOException;
 
+    default Optional<byte[][]> getFullBytes() {
+        return Optional.empty();
+    }
 
     default Publisher<ByteBuffer> getFullContentReactive() {
         try {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMessage.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -115,6 +116,11 @@ public class SimpleMessage implements Message {
     @Override
     public InputStream getFullContent() throws IOException {
         return content.getInputStream();
+    }
+
+    @Override
+    public Optional<byte[][]> getFullBytes() {
+        return content.asBytesSequence();
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/streaming/InputStreamContent.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/streaming/InputStreamContent.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.store.streaming;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 import org.apache.james.mailbox.model.Content;
 import org.apache.james.mailbox.store.mail.model.Message;
@@ -64,7 +65,16 @@ public final class InputStreamContent implements Content {
         default:
             return m.getBodyContent();
         }
-       
+    }
+
+    @Override
+    public Optional<byte[][]> asBytesSequence() {
+        switch (type) {
+            case FULL:
+                return m.getFullBytes();
+            default:
+                return m.getBodyBytes();
+        }
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/BytesBackedLiteral.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/BytesBackedLiteral.java
@@ -22,6 +22,7 @@ package org.apache.james.imap.message;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
@@ -59,5 +60,12 @@ public class BytesBackedLiteral implements Literal {
     @Override
     public InputStream getInputStream() {
         return new ByteArrayInputStream(content);
+    }
+
+    @Override
+    public Optional<byte[][]> asBytesSequence() {
+        byte[][] answer = new byte[1][];
+        answer[0] = content;
+        return Optional.of(answer);
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/Literal.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/Literal.java
@@ -21,6 +21,7 @@ package org.apache.james.imap.message;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Content;
@@ -41,6 +42,10 @@ public interface Literal {
      * @return elementIn
      */
     InputStream getInputStream() throws IOException;
+
+    default Optional<byte[][]> asBytesSequence() {
+        return Optional.empty();
+    }
 
     default Content asMailboxContent() {
         Literal literal = this;

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/ContentBodyElement.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/ContentBodyElement.java
@@ -24,6 +24,7 @@ package org.apache.james.imap.processor.fetch;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import org.apache.james.imap.message.response.FetchResponse.BodyElement;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -51,7 +52,11 @@ class ContentBodyElement implements BodyElement {
             throw new IOException("Unable to get size for body element", e);
         }
     }
-
+    
+    @Override
+    public Optional<byte[][]> asBytesSequence() {
+        return content.asBytesSequence();
+    }
 
     @Override
     public InputStream getInputStream() throws IOException {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ChannelImapResponseWriter.java
@@ -77,6 +77,10 @@ public class ChannelImapResponseWriter implements ImapResponseWriter {
     public void write(Literal literal) throws IOException {
         flushCallback.run();
         if (channel.isActive()) {
+            if (literal.asBytesSequence().isPresent()) {
+                channel.writeAndFlush(Unpooled.wrappedBuffer(literal.asBytesSequence().get()));
+                return;
+            }
             InputStream in = literal.getInputStream();
             if (in instanceof FileInputStream) {
                 FileChannel fc = ((FileInputStream) in).getChannel();


### PR DESCRIPTION
Backpressure results.

Set up:

```
channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(100 * 1024, 500 * 1014));
```

(100 KB low level watermark, 500 KB high level watermark) higher than the defaults to fasten overall streaming.

Results:

Message size (bytes) | Count at which backpressure trigger | Total memory loaded |
---------------------|-------------------------------------|---------------------|
4532                 | NEVER                               |         2.3 MB      |
9032                 | 349                                 |         3.2 MB      |
18032                | 176                                 |         3.2 MB      | 
36032                | 86                                  |         3.1 MB      | 
72032                | 44                                  |         3.2 MB      | 
144032               | 22                                  |         3.2 MB      | 
288032               | 11                                  |         3.2 MB      | 
576032               | 5                                   |         2.9 MB      | 
1152032              | 3                                   |         4.6 MB      | 
2304032              | 2          (min)                    |         4.6 MB      | 
4608032              | 2                                   |         9.2 MB      | 