### PR TITLE
[FIX] JamesMailSpooler should be more resilient on JVM Error

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/NoSuchMethodErrorMailet.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/NoSuchMethodErrorMailet.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets;
+
+import jakarta.mail.MessagingException;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+public class NoSuchMethodErrorMailet extends GenericMailet {
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        throw new NoSuchMethodError();
+    }
+}

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -138,14 +138,14 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
                     throw new InterruptedException("Thread has been interrupted");
                 }
                 queueItem.done(MailQueueItem.CompletionStatus.SUCCESS);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 handleError(queueItem, mail, originalRecipients, e);
             } finally {
                 LOGGER.debug("==== End processing mail {} ====", mail.getName());
             }
         }
 
-        private void handleError(MailQueueItem queueItem, Mail mail, ImmutableList<MailAddress> originalRecipients, Exception processingException) {
+        private void handleError(MailQueueItem queueItem, Mail mail, ImmutableList<MailAddress> originalRecipients, Throwable processingException) {
             int failureCount = computeFailureCount(mail);
 
             // Restore original recipients
@@ -184,7 +184,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
             queueItem.done(MailQueueItem.CompletionStatus.SUCCESS);
         }
 
-        private void nack(MailQueueItem queueItem, Exception processingException) {
+        private void nack(MailQueueItem queueItem, Throwable processingException) {
             try {
                 queueItem.done(MailQueueItem.CompletionStatus.REJECT);
             } catch (MailQueue.MailQueueException ex) {

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/ProcessorImpl.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/ProcessorImpl.java
@@ -79,7 +79,7 @@ public class ProcessorImpl {
                      .build()) {
             MailetPipelineLogging.logBeginOfMailetProcess(mailet, mail);
             mailet.service(mail);
-        } catch (Exception | NoClassDefFoundError me) {
+        } catch (Throwable me) {
             ex = me;
             String onMailetException = null;
 


### PR DESCRIPTION
Upon JVM Error, the error would not be caught to be retried. Therefore, the message would not be acked -> RabbitMQ would disconnect the MailQueue consumer after the [Delivery Acknowledgement Timeout](https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout).

For example, a custom mailet that depends on the old `javax` APIs caused `java.lang.NoSuchMethodError: 'javax.mail.internet.MimeMessage org.apache.mailet.Mail.getMessage()` that caused the RabbitMQ consumer being disconnected.

And `NoSuchMethodError` is a subclass of `Throwable`, not `Exception`.

```json
{
    "timestamp": "2024-03-26T11:34:42.677Z",
    "level": "WARN",
    "thread": "spooler-39",
    "logger": "reactor.core.Exceptions",
    "message": "throwIfFatal detected a jvm fatal exception, which is thrown and logged below:",
    "context": "default",
    "exception": "java.lang.NoSuchMethodError: 'javax.mail.internet.MimeMessage org.apache.mailet.Mail.getMessage()'\n\tat com.linagora.workathome.james.JsonSummaryAsAttribute.extractJsonSummary(JsonSummaryAsAttribute.java:79)\n\tat com.linagora.workathome.james.JsonSummaryAsAttribute.service(JsonSummaryAsAttribute.java:70)\n\tat org.apache.james.mailetcontainer.impl.ProcessorImpl.process(ProcessorImpl.java:81)\n\tat com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)\n\tat java.base/java.util.Collections$2.tryAdvance(Unknown Source)\n\tat java.base/java.util.Collections$2.forEachRemaining(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.executeProcessingStep(MailetProcessorImpl.java:163)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$service$0(MailetProcessorImpl.java:131)\n\tat java.base/java.util.stream.ReduceOps$1ReducingSink.accept(Unknown Source)\n\tat java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)\n\tat java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.service(MailetProcessorImpl.java:129)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:99)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:81)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor.toProcessor(AbstractStateMailetProcessor.java:152)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$executeProcessingStep$7(MailetProcessorImpl.java:168)\n\tat com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)\n\tat java.base/java.util.Collections$2.tryAdvance(Unknown Source)\n\tat java.base/java.util.Collections$2.forEachRemaining(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.executeProcessingStep(MailetProcessorImpl.java:168)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$service$0(MailetProcessorImpl.java:131)\n\tat java.base/java.util.stream.ReduceOps$1ReducingSink.accept(Unknown Source)\n\tat java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)\n\tat java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.service(MailetProcessorImpl.java:129)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:99)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:81)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor.toProcessor(AbstractStateMailetProcessor.java:152)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$executeProcessingStep$7(MailetProcessorImpl.java:168)\n\tat com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)\n\tat java.base/java.util.Collections$2.tryAdvance(Unknown Source)\n\tat java.base/java.util.Collections$2.forEachRemaining(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.executeProcessingStep(MailetProcessorImpl.java:168)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$service$0(MailetProcessorImpl.java:131)\n\tat java.base/java.util.stream.ReduceOps$1ReducingSink.accept(Unknown Source)\n\tat java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)\n\tat java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source)\n\tat org.apache.james.mailetcontainer.impl.MailetProcessorImpl.service(MailetProcessorImpl.java:129)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:99)\n\tat org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:81)\n\tat org.apache.james.mailetcontainer.impl.JamesMailSpooler$Runner.performProcessMail(JamesMailSpooler.java:136)\n\tat org.apache.james.mailetcontainer.impl.JamesMailSpooler$Runner.lambda$processMail$4(JamesMailSpooler.java:128)\n\tat reactor.core.publisher.MonoRunnable.subscribe(MonoRunnable.java:49)\n\tat reactor.core.publisher.MonoUsing.subscribe(MonoUsing.java:109)\n\tat reactor.core.publisher.Mono.subscribe(Mono.java:4512)\n\tat reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:202)\n\tat reactor.core.publisher.MonoFlatMap.subscribeOrReturn(MonoFlatMap.java:53)\n\tat reactor.core.publisher.Mono.subscribe(Mono.java:4496)\n\tat reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:126)\n\tat reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)\n\tat reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)\n\tat java.base/java.util.concurrent.FutureTask.run(Unknown Source)\n\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n"
}
```