### PR TITLE
JAMES-3961 Remove VM arg --illegal-access=permit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3311,7 +3311,7 @@
                         </systemPropertyVariables>
                         <argLine>-Djava.library.path=
                             -javaagent:"${settings.localRepository}"/org/jacoco/org.jacoco.agent/${jacoco-maven-plugin.version}/org.jacoco.agent-${jacoco-maven-plugin.version}-runtime.jar=destfile=${basedir}/target/jacoco.exec
-                            -Xms512m -Xmx1024m --illegal-access=permit
+                            -Xms512m -Xmx1024m
                             --add-opens java.base/java.lang=ALL-UNNAMED
                             --add-opens java.base/java.math=ALL-UNNAMED
                             --add-opens java.base/java.net=ALL-UNNAMED


### PR DESCRIPTION
Support was removed in 17.0

![image](https://github.com/apache/james-project/assets/81145350/60ab7366-46f9-4bc5-ba7a-891b2fbea860)
