### PR TITLE
[ENHANCEMENT] Explicitly close FileInputStream

### DIFF
--- a/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
+++ b/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
@@ -121,7 +121,10 @@ public interface Store<T, I> {
                     FileBackedOutputStream out = new FileBackedOutputStream(FILE_THRESHOLD);
                     try {
                         long size = in.transferTo(out);
-                        return Mono.just(new DelegateCloseableByteSource(out.asByteSource(), out::reset, size));
+                        return Mono.just(new DelegateCloseableByteSource(out.asByteSource(), () -> {
+                            out.reset();
+                            out.close();
+                        }, size));
                     } catch (Exception e) {
                         out.reset();
                         out.close();

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/AbstractNettyImapRequestLineReader.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/AbstractNettyImapRequestLineReader.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.imapserver.netty;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
@@ -27,7 +29,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 
-public abstract class AbstractNettyImapRequestLineReader extends ImapRequestLineReader {
+public abstract class AbstractNettyImapRequestLineReader extends ImapRequestLineReader implements Closeable {
     private static final Supplier<ByteBuf> CONTINUATION_REQUEST = () -> Unpooled.wrappedUnmodifiableBuffer(Unpooled.wrappedBuffer("+ Ok\r\n".getBytes(StandardCharsets.US_ASCII)));
 
     private final Channel channel;
@@ -49,4 +51,8 @@ public abstract class AbstractNettyImapRequestLineReader extends ImapRequestLine
         }
     }
 
+    @Override
+    public void close() throws IOException {
+
+    }
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyStreamImapRequestLineReader.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyStreamImapRequestLineReader.java
@@ -55,7 +55,10 @@ public class NettyStreamImapRequestLineReader extends AbstractNettyImapRequestLi
 
         @Override
         public void close() {
-            Mono.fromRunnable(Throwing.runnable(() -> file.dispose()))
+            Mono.fromRunnable(Throwing.runnable(() -> {
+                    file.dispose();
+                    reader.close();
+                }))
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe();
         }


### PR DESCRIPTION
I noticed some file descriptors for deleted files:

```
# lsof -p 1 | grep /tmp
java      1 root  DEL       REG              0,144                   7 /tmp/libnetty_transport_native_epoll_x86_645311867425088058321.so
java      1 root  DEL       REG              0,144                   6 /tmp/jffi8865510689510247619.so
java      1 root  mem-W     REG              0,144     32768         5 /tmp/hsperfdata_root/1
java      1 root  774u     unix 0x0000000000000000       0t0 621499767 /tmp/.java_pid1.tmp type=STREAM
java      1 root  787w      REG              0,144   3022948        16 /tmp/imap-literal11264261390326828628.tmp
java      1 root  934r      REG              0,144    280223         9 /tmp/DelegateCloseableByteSource1691427123218830736.tmp (deleted)
java      1 root  936r      REG              0,144   3666705        11 /tmp/imap-literal9932103542018273411.tmp (deleted)
java      1 root  976r      REG              0,144    207050        12 /tmp/imap-literal1300588447752359868.tmp (deleted)
java      1 root 1021r      REG              0,144   3666705        11 /tmp/imap-literal9932103542018273411.tmp (deleted)
java      1 root 1026r      REG              0,144    207050        12 /tmp/imap-literal1300588447752359868.tmp (deleted)
```