### PR TITLE
Fix simple typo in run-kubernetes.adoc

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/run/run-kubernetes.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/run/run-kubernetes.adoc
@@ -34,7 +34,7 @@ To verify the coherence and avoid errors, the packages can validate the input.
 
 This package contains a default `values.yaml` file, but that you should override with proper configuration for your deployment (`conf.yaml`).
 The file `secrets.sample.yaml` will show you the possible values of the secrets file. To generate the `secrets.yaml` file, 
-you will need a plugin for Helm called link:https://github.com/jkroepke/helm-secrets)[helm-scecrets].
+you will need a plugin for Helm called link:https://github.com/jkroepke/helm-secrets[helm-secrets].
 
 Usually, you will save those configurations in different repositories, per deployment.
 


### PR DESCRIPTION
Very simple typo fix for helm-secrets link in Run with Kubernetes guide.

Updated line 37.

Unclear why line 184,

link:https://helm.sh/docs/chart_template_guide/getting_started/[Helm templates]

is displayed as an deletion and addition by Github.