### PR TITLE
[FIX] Avoid sending bounce when reprocessing - fix mailet class

### DIFF
--- a/server/apps/distributed-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/distributed-app/sample-configuration/mailetcontainer.xml
@@ -52,7 +52,7 @@
             <mailet match="All" class="MetricsMailet">
                 <metricName>mailetContainerErrors</metricName>
             </mailet>
-            <mailet match="not-reprocessed" class="MetricsMailet">
+            <mailet match="not-reprocessed" class="Bounce">
                 <onMailetException>ignore</onMailetException>
             </mailet>
             <mailet match="All" class="ToRepository">


### PR DESCRIPTION
At commit: https://github.com/apache/james-project/pull/2139/files#diff-cff23544a088a4764e404fea6ba9c132649cbcbdcab611c71d3e9affcedf126f  

It should be "Bounce", not "MetricsMailet"

The MetricsMailet without `metricName` make NullPointerException  (when startup james docker compose)

```
10:22:37.356 [ERROR] o.a.j.m.l.AbstractStateMailetProcessor - Unable to init mailet MetricsMailet
2024-04-05T10:22:37.357306362Z java.lang.NullPointerException: null
2024-04-05T10:22:37.357309458Z 	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:903)
2024-04-05T10:22:37.357312423Z 	at org.apache.james.transport.mailets.MetricsMailet.init(MetricsMailet.java:63)
2024-04-05T10:22:37.357315339Z 	at org.apache.james.transport.mailets.MetricsMailet.init(MetricsMailet.java:59)
2024-04-05T10:22:37.357318184Z 	at org.apache.mailet.base.GenericMailet.init(GenericMailet.java:238)
2024-04-05T10:22:37.357320909Z 	at org.apache.james.utils.GuiceMailetLoader.getMailet(GuiceMailetLoader.java:57)
2024-04-05T10:22:37.357323644Z 	... 36 common frames omitted
2024-04-05T10:22:37.357326340Z Wrapped by: jakarta.mail.MessagingException: Can not load mailet MetricsMailet
2024-04-05T10:22:37.357329095Z 	at org.apache.james.utils.GuiceMailetLoader.getMailet(GuiceMailetLoader.java:60)
```
