### PR TITLE
Added ingressClassName support and adminIngress for k8s

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/run/k8s-values.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/run/k8s-values.adoc
@@ -101,6 +101,10 @@ James. It’s better to disable it for prod environments
 using it to expose JMAP and attach our SSL certificates for
 SMTP/IMAP/JMAP. Default is false
 
+|ingress.ingressClassName |change-me |kubernetes.io/ingress.class is 
+deprecated from Kubernetes v1.22+. Used ingressClassName instead for 
+Kubernetes v1.18+
+
 |james.tls.secretName |the-name-of-a-secret |The name of the secret
 created separately contenting the SSL certificate for JMAP, IMAPS and
 SMTPS

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/run/k8s-values.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/run/k8s-values.adoc
@@ -97,11 +97,17 @@ pod
 |glowroot.enabled |true |Enabling or disabling Glowroot usage with
 James. It’s better to disable it for prod environments
 
-|ingress.enabled |false |Enabling or disabling Nginx Ingress. We are
+|ingress.enabled |false |Enabling or disabling Ingress. We are
 using it to expose JMAP and attach our SSL certificates for
 SMTP/IMAP/JMAP. Default is false
 
 |ingress.ingressClassName |change-me |kubernetes.io/ingress.class is 
+deprecated from Kubernetes v1.22+. Use ingressClassName instead for 
+Kubernetes v1.18+
+
+|adminIngress.enabled |false |Enabling or disabling Ingress for Web Admin.
+
+|adminIngress.ingressClassName |change-me |kubernetes.io/ingress.class is 
 deprecated from Kubernetes v1.22+. Use ingressClassName instead for 
 Kubernetes v1.18+
 

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/run/k8s-values.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/run/k8s-values.adoc
@@ -102,7 +102,7 @@ using it to expose JMAP and attach our SSL certificates for
 SMTP/IMAP/JMAP. Default is false
 
 |ingress.ingressClassName |change-me |kubernetes.io/ingress.class is 
-deprecated from Kubernetes v1.22+. Used ingressClassName instead for 
+deprecated from Kubernetes v1.22+. Use ingressClassName instead for 
 Kubernetes v1.18+
 
 |james.tls.secretName |the-name-of-a-secret |The name of the secret

--- a/server/apps/distributed-app/helm-chart/james/templates/james-admin-ingress.yaml
+++ b/server/apps/distributed-app/helm-chart/james/templates/james-admin-ingress.yaml
@@ -1,18 +1,21 @@
-{{- if .Values.ingress.enabled }}
+{{- if .Values.adminIngress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: james-admin
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.adminIngress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+{{- if .Values.adminIngress.ingressClassName }}
+  ingressClassName: {{ .Values.adminIngress.ingressClassName }}
+{{- end }} 
+{{- if .Values.adminIngress.tls }}
   tls:
   - hosts:
     - {{ .Values.dns.adminUrl }}
-    {{ toYaml .Values.ingress.tls }}
+    {{ toYaml .Values.adminIngress.tls }}
 {{- end }}    
   rules:
   - host: {{ .Values.dns.adminUrl }}

--- a/server/apps/distributed-app/helm-chart/james/templates/jmap-ingress.yaml
+++ b/server/apps/distributed-app/helm-chart/james/templates/jmap-ingress.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }} 
 {{- if .Values.ingress.tls }}
   tls:
   - hosts:

--- a/server/apps/distributed-app/helm-chart/james/values.yaml
+++ b/server/apps/distributed-app/helm-chart/james/values.yaml
@@ -55,7 +55,6 @@ ingress:
   enabled: false
   # ingressClassName: "change-me"
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: name-of-the-cluster-issuer
   tls:
       secretName: the-name-of-a-secret      

--- a/server/apps/distributed-app/helm-chart/james/values.yaml
+++ b/server/apps/distributed-app/helm-chart/james/values.yaml
@@ -57,7 +57,15 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: name-of-the-cluster-issuer
   tls:
-      secretName: the-name-of-a-secret      
+      secretName: the-name-of-a-secret
+
+adminIngress:
+  enabled: false
+  # ingressClassName: "change-me"
+  annotations:
+    cert-manager.io/cluster-issuer: name-of-the-cluster-issuer
+  tls:
+      secretName: the-name-of-a-secret
 
 ###
 # Please refer to the values.yaml from the Helm package for databases

--- a/server/apps/distributed-app/helm-chart/james/values.yaml
+++ b/server/apps/distributed-app/helm-chart/james/values.yaml
@@ -53,6 +53,7 @@ serviceMonitor:
 
 ingress:
   enabled: false
+  # ingressClassName: "change-me"
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: name-of-the-cluster-issuer


### PR DESCRIPTION
For James Helm Chart, the current version uses kubernetes.io/ingress.class annotation that has been deprecated. It is encouraged to use ingressClassName instead for Kubernetes v1.18+.