### PR TITLE
[FIX] JWT should not attempt to unzip data by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2409,7 +2409,6 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-impl</artifactId>
                 <version>${jjwt.version}</version>
-                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>

--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -63,3 +63,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # Value from which dedicated BodyFactory shall start buffering data to a file.
 # Used for attachment parsing upon message creation. Default value: 100K.
 # james.mime4j.buffered.body.factory.file.threshold=100K
+
+# Whether James should unzip JWTs. Default to false
+# james.jwt.zip.allow=false

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -53,3 +53,6 @@ james.jmx.credential.generation=true
 # Disable Remote Code Execution feature from JMX
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
+
+# Whether James should unzip JWTs. Default to false
+# james.jwt.zip.allow=false

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -51,3 +51,6 @@ james.jmx.credential.generation=true
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
 openjpa.Multithreaded=true
+
+# Whether James should unzip JWTs. Default to false
+# james.jwt.zip.allow=false

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -51,3 +51,6 @@ james.jmx.credential.generation=true
 # CF https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java#L646
 jmx.remote.x.mlet.allow.getMBeansFromURL=false
 openjpa.Multithreaded=true
+
+# Whether James should unzip JWTs. Default to false
+# james.jwt.zip.allow=false

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -53,3 +53,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # Default charset to use in JMAP to present text body parts
 # james.jmap.default.charset=US-ASCII
+
+# Whether James should unzip JWTs. Default to false
+# james.jwt.zip.allow=false

--- a/server/apps/scaling-pulsar-smtp/sample-configuration/jvm.properties
+++ b/server/apps/scaling-pulsar-smtp/sample-configuration/jvm.properties
@@ -43,3 +43,6 @@
 # JMX, when enable causes RMI to plan System.gc every hour. Set this instead to once every 1000h.
 #sun.rmi.dgc.server.gcInterval=3600000000
 #sun.rmi.dgc.client.gcInterval=3600000000
+
+# Whether James should unzip JWTs. Default to false
+# james.jwt.zip.allow=false

--- a/server/protocols/jwt/pom.xml
+++ b/server/protocols/jwt/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/server/protocols/jwt/src/test/java/org/apache/james/jwt/OidcTokenFixture.java
+++ b/server/protocols/jwt/src/test/java/org/apache/james/jwt/OidcTokenFixture.java
@@ -21,8 +21,7 @@ package org.apache.james.jwt;
 
 public class OidcTokenFixture {
 
-    public static final String PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n" +
-        "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCroSIEhNYajXzC\n" +
+    public static final String PRIVATE_KEY_BASE64 = "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCroSIEhNYajXzC\n" +
         "gsn+xetgjqYc/SaihaHCIjWra2xMbkyl42BITRmjBFGbUxThMEg5YvaBXC1XQeib\n" +
         "auW7gJnBZs8S54K5FMyjgUXOKbjHqPRxE76vUaIYkAZoeufAnXosfDf/XUZTTKE2\n" +
         "yxyZJhdfgU/RSEpN19joXfskIQWmIXlMKkIG9lGqj7eIcyomdlHHuYxb9owqU+lP\n" +
@@ -47,7 +46,9 @@ public class OidcTokenFixture {
         "EdbOTUKhdenKEcSvICOjCrRL/sZHQCSZCH+d7UkCgYAbGniqH/pp73sGd9NZyVT/\n" +
         "HJdOH5dfBfS9sBBJ1f0/pySJLKcArOXS9BMIFueOq4EIc+7hKDCQuqeyhpYZ6UCe\n" +
         "C9h0QNig49qGI/UEtlNrIlydHyPinTa1fDqu99EuRHG0d4RuONW45tmZAY7mGIbf\n" +
-        "PRhJhwOHZT9xO+uPrtQIAw==\n" +
+        "PRhJhwOHZT9xO+uPrtQIAw==\n";
+    public static final String PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n" +
+        PRIVATE_KEY_BASE64 +
         "-----END PRIVATE KEY-----";
 
     public static final String PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----\n" +


### PR DESCRIPTION
jjwt support zip by default yet uncompression of untrusted data can result in excessive memory/cpu usage for special crafted malicious payload.