### PR TITLE
[ENHANCEMENT] More information in mailrepository audit log

### DIFF
--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepository.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepository.java
@@ -81,6 +81,8 @@ public class CassandraMailRepository implements MailRepository {
                     "mimeMessageId", Optional.ofNullable(mail.getMessage())
                         .map(Throwing.function(MimeMessage::getMessageID))
                         .orElse(""),
+                    "url", url.asString(),
+                    "error", Optional.ofNullable(mail.getErrorMessage()).orElse(""),
                     "sender", mail.getMaybeSender().asString(),
                     "recipients", StringUtils.join(mail.getRecipients()))))
                 .log("CassandraMailRepository stored mail.")))


### PR DESCRIPTION
Have the repository URL and the error for sure is nice. 

I miss those on a mail loop investigation, getting the history of errors, that I cannot otherwise find in logs, would be handy.