### PR TITLE
Fix resource leak for MemoryMailRepository

### DIFF
--- a/server/mailrepository/mailrepository-memory/src/main/java/org/apache/james/mailrepository/memory/MemoryMailRepository.java
+++ b/server/mailrepository/mailrepository-memory/src/main/java/org/apache/james/mailrepository/memory/MemoryMailRepository.java
@@ -46,7 +46,7 @@ public class MemoryMailRepository implements MailRepository {
     @Override
     public MailKey store(Mail mail) throws MessagingException {
         MailKey mailKey = MailKey.forMail(mail);
-        mails.put(mailKey, cloneMail(mail));
+        mails.put(mailKey, mail);
 
         AuditTrail.entry()
             .protocol("mailrepository")
@@ -69,9 +69,7 @@ public class MemoryMailRepository implements MailRepository {
 
     @Override
     public Mail retrieve(MailKey key) {
-        return Optional.ofNullable(mails.get(key))
-            .map(this::cloneMail)
-            .orElse(null);
+        return mails.get(key);
     }
 
     @Override
@@ -89,14 +87,4 @@ public class MemoryMailRepository implements MailRepository {
         mails.clear();
     }
 
-    private Mail cloneMail(Mail mail) {
-        try {
-            Mail newMail = mail.duplicate();
-            newMail.setName(mail.getName());
-            newMail.setState(mail.getState());
-            return newMail;
-        } catch (MessagingException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }


### PR DESCRIPTION
- Fix error: Leak detected! Resource org.apache.james.server.core.MimeMessageInputStreamSource$Resource@xxxx was not released before its referent was garbage-collected.

Note: 
- I see the commit https://github.com/linagora/james-project/pull/2359/commits/d6d68d6615cc79cd5d088880920d75c74ec95fff changed the code from save directly mail to save cloneMail

I reverted it and the MailRepositoryContract still passed 