### PR TITLE
JAMES-2586 Remove mailbox index

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxModule.java
@@ -23,7 +23,6 @@ import static org.jooq.impl.SQLDataType.BIGINT;
 
 import java.util.UUID;
 
-import org.apache.james.backends.postgres.PostgresIndex;
 import org.apache.james.backends.postgres.PostgresModule;
 import org.apache.james.backends.postgres.PostgresTable;
 import org.jooq.Field;
@@ -64,13 +63,9 @@ public interface PostgresMailboxModule {
                 .constraint(DSL.constraint(MAILBOX_NAME_USER_NAME_NAMESPACE_UNIQUE_CONSTRAINT).unique(MAILBOX_NAME, USER_NAME, MAILBOX_NAMESPACE))))
             .supportsRowLevelSecurity()
             .build();
-        PostgresIndex MAILBOX_USERNAME_NAMESPACE_INDEX = PostgresIndex.name("mailbox_username_namespace_index")
-            .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
-                .on(TABLE_NAME, USER_NAME, MAILBOX_NAMESPACE));
     }
 
     PostgresModule MODULE = PostgresModule.builder()
         .addTable(PostgresMailboxTable.TABLE)
-        .addIndex(PostgresMailboxTable.MAILBOX_USERNAME_NAMESPACE_INDEX)
         .build();
 }


### PR DESCRIPTION
I don't see any sql select where we query on only username and namespace, there is always also the maibox name as well (cf `findMailboxByPath`, `findMailboxWithPathLike`, `hasChildren` methods in `PostgresMailboxDAO`)

Thus I conclude that this field was missing from the index?