### PR TITLE
[FIX] FetchProcessor: only log Resuming IMAP FETCH once

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -99,8 +99,8 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
             AtomicBoolean mustRequestOne = new AtomicBoolean(true);
             responder.respond(fetchResponse);
             Runnable requestOne = () -> {
-                LOGGER.info("Resuming IMAP FETCH for user {}", imapSession.getUserName().asString());
                 if (mustRequestOne.getAndSet(false)) {
+                    LOGGER.info("Resuming IMAP FETCH for user {}", imapSession.getUserName().asString());
                     requestOne();
                 }
             };


### PR DESCRIPTION
The log mistakenly lead to think backpressure was restored multiple time