### PR TITLE
JAMES-3693 Fixup parsing `redisURL` when cluster with multi url endpoint

### DIFF
--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
@@ -21,6 +21,7 @@ package org.apache.james.backends.redis
 
 import io.lettuce.core.RedisURI
 import org.apache.commons.configuration2.PropertiesConfiguration
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -44,6 +45,7 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
 
   it should "parse multiple Redis URIs from config" in {
     val config = new PropertiesConfiguration()
+    config.setListDelimiterHandler(new DefaultListDelimiterHandler(','))
     config.addProperty("redisURL", "redis://localhost:6379,redis://localhost:6380")
     config.addProperty("cluster.enabled", true)
     config.addProperty("redis.ioThreads", 16)


### PR DESCRIPTION
## BUG
- Before: Ex: redisURL=redis://redis1:6379,redis://redis2:6379 Then RedisUris has size = 1

## Reason

When runtime, the `Configuration` is `org.apache.james.utils.DelegatedPropertiesConfiguration` with `delimiter` is `,` 
=> `config.getString("redisURL")` return only the first element of an array

## Expected
RedisUris has size = 2 with example above