### PR TITLE
[FIX] Remove some blocking calls in IMAP event loop

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapLineHandler.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/process/ImapLineHandler.java
@@ -19,7 +19,9 @@
 
 package org.apache.james.imap.api.process;
 
+import org.reactivestreams.Publisher;
+
 public interface ImapLineHandler {
 
-    void onLine(ImapSession session, byte[] data);
+    Publisher<Void> onLine(ImapSession session, byte[] data);
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -86,7 +86,7 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
 
         final AtomicBoolean idleActive = new AtomicBoolean(true);
 
-        session.pushLineHandler((session1, data) -> {
+        session.pushLineHandler((session1, data) -> Mono.fromRunnable(() -> {
             String line;
             if (data.length > 2) {
                 line = new String(data, 0, data.length - 2);
@@ -112,7 +112,7 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
             }
             session1.popLineHandler();
             idleActive.set(false);
-        });
+        }));
 
         // Check if we should send heartbeats
         if (enableIdle) {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapLineHandlerAdapter.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapLineHandlerAdapter.java
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import reactor.core.publisher.Mono;
 
 /**
  * {@link ChannelInboundHandlerAdapter} implementation which will delegate the
@@ -48,8 +49,9 @@ public class ImapLineHandlerAdapter extends ChannelInboundHandlerAdapter {
         ByteBuf buf = (ByteBuf) msg;
         byte[] data = new byte[buf.readableBytes()];
         buf.readBytes(data);
-        lineHandler.onLine(session, data);
-        ctx.channel().flush();
+        Mono.from(lineHandler.onLine(session, data))
+            .then(Mono.fromRunnable(() -> ctx.channel().flush()))
+            .subscribe();
     }
 
 }


### PR DESCRIPTION
Line handlers overrides are run directly on the event loop and thus should be non-blocking. We thus redefine them as a reactive construct in order to handle them asynchronously might it need be.

This finding was done by doing wall clock profiling.

Command used:

```
 ./profiler.sh -e wall -d 600 -t -i 1ms -I '*james*' -X '*JamesMailSpooler*' -X '*smtp*' -f /root/wall7.html 1
```

(this command assume that blocking calls will be done in apache james and narrow the traces, exclude known blocking patterns handled safely)

![Screenshot from 2024-04-30 16-29-22](https://github.com/apache/james-project/assets/6928740/1bdd9be9-2b1c-4450-b484-3c97a6bc8211)
