### PR TITLE
JAMES-3693 Fixup RedisHealthCheck wrong check when Redis Cluster

### DIFF
--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisHealthCheck.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisHealthCheck.scala
@@ -54,7 +54,7 @@ class RedisHealthCheck @Inject()(redisConfiguration: RedisConfiguration) extends
       .onErrorResume(_ => SMono.just(Result.degraded(redisComponent, "Can not connect to Redis.")))
 }
 
-trait RedisHealthcheckPerform {
+sealed trait RedisHealthcheckPerform {
   def check(): SMono[Result]
 }
 

--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisHealthCheck.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisHealthCheck.scala
@@ -21,44 +21,77 @@ package org.apache.james.backends.redis
 
 import java.time.Duration
 
-import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.cluster.RedisClusterClient
 import io.lettuce.core.codec.StringCodec
 import io.lettuce.core.{RedisClient, RedisURI}
 import jakarta.inject.Inject
+import org.apache.commons.lang3.StringUtils
+import org.apache.james.backends.redis.RedisHealthCheck.redisComponent
 import org.apache.james.core.healthcheck.{ComponentName, HealthCheck, Result}
 import org.reactivestreams.Publisher
-import reactor.core.scala.publisher.SMono
+import reactor.core.scala.publisher.{SFlux, SMono}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
 
+object RedisHealthCheck {
+  val redisComponent: ComponentName = new ComponentName("Redis")
+}
+
 class RedisHealthCheck @Inject()(redisConfiguration: RedisConfiguration) extends HealthCheck {
-  private val redisComponent: ComponentName = new ComponentName("Redis")
-  private val healthcheckTimeout = Duration.ofSeconds(3)
+
+  private val healthcheckTimeout: Duration = Duration.ofSeconds(3)
+  private val healthcheckPerform: RedisHealthcheckPerform = redisConfiguration.isCluster match {
+    case true => new RedisClusterHealthCheckPerform(redisConfiguration, healthcheckTimeout)
+    case false => new RedisStandaloneHealthCheckPerform(redisConfiguration, healthcheckTimeout)
+  }
 
   override def componentName(): ComponentName = redisComponent
 
   override def check(): Publisher[Result] =
-    connectRedis()
-      .`then`(SMono.just(Result.healthy(redisComponent)))
+    healthcheckPerform.check()
       .onErrorResume(_ => SMono.just(Result.degraded(redisComponent, "Can not connect to Redis.")))
+}
 
-  private def connectRedis(): SMono[StatefulConnection[String, String]] =
-    if (redisConfiguration.isCluster) {
-      val redisUris = redisConfiguration.redisURI.value.asJava
-      redisUris.forEach(redisUri => redisUri.setTimeout(healthcheckTimeout))
-      val redisClusterClient = RedisClusterClient.create(redisUris)
+trait RedisHealthcheckPerform {
+  def check(): SMono[Result]
+}
 
-      SMono.fromFuture(redisClusterClient.connectAsync(StringCodec.UTF8).asScala)
-        .doOnTerminate(() => redisClusterClient.shutdownAsync())
-    } else {
-      val redisUri: RedisURI = redisConfiguration.redisURI.value.last
-      redisUri.setTimeout(healthcheckTimeout)
-      val redisClient = RedisClient.create(redisUri)
+class RedisClusterHealthCheckPerform(val redisConfiguration: RedisConfiguration,
+                                     val healthcheckTimeout: Duration) extends RedisHealthcheckPerform {
 
-      SMono.fromFuture(redisClient.connectAsync(StringCodec.UTF8, redisUri).asScala)
-        .doOnTerminate(() => redisClient.shutdownAsync())
-    }
+  private val CLUSTER_STATUS_OK: String = "ok"
+
+  override def check(): SMono[Result] =
+    SFlux.fromIterable(redisConfiguration.redisURI.value)
+      .doOnNext(redisUri => redisUri.setTimeout(healthcheckTimeout))
+      .collectSeq()
+      .map(redisUris => RedisClusterClient.create(redisUris.asJava))
+      .flatMap(getClusterInfo)
+      .map {
+        case CLUSTER_STATUS_OK => Result.healthy(redisComponent)
+        case unExpectedState => Result.degraded(redisComponent, "Redis cluster state: " + unExpectedState)
+      }
+
+  private def getClusterInfo(redisClusterClient: RedisClusterClient): SMono[String] =
+    SMono.fromCallable(() => redisClusterClient.getPartitions)
+      .flatMap(_ => SMono.fromFuture(redisClusterClient.connectAsync(StringCodec.UTF8).asScala)
+        .flatMap(con => SMono.fromPublisher(con.reactive().clusterInfo())))
+      .map(clusterInfo => StringUtils.substringBetween(clusterInfo, "cluster_state:", "\n").trim)
+      .doOnTerminate(() => redisClusterClient.shutdownAsync())
+
+}
+
+class RedisStandaloneHealthCheckPerform(val redisConfiguration: RedisConfiguration,
+                                        val healthcheckTimeout: Duration) extends RedisHealthcheckPerform {
+
+  override def check(): SMono[Result] =
+    SMono.just(redisConfiguration.redisURI.value.last)
+      .doOnNext(redisUri => redisUri.setTimeout(healthcheckTimeout))
+      .map(redisUri => (RedisClient.create(redisUri), redisUri))
+      .flatMap {
+        case (redisClient: RedisClient, redisUri: RedisURI) => SMono.fromFuture(redisClient.connectAsync(StringCodec.UTF8, redisUri).asScala)
+          .doOnTerminate(() => redisClient.shutdownAsync())
+      }.`then`(SMono.just(Result.healthy(redisComponent)))
 }

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/DockerRedis.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/DockerRedis.java
@@ -37,8 +37,8 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.sync.RedisCommands;
 
 public class DockerRedis {
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("redis").withTag("7.0.12");
-    private static final int DEFAULT_PORT = 6379;
+    public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("redis").withTag("7.0.12");
+    public static final int DEFAULT_PORT = 6379;
 
     private final GenericContainer<?> container;
 

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
@@ -1,0 +1,180 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.redis;
+
+import static java.lang.Boolean.TRUE;
+import static org.apache.james.backends.redis.DockerRedis.DEFAULT_IMAGE_NAME;
+import static org.apache.james.backends.redis.DockerRedis.DEFAULT_PORT;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import jakarta.inject.Singleton;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.james.GuiceModuleTestExtension;
+import org.apache.james.util.Runnables;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+
+import scala.jdk.javaapi.OptionConverters;
+
+public class RedisClusterExtension implements GuiceModuleTestExtension {
+
+    public static class RedisClusterContainer extends ArrayList<GenericContainer> {
+        public RedisClusterContainer(Collection<? extends GenericContainer> c) {
+            super(c);
+        }
+
+        public RedisConfiguration getRedisConfiguration() {
+            return RedisConfiguration.from(this.stream()
+                    .map(redisURIFunction())
+                    .map(URI::toString)
+                    .toArray(String[]::new),
+                true, OptionConverters.toScala(Optional.empty()), OptionConverters.toScala(Optional.empty()));
+        }
+
+        public void pauseOne() {
+            GenericContainer firstNode = this.get(0);
+            firstNode.getDockerClient().pauseContainerCmd(firstNode.getContainerId()).exec();
+        }
+
+        public void unPauseOne() {
+            GenericContainer firstNode = this.get(0);
+            if (TRUE.equals(firstNode.getDockerClient().inspectContainerCmd(firstNode.getContainerId())
+                .exec()
+                .getState()
+                .getPaused())) {
+                firstNode.getDockerClient().unpauseContainerCmd(firstNode.getContainerId()).exec();
+            }
+        }
+    }
+
+    public static final Function<String, GenericContainer> redisContainerSupplier = alias ->
+        new GenericContainer<>(DEFAULT_IMAGE_NAME)
+            .withExposedPorts(DEFAULT_PORT)
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("james-" + alias + "-test-" + UUID.randomUUID()))
+            .withCommand("redis-server", "/usr/local/etc/redis/redis.conf")
+            .withNetworkAliases(alias)
+            .withClasspathResourceMapping("redis_cluster.conf",
+                "/usr/local/etc/redis/redis.conf",
+                BindMode.READ_WRITE)
+            .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1)
+                .withStartupTimeout(Duration.ofMinutes(2)));
+
+    static final GenericContainer redis1 = redisContainerSupplier.apply("redis1");
+    static final GenericContainer redis2 = redisContainerSupplier.apply("redis2");
+    static final GenericContainer redis3 = redisContainerSupplier.apply("redis3").dependsOn(redis1, redis2);
+
+    private RedisClusterContainer redisClusterContainer;
+    private final Network network;
+
+    public RedisClusterExtension() {
+        this(Network.newNetwork());
+    }
+
+    public RedisClusterExtension(Network network) {
+        this.network = network;
+        redis1.withNetwork(network);
+        redis2.withNetwork(network);
+        redis3.withNetwork(network);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws IOException, InterruptedException {
+        redis3.start();
+        initialRedisCluster();
+        redisClusterContainer = new RedisClusterContainer(List.of(redis1, redis2, redis3));
+    }
+
+    private static void initialRedisCluster() throws IOException, InterruptedException {
+        String executeResult = redis3.execInContainer("sh",
+            "-c",
+            "echo 'yes' | redis-cli --cluster create " +
+                "redis1:6379 " +
+                "redis2:6379 " +
+                "redis3:6379 " +
+                "--cluster-replicas 0").getStdout();
+        if (!Pattern.compile("\\[OK\\] All \\d+ slots covered\\.").matcher(executeResult).find()) {
+            throw new RuntimeException("Error when initial redis-cluster. " + executeResult);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        Runnables.runParallel(
+            redis1::stop,
+            redis2::stop,
+            redis3::stop);
+        network.close();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        redisClusterContainer.forEach(Throwing.consumer(container -> container.execInContainer("redis-cli", "flushall")));
+    }
+
+    @Override
+    public Module getModule() {
+        return new AbstractModule() {
+            @Provides
+            @Singleton
+            public RedisConfiguration provideRedisConfiguration() {
+                return redisClusterContainer.getRedisConfiguration();
+            }
+        };
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == RedisClusterContainer.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return new RedisClusterContainer(List.of(redis1, redis2, redis3));
+    }
+
+    private static Function<GenericContainer, URI> redisURIFunction() {
+        return redisContainer -> Throwing.supplier(() -> new URIBuilder()
+            .setScheme("redis")
+            .setHost(redisContainer.getHost())
+            .setPort(redisContainer.getMappedPort(DEFAULT_PORT))
+            .build()).get();
+    }
+}

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterHealthCheckTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterHealthCheckTest.scala
@@ -1,0 +1,76 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ************************************************************** */
+
+package org.apache.james.backends.redis
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.james.backends.redis.RedisClusterExtension.RedisClusterContainer
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import reactor.core.scala.publisher.SMono
+
+@ExtendWith(Array(classOf[RedisClusterExtension]))
+class RedisClusterHealthCheckTest {
+  var redisHealthCheck: RedisHealthCheck = _
+
+  @BeforeEach
+  def setup(redis: RedisClusterContainer): Unit = {
+    redisHealthCheck = new RedisHealthCheck(redis.getRedisConfiguration)
+  }
+
+  @AfterEach
+  def afterEach(redis: RedisClusterContainer): Unit = {
+    redis.unPauseOne();
+  }
+
+  @Test
+  def checkShouldReturnHealthyWhenRedisIsRunning(): Unit = {
+    val result = SMono.fromPublisher(redisHealthCheck.check()).block()
+
+    assertThat(result.isHealthy).isTrue
+  }
+
+  @Test
+  def checkShouldReturnDegradedWhenRedisIsDown(redis: RedisClusterContainer): Unit = {
+    redis.pauseOne()
+
+    Thread.sleep(4000) // cluster-node-timeout 3000
+
+    Awaitility.await()
+      .pollInterval(2, TimeUnit.SECONDS)
+      .atMost(20, TimeUnit.SECONDS)
+      .untilAsserted(() => assertThat(SMono.fromPublisher(redisHealthCheck.check()).block().isDegraded).isTrue)
+  }
+
+  @Test
+  def checkShouldReturnHealthyWhenRedisIsRecovered(redis: RedisClusterContainer): Unit = {
+    redis.pauseOne()
+
+    Thread.sleep(4000) // cluster-node-timeout 3000
+    redis.unPauseOne()
+
+    Awaitility.await()
+      .pollInterval(2, TimeUnit.SECONDS)
+      .atMost(20, TimeUnit.SECONDS)
+      .untilAsserted(() => assertThat(SMono.fromPublisher(redisHealthCheck.check()).block().isHealthy).isTrue)
+  }
+}

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisStandaloneHealthCheckTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisStandaloneHealthCheckTest.scala
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import reactor.core.scala.publisher.SMono
 
 @ExtendWith(Array(classOf[RedisExtension]))
-class RedisHealthCheckTest {
+class RedisStandaloneHealthCheckTest {
 
   var redisHealthCheck: RedisHealthCheck = _
 

--- a/backends-common/redis/src/test/resources/redis_cluster.conf
+++ b/backends-common/redis/src/test/resources/redis_cluster.conf
@@ -1,0 +1,7 @@
+# Custom config file to enable cluster mode
+# on all Redis instances started via Docker
+cluster-enabled yes
+# The cluster file is created and managed by Redis
+# We just need to declare it here
+cluster-node-timeout 3000
+appendonly yes


### PR DESCRIPTION
The healthcheck: `org.apache.james.backends.redis.RedisHealthCheck` always log can not connect to Redis.
even when Redis cluster work up normal

## Reason 
- Before invoking method `redisClusterClient.connectAsync` we need to initial partition first by invoking method `redisClusterClient.getPartitions
- The method `redisClusterClient.connectAsync(StringCodec.UTF8)` always success when the cluster fail (eg: 1 /3 node down) => We need one more step for checking. 

## How to fix it
- call `.getPartitions` first, then `.connectAsync` -> `.clusterInfo()` 

