### PR TITLE
[METRICS] Add some useful S3 connection metrics

### DIFF
--- a/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
+++ b/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
@@ -36,4 +36,6 @@ public interface TimeMetric {
 
     ExecutionResult stopAndPublish();
 
+    void record(Duration duration);
+
 }

--- a/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardTimeMetric.java
+++ b/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardTimeMetric.java
@@ -96,4 +96,9 @@ public class DropWizardTimeMetric implements TimeMetric {
         return new DropWizardExecutionResult(name, Duration.ofNanos(context.stop()),
             () -> Duration.ofNanos(Math.round(timer.getSnapshot().get999thPercentile())));
     }
+
+    @Override
+    public void record(Duration duration) {
+        timer.update(duration);
+    }
 }

--- a/metrics/metrics-dropwizard/src/test/java/org/apache/james/metrics/dropwizard/DropWizardMetricFactoryTest.java
+++ b/metrics/metrics-dropwizard/src/test/java/org/apache/james/metrics/dropwizard/DropWizardMetricFactoryTest.java
@@ -133,4 +133,22 @@ class DropWizardMetricFactoryTest implements MetricFactoryContract {
                  .isGreaterThan(duration.get(ChronoUnit.NANOS) * 6);
          });
     }
+
+    @Test
+    void recordElapsedTimeManuallyShouldWork() {
+        Duration duration = Duration.ofMillis(100);
+
+        testee.timer("manualRecordTimer").record(duration);
+        testee.timer("manualRecordTimer").record(duration.plusMillis(50));
+        testee.timer("manualRecordTimer").record(duration.plusMillis(90));
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(testee.timer("manualRecordTimer").getTimer().getCount())
+                .isEqualTo(3);
+
+            softly.assertThat(testee.timer("manualRecordTimer").getTimer().getSnapshot().get99thPercentile())
+                .isLessThan(duration.get(ChronoUnit.NANOS) * 2)
+                .isGreaterThan(duration.get(ChronoUnit.NANOS));
+        });
+    }
 }

--- a/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
+++ b/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
@@ -64,4 +64,9 @@ public class DefaultTimeMetric implements TimeMetric {
         return new DefaultExecutionResult(Duration.ofNanos(elapsed));
     }
 
+    @Override
+    public void record(Duration duration) {
+        DefaultMetricFactory.LOGGER.debug("Time spent in {}: {} ms.", name, duration.toMillis());
+    }
+
 }

--- a/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
+++ b/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
@@ -66,4 +66,9 @@ public class RecordingTimeMetric implements TimeMetric {
         publishCallback.accept(elapsed);
         return new DefaultExecutionResult(elapsed);
     }
+
+    @Override
+    public void record(Duration duration) {
+        publishCallback.accept(duration);
+    }
 }

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
@@ -78,3 +78,18 @@ james.jmap.quota.draft.compatibility=true
 ----
 To enable the compatibility.
 
+== Enable S3 metrics
+
+James supports extracting some S3 client-level metrics e.g. number of connections being used, time to acquire an S3 connection, total time to finish a S3 request...
+
+The property `james.s3.metrics.enabled` allows to enable S3 metrics collection. Please pay attention that enable this
+would impact a bit on S3 performance.
+
+Optional. Boolean. Default to true.
+
+Ex in `jvm.properties`
+----
+james.s3.metrics.enabled=false
+----
+To disable the S3 metrics.
+

--- a/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
+++ b/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
@@ -71,7 +71,8 @@ public class Main implements JamesServerMain {
         new S3BlobStoreModule(),
         new S3BucketModule(),
         binder -> {
-            binder.bind(BlobStoreDAO.class).to(S3BlobStoreDAO.class);
+            binder.bind(BlobStoreDAO.class).to(S3BlobStoreDAO.class)
+                .in(Scopes.SINGLETON);
             binder.bind(BlobStore.class)
                 .annotatedWith(Names.named(MetricableBlobStore.BLOB_STORE_IMPLEMENTATION))
                 .to(PassThroughBlobStore.class);

--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -66,6 +66,11 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
         </dependency>

--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/JamesS3MetricPublisher.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/JamesS3MetricPublisher.java
@@ -1,0 +1,83 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage.aws;
+
+import static software.amazon.awssdk.core.metrics.CoreMetric.API_CALL_DURATION;
+import static software.amazon.awssdk.http.HttpMetric.AVAILABLE_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.CONCURRENCY_ACQUIRE_DURATION;
+import static software.amazon.awssdk.http.HttpMetric.LEASED_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.PENDING_CONCURRENCY_ACQUIRES;
+
+import java.time.Duration;
+
+import org.apache.james.metrics.api.GaugeRegistry;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.TimeMetric;
+
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+public class JamesS3MetricPublisher implements MetricPublisher {
+    private final GaugeRegistry.SettableGauge<Integer> availableConcurrency; // The number of remaining concurrent requests that can be supported by the HTTP client without needing to establish another connection.
+    private final GaugeRegistry.SettableGauge<Integer> leasedConcurrency; // The number of request currently being executed by the HTTP client.
+    private final GaugeRegistry.SettableGauge<Integer> pendingConcurrencyAcquires; // The number of requests that are blocked, waiting for another TCP connection or a new stream to be available from the connection pool.
+    private final TimeMetric concurrencyAcquireDuration; // The time taken to acquire a channel from the connection pool.
+    private final TimeMetric apiCallDuration; // The total time taken to finish a request (inclusive of all retries).
+
+    public JamesS3MetricPublisher(MetricFactory metricFactory, GaugeRegistry gaugeRegistry) {
+        this.availableConcurrency = gaugeRegistry.settableGauge("s3_httpClient_availableConcurrency");
+        this.leasedConcurrency = gaugeRegistry.settableGauge("s3_httpClient_leasedConcurrency");
+        this.pendingConcurrencyAcquires = gaugeRegistry.settableGauge("s3_httpClient_pendingConcurrencyAcquires");
+        this.concurrencyAcquireDuration = metricFactory.timer("s3_httpClient_concurrencyAcquireDuration");
+        this.apiCallDuration = metricFactory.timer("s3_apiCall_apiCallDuration");
+    }
+
+    @Override
+    public void publish(MetricCollection s3ClientMetrics) {
+        extractS3ClientMetrics(s3ClientMetrics);
+    }
+
+    private void extractS3ClientMetrics(MetricCollection s3ClientMetrics) {
+        // Extract useful metrics from https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/metrics-list.html
+        s3ClientMetrics.stream().forEach(metricRecord -> {
+            if (metricRecord.metric().equals(AVAILABLE_CONCURRENCY)) {
+                availableConcurrency.setValue((Integer) metricRecord.value());
+            }
+            if (metricRecord.metric().equals(LEASED_CONCURRENCY)) {
+                leasedConcurrency.setValue((Integer) metricRecord.value());
+            }
+            if (metricRecord.metric().equals(PENDING_CONCURRENCY_ACQUIRES)) {
+                pendingConcurrencyAcquires.setValue((Integer) metricRecord.value());
+            }
+            if (metricRecord.metric().equals(CONCURRENCY_ACQUIRE_DURATION)) {
+                concurrencyAcquireDuration.record((Duration) metricRecord.value());
+            }
+            if (metricRecord.metric().equals(API_CALL_DURATION)) {
+                apiCallDuration.record((Duration) metricRecord.value());
+            }
+        });
+
+        s3ClientMetrics.children().forEach(this::extractS3ClientMetrics);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -40,6 +40,7 @@ import javax.net.ssl.X509TrustManager;
 
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.blob.api.BlobId;
@@ -143,6 +144,7 @@ public class S3BlobStoreDAO implements BlobStoreDAO, Startable, Closeable {
     private final S3BlobStoreConfiguration configuration;
 
     @Inject
+    @Singleton
     S3BlobStoreDAO(S3BlobStoreConfiguration configuration, BlobId.Factory blobIdFactory) {
         this.blobIdFactory = blobIdFactory;
         this.configuration = configuration;

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAOTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAOTest.java
@@ -32,6 +32,8 @@ import java.util.stream.IntStream;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BlobStoreDAOContract;
 import org.apache.james.blob.api.TestBlobId;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,7 +65,7 @@ public class S3BlobStoreDAOTest implements BlobStoreDAOContract {
                 .filter(UPLOAD_RETRY_EXCEPTION_PREDICATE)))
             .build();
 
-        testee = new S3BlobStoreDAO(s3Configuration, new TestBlobId.Factory());
+        testee = new S3BlobStoreDAO(s3Configuration, new TestBlobId.Factory(), new RecordingMetricFactory(), new NoopGaugeRegistry());
     }
 
     @AfterEach

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3DeDuplicationBlobStoreTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3DeDuplicationBlobStoreTest.java
@@ -23,6 +23,8 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +51,7 @@ class S3DeDuplicationBlobStoreTest implements BlobStoreContract {
             .build();
 
         HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
-        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory);
+        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory, new RecordingMetricFactory(), new NoopGaugeRegistry());
 
         testee = BlobStoreFactory.builder()
             .blobStoreDAO(s3BlobStoreDAO)

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3HealthCheckTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3HealthCheckTest.java
@@ -25,6 +25,8 @@ import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.ObjectStorageHealthCheck;
 import org.apache.james.blob.api.TestBlobId;
 import org.apache.james.core.healthcheck.Result;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +50,7 @@ public class S3HealthCheckTest {
             .region(dockerAwsS3.dockerAwsS3().region())
             .build();
 
-        BlobStoreDAO s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, new TestBlobId.Factory());
+        BlobStoreDAO s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, new TestBlobId.Factory(), new RecordingMetricFactory(), new NoopGaugeRegistry());
         s3HealthCheck = new ObjectStorageHealthCheck(s3BlobStoreDAO);
     }
 

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
@@ -38,6 +38,8 @@ import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BlobStoreDAOContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.TestBlobId;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -84,7 +86,7 @@ public class S3MinioTest implements BlobStoreDAOContract {
                 .filter(UPLOAD_RETRY_EXCEPTION_PREDICATE)))
             .build();
 
-        testee = new S3BlobStoreDAO(s3Configuration, new TestBlobId.Factory());
+        testee = new S3BlobStoreDAO(s3Configuration, new TestBlobId.Factory(), new RecordingMetricFactory(), new NoopGaugeRegistry());
     }
 
     @AfterAll

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3NamespaceTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3NamespaceTest.java
@@ -24,6 +24,8 @@ import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -50,7 +52,7 @@ class S3NamespaceTest implements BlobStoreContract {
             .build();
 
         HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
-        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory);
+        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory, new RecordingMetricFactory(), new NoopGaugeRegistry());
 
         testee = BlobStoreFactory.builder()
             .blobStoreDAO(s3BlobStoreDAO)

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PassThroughBlobStoreTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PassThroughBlobStoreTest.java
@@ -23,6 +23,8 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +51,7 @@ class S3PassThroughBlobStoreTest implements BlobStoreContract {
             .build();
 
         HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
-        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory);
+        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory, new RecordingMetricFactory(), new NoopGaugeRegistry());
 
         testee = BlobStoreFactory.builder()
             .blobStoreDAO(s3BlobStoreDAO)

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixAndNamespaceTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixAndNamespaceTest.java
@@ -24,6 +24,8 @@ import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -51,7 +53,7 @@ class S3PrefixAndNamespaceTest implements BlobStoreContract {
             .build();
 
         HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
-        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory);
+        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory, new RecordingMetricFactory(), new NoopGaugeRegistry());
 
         testee = BlobStoreFactory.builder()
             .blobStoreDAO(s3BlobStoreDAO)

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixTest.java
@@ -23,6 +23,8 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +51,7 @@ class S3PrefixTest implements BlobStoreContract {
             .build();
 
         HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
-        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory);
+        s3BlobStoreDAO = new S3BlobStoreDAO(s3Configuration, blobIdFactory, new RecordingMetricFactory(), new NoopGaugeRegistry());
 
         testee = BlobStoreFactory.builder()
             .blobStoreDAO(s3BlobStoreDAO)

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/blobstore/BlobStoreModulesChooser.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/blobstore/BlobStoreModulesChooser.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
@@ -71,7 +72,8 @@ public class BlobStoreModulesChooser {
             install(new S3BlobStoreModule());
             install(new S3BucketModule());
 
-            bind(BlobStoreDAO.class).annotatedWith(Names.named(UNENCRYPTED)).to(S3BlobStoreDAO.class);
+            bind(BlobStoreDAO.class).annotatedWith(Names.named(UNENCRYPTED)).to(S3BlobStoreDAO.class)
+                .in(Scopes.SINGLETON);
             Multibinder.newSetBinder(binder(), HealthCheck.class).addBinding().to(ObjectStorageHealthCheck.class);
         }
     }


### PR DESCRIPTION
Print some S3 client buillt-in metrics:
```log
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] ApiCall
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] ┌─────────────────────────────────────────┐
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ MarshallingDuration=PT0.000082267S      │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ RetryCount=0                            │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ ApiCallSuccessful=true                  │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ OperationName=DeleteBucket              │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ ApiCallDuration=PT0.011391168S          │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ CredentialsFetchDuration=PT0.000002273S │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ ServiceEndpoint=http://localhost:32814  │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] │ ServiceId=S3                            │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81] └─────────────────────────────────────────┘
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     ApiCallAttempt
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     ┌───────────────────────────────────────────┐
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     │ HttpStatusCode=204                        │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     │ BackoffDelayDuration=PT0S                 │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     │ SigningDuration=PT0.000143366S            │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     │ AwsRequestId=9198495c0d439b60cd0f         │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     │ ServiceCallDuration=PT0.010762143S        │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     │ AwsExtendedRequestId=9198495c0d439b60cd0f │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]     └───────────────────────────────────────────┘
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         HttpClient
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         ┌───────────────────────────────────────────┐
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         │ AvailableConcurrency=100                  │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         │ MaxConcurrency=100                        │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         │ LeasedConcurrency=0                       │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         │ ConcurrencyAcquireDuration=PT0.000391434S │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         │ PendingConcurrencyAcquires=0              │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         │ HttpClientName=NettyNio                   │
17:47:15.719 [INFO ] s.a.a.m.LoggingMetricPublisher - [94c9c81]         └───────────────────────────────────────────┘
```

[LeasedConcurrency](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/HttpMetric.html#LEASED_CONCURRENCY) -> likely the wanted `the count of S3 connection in use`.

TODO: extract some useful metrics into James metrics.