### PR TITLE
[ENHANCEMENT] Better reactify Identity methods

### DIFF
--- a/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
@@ -21,20 +21,11 @@ package org.apache.james.util;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
-import java.util.Spliterator;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 public class StreamUtils {
-
-    private static final boolean PARALLEL = true;
 
     @SafeVarargs
     public static <T> Stream<T> ofNullables(T... array) {
@@ -59,73 +50,8 @@ public class StreamUtils {
         return streams.flatMap(Function.identity());
     }
 
-    public static <T> boolean isSingleValued(Stream<T> stream) {
-        return stream.distinct()
-            .limit(2)
-            .count() == 1;
-    }
-
     @SafeVarargs
     public static <T> Stream<T> flatten(Stream<T>... streams) {
         return flatten(Arrays.stream(streams));
-    }
-
-    public static <T> Stream<T> unfold(T seed, Function<T, Optional<T>> generator) {
-        return StreamSupport.stream(new UnfoldSpliterator(seed, generator), !PARALLEL);
-    }
-
-    public static <T> Stream<T> iterate(T seed, Long limit, Function<T, Stream<T>> generator) {
-        Preconditions.checkArgument(limit >= 0, "StreamUtils.iterate have a given limit '{}', while it should not be negative", limit);
-        return StreamUtils.unfold(Arrays.asList(seed), conservativeGenerator(generator))
-            .limit(limit + 1)
-            .flatMap(List::stream);
-    }
-
-    private static <T> Function<List<T>, Optional<List<T>>> conservativeGenerator(Function<T, Stream<T>> generator) {
-        return previous -> {
-            List<T> generated = previous.stream()
-                .flatMap(generator)
-                .collect(ImmutableList.toImmutableList());
-
-            if (generated.isEmpty()) {
-                return Optional.empty();
-            } else {
-                return Optional.of(generated);
-            }
-        };
-    }
-
-    private static class UnfoldSpliterator<T> implements Spliterator<T> {
-
-        private static final Spliterator<?> NOT_ABLE_TO_SPLIT_SPLITERATOR = null;
-        private Optional<T> current;
-        private final Function<T, Optional<T>> generator;
-
-        private UnfoldSpliterator(T seed, Function<T, Optional<T>> generator) {
-            this.current = Optional.of(seed);
-            this.generator = generator;
-        }
-
-        @Override
-        public boolean tryAdvance(Consumer<? super T> action) {
-            current.ifPresent(action);
-            current = current.flatMap(generator);
-            return current.isPresent();
-        }
-
-        @Override
-        public Spliterator<T> trySplit() {
-            return (Spliterator<T>) NOT_ABLE_TO_SPLIT_SPLITERATOR;
-        }
-
-        @Override
-        public long estimateSize() {
-            return Long.MAX_VALUE;
-        }
-
-        @Override
-        public int characteristics() {
-            return Spliterator.IMMUTABLE & Spliterator.NONNULL & Spliterator.ORDERED;
-        }
     }
 }

--- a/server/container/util/src/test/java/org/apache/james/util/StreamUtilsTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/StreamUtilsTest.java
@@ -20,11 +20,8 @@
 package org.apache.james.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -113,72 +110,5 @@ class StreamUtilsTest {
         assertThat(StreamUtils.ofNullable(ImmutableList.of(1, 2).toArray())
             .collect(ImmutableList.toImmutableList()))
             .containsExactly(1, 2);
-    }
-
-    @Test
-    void unfoldShouldGenerateAFiniteStream() {
-        Stream<Integer> unfolded = StreamUtils.unfold(1, i -> {
-            if (i < 10) {
-                return Optional.of(i + 1);
-            } else {
-                return Optional.empty();
-            }
-        });
-
-        assertThat(unfolded.collect(ImmutableList.toImmutableList()))
-            .contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    }
-
-    @Test
-    void unfoldShouldGenerateALazyInfiniteStream() {
-        AtomicInteger counter = new AtomicInteger(0);
-        Stream<Integer> unfolded = StreamUtils.unfold(1, i -> {
-            counter.incrementAndGet();
-            return Optional.of(i + 1);
-        });
-
-        assertThat(unfolded.limit(10).collect(ImmutableList.toImmutableList()))
-            .contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-
-        assertThat(counter.get())
-            .isEqualTo(10);
-    }
-
-    @Test
-    void unfoldShouldHaveAtLeastTheSeed() {
-        Stream<Integer> unfolded = StreamUtils.unfold(1, i -> Optional.empty());
-
-        assertThat(unfolded.collect(ImmutableList.toImmutableList()))
-            .contains(1);
-    }
-
-    @Test
-    void iterateWithANegativeLimitShouldThrow() {
-        assertThatCode(() -> StreamUtils.iterate(1, (long) -1, Stream::of))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void iterateWithZeroLimitShouldHaveOnlyTheSeed() {
-        Stream<Integer> generated = StreamUtils.iterate(1, (long) 0, Stream::of);
-
-        assertThat(generated.collect(ImmutableList.toImmutableList()))
-            .containsOnly(1);
-    }
-
-    @Test
-    void iterateWithEmptyGeneratorShouldHaveOnlyTheSeed() {
-        Stream<Integer> generated = StreamUtils.iterate(1, (long) 10, i -> Stream.of());
-
-        assertThat(generated.collect(ImmutableList.toImmutableList()))
-            .containsOnly(1);
-    }
-
-    @Test
-    void iterateWithGeneratorShouldHaveOnlyTheLimitedElements() {
-        Stream<Integer> generated = StreamUtils.iterate(1, (long) 5, i -> Stream.of(i + 1));
-
-        assertThat(generated.collect(ImmutableList.toImmutableList()))
-            .containsOnly(1, 2, 3, 4, 5, 6);
     }
 }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/AliasReverseResolver.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/AliasReverseResolver.java
@@ -24,5 +24,5 @@ import org.apache.james.core.Username;
 import org.reactivestreams.Publisher;
 
 public interface AliasReverseResolver {
-    Publisher<MailAddress> listAddresses(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException;
+    Publisher<MailAddress> listAddresses(Username user);
 }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/AliasReverseResolver.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/AliasReverseResolver.java
@@ -19,11 +19,10 @@
 
 package org.apache.james.rrt.api;
 
-import java.util.stream.Stream;
-
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
+import org.reactivestreams.Publisher;
 
 public interface AliasReverseResolver {
-    Stream<MailAddress> listAddresses(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException;
+    Publisher<MailAddress> listAddresses(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException;
 }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
@@ -18,8 +18,6 @@
  ****************************************************************/
 package org.apache.james.rrt.api;
 
-import java.util.stream.Stream;
-
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.reactivestreams.Publisher;
@@ -36,6 +34,6 @@ public interface CanSendFrom {
     /**
      * For a given user, return all the addresses he can use in the from clause of an email.
      */
-    Stream<MailAddress> allValidFromAddressesForUser(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException;
+    Publisher<MailAddress> allValidFromAddressesForUser(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException;
 
 }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -31,6 +31,8 @@ import org.apache.james.rrt.lib.MappingsImpl;
 
 import com.google.common.base.Preconditions;
 
+import reactor.core.publisher.Flux;
+
 /**
  * Interface which should be implemented of classes which map recipients.
  */
@@ -136,6 +138,14 @@ public interface RecipientRewriteTable {
             .entrySet().stream()
             .filter(entry -> entry.getValue().contains(mapping))
             .map(Map.Entry::getKey);
+    }
+
+    default Flux<MappingSource> listSourcesReactive(Mapping mapping) {
+        try {
+            return Flux.fromStream(listSources(mapping));
+        } catch (RecipientRewriteTableException e) {
+            return Flux.error(e);
+        }
     }
 
     default Stream<MappingSource> getSourcesForType(Mapping.Type type) throws RecipientRewriteTableException {

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
 
+import reactor.core.publisher.Flux;
+
 public interface AliasReverseResolverContract {
 
     Domain DOMAIN = Domain.of("example.com");
@@ -66,14 +68,14 @@ public interface AliasReverseResolverContract {
 
     @Test
     default void listAddressesShouldContainOnlyUserAddressWhenUserHasNoAlias() throws Exception {
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .containsExactly(USER.asMailAddress());
     }
 
     @Test
     default void listAddressesShouldContainOnlyUserAddressWhenUserHasNoAliasAndAnotherUserHasOne() throws Exception {
         redirectUser(USER_ALIAS).to(OTHER_USER);
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .containsExactly(USER.asMailAddress());
     }
 
@@ -81,7 +83,7 @@ public interface AliasReverseResolverContract {
     default void listAddressesShouldContainUserAddressAndAnAliasOfTheUser() throws Exception {
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), USER_ALIAS.asMailAddress());
     }
 
@@ -91,7 +93,7 @@ public interface AliasReverseResolverContract {
         redirectUser(userAliasBis).to(USER_ALIAS);
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), USER_ALIAS.asMailAddress(), userAliasBis.asMailAddress());
     }
 
@@ -101,7 +103,7 @@ public interface AliasReverseResolverContract {
 
         redirectDomain(OTHER_DOMAIN).to(DOMAIN);
 
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), fromUser.asMailAddress());
     }
 
@@ -114,7 +116,7 @@ public interface AliasReverseResolverContract {
 
         Username userAliasMainDomain = USER_ALIAS.withOtherDomain(DOMAIN);
         Username userOtherDomain = USER.withOtherDomain(OTHER_DOMAIN);
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), userAliasOtherDomain.asMailAddress(), userAliasMainDomain.asMailAddress(), userOtherDomain.asMailAddress());
     }
 
@@ -136,7 +138,7 @@ public interface AliasReverseResolverContract {
         Username userAliasExcluded = Username.of("alias" + (recursionLevel - 1) + "@" + DOMAIN.asString());
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .doesNotContain(userAliasExcluded.asMailAddress());
     }
 
@@ -147,7 +149,7 @@ public interface AliasReverseResolverContract {
         redirectUser(userAliasBis).to(userAlias);
         redirectUser(userAlias).to(USER);
 
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .contains(userAliasBis.asMailAddress());
     }
 
@@ -157,7 +159,7 @@ public interface AliasReverseResolverContract {
         redirectUser(userAliasBis).to(USER_ALIAS);
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(aliasReverseResolver().listAddresses(USER))
+        assertThat(Flux.from(aliasReverseResolver().listAddresses(USER)).toStream())
             .contains(userAliasBis.asMailAddress());
     }
 }

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
 
+import reactor.core.publisher.Flux;
+
 public interface CanSendFromContract {
 
     Domain DOMAIN = Domain.of("example.com");
@@ -173,14 +175,14 @@ public interface CanSendFromContract {
 
     @Test
     default void allValidFromAddressesShouldContainOnlyUserAddressWhenUserHasNoAlias() throws Exception {
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .containsExactly(USER.asMailAddress());
     }
 
     @Test
     default void allValidFromAddressesShouldContainOnlyUserAddressWhenUserHasNoAliasAndAnotherUserHasOne() throws Exception {
         redirectUser(USER_ALIAS).to(OTHER_USER);
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .containsExactly(USER.asMailAddress());
     }
 
@@ -188,7 +190,7 @@ public interface CanSendFromContract {
     default void allValidFromAddressesShouldContainUserAddressAndAnAliasOfTheUser() throws Exception {
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), USER_ALIAS.asMailAddress());
     }
 
@@ -198,7 +200,7 @@ public interface CanSendFromContract {
         redirectUser(userAliasBis).to(USER_ALIAS);
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), USER_ALIAS.asMailAddress(), userAliasBis.asMailAddress());
     }
 
@@ -208,7 +210,7 @@ public interface CanSendFromContract {
 
         redirectDomain(OTHER_DOMAIN).to(DOMAIN).asAlias();
 
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), fromUser.asMailAddress());
     }
 
@@ -221,7 +223,7 @@ public interface CanSendFromContract {
 
         Username userAliasMainDomain = USER_ALIAS.withOtherDomain(DOMAIN);
         Username userOtherDomain = USER.withOtherDomain(OTHER_DOMAIN);
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .containsExactlyInAnyOrder(USER.asMailAddress(), userAliasOtherDomain.asMailAddress(), userAliasMainDomain.asMailAddress(), userOtherDomain.asMailAddress());
     }
 
@@ -252,7 +254,7 @@ public interface CanSendFromContract {
         Username userAliasExcluded = Username.of("alias" + (recursionLevel - 1) + "@" + DOMAIN.asString());
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .doesNotContain(userAliasExcluded.asMailAddress());
     }
 
@@ -263,7 +265,7 @@ public interface CanSendFromContract {
         redirectUser(userAliasBis).to(userAlias);
         redirectUser(userAlias).to(USER);
 
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .contains(userAliasBis.asMailAddress());
     }
 
@@ -273,7 +275,7 @@ public interface CanSendFromContract {
         redirectUser(userAliasBis).to(USER_ALIAS);
         redirectUser(USER_ALIAS).to(USER);
 
-        assertThat(canSendFrom().allValidFromAddressesForUser(USER))
+        assertThat(Flux.from(canSendFrom().allValidFromAddressesForUser(USER)).toStream())
             .contains(userAliasBis.asMailAddress());
     }
 }

--- a/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
@@ -35,6 +35,8 @@ import org.apache.james.rrt.lib.MappingsImpl;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
+import reactor.core.publisher.Flux;
+
 public class CassandraRecipientRewriteTable extends AbstractRecipientRewriteTable {
     private final CassandraRecipientRewriteTableDAO cassandraRecipientRewriteTableDAO;
     private final CassandraMappingsSourcesDAO cassandraMappingsSourcesDAO;
@@ -90,5 +92,12 @@ public class CassandraRecipientRewriteTable extends AbstractRecipientRewriteTabl
             "Not supported mapping of type %s", mapping.getType());
 
         return cassandraMappingsSourcesDAO.retrieveSources(mapping).toStream();
+    }
+
+    @Override
+    public Flux<MappingSource> listSourcesReactive(Mapping mapping) {
+        Preconditions.checkArgument(listSourcesSupportedType.contains(mapping.getType()),
+            "Not supported mapping of type %s", mapping.getType());
+        return cassandraMappingsSourcesDAO.retrieveSources(mapping);
     }
 }

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AliasReverseResolverImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AliasReverseResolverImpl.java
@@ -19,25 +19,25 @@
 
 package org.apache.james.rrt.lib;
 
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Stream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.apache.james.rrt.api.AliasReverseResolver;
 import org.apache.james.rrt.api.RecipientRewriteTable;
-import org.apache.james.rrt.api.RecipientRewriteTableException;
-import org.apache.james.util.StreamUtils;
+import org.apache.james.util.ReactorUtils;
 
 import com.github.fge.lambdas.Throwing;
-import com.google.common.collect.ImmutableList;
+import com.google.common.base.Preconditions;
+
+import reactor.core.publisher.Flux;
 
 public class AliasReverseResolverImpl implements AliasReverseResolver {
     private final RecipientRewriteTable recipientRewriteTable;
@@ -48,58 +48,63 @@ public class AliasReverseResolverImpl implements AliasReverseResolver {
     }
 
     @Override
-    public Stream<MailAddress> listAddresses(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {
-        CanSendFromImpl.DomainFetcher domains = domainFetcher(user);
+    public Flux<MailAddress> listAddresses(Username user) {
+        CanSendFromImpl.DomainFetcher domains = domainFetcher();
 
         return relatedAliases(user)
-            .flatMap(allowedUser -> domains.fetch(allowedUser)
-                .stream()
-                .map(Optional::of)
-                .map(allowedUser::withOtherDomain)
-                .map(Throwing.function(Username::asMailAddress).sneakyThrow()))
+            .flatMap(allowedUser -> user.getDomainPart()
+                .map(domain -> Flux.concat(
+                    Flux.just(allowedUser),
+                    domains.fetch(domain).map(allowedUser::withOtherDomain)))
+                .orElseGet(() -> Flux.just(allowedUser)))
+            .map(Throwing.function(Username::asMailAddress).sneakyThrow())
             .distinct();
     }
 
-    private Stream<Username> relatedAliases(Username user) {
-        return StreamUtils.iterate(
-            user,
-            getMappingLimit(),
-            Throwing.<Username, Stream<Username>>function(targetUser ->
-                recipientRewriteTable
-                    .listSources(Mapping.alias(targetUser.asString()))
+    private Flux<Username> relatedAliases(Username user) {
+        Pair<Username, Integer> userWithDepth = Pair.of(user, 0);
+        return Flux.just(userWithDepth)
+            .expand(value -> {
+                if (value.getRight() >= getMappingLimit()) {
+                    return Flux.empty();
+                }
+                return recipientRewriteTable.listSourcesReactive(Mapping.alias(value.getLeft().asString()))
                     .map(MappingSource::asUsername)
-                    .flatMap(Optional::stream)).sneakyThrow()
-        );
+                    .handle(ReactorUtils.publishIfPresent())
+                    .map(u -> Pair.of(u, value.getRight() + 1));
+            }).map(Pair::getLeft);
     }
 
-    private CanSendFromImpl.DomainFetcher domainFetcher(Username user) {
-        HashMap<Domain, List<Domain>> fetchedDomains = new HashMap<>();
-        List<Domain> userDomains = relatedDomains(user).collect(ImmutableList.toImmutableList());
-        user.getDomainPart().ifPresent(domain -> fetchedDomains.put(domain, userDomains));
-        Function<Domain, List<Domain>> computeDomain = givenDomain -> Stream.concat(userDomains.stream(), fetchDomains(givenDomain)).collect(ImmutableList.toImmutableList());
-        return givenUsername ->
-            givenUsername
-                .getDomainPart()
-                .map(domain -> fetchedDomains.computeIfAbsent(domain, computeDomain))
-                .orElseGet(Arrays::asList);
+    private CanSendFromImpl.DomainFetcher domainFetcher() {
+        return new CanSendFromImpl.DomainFetcher() {
+            private final Map<Domain, List<Domain>> memoized = new ConcurrentHashMap<>();
+            @Override
+            public Flux<Domain> fetch(Domain domain) {
+                if (memoized.containsKey(domain)) {
+                    return Flux.fromIterable(memoized.get(domain));
+                }
+                return fetchDomains(domain)
+                    .collect(Collectors.toList())
+                    .doOnNext(next -> memoized.put(domain, next))
+                    .flatMapIterable(i -> i);
+            }
+        };
     }
 
-    private Stream<Domain> relatedDomains(Username user) {
-        return user.getDomainPart()
-            .map(this::fetchDomains)
-            .orElseGet(Stream::empty);
+    private Flux<Domain> fetchDomains(Domain domain) {
+        Pair<Domain, Integer> domainWithDepth = Pair.of(domain, 0);
+        Flux<Pair<Domain, Integer>> flux = Flux.just(domainWithDepth);
+        return expandDomains(flux);
     }
 
-    private Stream<Domain> fetchDomains(Domain domain) {
-        return StreamUtils.iterate(
-            domain,
-            getMappingLimit(),
-            Throwing.<Domain, Stream<Domain>>function(targetDomain ->
-                recipientRewriteTable
-                    .listSources(Mapping.domainAlias(targetDomain))
+    private Flux<Domain> expandDomains(Flux<Pair<Domain, Integer>> flux) {
+        return flux.expand(value -> {
+                Preconditions.checkArgument(value.getRight() < getMappingLimit());
+                return recipientRewriteTable.listSourcesReactive(Mapping.domainAlias(value.getKey()))
                     .map(MappingSource::asDomain)
-                    .flatMap(Optional::stream)).sneakyThrow()
-        );
+                    .handle(ReactorUtils.publishIfPresent())
+                    .map(u -> Pair.of(u, value.getRight() + 1));
+            }).map(Pair::getLeft);
     }
 
     private long getMappingLimit() {

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
@@ -22,9 +22,7 @@ import static org.apache.james.rrt.lib.Mapping.Type.Alias;
 import static org.apache.james.rrt.lib.Mapping.Type.DomainAlias;
 
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
@@ -40,13 +38,14 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class CanSendFromImpl implements CanSendFrom {
 
     @FunctionalInterface
     interface DomainFetcher {
-        List<Domain> fetch(Username user);
+        Flux<Domain> fetch(Domain user);
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CanSendFromImpl.class);
@@ -80,8 +79,8 @@ public class CanSendFromImpl implements CanSendFrom {
     }
 
     @Override
-    public Stream<MailAddress> allValidFromAddressesForUser(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {
-        return aliasReverseResolver.listAddresses(user);
+    public Flux<MailAddress> allValidFromAddressesForUser(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {
+        return Flux.from(aliasReverseResolver.listAddresses(user));
     }
 
     private boolean emailIsAnAliasOfTheConnectedUser(Username connectedUser, Username fromUser) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
@@ -18,12 +18,6 @@
  ****************************************************************/
 package org.apache.james.rrt.lib;
 
-import static org.apache.james.rrt.lib.Mapping.Type.Alias;
-import static org.apache.james.rrt.lib.Mapping.Type.DomainAlias;
-
-import java.util.EnumSet;
-import java.util.Optional;
-
 import jakarta.inject.Inject;
 
 import org.apache.james.core.Domain;
@@ -31,9 +25,6 @@ import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.apache.james.rrt.api.AliasReverseResolver;
 import org.apache.james.rrt.api.CanSendFrom;
-import org.apache.james.rrt.api.RecipientRewriteTable;
-import org.apache.james.rrt.api.RecipientRewriteTableException;
-import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,22 +40,21 @@ public class CanSendFromImpl implements CanSendFrom {
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CanSendFromImpl.class);
-    private static final EnumSet<Mapping.Type> ALIAS_TYPES_ACCEPTED_IN_FROM = EnumSet.of(Alias, DomainAlias);
-
-    private final RecipientRewriteTable recipientRewriteTable;
     private final AliasReverseResolver aliasReverseResolver;
 
     @Inject
-    public CanSendFromImpl(RecipientRewriteTable recipientRewriteTable, AliasReverseResolver aliasReverseResolver) {
-        this.recipientRewriteTable = recipientRewriteTable;
+    public CanSendFromImpl(AliasReverseResolver aliasReverseResolver) {
         this.aliasReverseResolver = aliasReverseResolver;
     }
 
     @Override
     public boolean userCanSendFrom(Username connectedUser, Username fromUser) {
         try {
-            return connectedUser.equals(fromUser) || emailIsAnAliasOfTheConnectedUser(connectedUser, fromUser);
-        } catch (RecipientRewriteTableException | RecipientRewriteTable.ErrorMappingException e) {
+            return connectedUser.equals(fromUser) ||  allValidFromAddressesForUser(connectedUser)
+                .map(Username::fromMailAddress)
+                .any(fromUser::equals)
+                .block();
+        } catch (Exception e) {
             LOGGER.warn("Error upon {} mapping resolution for {}. You might want to audit mapping content for this mapping entry. ",
                 fromUser.asString(),
                 connectedUser.asString());
@@ -74,22 +64,16 @@ public class CanSendFromImpl implements CanSendFrom {
 
     @Override
     public Publisher<Boolean> userCanSendFromReactive(Username connectedUser, Username fromUser) {
-        return Mono.fromCallable(() -> userCanSendFrom(connectedUser, fromUser))
-            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
+        if (connectedUser.equals(fromUser)) {
+            return Mono.just(true);
+        }
+        return allValidFromAddressesForUser(connectedUser)
+            .map(Username::fromMailAddress)
+            .any(fromUser::equals);
     }
 
     @Override
-    public Flux<MailAddress> allValidFromAddressesForUser(Username user) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {
+    public Flux<MailAddress> allValidFromAddressesForUser(Username user) {
         return Flux.from(aliasReverseResolver.listAddresses(user));
-    }
-
-    private boolean emailIsAnAliasOfTheConnectedUser(Username connectedUser, Username fromUser) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {
-        return fromUser.getDomainPart().isPresent()
-            && recipientRewriteTable.getResolvedMappings(fromUser.getLocalPart(), fromUser.getDomainPart().get(), ALIAS_TYPES_ACCEPTED_IN_FROM)
-            .asStream()
-            .map(Mapping::asMailAddress)
-            .flatMap(Optional::stream)
-            .map(Username::fromMailAddress)
-            .anyMatch(alias -> alias.equals(connectedUser));
     }
 }

--- a/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
@@ -54,7 +54,7 @@ public class CanSendFromImplTest implements CanSendFromContract {
         recipientRewriteTable.setUserEntityValidator(UserEntityValidator.NOOP);
 
         AliasReverseResolver aliasReverseResolver = new AliasReverseResolverImpl(recipientRewriteTable);
-        canSendFrom = new CanSendFromImpl(recipientRewriteTable, aliasReverseResolver);
+        canSendFrom = new CanSendFromImpl(aliasReverseResolver);
     }
 
     @Override

--- a/server/protocols/protocols-lmtp/src/test/java/org/apache/james/lmtpserver/LmtpServerTest.java
+++ b/server/protocols/protocols-lmtp/src/test/java/org/apache/james/lmtpserver/LmtpServerTest.java
@@ -153,7 +153,7 @@ class LmtpServerTest {
         MemoryRecipientRewriteTable rewriteTable = new MemoryRecipientRewriteTable();
         rewriteTable.setConfiguration(RecipientRewriteTableConfiguration.DEFAULT_ENABLED);
         AliasReverseResolver aliasReverseResolver = new AliasReverseResolverImpl(rewriteTable);
-        CanSendFrom canSendFrom = new CanSendFromImpl(rewriteTable, aliasReverseResolver);
+        CanSendFrom canSendFrom = new CanSendFromImpl(aliasReverseResolver);
         return MockProtocolHandlerLoader.builder()
             .put(binder -> binder.bind(DomainList.class).toInstance(domainList))
             .put(binder -> binder.bind(RecipientRewriteTable.class).toInstance(rewriteTable))

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTestSystem.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTestSystem.java
@@ -156,7 +156,7 @@ class SMTPServerTestSystem {
         rewriteTable = new MemoryRecipientRewriteTable();
         rewriteTable.setConfiguration(RecipientRewriteTableConfiguration.DEFAULT_ENABLED);
         AliasReverseResolver aliasReverseResolver = new AliasReverseResolverImpl(rewriteTable);
-        CanSendFrom canSendFrom = new CanSendFromImpl(rewriteTable, aliasReverseResolver);
+        CanSendFrom canSendFrom = new CanSendFromImpl(aliasReverseResolver);
         queueFactory = new MemoryMailQueueFactory(new RawMailQueueItemDecoratorFactory(), CLOCK);
         queue = queueFactory.createQueue(MailQueueFactory.SPOOL);
 

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/UserRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/UserRoutes.java
@@ -374,10 +374,10 @@ public class UserRoutes implements Routes {
                     .haltError();
             }
 
-            return canSendFrom
-                .allValidFromAddressesForUser(username)
+            return Flux.from(canSendFrom.allValidFromAddressesForUser(username))
                 .map(MailAddress::asString)
-                .collect(ImmutableList.toImmutableList());
+                .collect(ImmutableList.toImmutableList())
+                .block();
         } catch (RecipientRewriteTable.ErrorMappingException | RecipientRewriteTableException | UsersRepositoryException e) {
             String errorMessage = String.format("Error while listing allowed From headers for user '%s'", username);
             LOGGER.info(errorMessage, e);

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/UserRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/UserRoutesTest.java
@@ -127,7 +127,7 @@ class UserRoutesTest {
             this.recipientRewriteTable.setDomainList(domainList);
             this.recipientRewriteTable.setConfiguration(RecipientRewriteTableConfiguration.DEFAULT_ENABLED);
             this.aliasReverseResolver = new AliasReverseResolverImpl(recipientRewriteTable);
-            this.canSendFrom = new CanSendFromImpl(recipientRewriteTable, aliasReverseResolver);
+            this.canSendFrom = new CanSendFromImpl(aliasReverseResolver);
             UserEntityValidator validator = UserEntityValidator.aggregate(
                 new DefaultUserEntityValidator(this.usersRepository),
                 new RecipientRewriteTableUserEntityValidator(recipientRewriteTable));

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/UserIdentitiesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/UserIdentitiesRoutesTest.java
@@ -57,7 +57,6 @@ import net.javacrumbs.jsonunit.core.Option;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scala.publisher.SMono;
-import scala.jdk.javaapi.CollectionConverters;
 
 class UserIdentitiesRoutesTest {
 
@@ -95,7 +94,7 @@ class UserIdentitiesRoutesTest {
     void listIdentitiesShouldReturnBothCustomAndServerSetIdentities() throws Exception {
         // identity: server set
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         IdentityCreationRequest creationRequest = IdentityCreationRequest.fromJava(
             BOB.asMailAddress(),
@@ -181,7 +180,7 @@ class UserIdentitiesRoutesTest {
     void listIdentitiesShouldSupportDefaultParam() throws Exception {
         // identity: server set
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         Integer highPriorityOrder = 1;
         Integer lowPriorityOrder = 2;
@@ -248,7 +247,7 @@ class UserIdentitiesRoutesTest {
     @Test
     void listIdentitiesShouldReturnBadRequestWhenInvalidDefaultParam() {
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         String response = given()
             .queryParam("default", "invalid")
@@ -272,7 +271,7 @@ class UserIdentitiesRoutesTest {
     @Test
     void listIdentitiesShouldReturnNotFoundWhenCanNotQueryDefaultIdentity() {
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.<Identity>of()).toList());
+            .thenReturn(Flux.empty());
 
         String response = given()
             .queryParam("default", "true")
@@ -318,7 +317,7 @@ class UserIdentitiesRoutesTest {
             "";
 
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         given()
             .body(creationRequest)
@@ -373,7 +372,7 @@ class UserIdentitiesRoutesTest {
             "";
 
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         given()
             .body(creationRequest)
@@ -416,7 +415,7 @@ class UserIdentitiesRoutesTest {
             "    }";
 
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         String response = given()
             .body(creationRequest)
@@ -438,7 +437,7 @@ class UserIdentitiesRoutesTest {
     @Test
     void createIdentityShouldFailWhenInvalidRequest() {
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         String response = given()
             .body("invalid")
@@ -468,7 +467,7 @@ class UserIdentitiesRoutesTest {
             "";
 
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         given()
             .body(creationRequest)
@@ -503,7 +502,7 @@ class UserIdentitiesRoutesTest {
     @Test
     void updateIdentityShouldWork() throws Exception {
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         IdentityCreationRequest creationRequest = IdentityCreationRequest.fromJava(
             BOB.asMailAddress(),
@@ -582,7 +581,7 @@ class UserIdentitiesRoutesTest {
     @Test
     void updateIdentityShouldFailWhenIdNotFound() {
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         String updateRequest = "" +
             "    {" +
@@ -628,7 +627,7 @@ class UserIdentitiesRoutesTest {
     @Test
     void updateIdentityShouldNotModifyAbsentPropertyInRequest() throws Exception {
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         IdentityCreationRequest creationRequest = IdentityCreationRequest.fromJava(
             BOB.asMailAddress(),
@@ -695,7 +694,7 @@ class UserIdentitiesRoutesTest {
     @Test
     void updateIdentityShouldNotAcceptChangeMayDeleteProperty() throws Exception {
         Mockito.when(identityFactory.listIdentities(BOB))
-            .thenReturn(CollectionConverters.asScala(List.of(IdentityRepositoryTest.IDENTITY1())).toList());
+            .thenReturn(Flux.just(IdentityRepositoryTest.IDENTITY1()));
 
         IdentityCreationRequest creationRequest = IdentityCreationRequest.fromJava(
             BOB.asMailAddress(),


### PR DESCRIPTION
The underlying RRT exposes iterables which are inherantly blocking.

`recipientRewriteTable.listSources(...)` actually is just a mere wrapper around a cassandra table and would be easy to reactify.

Then the overall algorithm could be reactified CF https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#expand-java.util.function.Function-

This is called upon sending email (likely to be blocking anyway) but also listing identities which is not an uncommon request.

![Screenshot from 2024-05-02 10-49-14](https://github.com/linagora/james-project/assets/6928740/281c3bec-e4f2-42e1-8070-b6247cf94248)
