### PR TITLE
[ENHANCEMENT] Use the correct AES segment size

### DIFF
--- a/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
+++ b/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
@@ -112,9 +112,8 @@ public class AESBlobStoreDAO implements BlobStoreDAO {
         return Mono.from(underlying.readBytes(bucketName, blobId))
             .map(Throwing.function(bytes -> {
                 InputStream inputStream = decrypt(new ByteArrayInputStream(bytes));
-                int aesPadding = 128;
                 try (UnsynchronizedByteArrayOutputStream outputStream = UnsynchronizedByteArrayOutputStream.builder()
-                    .setBufferSize(bytes.length + aesPadding)
+                    .setBufferSize(bytes.length + PBKDF2StreamingAeadFactory.SEGMENT_SIZE)
                     .get()) {
                     IOUtils.copy(inputStream, outputStream);
                     return outputStream.toByteArray();

--- a/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/PBKDF2StreamingAeadFactory.java
+++ b/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/PBKDF2StreamingAeadFactory.java
@@ -35,7 +35,7 @@ public class PBKDF2StreamingAeadFactory {
     private static final String SECRET_KEY_FACTORY_ALGORITHM = "PBKDF2WithHmacSHA512";
     private static final String HKDF_ALGO = "HmacSha256";
     private static final int KEY_SIZE_IN_BYTES = 32;
-    private static final int SEGMENT_SIZE = 4096;
+    static final int SEGMENT_SIZE = 4096;
     private static final int OFFSET = 0;
     public static final byte[] EMPTY_ASSOCIATED_DATA = new byte[0];
 


### PR DESCRIPTION
Prevent needless copies / reallocations