### PR TITLE
JAMES-3693 Fix guice binding Redis Health check in RateLimiter module

### DIFF
--- a/server/mailet/rate-limiter-redis/docker-compose.yml
+++ b/server/mailet/rate-limiter-redis/docker-compose.yml
@@ -20,3 +20,4 @@ services:
       - $PWD/extensions.properties:/root/conf/extensions.properties
       - $PWD/redis.properties:/root/conf/redis.properties
       - $PWD/mailetcontainer.xml:/root/conf/mailetcontainer.xml
+      - $PWD/healthcheck.properties:/root/conf/healthcheck.properties

--- a/server/mailet/rate-limiter-redis/healthcheck.properties
+++ b/server/mailet/rate-limiter-redis/healthcheck.properties
@@ -1,0 +1,1 @@
+additional.healthchecks=org.apache.james.backends.redis.RedisHealthCheck

--- a/server/mailet/rate-limiter-redis/src/main/scala/org/apache/james/rate/limiter/redis/RedisRateLimiter.scala
+++ b/server/mailet/rate-limiter-redis/src/main/scala/org/apache/james/rate/limiter/redis/RedisRateLimiter.scala
@@ -21,16 +21,14 @@ package org.apache.james.rate.limiter.redis
 
 import java.time.Duration
 
-import com.google.inject.multibindings.Multibinder
 import com.google.inject.{AbstractModule, Provides, Scopes}
 import es.moki.ratelimitj.core.limiter.request.{AbstractRequestRateLimiterFactory, ReactiveRequestRateLimiter, RequestLimitRule}
 import es.moki.ratelimitj.redis.request.{RedisClusterRateLimiterFactory, RedisSlidingWindowRequestRateLimiter, RedisRateLimiterFactory => RedisSingleInstanceRateLimitjFactory}
 import io.lettuce.core.RedisClient
 import io.lettuce.core.cluster.RedisClusterClient
 import io.lettuce.core.resource.ClientResources
-import org.apache.james.backends.redis.{Cluster, MasterReplica, RedisConfiguration, RedisHealthCheck, RedisTopology, Standalone}
 import jakarta.inject.Inject
-import org.apache.james.core.healthcheck.HealthCheck
+import org.apache.james.backends.redis.{Cluster, MasterReplica, RedisConfiguration, Standalone}
 import org.apache.james.rate.limiter.api.Increment.Increment
 import org.apache.james.rate.limiter.api.{AcceptableRate, RateExceeded, RateLimiter, RateLimiterFactory, RateLimitingKey, RateLimitingResult, Rule, Rules}
 import org.apache.james.util.concurrent.NamedThreadFactory
@@ -46,10 +44,6 @@ class RedisRateLimiterModule() extends AbstractModule {
       .to(classOf[RedisRateLimiterFactory])
 
     bind(classOf[RedisRateLimiterFactory]).in(Scopes.SINGLETON)
-
-    Multibinder.newSetBinder(binder(), classOf[HealthCheck])
-      .addBinding()
-      .to(classOf[RedisHealthCheck])
   }
 
   @Provides


### PR DESCRIPTION
## Bug

James can not start when running rate-limiter-redis docker-compose: https://github.com/apache/james-project/blob/master/server/mailet/rate-limiter-redis/docker-compose.yml

Error
```
03:32:17.943 [INFO ] o.a.j.u.GuiceGenericLoader - Enabling injects contained in org.apache.james.rate.limiter.redis.RedisRateLimiterModule
2024-05-07T03:32:17.961261846Z 03:32:17.954 [ERROR] o.a.j.GuiceJamesServer - Fatal error while starting James
2024-05-07T03:32:17.961282565Z com.google.inject.ProvisionException: Unable to provision, see the following errors:
2024-05-07T03:32:17.961285240Z 
2024-05-07T03:32:17.961287504Z 1) [Guice/BindingAlreadySet]: Set<HealthCheck> was bound multiple times.
2024-05-07T03:32:17.961290069Z 
2024-05-07T03:32:17.961292093Z Bound at:
2024-05-07T03:32:17.961294147Z 1  : IsStartedProbeModule.configure(IsStartedProbeModule.java:42)
2024-05-07T03:32:17.961296531Z       \_ installed by: Modules$OverrideModule -> Modules$CombinedModule -> Modules$CombinedModule -> Modules$CombinedModule -> Modules$CombinedModule -> Modules$CombinedModule -> IsStartedProbeModule -> RealMultibinder
2024-05-07T03:32:17.961299597Z 2  : RedisRateLimiterModule.configure(RedisRateLimiter.scala:50)
2024-05-07T03:32:17.961301641Z       \_ installed by: Modules$CombinedModule -> RedisRateLimiterModule -> RealMultibinder
2024-05-07T03:32:17.961303765Z 
```

## How to fix it

Add manually in  `healthcheck.properties` 
