### PR TITLE
James 3693 update redis config to support read from replicas

### DIFF
--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisConfiguration.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisConfiguration.scala
@@ -45,7 +45,7 @@ object RedisConfiguration {
       case STANDALONE_TOPOLOGY => StandaloneRedisConfiguration.from(config)
       case CLUSTER_TOPOLOGY => ClusterRedisConfiguration.from(config)
       case MASTER_REPLICA_TOPOLOGY => MasterReplicaRedisConfiguration.from(config)
-      case _ => throw new NotImplementedError()
+      case _ => throw new IllegalArgumentException("Invalid topology")
     }
 
     LOGGER.info(s"Configured Redis with: ${redisConfiguration.asString}")

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
@@ -61,12 +61,11 @@ public class RedisClusterExtension implements GuiceModuleTestExtension {
             super(c);
         }
 
-        public RedisConfiguration getRedisConfiguration() {
-            return RedisConfiguration.from(this.stream()
+        public ClusterRedisConfiguration getRedisConfiguration() {
+            return ClusterRedisConfiguration.from(this.stream()
                     .map(redisURIFunction())
                     .map(URI::toString)
                     .toArray(String[]::new),
-                Cluster$.MODULE$,
                 OptionConverters.toScala(Optional.empty()),
                 OptionConverters.toScala(Optional.empty()));
         }

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
@@ -31,11 +31,12 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
     val config = new PropertiesConfiguration()
     config.addProperty("redisURL", "redis://localhost:6379")
     config.addProperty("redis.topology", "master-replica")
+    config.addProperty("redis.readFrom", "any")
     config.addProperty("redis.ioThreads", 16)
     config.addProperty("redis.workerThreads", 32)
 
     val redisConfig = RedisConfiguration.from(config)
-    redisConfig shouldEqual MasterReplicaRedisConfiguration.from(Array("redis://localhost:6379"), ReadFrom.MASTER, Some(16), Some(32))
+    redisConfig shouldEqual MasterReplicaRedisConfiguration.from(Array("redis://localhost:6379"), ReadFrom.ANY, Some(16), Some(32))
   }
 
   it should "parse multiple Redis URIs from config" in {
@@ -61,6 +62,27 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
   it should "throw exception for invalid Redis URI" in {
     val config = new PropertiesConfiguration()
     config.addProperty("redisURL", "invalid://localhost:6379")
+
+    intercept[IllegalArgumentException] {
+      RedisConfiguration.from(config)
+    }
+  }
+
+  it should "throw exception for invalid Redis topology" in {
+    val config = new PropertiesConfiguration()
+    config.addProperty("redisURL", "redis://localhost:6379")
+    config.addProperty("redis.topology", "invalid")
+
+    intercept[IllegalArgumentException] {
+      RedisConfiguration.from(config)
+    }
+  }
+
+  it should "throw exception for invalid Redis readFrom" in {
+    val config = new PropertiesConfiguration()
+    config.addProperty("redisURL", "redis://localhost:6379")
+    config.addProperty("redis.topology", "master-replica")
+    config.addProperty("redis.readFrom", "invalid")
 
     intercept[IllegalArgumentException] {
       RedisConfiguration.from(config)

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
@@ -19,7 +19,7 @@
 
 package org.apache.james.backends.redis
 
-import io.lettuce.core.RedisURI
+import io.lettuce.core.{ReadFrom, RedisURI}
 import org.apache.commons.configuration2.PropertiesConfiguration
 import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler
 import org.scalatest.flatspec.AnyFlatSpec
@@ -35,12 +35,7 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
     config.addProperty("redis.workerThreads", 32)
 
     val redisConfig = RedisConfiguration.from(config)
-
-    redisConfig.redisURI.value should have length 1
-    redisConfig.redisURI.value should contain theSameElementsAs List(RedisURI.create("redis://localhost:6379"))
-    redisConfig.redisTopology shouldEqual MasterReplica
-    redisConfig.ioThreads shouldEqual Some(16)
-    redisConfig.workerThreads shouldEqual Some(32)
+    redisConfig shouldEqual MasterReplicaRedisConfiguration.from(Array("redis://localhost:6379"), ReadFrom.MASTER, Some(16), Some(32))
   }
 
   it should "parse multiple Redis URIs from config" in {
@@ -52,12 +47,7 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
     config.addProperty("redis.workerThreads", 32)
 
     val redisConfig = RedisConfiguration.from(config)
-
-    redisConfig.redisURI.value should have length 2
-    redisConfig.redisURI.value should contain theSameElementsAs List(RedisURI.create("redis://localhost:6379"), RedisURI.create("redis://localhost:6380"))
-    redisConfig.redisTopology shouldEqual Cluster
-    redisConfig.ioThreads shouldEqual Some(16)
-    redisConfig.workerThreads shouldEqual Some(32)
+    redisConfig shouldEqual ClusterRedisConfiguration(RedisUris.liftOrThrow(List(RedisURI.create("redis://localhost:6379"), RedisURI.create("redis://localhost:6380"))), Some(16), Some(32))
   }
 
   it should "use default values for missing config values" in {
@@ -65,12 +55,7 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
     config.addProperty("redisURL", "redis://localhost:6379")
 
     val redisConfig = RedisConfiguration.from(config)
-
-    redisConfig.redisURI.value should have length 1
-    redisConfig.redisURI.value should contain theSameElementsAs List(RedisURI.create("redis://localhost:6379"))
-    redisConfig.redisTopology shouldEqual Standalone
-    redisConfig.ioThreads shouldEqual None
-    redisConfig.workerThreads shouldEqual None
+    redisConfig shouldEqual StandaloneRedisConfiguration(RedisURI.create("redis://localhost:6379"), None, None)
   }
 
   it should "throw exception for invalid Redis URI" in {

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisExtension.java
@@ -53,8 +53,8 @@ public class RedisExtension implements GuiceModuleTestExtension {
         return new AbstractModule() {
             @Provides
             @Singleton
-            public  RedisConfiguration provideConfig() {
-                return RedisConfiguration.from(dockerRedis().redisURI().toString(), Standalone$.MODULE$);
+            public RedisConfiguration provideConfig() {
+                return StandaloneRedisConfiguration.from(dockerRedis().redisURI().toString());
             }
         };
     }

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisMasterReplicaHealthCheckTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisMasterReplicaHealthCheckTest.scala
@@ -20,8 +20,7 @@
 package org.apache.james.backends.redis
 
 import java.util.concurrent.TimeUnit
-
-import org.apache.james.backends.redis.RedisMasterReplicaExtension.RedisClusterContainer
+import org.apache.james.backends.redis.RedisMasterReplicaExtension.RedisMasterReplicaContainer
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility
 import org.junit.jupiter.api.extension.ExtendWith
@@ -33,12 +32,12 @@ class RedisMasterReplicaHealthCheckTest {
   var redisHealthCheck: RedisHealthCheck = _
 
   @BeforeEach
-  def setup(redis: RedisClusterContainer): Unit = {
+  def setup(redis: RedisMasterReplicaContainer): Unit = {
     redisHealthCheck = new RedisHealthCheck(redis.getRedisConfiguration)
   }
 
   @AfterEach
-  def afterEach(redis: RedisClusterContainer): Unit = {
+  def afterEach(redis: RedisMasterReplicaContainer): Unit = {
     redis.unPauseOne();
   }
 
@@ -50,7 +49,7 @@ class RedisMasterReplicaHealthCheckTest {
   }
 
   @Test
-  def checkShouldReturnDegradedWhenRedisIsDown(redis: RedisClusterContainer): Unit = {
+  def checkShouldReturnDegradedWhenRedisIsDown(redis: RedisMasterReplicaContainer): Unit = {
     redis.pauseOne()
 
     Awaitility.await()
@@ -60,7 +59,7 @@ class RedisMasterReplicaHealthCheckTest {
   }
 
   @Test
-  def checkShouldReturnHealthyWhenRedisIsRecovered(redis: RedisClusterContainer): Unit = {
+  def checkShouldReturnHealthyWhenRedisIsRecovered(redis: RedisMasterReplicaContainer): Unit = {
     redis.pauseOne()
     redis.unPauseOne()
 

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisStandaloneHealthCheckTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisStandaloneHealthCheckTest.scala
@@ -33,7 +33,7 @@ class RedisStandaloneHealthCheckTest {
 
   @BeforeEach
   def setup(redis: DockerRedis): Unit = {
-    val redisConfiguration: RedisConfiguration = RedisConfiguration.from(redis.redisURI().toString, Standalone)
+    val redisConfiguration: StandaloneRedisConfiguration = StandaloneRedisConfiguration.from(redis.redisURI().toString)
 
     redisHealthCheck = new RedisHealthCheck(redisConfiguration)
   }

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/redis.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/redis.adoc
@@ -18,6 +18,11 @@ to get some examples and hints.
 | redis.topology
 | Redis server topology. Defaults to standalone. Possible values: standalone, cluster, master-replica
 
+| redis.readFrom
+| The property to determine how Lettuce routes read operations to Redis server with topologies other than standalone. Defaults to master. Possible values: master, masterPreferred, replica, replicaPreferred, any
+
+Reference: https://github.com/redis/lettuce/wiki/ReadFrom-Settings
+
 | redis.ioThreads
 | IO threads to be using for the underlying Netty networking resources. If unspecified driver defaults applies.
 

--- a/server/mailet/rate-limiter-redis/redis.properties
+++ b/server/mailet/rate-limiter-redis/redis.properties
@@ -1,2 +1,3 @@
 redisURL=redis://redis:6379
 redis.topology=standalone
+#redis.readFrom=master

--- a/server/mailet/rate-limiter-redis/src/main/java/org/apache/james/rate/limiter/redis/RedisMasterReplicaRateLimiterFactory.java
+++ b/server/mailet/rate-limiter-redis/src/main/java/org/apache/james/rate/limiter/redis/RedisMasterReplicaRateLimiterFactory.java
@@ -27,6 +27,7 @@ import es.moki.ratelimitj.core.limiter.request.ReactiveRequestRateLimiter;
 import es.moki.ratelimitj.core.limiter.request.RequestLimitRule;
 import es.moki.ratelimitj.core.limiter.request.RequestRateLimiter;
 import es.moki.ratelimitj.redis.request.RedisSlidingWindowRequestRateLimiter;
+import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.codec.StringCodec;
@@ -36,11 +37,17 @@ import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 public class RedisMasterReplicaRateLimiterFactory extends AbstractRequestRateLimiterFactory<RedisSlidingWindowRequestRateLimiter> {
     private final RedisClient client;
     private final List<RedisURI> redisURIs;
+    private final ReadFrom readFrom;
     private StatefulRedisMasterReplicaConnection<String, String> connection;
 
-    public RedisMasterReplicaRateLimiterFactory(RedisClient client, List<RedisURI> redisURIs) {
+    public RedisMasterReplicaRateLimiterFactory(RedisClient client, List<RedisURI> redisURIs, ReadFrom readFrom) {
         this.client = client;
         this.redisURIs = redisURIs;
+        this.readFrom = readFrom;
+    }
+
+    public RedisMasterReplicaRateLimiterFactory(RedisClient client, List<RedisURI> redisURIs) {
+        this(client, redisURIs, ReadFrom.MASTER);
     }
 
     @Override
@@ -66,6 +73,7 @@ public class RedisMasterReplicaRateLimiterFactory extends AbstractRequestRateLim
     private StatefulRedisMasterReplicaConnection<String, String> getConnection() {
         if (this.connection == null) {
             this.connection = MasterReplica.connect(this.client, StringCodec.UTF8, redisURIs);
+            this.connection.setReadFrom(readFrom);
         }
 
         return this.connection;

--- a/server/mailet/rate-limiter-redis/src/main/scala/org/apache/james/rate/limiter/redis/RedisRateLimiter.scala
+++ b/server/mailet/rate-limiter-redis/src/main/scala/org/apache/james/rate/limiter/redis/RedisRateLimiter.scala
@@ -64,7 +64,8 @@ class RedisRateLimiterFactory @Inject()(redisConfiguration: RedisConfiguration) 
 
     case masterReplicaRedisConfiguration: MasterReplicaRedisConfiguration => new RedisMasterReplicaRateLimiterFactory(
       RedisClient.create(masterReplicaRedisConfiguration.redisURI.value.last),
-      masterReplicaRedisConfiguration.redisURI.value.asJava)
+      masterReplicaRedisConfiguration.redisURI.value.asJava,
+      masterReplicaRedisConfiguration.readFrom)
 
     case _ => throw new NotImplementedError()
   }

--- a/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/RedisRateLimiterTest.scala
+++ b/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/RedisRateLimiterTest.scala
@@ -19,9 +19,9 @@
 
 package org.apache.james.rate.limiter
 
-import org.apache.james.backends.redis.{DockerRedis, RedisConfiguration, RedisExtension, Standalone}
 import java.time.Duration
 
+import org.apache.james.backends.redis.{RedisConfiguration, DockerRedis, RedisExtension, StandaloneRedisConfiguration}
 import org.apache.james.rate.limiter.api.{RateLimiterContract, RateLimiterFactory}
 import org.apache.james.rate.limiter.redis.RedisRateLimiterFactory
 import org.junit.jupiter.api.BeforeEach
@@ -34,7 +34,7 @@ class RedisRateLimiterTest extends RateLimiterContract {
 
   @BeforeEach
   def setup(redis: DockerRedis): Unit = {
-    redisRateLimiterConfiguration = RedisConfiguration.from(redis.redisURI().toString, Standalone)
+    redisRateLimiterConfiguration = StandaloneRedisConfiguration.from(redis.redisURI().toString)
   }
 
   override def testee(): RateLimiterFactory = new RedisRateLimiterFactory(redisRateLimiterConfiguration)

--- a/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/RedisRateLimiterWithMasterReplicaTopologyTest.scala
+++ b/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/RedisRateLimiterWithMasterReplicaTopologyTest.scala
@@ -28,8 +28,8 @@ import org.apache.james.rate.limiter.RedisRateLimiterWithMasterReplicaTopologyTe
 import org.apache.james.rate.limiter.api.{AcceptableRate, RateLimitingKey, RateLimitingResult, Rule, Rules}
 import org.apache.james.rate.limiter.redis.RedisRateLimiterFactory
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.api.{BeforeEach, Test}
 import reactor.core.scala.publisher.SMono
 
 object RedisRateLimiterWithMasterReplicaTopologyTest {
@@ -39,16 +39,9 @@ object RedisRateLimiterWithMasterReplicaTopologyTest {
 
 @ExtendWith(Array(classOf[RedisMasterReplicaExtension]))
 class RedisRateLimiterWithMasterReplicaTopologyTest {
-  var rateLimiterFactory: RedisRateLimiterFactory = _
-
-  @BeforeEach
-  def setup(redisClusterContainer: RedisMasterReplicaContainer): Unit = {
-    rateLimiterFactory = new RedisRateLimiterFactory(redisClusterContainer.getRedisConfiguration)
-  }
-
   @Test
-  def test(redisClusterContainer: RedisMasterReplicaContainer): Unit = {
-    val rateLimiterFactory = new RedisRateLimiterFactory(redisClusterContainer.getRedisConfiguration)
+  def rateLimitShouldWorkNormally(redisClusterContainer: RedisMasterReplicaContainer): Unit = {
+    val rateLimiterFactory: RedisRateLimiterFactory = new RedisRateLimiterFactory(redisClusterContainer.getRedisConfiguration)
     val rateLimiter = rateLimiterFactory.withSpecification(RULES, SLIDING_WIDOW_PRECISION)
     val actual: RateLimitingResult = SMono(rateLimiter.rateLimit(TestKey("key1"), 4)).block()
     assertThat(actual).isEqualTo(AcceptableRate)

--- a/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/RedisRateLimiterWithMasterReplicaTopologyTest.scala
+++ b/server/mailet/rate-limiter-redis/src/test/java/org/apache/james/rate/limiter/RedisRateLimiterWithMasterReplicaTopologyTest.scala
@@ -23,6 +23,7 @@ import java.time.Duration
 
 import eu.timepit.refined.auto._
 import org.apache.james.backends.redis.RedisMasterReplicaExtension
+import org.apache.james.backends.redis.RedisMasterReplicaExtension.RedisMasterReplicaContainer
 import org.apache.james.rate.limiter.RedisRateLimiterWithMasterReplicaTopologyTest.{RULES, SLIDING_WIDOW_PRECISION}
 import org.apache.james.rate.limiter.api.{AcceptableRate, RateLimitingKey, RateLimitingResult, Rule, Rules}
 import org.apache.james.rate.limiter.redis.RedisRateLimiterFactory
@@ -41,12 +42,12 @@ class RedisRateLimiterWithMasterReplicaTopologyTest {
   var rateLimiterFactory: RedisRateLimiterFactory = _
 
   @BeforeEach
-  def setup(redisClusterContainer: RedisMasterReplicaExtension.RedisClusterContainer): Unit = {
+  def setup(redisClusterContainer: RedisMasterReplicaContainer): Unit = {
     rateLimiterFactory = new RedisRateLimiterFactory(redisClusterContainer.getRedisConfiguration)
   }
 
   @Test
-  def test(redisClusterContainer: RedisMasterReplicaExtension.RedisClusterContainer): Unit = {
+  def test(redisClusterContainer: RedisMasterReplicaContainer): Unit = {
     val rateLimiterFactory = new RedisRateLimiterFactory(redisClusterContainer.getRedisConfiguration)
     val rateLimiter = rateLimiterFactory.withSpecification(RULES, SLIDING_WIDOW_PRECISION)
     val actual: RateLimitingResult = SMono(rateLimiter.rateLimit(TestKey("key1"), 4)).block()


### PR DESCRIPTION
https://github.com/linagora/james-project/issues/5172

RedisRateLimiter is not updated because I see that ratelimit library mostly run redisScriptingReactiveCommands.evalsha which has to work with master node (this method is used to run lua script).