### PR TITLE
[ENHANCEMENT] Apply RabbitMQ classic queue version 2

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/QueueArguments.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/QueueArguments.java
@@ -70,6 +70,11 @@ public class QueueArguments {
             return this;
         }
 
+        public Builder classicQueueVersion(int version) {
+            arguments.put("x-queue-version", version);
+            return this;
+        }
+
         public Builder put(String key, Object value) {
             arguments.put(key, value);
             return this;

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -601,6 +601,7 @@ public class RabbitMQConfiguration {
 
     private static final String URI_PROPERTY_NAME = "uri";
     private static final String MANAGEMENT_URI_PROPERTY_NAME = "management.uri";
+    private static final boolean STICK_TO_CLASSIC_QUEUES_VERSION_1 = Boolean.parseBoolean(System.getProperty("james.rabbitmq.stick.to.classic.queues.version.1", "false"));
 
     public static RequireAmqpUri builder() {
         return amqpUri -> managementUri -> managementCredentials -> new Builder(amqpUri, managementUri, managementCredentials);
@@ -818,9 +819,15 @@ public class RabbitMQConfiguration {
             builder.quorumQueue().replicationFactor(quorumQueueReplicationFactor);
             quorumQueueDeliveryLimit.ifPresent(builder::deliveryLimit);
         } else {
-            builder.classicQueueVersion(2);
+            applyClassicQueueArguments(builder);
         }
         return builder;
+    }
+
+    private void applyClassicQueueArguments(QueueArguments.Builder builder) {
+        if (!STICK_TO_CLASSIC_QUEUES_VERSION_1) {
+            builder.classicQueueVersion(2);
+        }
     }
 
     public boolean isQuorumQueuesUsed() {

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -601,7 +601,7 @@ public class RabbitMQConfiguration {
 
     private static final String URI_PROPERTY_NAME = "uri";
     private static final String MANAGEMENT_URI_PROPERTY_NAME = "management.uri";
-    private static final boolean STICK_TO_CLASSIC_QUEUES_VERSION_1 = Boolean.parseBoolean(System.getProperty("james.rabbitmq.stick.to.classic.queues.version.1", "false"));
+    private static final boolean FALLBACK_CLASSIC_QUEUES_VERSION_1 = Boolean.parseBoolean(System.getProperty("fallback.classic.queues.v1", "false"));
 
     public static RequireAmqpUri builder() {
         return amqpUri -> managementUri -> managementCredentials -> new Builder(amqpUri, managementUri, managementCredentials);
@@ -825,7 +825,7 @@ public class RabbitMQConfiguration {
     }
 
     private void applyClassicQueueArguments(QueueArguments.Builder builder) {
-        if (!STICK_TO_CLASSIC_QUEUES_VERSION_1) {
+        if (!FALLBACK_CLASSIC_QUEUES_VERSION_1) {
             builder.classicQueueVersion(2);
         }
     }

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -817,6 +817,8 @@ public class RabbitMQConfiguration {
         if (useQuorumQueues) {
             builder.quorumQueue().replicationFactor(quorumQueueReplicationFactor);
             quorumQueueDeliveryLimit.ifPresent(builder::deliveryLimit);
+        } else {
+            builder.classicQueueVersion(2);
         }
         return builder;
     }

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -30,6 +30,18 @@ Change list:
  - [Java 21](#java-21)
  - [javax -> jakarta](#javax---jakarta)
  - [Make all queues on RabbitMQ quorum queue when `quorum.queues.enable=true`](#make-all-queues-on-rabbitmq-quorum-queue-when-quorumqueuesenabletrue)
+ - [Migrate RabbitMQ classic queues to version 2](#migrate-rabbitmq-classic-queues-to-version-2)
+
+### Migrate RabbitMQ classic queues to version 2
+
+Date: 14/05/2024
+
+It is recommended by RabbitMQ to upgrade the classic queues to version 2 for better performance: https://www.rabbitmq.com/blog/2023/05/17/rabbitmq-3.12-performance-improvements#classic-queues-massively-improved-classic-queues-v2-cqv2.
+
+Existing version 1 classic queues would need to be deleted and let James re-create them as version 2.
+
+Notice that to use classic queues version 2, you need at least RabbitMQ 3.10.0. If you want to stick with the older RabbitMQ 
+versions and avoid this breaking change, you could set the JVM property `james.rabbitmq.stick.to.classic.queues.version.1` to `true` (defaults to `false`).
 
 ### Make all queues on RabbitMQ quorum queue when `quorum.queues.enable=true`
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -41,7 +41,7 @@ It is recommended by RabbitMQ to upgrade the classic queues to version 2 for bet
 Existing version 1 classic queues would need to be deleted and let James re-create them as version 2.
 
 Notice that to use classic queues version 2, you need at least RabbitMQ 3.10.0. If you want to stick with the older RabbitMQ 
-versions and avoid this breaking change, you could set the JVM property `james.rabbitmq.stick.to.classic.queues.version.1` to `true` (defaults to `false`).
+versions and avoid this breaking change, you could set the JVM property `fallback.classic.queues.v1` to `true` (defaults to `false`).
 
 ### Make all queues on RabbitMQ quorum queue when `quorum.queues.enable=true`
 


### PR DESCRIPTION
Claimed to be better than version 1 cf:
- https://www.rabbitmq.com/blog/2023/05/17/rabbitmq-3.12-performance-improvements#classic-queues-massively-improved-classic-queues-v2-cqv2
- https://www.rabbitmq.com/blog/2023/05/17/rabbitmq-3.12-performance-improvements#312-cqv1-vs-cqv2

### Before (all classic queues v1)
![Screenshot from 2024-05-13 16-46-30](https://github.com/apache/james-project/assets/55171818/27dd9522-ec48-48ae-be7c-e5e3eb7d64e3)


### After (all classic queues v2)
![Screenshot from 2024-05-13 16-37-40](https://github.com/apache/james-project/assets/55171818/34489e17-125a-4f43-9042-5f4f4c6b436c)

Better performance overall (p99 805ms vs 914ms).
SELECT p99 1874ms vs 2049ms
UNSELECT p99 1420ms vs 1755ms  