### PR TITLE
[ENHANCEMENT] MDN/send shall be reactive

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MDNSendMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MDNSendMethodContract.scala
@@ -860,6 +860,7 @@ trait MDNSendMethodContract {
         .build(buildOriginalMessage("2")))
       .getMessageId
 
+    val serializedRandomId = randomMessageId.serialize()
     val request: String =
       s"""{
          |  "using": [
@@ -891,7 +892,7 @@ trait MDNSendMethodContract {
          |            }
          |          },
          |          "k1548": {
-         |            "forEmailId": "${randomMessageId.serialize()}",
+         |            "forEmailId": "$serializedRandomId",
          |            "disposition": {
          |              "actionMode": "manual-action",
          |              "sendingMode": "mdn-sent-manually",
@@ -957,7 +958,7 @@ trait MDNSendMethodContract {
                    |                    },
                    |                    "k1548": {
                    |                        "type": "notFound",
-                   |                        "description": "The reference \\"forEmailId\\" cannot be found."
+                   |                        "description": "The reference \\"forEmailId\\" $serializedRandomId cannot be found for user andre@domain.tld."
                    |                    }
                    |                }
                    |            },
@@ -1177,6 +1178,7 @@ trait MDNSendMethodContract {
     val mailboxProbe: MailboxProbeImpl = server.getProbe(classOf[MailboxProbeImpl])
     mailboxProbe.createMailbox(path)
 
+    val randomMessageId1 = randomMessageId
     val request: String =
       s"""{
          |  "using": [
@@ -1192,7 +1194,7 @@ trait MDNSendMethodContract {
          |        "identityId": "$IDENTITY_ID",
          |        "send": {
          |          "k1546": {
-         |            "forEmailId": "${randomMessageId.serialize()}",
+         |            "forEmailId": "${randomMessageId1.serialize()}",
          |            "disposition": {
          |              "actionMode": "manual-action",
          |              "sendingMode": "mdn-sent-manually",
@@ -1225,10 +1227,10 @@ trait MDNSendMethodContract {
 
     assertThatJson(response)
       .inPath("methodResponses[0][1].notSent")
-      .isEqualTo("""{
+      .isEqualTo(s"""{
                    |    "k1546": {
                    |        "type": "notFound",
-                   |        "description": "The reference \"forEmailId\" cannot be found."
+                   |        "description": "The reference \\\"forEmailId\\\" ${randomMessageId1.serialize()} cannot be found for user bob@domain.tld."
                    |    }
                    |}""".stripMargin)
   }


### PR DESCRIPTION
3% of CPU wall time on CNB JMAP pods. Contributes to 12% of overall blockingCallWrapper thread usage.
Along with 18% of XUser...

This move would help slightly lowering the count of threads and limit context switches.

![image](https://github.com/apache/james-project/assets/6928740/efdf245c-ca69-4701-80cf-eb3d31f8da04)
