### PR TITLE
[ENHANCEMENT] Allow custom prefetch in Flux => InputStream convertions

### DIFF
--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/jvm.adoc
@@ -93,3 +93,13 @@ james.s3.metrics.enabled=false
 ----
 To disable the S3 metrics.
 
+== Reactor Stream Prefetch
+
+Prefetch to use in Reactor to stream convertions (S3 => InputStream). Default to 1.
+Higher values will tend to block less often at the price of higher memory consumptions.
+
+Ex in `jvm.properties`
+----
+# james.reactor.inputstream.prefetch=4
+----
+

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -78,3 +78,7 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # Maximum size of a blob. Larger blobs will be rejected.
 # Unit supported: K, M, G, default to no unit
 #james.blob.aes.blob.max.size=100M
+
+# Prefetch to use in Reactor to stream convertions (S3 => InputStream). Default to 1.
+# Higher values will tend to block less often at the price of higher memory consumptions.
+# james.reactor.inputstream.prefetch=4

--- a/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
@@ -57,6 +57,9 @@ public class ReactorUtils {
     public static final int DEFAULT_BOUNDED_ELASTIC_QUEUESIZE = Optional.ofNullable(System.getProperty("james.schedulers.defaultBoundedElasticQueueSize"))
         .map(Integer::parseInt)
         .orElse(100000);
+    public static final int DEFAULT_INPUT_STREAM_PREFETCH = Optional.ofNullable(System.getProperty("james.reactor.inputstream.prefetch"))
+        .map(Integer::parseInt)
+        .orElse(1);
     private static final int TTL_SECONDS = 60;
     private static final boolean DAEMON = true;
     public static final Scheduler BLOCKING_CALL_WRAPPER = Schedulers.newBoundedElastic(DEFAULT_BOUNDED_ELASTIC_SIZE, DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
@@ -105,7 +108,7 @@ public class ReactorUtils {
     }
 
     public static InputStream toInputStream(Flux<ByteBuffer> byteArrays) {
-        return new StreamInputStream(byteArrays.toStream(1));
+        return new StreamInputStream(byteArrays.toStream(DEFAULT_INPUT_STREAM_PREFETCH));
     }
 
     public static Flux<ByteBuffer> toChunks(InputStream inputStream, int bufferSize) {


### PR DESCRIPTION
`boundedElastic` threads as well as AWS response threads spends a lot of time blocking on this, adding a prefertch could smooth things up and help having a lower thread count as well as lower user facing latencies.

![image](https://github.com/apache/james-project/assets/6928740/e3222aaf-84ee-4e11-af0c-5785bfd4bcca)

Up to 25% wall clock time.