### PR TITLE
JAMES-2586 Fix sequential issue with updating flags in the reactive p…

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.postgres.mail;
 
 import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -290,7 +291,7 @@ public class PostgresMessageMapper implements MessageMapper {
                                             FlagsUpdateCalculator flagsUpdateCalculator) {
         return modSeqProvider.nextModSeqReactive(mailbox.getMailboxId())
             .flatMapMany(newModSeq -> Flux.fromIterable(listMessagesMetaData)
-                .flatMap(messageMetaData -> updateFlags(messageMetaData, flagsUpdateCalculator, newModSeq)));
+                .flatMapSequential(messageMetaData -> updateFlags(messageMetaData, flagsUpdateCalculator, newModSeq), DEFAULT_CONCURRENCY));
     }
 
     private Mono<UpdatedFlags> updateFlags(ComposedMessageIdWithMetaData currentMetaData,

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -60,6 +60,7 @@ import org.apache.james.mailbox.store.mail.model.MapperProvider.Capabilities;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.apache.james.util.streams.Iterators;
 import org.apache.james.utils.UpdatableTickingClock;
 import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
@@ -848,6 +849,51 @@ public abstract class MessageMapperTest {
         assertThat(messageMapper.updateFlags(benwaInboxMailbox, new FlagsUpdateCalculator(new Flags(Flags.Flag.SEEN), FlagsUpdateMode.REPLACE), MessageRange.all()))
             .toIterable()
             .hasSize(5);
+    }
+
+    @Test
+    void updateFlagsOnRangeShouldReturnUpdatedFlagsWithUidOrderAsc() throws MailboxException {
+        saveMessages();
+
+        Iterator<UpdatedFlags> it = messageMapper.updateFlags(benwaInboxMailbox,
+            new FlagsUpdateCalculator(new Flags(Flags.Flag.SEEN), FlagsUpdateMode.REPLACE),
+            MessageRange.range(message1.getUid(), message3.getUid()));
+        List<MessageUid> updatedFlagsUids = Iterators.toStream(it)
+            .map(UpdatedFlags::getUid)
+            .collect(ImmutableList.toImmutableList());
+
+        assertThat(updatedFlagsUids)
+            .containsExactly(message1.getUid(), message2.getUid(), message3.getUid());
+    }
+
+    @Test
+    void updateFlagsWithRangeFromShouldReturnUpdatedFlagsWithUidOrderAsc() throws MailboxException {
+        saveMessages();
+
+        Iterator<UpdatedFlags> it = messageMapper.updateFlags(benwaInboxMailbox,
+            new FlagsUpdateCalculator(new Flags(Flags.Flag.SEEN), FlagsUpdateMode.REPLACE),
+            MessageRange.from(message3.getUid()));
+        List<MessageUid> updatedFlagsUids = Iterators.toStream(it)
+            .map(UpdatedFlags::getUid)
+            .collect(ImmutableList.toImmutableList());
+
+        assertThat(updatedFlagsUids)
+            .containsExactly(message3.getUid(), message4.getUid(), message5.getUid());
+    }
+
+    @Test
+    void updateFlagsWithRangeAllRangeShouldReturnUpdatedFlagsWithUidOrderAsc() throws MailboxException {
+        saveMessages();
+
+        Iterator<UpdatedFlags> it = messageMapper.updateFlags(benwaInboxMailbox,
+            new FlagsUpdateCalculator(new Flags(Flags.Flag.SEEN), FlagsUpdateMode.REPLACE),
+            MessageRange.all());
+        List<MessageUid> updatedFlagsUids = Iterators.toStream(it)
+            .map(UpdatedFlags::getUid)
+            .collect(ImmutableList.toImmutableList());
+
+        assertThat(updatedFlagsUids)
+            .containsExactly(message1.getUid(), message2.getUid(), message3.getUid(), message4.getUid(), message5.getUid());
     }
 
     @Test


### PR DESCRIPTION
…ipeline

The deployments tests (that aren't being tested anymore in apache james) were not passing for TMail since Postgresql latest updates with pg-pool => https://github.com/linagora/tmail-backend/pull/1035

The store imap command on message flags seems not always returning in the right order fetch responses. The one little change flatMap to concatMap here makes sure we keep it sequential in order, that's where the UpdatedFlags were being mixed up in order in the pipeline. 