### PR TITLE
JAMES-2586 - Update primaryKey constraint for Postgres mailbox_change and email_change

### DIFF
--- a/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresEmailChangeModule.java
+++ b/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresEmailChangeModule.java
@@ -55,7 +55,7 @@ public interface PostgresEmailChangeModule {
                 .column(CREATED)
                 .column(UPDATED)
                 .column(DESTROYED)
-                .constraint(DSL.primaryKey(ACCOUNT_ID, STATE))))
+                .constraint(DSL.primaryKey(ACCOUNT_ID, STATE, IS_SHARED))))
             .supportsRowLevelSecurity()
             .build();
 

--- a/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresMailboxChangeModule.java
+++ b/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/change/PostgresMailboxChangeModule.java
@@ -57,7 +57,7 @@ public interface PostgresMailboxChangeModule {
                 .column(CREATED)
                 .column(UPDATED)
                 .column(DESTROYED)
-                .constraint(DSL.primaryKey(ACCOUNT_ID, STATE))))
+                .constraint(DSL.primaryKey(ACCOUNT_ID, STATE, IS_SHARED))))
             .supportsRowLevelSecurity()
             .build();
 


### PR DESCRIPTION
As the logic of method [MailboxAndEmailChange.Factory#fromExpunged](https://github.com/apache/james-project/blob/ae536b8dbc8ab2f56d6eea5610c9a0e175a4703e/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxAndEmailChange.java#L151)
We can have 2 records that have the same `accountId` & `state`, but  different `is_share`
