### PR TITLE
JAMES-2586 - Rename class DeletedMessageVaultDeletionCallback -> PostgresDeletedMessageVaultDeletionCallback

### DIFF
--- a/mailbox/plugin/deleted-messages-vault-postgres/src/main/java/org/apache/james/vault/metadata/PostgresDeletedMessageVaultDeletionCallback.java
+++ b/mailbox/plugin/deleted-messages-vault-postgres/src/main/java/org/apache/james/vault/metadata/PostgresDeletedMessageVaultDeletionCallback.java
@@ -55,15 +55,15 @@ import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Mono;
 
-public class DeletedMessageVaultDeletionCallback implements DeleteMessageListener.DeletionCallback {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeletedMessageVaultDeletionCallback.class);
+public class PostgresDeletedMessageVaultDeletionCallback implements DeleteMessageListener.DeletionCallback {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresDeletedMessageVaultDeletionCallback.class);
 
     private final DeletedMessageVault deletedMessageVault;
     private final BlobStore blobStore;
     private final Clock clock;
 
     @Inject
-    public DeletedMessageVaultDeletionCallback(DeletedMessageVault deletedMessageVault, BlobStore blobStore, Clock clock) {
+    public PostgresDeletedMessageVaultDeletionCallback(DeletedMessageVault deletedMessageVault, BlobStore blobStore, Clock clock) {
         this.deletedMessageVault = deletedMessageVault;
         this.blobStore = blobStore;
         this.clock = clock;

--- a/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresDeletedMessageVaultModule.java
+++ b/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresDeletedMessageVaultModule.java
@@ -23,9 +23,9 @@ import org.apache.james.backends.postgres.PostgresModule;
 import org.apache.james.mailbox.postgres.DeleteMessageListener;
 import org.apache.james.modules.vault.DeletedMessageVaultModule;
 import org.apache.james.vault.metadata.DeletedMessageMetadataVault;
-import org.apache.james.vault.metadata.DeletedMessageVaultDeletionCallback;
 import org.apache.james.vault.metadata.PostgresDeletedMessageMetadataModule;
 import org.apache.james.vault.metadata.PostgresDeletedMessageMetadataVault;
+import org.apache.james.vault.metadata.PostgresDeletedMessageVaultDeletionCallback;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -45,6 +45,6 @@ public class PostgresDeletedMessageVaultModule extends AbstractModule {
 
         Multibinder.newSetBinder(binder(), DeleteMessageListener.DeletionCallback.class)
             .addBinding()
-            .to(DeletedMessageVaultDeletionCallback.class);
+            .to(PostgresDeletedMessageVaultDeletionCallback.class);
     }
 }


### PR DESCRIPTION
To fix exception: 

`java.lang.ClassCastException: class org.apache.james.vault.metadata.DeletedMessageVaultDeletionCallback cannot be cast to class org.apache.james.mailbox.postgres.DeleteMessageListener$DeletionCallback (org.apache.james.vault.metadata.DeletedMessageVaultDeletionCallback and org.apache.james.mailbox.postgres.DeleteMessageListener$DeletionCallback are in unnamed module of loader 'app')`


because we have 2 classes that have the same name, and same package: `org.apache.james.modules.mailbox.DeletedMessageVaultModule` : one for Cassandra, one for Postgres 