### PR TITLE
JAMES-3955 Software timeout before consumer timeout

### DIFF
--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueTest.java
@@ -84,7 +84,7 @@ class RabbitMQWorkQueueTest {
         assertThat(managementAPI.queueDetails("/", "taskManagerWorkQueue")
             .getArguments()
             .get("x-consumer-timeout"))
-            .isEqualTo("86400000");
+            .isEqualTo("95040000");
     }
 
     @Test


### PR DESCRIPTION
This avoids a long task to crash the consumer. Instead the task is aborted and marked as "failed".