### PR TITLE
[FIX] registrations multimap made fully thread safe

### DIFF
--- a/event-bus/in-vm/src/main/java/org/apache/james/events/InVMEventBus.java
+++ b/event-bus/in-vm/src/main/java/org/apache/james/events/InVMEventBus.java
@@ -20,6 +20,8 @@
 package org.apache.james.events;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,7 +30,6 @@ import jakarta.inject.Inject;
 
 import org.apache.james.events.delivery.EventDelivery;
 
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -51,7 +52,8 @@ public class InVMEventBus implements EventBus {
         this.eventDelivery = eventDelivery;
         this.retryBackoff = retryBackoff;
         this.eventDeadLetters = eventDeadLetters;
-        this.registrations = Multimaps.synchronizedSetMultimap(HashMultimap.create());
+        this.registrations = Multimaps.synchronizedSetMultimap(
+                Multimaps.newSetMultimap(new HashMap<>(), () -> Collections.newSetFromMap(new ConcurrentHashMap<>())));
         this.groups = new ConcurrentHashMap<>();
     }
 

--- a/event-bus/in-vm/src/test/java/org/apache/james/events/InVMEventBusTest.java
+++ b/event-bus/in-vm/src/test/java/org/apache/james/events/InVMEventBusTest.java
@@ -22,6 +22,7 @@ package org.apache.james.events;
 import org.apache.james.events.delivery.InVmEventDelivery;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 
 public class InVMEventBusTest implements KeyContract.SingleEventBusKeyContract, GroupContract.SingleEventBusGroupContract,
     ErrorHandlingContract {
@@ -34,6 +35,19 @@ public class InVMEventBusTest implements KeyContract.SingleEventBusKeyContract, 
         deadLetters = new MemoryEventDeadLetters();
         eventBus = new InVMEventBus(
             new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, deadLetters);
+    }
+
+    @Nested
+    class ConcurrentTest implements EventBusConcurrentTestContract.SingleEventBusConcurrentContract {
+        @Override
+        public EnvironmentSpeedProfile getSpeedProfile() {
+            return EnvironmentSpeedProfile.FAST;
+        }
+
+        @Override
+        public EventBus eventBus() {
+            return eventBus;
+        }
     }
 
     @Override


### PR DESCRIPTION
It used to throw a `ConcurrentModificationException` when there was a high level of concurrency.

Here's a simple demo that reproduces the issue:

```java
import java.util.Collections;
import java.util.HashMap;
import java.util.concurrent.ConcurrentHashMap;
import java.util.function.Supplier;
import java.util.stream.IntStream;

import com.google.common.collect.HashMultimap;
import com.google.common.collect.Multimap;
import com.google.common.collect.Multimaps;

public class SimpleDemo {
    private static final String KEY = "key";

    public static void main(String[] args) {
        System.out.println("Thread safe demo");
        demo(SimpleDemo::threadSafe);
        System.out.println("Partially thread safe demo");
        demo(SimpleDemo::partiallyThreadSafe);
    }

    private static Multimap<String, Integer> threadSafe() {
        return Multimaps.synchronizedSetMultimap(
                Multimaps.newSetMultimap(new HashMap<>(), () -> Collections.newSetFromMap(new ConcurrentHashMap<>())));
    }

    private static Multimap<String, Integer> partiallyThreadSafe() {
        return Multimaps.synchronizedSetMultimap(HashMultimap.create());
    }

    private static void demo(Supplier<Multimap<String, Integer>> multimapSupplier) {
        var multimap = multimapSupplier.get();
        IntStream.range(0, 128).parallel().forEach(i -> {
            multimap.put(KEY, i);
            multimap.get(KEY).stream().mapToInt(j -> j).sum();
        });
    }
}
```

