### PR TITLE
[CLEAN CODE] Remove unused buggy Rfc4314Rights::isSupported

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
@@ -289,20 +289,6 @@ public class MailboxACL {
             return value.isEmpty();
         }
 
-        /**
-         * Tells whether the implementation supports the given right.
-         *
-         * @return true if this supports the given right.
-         */
-        public boolean isSupported(Right right) {
-            try {
-                contains(right.asCharacter());
-                return true;
-            } catch (UnsupportedRightException e) {
-                return false;
-            }
-        }
-
         public Iterator<Right> iterator() {
             ImmutableList<Right> rights = ImmutableList.copyOf(value);
             return rights.iterator();


### PR DESCRIPTION
The method was buggy as always returning true.
It is not being used anywhere anyway.