### PR TITLE
[FIX] Allow delivering emails to a&b@linagora.com

### DIFF
--- a/core/src/test/java/org/apache/james/core/MailAddressTest.java
+++ b/core/src/test/java/org/apache/james/core/MailAddressTest.java
@@ -47,6 +47,7 @@ class MailAddressTest {
                 GOOD_ADDRESS,
                 GOOD_QUOTED_LOCAL_PART,
                 "server-dev@james-apache.org",
+                "a&b@james-apache.org",
                 "server-dev@[127.0.0.1]",
                 "server.dev@james.apache.org",
                 "\\.server-dev@james.apache.org",

--- a/core/src/test/java/org/apache/james/core/UsernameTest.java
+++ b/core/src/test/java/org/apache/james/core/UsernameTest.java
@@ -185,6 +185,12 @@ class UsernameTest {
     }
 
     @Test
+    void fromUsernameShouldParseUsernameWithDomainWithAnd() {
+        assertThat(Username.of("a&a@bb"))
+            .isEqualTo(Username.from("a&a", Optional.of("bb")));
+    }
+
+    @Test
     void fromUsernameShouldParseUsernameWithoutDomain() {
         assertThat(Username.of("aa"))
             .isEqualTo(Username.from("aa", Optional.empty()));

--- a/mailbox/event/json/src/test/java/org/apache/james/event/json/dtos/QuotaRootTest.java
+++ b/mailbox/event/json/src/test/java/org/apache/james/event/json/dtos/QuotaRootTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.Optional;
 
 import org.apache.james.core.Domain;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.junit.jupiter.api.Test;
 

--- a/mailbox/event/json/src/test/java/org/apache/james/event/json/dtos/QuotaRootTest.java
+++ b/mailbox/event/json/src/test/java/org/apache/james/event/json/dtos/QuotaRootTest.java
@@ -62,6 +62,12 @@ class QuotaRootTest {
     }
 
     @Test
+    void quotaRootWithAndShouldBeWellDeSerialized() {
+        assertThat(DTO_JSON_SERIALIZE.quotaRootReads().reads(new JsString("#private&bob&marley")).get())
+            .isEqualTo(QuotaRoot.quotaRoot("#private&bob&marley", Optional.empty()));
+    }
+
+    @Test
     void emptyQuotaRootShouldBeWellSerialized() {
         assertThat(DTO_JSON_SERIALIZE.quotaRootWrites().writes(QuotaRoot.quotaRoot("", Optional.empty())))
             .isEqualTo(new JsString(""));
@@ -70,8 +76,8 @@ class QuotaRootTest {
     @Test
     void emptyQuotaRootShouldBeWellDeSerialized() {
         assertThatThrownBy(() -> DTO_JSON_SERIALIZE.quotaRootReads().reads(new JsString("")).get())
-            .isInstanceOf(MailboxException.class)
-            .hasMessage(" used as QuotaRoot should contain exactly one \"&\"");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("username should not be null or empty after being trimmed");
     }
 
     @Test

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SieveDelivery.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SieveDelivery.java
@@ -88,4 +88,20 @@ class SieveDelivery {
             .select(TARGETED_MAILBOX)
             .awaitMessage(awaitAtMostOneMinute);
     }
+
+    @Test
+    void shouldDeliverToEmailAddressWithAND() throws Exception {
+        String recipient = "a&b@james.org";
+        jamesServer.getProbe(DataProbeImpl.class)
+            .addUser(recipient, PASSWORD);
+
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .authenticate(FROM, PASSWORD)
+            .sendMessage(FROM, recipient);
+
+        testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(recipient, PASSWORD)
+            .select("INBOX")
+            .awaitMessage(awaitAtMostOneMinute);
+    }
 }

--- a/server/mailet/ldap/pom.xml
+++ b/server/mailet/ldap/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>james-server</artifactId>
+        <version>3.9.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>james-server-mailet-ldap</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Apache James :: Server :: Matcher :: LDAP</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-data-ldap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-mailets</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/server/mailet/ldap/src/main/java/org/apache/james/transport/matchers/HasLDAPAttribute.java
+++ b/server/mailet/ldap/src/main/java/org/apache/james/transport/matchers/HasLDAPAttribute.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.matchers;
+
+import java.util.Collection;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+
+import jakarta.mail.MessagingException;
+
+public class HasLDAPAttribute extends GenericMatcher {
+    private final LdapRepositoryConfiguration configuration;
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) throws MessagingException {
+        return null;
+    }
+}


### PR DESCRIPTION
Reported by @samiulsami on gitter chat.

Delivery to this valid mail address and username failed due to quota root limitations that was not pushed to system edge.

We lift this limitation bu reworking the way
DefaultUserQuotaRootResolver is working.