### PR TITLE
[FIX] race condition avoided

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -96,7 +96,6 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
                         .action("AUTH")
                         .log("IMAP Authentication succeeded.");
                     okComplete(request, responder);
-                    responder.flush();
                     session.stopDetectingCommandInjection();
                 } catch (BadCredentialsException e) {
                     authFailure = true;
@@ -113,7 +112,6 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         } catch (MailboxException e) {
             LOGGER.error("Error encountered while login", e);
             no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
-            responder.flush();
         }
     }
 


### PR DESCRIPTION
With PLAIN auth, flushing before popping `ImapLineHandler` in `AuthenticateProcessor` will result sometimes in this `ImapLineHandler` to also consume the next IMAP command.

It can be reproduced with this simple demo:

```java
for (var i = 0; i < 10_000; i++) {
	Session.getInstance(getProperties()).getStore().connect("user", "password");
}
```

Without this patch, the problem occurs on average every 500 authentications in my environment.
With the patch, the demo loop completes every time.