### PR TITLE
JAMES-4023 Graceful shutdown: executor should be shutdown before eventloop

### DIFF
--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
@@ -285,9 +285,9 @@ public abstract class AbstractConfigurableAsyncServer
         LOGGER.info("Dispose {}", getServiceType());
         
         if (isEnabled()) {
+            executorGroup.shutdownGracefully();
             unbind();
             postDestroy();
-            executorGroup.shutdownGracefully();
 
             unregisterMBean();
         }


### PR DESCRIPTION
Otherwise, the client can not be aware of the actual result of the request because the eventloop can not return the actual result executed by the executor and the client may retry e.g. send 2 identical emails.

A test tries to fire SMTP requests during the shutdown:

```java
    @Test
    void test() throws Exception {
        // Connect 10000 SMTP clients before sending requests
        List<Pair<SMTPClient, Integer>> smtpClients = Flux.fromStream(IntStream.rangeClosed(1, 10000).boxed())
            .map(Throwing.function(counter -> {
                SMTPClient smtpClient = new SMTPClient();
                InetSocketAddress bindedAddress = testSystem.getBindedAddress();
                smtpClient.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
                smtpClient.sendCommand("EHLO whatever.tld");
                return Pair.of(smtpClient, counter);
            }))
            .collectList()
            .block();

        // Send concurrent requests during the SMTP server graceful shutdown process
        Flux.fromIterable(smtpClients)
            .flatMap(smtpClientAndCounter -> Mono.fromRunnable(() -> {
                try {
                    smtpClientAndCounter.getLeft().sendCommand("MAIL FROM: <bob@whatever.tld> HOLDFOR=" + smtpClientAndCounter.getRight());
                } catch (IOException e) {
                    System.out.println("Request " + smtpClientAndCounter.getRight() + " failed: " + e);
                }
            }), 200)
            .then()
            .doFinally(any -> System.out.println("Finished sending SMTP commands"))
            .subscribeOn(Schedulers.boundedElastic())
            .subscribe();

        // delay a bit before shutdown SMTP server
        Thread.sleep(500L);

        System.out.println("Start shutdown SMTP server at " + Instant.now());
        testSystem.smtpServer.destroy();
        System.out.println("Finish shutdown SMTP server at " + Instant.now());
    }
``` 

### Before
The executor finishes the SMTP request, but the event loop is shutdown, therefore, the client can not receive the response.
```
  executor-7 is processing FutureReleaseMailParameterHook for request 4056
  executor-8 is processing FutureReleaseMailParameterHook for request 4057
  Start shutdown SMTP server at 2024-06-25T09:11:55.498265354Z
  executor-9 is processing FutureReleaseMailParameterHook for request 4058
  executor-10 is processing FutureReleaseMailParameterHook for request 4059
  executor-11 is processing FutureReleaseMailParameterHook for request 4060
  executor-12 is processing FutureReleaseMailParameterHook for request 4061
  Finish shutdown SMTP server at 2024-06-25T09:11:55.512004744Z
  Request 4061 failed: org.apache.commons.net.smtp.SMTPConnectionClosedException: Connection closed without indication.
  Request 4062 failed: org.apache.commons.net.smtp.SMTPConnectionClosedException: Connection closed without indication.
```
  => The request 4061 was falsely rejected. The executor is processing request 4061, but eventloop was shutdown first, therefore the client can not receive the response.

### After
No request is falsely rejected.
```
  executor-8 is processing FutureReleaseMailParameterHook for request 4201
  executor-9 is processing FutureReleaseMailParameterHook for request 4202
  Start shutdown SMTP server at 2024-06-25T09:13:13.838375111Z
  executor-10 is processing FutureReleaseMailParameterHook for request 4203
  executor-11 is processing FutureReleaseMailParameterHook for request 4204
  Finish shutdown SMTP server at 2024-06-25T09:13:13.843710123Z
  Request 4205 failed: org.apache.commons.net.smtp.SMTPConnectionClosedException: Connection closed without indication.
  Request 4206 failed: org.apache.commons.net.smtp.SMTPConnectionClosedException: Connection closed without indication.
```

  => request 4204 is processed by the executor, and the eventloop returns the response to the client successfully.
     While from the request 4205, it was fully rejected and was not processed.