### PR TITLE
[Antora] Fix droplists item position in navigation menu on the left

### DIFF
--- a/docs/modules/servers/nav.adoc
+++ b/docs/modules/servers/nav.adoc
@@ -46,7 +46,7 @@
 ***** xref:distributed/configure/batchsizes.adoc[batchsizes.properties]
 ***** xref:distributed/configure/dns.adoc[dnsservice.xml]
 ***** xref:distributed/configure/domainlist.adoc[domainlist.xml]
-**** xref:distributed/configure/droplists.adoc[DropLists]
+***** xref:distributed/configure/droplists.adoc[DropLists]
 ***** xref:distributed/configure/healthcheck.adoc[healthcheck.properties]
 ***** xref:distributed/configure/mailetcontainer.adoc[mailetcontainer.xml]
 ***** xref:distributed/configure/mailets.adoc[Packaged Mailets]


### PR DESCRIPTION
Mistake I did when rebasing last time the migration work on antora distributed doc, sorry.

The menu item for droplists is creating a mess with the distributed doc menu in configure section. This should fix it :)