### PR TITLE
Fixup - add missing dependencies in apache-james-mpt-smtp-cassandra-rabbitmq-object-storage

### DIFF
--- a/mpt/impl/smtp/cassandra-rabbitmq-object-storage/pom.xml
+++ b/mpt/impl/smtp/cassandra-rabbitmq-object-storage/pom.xml
@@ -112,6 +112,13 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>queue-rabbitmq-guice</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Fix the 'NotFoundException' error when running the test.