### PR TITLE
[FIX] shouldAddSSLInformationInReceivedHeaders() test

### DIFF
--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPSTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPSTest.java
@@ -104,6 +104,6 @@ class SMTPSTest {
         Mail lastMail = testSystem.queue.getLastMail();
         ImmutableList.copyOf(lastMail.getMessage().getHeader("Received")).forEach(System.out::println);
         assertThat(lastMail.getMessage().getHeader("Received"))
-            .hasOnlyOneElementSatisfying(s -> s.contains("(using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384)"));
+            .hasOnlyOneElementSatisfying(s -> assertThat(s).contains("(using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384)"));
     }
 }


### PR DESCRIPTION
The consumer argument of the hasOnlyOneElementSatisfying method does not include any assertions, causing the test to pass regardless of the expected string.