### PR TITLE
[IMPROVEMENT] results handlers also called for pushed line handlers

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/BasicChannelInboundHandler.java
@@ -63,7 +63,7 @@ import io.netty.util.AttributeKey;
 /**
  * {@link ChannelInboundHandlerAdapter} which is used by the SMTPServer and other line based protocols
  */
-public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter implements LineHandlerAware {
+public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter implements LineHandlerAware<LineHandler<? extends ProtocolSession>, ProtocolSession> {
     private static final Logger LOGGER = LoggerFactory.getLogger(BasicChannelInboundHandler.class);
     public static final ProtocolSession.AttachmentKey<MDCBuilder> MDC_ATTRIBUTE_KEY = ProtocolSession.AttachmentKey.of("bound_MDC", MDCBuilder.class);
     public static final AttributeKey<CommandDetectionSession> SESSION_ATTRIBUTE_KEY =
@@ -301,8 +301,8 @@ public class BasicChannelInboundHandler extends ChannelInboundHandlerAdapter imp
     }
 
     @Override
-    public void pushLineHandler(ChannelInboundHandlerAdapter lineHandlerUpstreamHandler) {
-        behaviourOverrides.addFirst(lineHandlerUpstreamHandler);
+    public void pushLineHandler(LineHandler<? extends ProtocolSession> overrideCommandHandler, ProtocolSession session) {
+        behaviourOverrides.addFirst(new LineHandlerUpstreamHandler(session, overrideCommandHandler, resultHandlers));
     }
 
     @Override

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/LineHandlerAware.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/LineHandlerAware.java
@@ -19,10 +19,8 @@
 
 package org.apache.james.protocols.netty;
 
-import io.netty.channel.ChannelInboundHandlerAdapter;
-
-public interface LineHandlerAware {
-    void pushLineHandler(ChannelInboundHandlerAdapter lineHandlerUpstreamHandler);
+public interface LineHandlerAware<H, S> {
+    void pushLineHandler(H lineHandler, S session);
 
     void popLineHandler();
 }

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyProtocolTransport.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyProtocolTransport.java
@@ -152,11 +152,10 @@ public class NettyProtocolTransport extends AbstractProtocolTransport {
     }
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void pushLineHandler(LineHandler<? extends ProtocolSession> overrideCommandHandler, ProtocolSession session) {
         LineHandlerAware channelHandler = (LineHandlerAware) channel.pipeline()
             .get(HandlerConstants.CORE_HANDLER);
-        channelHandler.pushLineHandler(new LineHandlerUpstreamHandler(session, overrideCommandHandler));
+        channelHandler.pushLineHandler(overrideCommandHandler, session);
     }
     
    

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -41,6 +41,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.ImapSessionState;
+import org.apache.james.imap.api.process.ImapLineHandler;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.decode.DecodingException;
 import org.apache.james.imap.decode.ImapDecoder;
@@ -65,7 +66,7 @@ import reactor.core.scheduler.Schedulers;
 /**
  * {@link ByteToMessageDecoder} which will decode via and {@link ImapDecoder} instance
  */
-public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements NettyConstants, LineHandlerAware {
+public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements NettyConstants, LineHandlerAware<ImapLineHandler, ImapSession> {
     @VisibleForTesting
     static final String NEEDED_DATA = "NEEDED_DATA";
     private static final boolean RETRY = true;
@@ -444,8 +445,8 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
     }
 
     @Override
-    public void pushLineHandler(ChannelInboundHandlerAdapter lineHandlerUpstreamHandler) {
-        behaviourOverrides.addFirst(lineHandlerUpstreamHandler);
+    public void pushLineHandler(ImapLineHandler lineHandler, ImapSession session) {
+        behaviourOverrides.addFirst(new ImapLineHandlerAdapter(session, lineHandler));
     }
 
     @Override

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/NettyImapSession.java
@@ -263,7 +263,7 @@ public class NettyImapSession implements ImapSession, NettyConstants {
     @Override
     public void pushLineHandler(ImapLineHandler lineHandler) {
         LineHandlerAware handler = (LineHandlerAware) channel.pipeline().get(REQUEST_DECODER);
-        handler.pushLineHandler(new ImapLineHandlerAdapter(this, lineHandler));
+        handler.pushLineHandler(lineHandler, this);
     }
 
     @Override

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/jmx/AbstractLineHandlerResultJMXMonitor.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/jmx/AbstractLineHandlerResultJMXMonitor.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
@@ -46,7 +47,7 @@ public abstract class AbstractLineHandlerResultJMXMonitor<R extends Response, S 
     @Override
     public Response onResponse(ProtocolSession session, Response response, long executionTime, ProtocolHandler handler) {
         if (handler instanceof LineHandler) {
-            lStats.get(handler.getClass().getName()).increment(response);
+            Optional.ofNullable(lStats.get(handler.getClass().getName())).ifPresent(handlerClassName -> handlerClassName.increment(response));
         }
         return response;
     }


### PR DESCRIPTION
Some responses don't currently pass through `ProtocolHandlerResultHandler`, for instance the response to the base64 encoded identifiers after the SMTP `AUTH PLAIN` command (i.e. 235 or 535), because these responses are issued by a dynamically pushed LineHandler, so this MR adds a call to the result handlers in this case.