### PR TITLE
[FIX] HookResultHook added to marker interfaces of AuthCmdHandler

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
@@ -521,8 +521,9 @@ public class AuthCmdHandler
 
     @Override
     public List<Class<?>> getMarkerInterfaces() {
-        List<Class<?>> classes = new ArrayList<>(1);
+        List<Class<?>> classes = new ArrayList<>(2);
         classes.add(AuthHook.class);
+        classes.add(HookResultHook.class);
         return classes;
     }
 


### PR DESCRIPTION
`AuthCmdHandler` supports `HookResultHook` in `wireExtensions` and with its `rHooks` field but not in `getMarkerInterfaces` so `rHooks` will always be empty; this PR fixes this to be able to get `AuthHook` results in `HookResultHook` (e.g. getting `UsersRepositoryAuthHook` result).