### PR TITLE
MailAddress should not contain backslash + comma character

### DIFF
--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  * <p/>
  * <p>This parses an address as per the BNF specification for <mailbox>
  * from RFC 821 on page 30 and 31, section 4.1.2. COMMAND SYNTAX.
- * http://www.freesoft.org/CIE/RFC/821/15.htm</p>
+ * <a href="http://www.freesoft.org/CIE/RFC/821/15.htm">...</a></p>
  *
  * @version 1.0
  */
@@ -239,6 +239,7 @@ public class MailAddress implements java.io.Serializable {
             throw new AddressException("Addresses cannot start end with '.' or contain two consecutive dots");
         }
 
+        // not handle by jakarta.mail
         if (haveBackSlashComma(localPart)) {
             throw new AddressException("Addresses cannot contain \\,");
         }

--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -239,11 +239,19 @@ public class MailAddress implements java.io.Serializable {
             throw new AddressException("Addresses cannot start end with '.' or contain two consecutive dots");
         }
 
+        if (haveBackSlashComma(localPart)) {
+            throw new AddressException("Addresses cannot contain \\,");
+        }
+
         domain = createDomain(domainSB.toString());
     }
 
     private boolean haveDoubleDot(String localPart) {
         return localPart.contains("..");
+    }
+
+    private boolean haveBackSlashComma(String localPart) {
+        return localPart.contains("\\,");
     }
 
     private Domain createDomain(String domain) throws AddressException {

--- a/core/src/test/java/org/apache/james/core/MailAddressTest.java
+++ b/core/src/test/java/org/apache/james/core/MailAddressTest.java
@@ -104,7 +104,8 @@ class MailAddressTest {
                 "我買@屋企.香港",
                 "二ノ宮@黒川.日本",
                 "медведь@с-балалайкой.рф",
-                "संपर्क@डाटामेल.भारत")
+                "संपर्क@डाटामेल.भारत",
+                "mail.allow\\,d@james.apache.org")
             .map(Arguments::of);
     }
 


### PR DESCRIPTION
In order to fix error
javax.mail.internet.AddressException: Domain contains illegal character

```
javax.mail.internet.AddressException: Domain contains illegal character
	at javax.mail.internet.InternetAddress.checkAddress(InternetAddress.java:1432)
	at javax.mail.internet.InternetAddress.parse(InternetAddress.java:1215)
	at javax.mail.internet.InternetAddress.parse(InternetAddress.java:752)
	at javax.mail.internet.InternetAddress.parse(InternetAddress.java:729)
	at javax.mail.internet.MimeMessage.setRecipients(MimeMessage.java:666)
	at org.apache.james.jmap.method.MDNSendMethod.buildMailAndMimeMessage(MDNSendMethod.scala:197)
	at org.apache.james.jmap.method.MDNSendMethod.$anonfun$buildMailAndResponse$2(MDNSendMethod.scala:189)
	at scala.util.Either.map(Either.scala:382)
	at org.apache.james.jmap.method.MDNSendMethod.$anonfun$buildMailAndResponse$1(MDNSendMethod.scala:185)
	at scala.util.Either.flatMap(Either.scala:352)
	at org.apache.james.jmap.method.MDNSendMethod.buildMailAndResponse(MDNSendMethod.scala:184)
	at org.apache.james.jmap.method.MDNSendMethod.$anonfun$sendMDN$3(MDNSendMethod.scala:152)
	at scala.util.Either.flatMap(Either.scala:352)
	at org.apache.james.jmap.method.MDNSendMethod.$anonfun$sendMDN$1(MDNSendMethod.scala:150)
	at scala.util.Either.flatMap(Either.scala:352)
	at org.apache.james.jmap.method.MDNSendMethod.sendMDN(MDNSendMethod.scala:149)
	at org.apache.james.jmap.method.MDNSendMethod.$anonfun$createMDNSend$1(MDNSendMethod.scala:133)
	at scala.util.Either.flatMap(Either.scala:352)
	at org.apache.james.jmap.method.MDNSendMethod.createMDNSend(MDNSendMethod.scala:133)
	at org.apache.james.jmap.method.MDNSendMethod.$anonfun$create$1(MDNSendMethod.scala:121)
	at reactor.core.scala.publisher.package$.$anonfun$scalaBiFunction2JavaBiFunction$1(package.scala:69)
	at reactor.core.publisher.MonoReduceSeed$ReduceSeedSubscriber.onNext(MonoReduceSeed.java:116)
	at reactor.core.publisher.FluxIterable$IterableSubscription.fastPath(FluxIterable.java:402)
	at reactor.core.publisher.FluxIterable$IterableSubscription.request(FluxIterable.java:291)
	at reactor.core.publisher.Operators$BaseFluxToMonoOperator.request(Operators.java:2067)
	at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.trySchedule(MonoSubscribeOn.java:189)
	at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.onSubscribe(MonoSubscribeOn.java:134)
	at reactor.core.publisher.Operators$BaseFluxToMonoOperator.onSubscribe(Operators.java:2051)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:201)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:83)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4512)
	at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:126)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```