### PR TITLE
[ENHANCEMENT] Remove benign verbose logs upon shutdown

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -693,7 +693,11 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
             })
             .destroyHandler(channel -> Mono.fromRunnable(Throwing.runnable(() -> {
                 if (channel.isOpen()) {
-                    channel.close();
+                    try {
+                        channel.close();
+                    } catch (ShutdownSignalException e) {
+                        // silent this error
+                    }
                 }
             }))
             .then()

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -818,9 +818,9 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
     @Override
     public void close() {
         sender.close();
-       Flux.fromIterable(refs.values())
-           .flatMap(PooledRef::invalidate)
-           .blockLast();
+        Flux.fromIterable(refs.values())
+            .flatMap(PooledRef::invalidate)
+            .blockLast();
         refs.clear();
         newPool.dispose();
     }


### PR DESCRIPTION
```
reactor.core.Exceptions$ErrorCallbackNotImplemented: com.rabbitmq.client.ShutdownSignalException: clean connection shutdown; protocol method: #method<connection.close>(reply-code=200, reply-text=OK, class-id=0, method-id=0)
Caused by: com.rabbitmq.client.ShutdownSignalException: clean connection shutdown; protocol method: #method<connection.close>(reply-code=200, reply-text=OK, class-id=0, method-id=0)
	at com.rabbitmq.utility.ValueOrException.getValue(ValueOrException.java:66)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.MonoRunnable] :
	reactor.core.publisher.Mono.fromRunnable(Mono.java:702)
	org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool.lambda$new$2(ReactorRabbitMQChannelPool.java:694)
Error has been observed at the following site(s):
	*__Mono.fromRunnable ⇢ at org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool.lambda$new$2(ReactorRabbitMQChannelPool.java:694)
	|_         Mono.then ⇢ at org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool.lambda$new$2(ReactorRabbitMQChannelPool.java:699)
	|_  Mono.subscribeOn ⇢ at org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool.lambda$new$2(ReactorRabbitMQChannelPool.java:700)
	|_    Mono.doFinally ⇢ at reactor.pool.AbstractPool.destroyPoolable(AbstractPool.java:181)
	*___________Mono.and ⇢ at reactor.pool.SimpleDequePool.lambda$disposeLater$2(SimpleDequePool.java:208)
	*_________Mono.defer ⇢ at reactor.pool.SimpleDequePool.disposeLater(SimpleDequePool.java:179)
Original Stack Trace:
		at com.rabbitmq.utility.ValueOrException.getValue(ValueOrException.java:66)
		at com.rabbitmq.utility.BlockingValueOrException.uninterruptibleGetValue(BlockingValueOrException.java:36)
		at com.rabbitmq.client.impl.AMQChannel$BlockingRpcContinuation.getReply(AMQChannel.java:552)
		at com.rabbitmq.client.impl.ChannelN.close(ChannelN.java:635)
		at com.rabbitmq.client.impl.ChannelN.close(ChannelN.java:557)
		at com.rabbitmq.client.impl.ChannelN.close(ChannelN.java:550)
		at com.rabbitmq.client.impl.recovery.AutorecoveringChannel.lambda$close$0(AutorecoveringChannel.java:74)
		at com.rabbitmq.client.impl.recovery.AutorecoveringChannel.executeAndClean(AutorecoveringChannel.java:102)
		at com.rabbitmq.client.impl.recovery.AutorecoveringChannel.close(AutorecoveringChannel.java:74)
		at org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool$SelectOnceChannel.close(ReactorRabbitMQChannelPool.java:109)
		at org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool.lambda$new$1(ReactorRabbitMQChannelPool.java:696)
		at com.github.fge.lambdas.runnable.RunnableChainer.doRun(RunnableChainer.java:18)
		at com.github.fge.lambdas.runnable.ThrowingRunnable.run(ThrowingRunnable.java:16)
		at reactor.core.publisher.MonoRunnable.subscribe(MonoRunnable.java:49)
		at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
		at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:126)
		at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
		at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
		at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
		at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
		at java.base/java.lang.Thread.run(Unknown Source)
```