### PR TITLE
JAMES-3763 Refactor blobstore api to fix BlobMailRepository

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -134,7 +134,7 @@ public class CassandraAttachmentDAOV2 {
         return new DAOAttachment(
             messageId,
             StringBackedAttachmentId.from(row.getString(ID)),
-            blobIfFactory.from(row.getString(BLOB_ID)),
+            blobIfFactory.parse(row.getString(BLOB_ID)),
             ContentType.of(row.getString(TYPE)),
             row.getLong(SIZE));
     }
@@ -217,6 +217,6 @@ public class CassandraAttachmentDAOV2 {
 
     public Flux<BlobId> listBlobs() {
         return cassandraAsyncExecutor.executeRows(listBlobs.bind())
-            .map(row -> blobIdFactory.from(row.getString(BLOB_ID)));
+            .map(row -> blobIdFactory.parse(row.getString(BLOB_ID)));
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
@@ -417,13 +417,13 @@ public class CassandraMessageDAOV3 {
     }
 
     private BlobId retrieveBlobId(CqlIdentifier field, Row row) {
-        return blobIdFactory.from(row.get(field, TypeCodecs.TEXT));
+        return blobIdFactory.parse(row.get(field, TypeCodecs.TEXT));
     }
 
     Flux<BlobId> listBlobs() {
         return cassandraAsyncExecutor.executeRows(listBlobs.bind())
             .flatMapIterable(row -> ImmutableList.of(
-                blobIdFactory.from(row.get(HEADER_CONTENT, TypeCodecs.TEXT)),
-                blobIdFactory.from(row.get(BODY_CONTENT, TypeCodecs.TEXT))));
+                blobIdFactory.parse(row.get(HEADER_CONTENT, TypeCodecs.TEXT)),
+                blobIdFactory.parse(row.get(BODY_CONTENT, TypeCodecs.TEXT))));
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -581,7 +581,7 @@ public class CassandraMessageIdDAO {
                 .map(Date::from))
             .size(row.get(FULL_CONTENT_OCTETS, Long.class))
             .headerContent(Optional.ofNullable(row.get(HEADER_CONTENT, TypeCodecs.TEXT))
-                .map(blobIdFactory::from))
+                .map(blobIdFactory::parse))
             .build());
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
@@ -408,7 +408,7 @@ public class CassandraMessageIdToImapUidDAO {
                 .map(Date::from))
             .size(row.get(FULL_CONTENT_OCTETS, Long.class))
             .headerContent(Optional.ofNullable(row.getString(HEADER_CONTENT))
-                .map(blobIdFactory::from))
+                .map(blobIdFactory::parse))
             .build();
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -41,7 +41,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.StatementRecorder;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.BlobTables;
 import org.apache.james.core.Username;
 import org.apache.james.events.EventBus;
@@ -812,18 +812,18 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
         private CassandraAttachmentDAOV2 attachmentDAO(CassandraCluster cassandraCluster) {
             return new CassandraAttachmentDAOV2(
-                new HashBlobId.Factory(),
+                new PlainBlobId.Factory(),
                 cassandraCluster.getConf());
         }
 
         private CassandraMessageIdDAO messageIdDAO(CassandraCluster cassandraCluster) {
-            return new CassandraMessageIdDAO(cassandraCluster.getConf(), new HashBlobId.Factory());
+            return new CassandraMessageIdDAO(cassandraCluster.getConf(), new PlainBlobId.Factory());
         }
 
         private CassandraMessageIdToImapUidDAO imapUidDAO(CassandraCluster cassandraCluster) {
             return new CassandraMessageIdToImapUidDAO(
                 cassandraCluster.getConf(),
-                new HashBlobId.Factory(),
+                new PlainBlobId.Factory(),
                 CassandraConfiguration.DEFAULT_CONFIGURATION);
         }
 
@@ -832,7 +832,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 cassandraCluster.getConf(),
                 cassandraCluster.getTypesProvider(),
                 mock(BlobStore.class),
-                new HashBlobId.Factory());
+                new PlainBlobId.Factory());
         }
 
         private CassandraThreadDAO threadDAO(CassandraCluster cassandraCluster) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
@@ -79,7 +79,7 @@ class CassandraAttachmentDAOV2Test {
             .type("application/json")
             .size(4)
             .build();
-        BlobId blobId = BLOB_ID_FACTORY.from("blobId");
+        BlobId blobId = BLOB_ID_FACTORY.parse("blobId");
         DAOAttachment daoAttachment = CassandraAttachmentDAOV2.from(attachment, blobId);
         testee.storeAttachment(daoAttachment).block();
 
@@ -96,7 +96,7 @@ class CassandraAttachmentDAOV2Test {
             .type("application/json")
             .size(36)
             .build();
-        BlobId blobId = BLOB_ID_FACTORY.from("blobId");
+        BlobId blobId = BLOB_ID_FACTORY.parse("blobId");
         DAOAttachment daoAttachment = CassandraAttachmentDAOV2.from(attachment, blobId);
         testee.storeAttachment(daoAttachment).block();
 
@@ -121,7 +121,7 @@ class CassandraAttachmentDAOV2Test {
             .messageId(CassandraMessageId.Factory.of(Uuids.timeBased()))
             .size(36)
             .build();
-        BlobId blobId1 = BLOB_ID_FACTORY.from("blobId");
+        BlobId blobId1 = BLOB_ID_FACTORY.parse("blobId");
         DAOAttachment daoAttachment1 = CassandraAttachmentDAOV2.from(attachment1, blobId1);
         testee.storeAttachment(daoAttachment1).block();
 
@@ -131,7 +131,7 @@ class CassandraAttachmentDAOV2Test {
             .messageId(CassandraMessageId.Factory.of(Uuids.timeBased()))
             .size(36)
             .build();
-        BlobId blobId2 = BLOB_ID_FACTORY.from("blobId");
+        BlobId blobId2 = BLOB_ID_FACTORY.parse("blobId");
         DAOAttachment daoAttachment2 = CassandraAttachmentDAOV2.from(attachment2, blobId2);
         testee.storeAttachment(daoAttachment2).block();
 
@@ -147,7 +147,7 @@ class CassandraAttachmentDAOV2Test {
             .messageId(CassandraMessageId.Factory.of(Uuids.timeBased()))
             .size(36)
             .build();
-        BlobId blobId = BLOB_ID_FACTORY.from("blobId");
+        BlobId blobId = BLOB_ID_FACTORY.parse("blobId");
         DAOAttachment daoAttachment1 = CassandraAttachmentDAOV2.from(attachment1, blobId);
         testee.storeAttachment(daoAttachment1).block();
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.blob.api.BlobId;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2.DAOAttachment;
 import org.apache.james.mailbox.cassandra.modules.CassandraAttachmentModule;
@@ -42,7 +42,7 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 class CassandraAttachmentDAOV2Test {
     private static final StringBackedAttachmentId ATTACHMENT_ID = StringBackedAttachmentId.from("id1");
     private static final StringBackedAttachmentId ATTACHMENT_ID_2 = StringBackedAttachmentId.from("id2");
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
 
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraAttachmentModule.MODULE);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3Test.java
@@ -35,7 +35,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
 import org.apache.james.mailbox.MessageUid;
@@ -96,7 +96,7 @@ class CassandraMessageDAOV3Test {
         threadId = ThreadId.fromBaseMessageId(messageId);
         BlobStore blobStore = CassandraBlobStoreFactory.forTesting(cassandra.getConf(), new RecordingMetricFactory())
             .passthrough();
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         testee = new CassandraMessageDAOV3(
             cassandra.getConf(),
             cassandra.getTypesProvider(),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
@@ -30,7 +30,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import reactor.core.publisher.Flux;
 
 class CassandraMessageIdDAOTest {
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
+    private static final PlainBlobId HEADER_BLOB_ID_1 = new PlainBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);
@@ -64,7 +64,7 @@ class CassandraMessageIdDAOTest {
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
         messageIdFactory = new CassandraMessageId.Factory();
-        testee = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+        testee = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import reactor.core.publisher.Flux;
 
 class CassandraMessageIdDAOTest {
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -31,7 +31,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.StatementRecorder;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.core.Username;
 import org.apache.james.junit.categories.Unstable;
 import org.apache.james.mailbox.MailboxSession;
@@ -159,7 +159,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.METADATA))
                     .isEmpty();
@@ -183,7 +183,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.METADATA))
                     .isEmpty();
@@ -207,7 +207,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.METADATA))
                     .isEmpty();
@@ -231,7 +231,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.METADATA))
                     .isEmpty();
@@ -257,7 +257,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
 
             CassandraMessageIdToImapUidDAO imapUidDAO = new CassandraMessageIdToImapUidDAO(
                 cassandra.getConf(),
-                new HashBlobId.Factory(),
+                new PlainBlobId.Factory(),
                 CassandraConfiguration.DEFAULT_CONFIGURATION);
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAOTest.java
@@ -31,7 +31,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
@@ -51,7 +51,7 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import reactor.core.publisher.Flux;
 
 class CassandraMessageIdToImapUidDAOTest {
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
+    private static final PlainBlobId HEADER_BLOB_ID_1 = new PlainBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraSchemaVersionModule.MODULE,
         CassandraMessageModule.MODULE);
@@ -66,7 +66,7 @@ class CassandraMessageIdToImapUidDAOTest {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
         testee = new CassandraMessageIdToImapUidDAO(
             cassandra.getConf(),
-            new HashBlobId.Factory(),
+            new PlainBlobId.Factory(),
             CassandraConfiguration.DEFAULT_CONFIGURATION);
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAOTest.java
@@ -51,7 +51,7 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import reactor.core.publisher.Flux;
 
 class CassandraMessageIdToImapUidDAOTest {
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraSchemaVersionModule.MODULE,
         CassandraMessageModule.MODULE);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -38,7 +38,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.StatementRecorder;
 import org.apache.james.backends.cassandra.StatementRecorder.Selector;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.junit.categories.Unstable;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
@@ -248,7 +248,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.METADATA, 1))
                     .toIterable()
@@ -271,7 +271,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.METADATA, 1))
                     .toIterable()
@@ -294,7 +294,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.METADATA, 1))
                     .toIterable()
@@ -317,7 +317,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 // ignoring expected error
             }
 
-            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+            CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.METADATA, 1))
                     .toIterable()
@@ -342,7 +342,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
 
             CassandraMessageIdToImapUidDAO imapUidDAO = new CassandraMessageIdToImapUidDAO(
                 cassandra.getConf(),
-                new HashBlobId.Factory(),
+                new PlainBlobId.Factory(),
                 CassandraConfiguration.DEFAULT_CONFIGURATION);
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
@@ -27,7 +27,7 @@ import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
 import org.apache.james.eventsourcing.Event;
 import org.apache.james.eventsourcing.eventstore.EventNestedTypes;
@@ -87,7 +87,7 @@ public class GuiceUtils {
             binder -> binder.bind(UidProvider.class).to(CassandraUidProvider.class),
             binder -> binder.bind(ModSeqProvider.class).to(CassandraModSeqProvider.class),
             binder -> binder.bind(ACLMapper.class).to(CassandraACLMapper.class),
-            binder -> binder.bind(BlobId.Factory.class).toInstance(new HashBlobId.Factory()),
+            binder -> binder.bind(BlobId.Factory.class).toInstance(new PlainBlobId.Factory()),
             binder -> binder.bind(BlobStore.class).toProvider(() -> CassandraBlobStoreFactory.forTesting(session, new RecordingMetricFactory()).passthrough()),
             binder -> binder.bind(CqlSession.class).toInstance(session),
             binder -> Multibinder.newSetBinder(binder, new TypeLiteral<EventDTOModule<? extends Event, ? extends EventDTO>>() {})

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/AllSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/AllSearchOverrideTest.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class AllSearchOverrideTest {
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
     private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/AllSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/AllSearchOverrideTest.java
@@ -31,7 +31,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class AllSearchOverrideTest {
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
     private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
+    private static final PlainBlobId HEADER_BLOB_ID_1 = new PlainBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);
@@ -69,7 +69,7 @@ class AllSearchOverrideTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        dao = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+        dao = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
         testee = new AllSearchOverride(dao);
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverrideTest.java
@@ -32,7 +32,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class NotDeletedWithRangeSearchOverrideTest {
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
     private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
+    private static final PlainBlobId HEADER_BLOB_ID_1 = new PlainBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);
@@ -71,7 +71,7 @@ class NotDeletedWithRangeSearchOverrideTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        dao = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+        dao = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
         testee = new NotDeletedWithRangeSearchOverride(dao);
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/NotDeletedWithRangeSearchOverrideTest.java
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class NotDeletedWithRangeSearchOverrideTest {
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
     private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UidSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UidSearchOverrideTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class UidSearchOverrideTest {
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
     private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UidSearchOverrideTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/search/UidSearchOverrideTest.java
@@ -31,7 +31,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class UidSearchOverrideTest {
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
     private static final Mailbox MAILBOX = new Mailbox(MailboxPath.inbox(MAILBOX_SESSION), UidValidity.of(12), CassandraId.timeBased());
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
+    private static final PlainBlobId HEADER_BLOB_ID_1 = new PlainBlobId.Factory().of("abc");
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
         CassandraMessageModule.MODULE,
         CassandraSchemaVersionModule.MODULE);
@@ -70,7 +70,7 @@ class UidSearchOverrideTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        dao = new CassandraMessageIdDAO(cassandra.getConf(), new HashBlobId.Factory());
+        dao = new CassandraMessageIdDAO(cassandra.getConf(), new PlainBlobId.Factory());
         testee = new UidSearchOverride(dao);
     }
 

--- a/mailbox/plugin/deleted-messages-vault-cassandra/src/main/java/org/apache/james/vault/metadata/StorageInformationDAO.java
+++ b/mailbox/plugin/deleted-messages-vault-cassandra/src/main/java/org/apache/james/vault/metadata/StorageInformationDAO.java
@@ -102,6 +102,6 @@ public class StorageInformationDAO {
             .setString(MESSAGE_ID, messageId.serialize()))
             .map(row -> StorageInformation.builder()
                     .bucketName(BucketName.of(row.getString(BUCKET_NAME)))
-                    .blobId(blobIdFactory.from(row.getString(BLOB_ID))));
+                    .blobId(blobIdFactory.parse(row.getString(BLOB_ID))));
     }
 }

--- a/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/CassandraDeletedMessageMetadataVaultTest.java
+++ b/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/CassandraDeletedMessageMetadataVaultTest.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.vault.dto.DeletedMessageWithStorageInformationConverter;
@@ -56,7 +56,7 @@ public class CassandraDeletedMessageMetadataVaultTest implements DeletedMessageM
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
         DeletedMessageWithStorageInformationConverter dtoConverter = new DeletedMessageWithStorageInformationConverter(blobIdFactory, messageIdFactory, new InMemoryId.Factory());
 

--- a/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/MetadataDAOTest.java
+++ b/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/MetadataDAOTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.model.MessageId;
@@ -49,7 +49,7 @@ class MetadataDAOTest {
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
         DeletedMessageWithStorageInformationConverter dtoConverter = new DeletedMessageWithStorageInformationConverter(
-            new HashBlobId.Factory(), new InMemoryMessageId.Factory(), new InMemoryId.Factory());
+            new PlainBlobId.Factory(), new InMemoryMessageId.Factory(), new InMemoryId.Factory());
 
         testee = new MetadataDAO(cassandra.getConf(), new InMemoryMessageId.Factory(),
             new MetadataSerializer(dtoConverter));

--- a/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/StorageInformationDAOTest.java
+++ b/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/StorageInformationDAOTest.java
@@ -42,8 +42,8 @@ class StorageInformationDAOTest {
     private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
     private static final Username OWNER = Username.of("owner");
     private static final TestMessageId MESSAGE_ID = TestMessageId.of(36);
-    private static final BlobId BLOB_ID = new HashBlobId.Factory().from("05dcb33b-8382-4744-923a-bc593ad84d23");
-    private static final BlobId BLOB_ID_2 = new HashBlobId.Factory().from("05dcb33b-8382-4744-923a-bc593ad84d24");
+    private static final BlobId BLOB_ID = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
+    private static final BlobId BLOB_ID_2 = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
     private static final StorageInformation STORAGE_INFORMATION = StorageInformation.builder().bucketName(BUCKET_NAME).blobId(BLOB_ID);
     private static final StorageInformation STORAGE_INFORMATION_2 = StorageInformation.builder().bucketName(BUCKET_NAME_2).blobId(BLOB_ID_2);
 

--- a/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/StorageInformationDAOTest.java
+++ b/mailbox/plugin/deleted-messages-vault-cassandra/src/test/java/org/apache/james/vault/metadata/StorageInformationDAOTest.java
@@ -29,7 +29,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.model.TestMessageId;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,11 +39,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class StorageInformationDAOTest {
     private static final BucketName BUCKET_NAME = BucketName.of("deletedMessages-2019-06-01");
     private static final BucketName BUCKET_NAME_2 = BucketName.of("deletedMessages-2019-07-01");
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private static final Username OWNER = Username.of("owner");
     private static final TestMessageId MESSAGE_ID = TestMessageId.of(36);
-    private static final BlobId BLOB_ID = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
-    private static final BlobId BLOB_ID_2 = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
+    private static final BlobId BLOB_ID = new PlainBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
+    private static final BlobId BLOB_ID_2 = new PlainBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
     private static final StorageInformation STORAGE_INFORMATION = StorageInformation.builder().bucketName(BUCKET_NAME).blobId(BLOB_ID);
     private static final StorageInformation STORAGE_INFORMATION_2 = StorageInformation.builder().bucketName(BUCKET_NAME_2).blobId(BLOB_ID_2);
 

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationConverter.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationConverter.java
@@ -56,7 +56,7 @@ public class DeletedMessageWithStorageInformationConverter {
     public StorageInformation toDomainObject(DeletedMessageWithStorageInformationDTO.StorageInformationDTO storageInformationDTO) {
         return StorageInformation.builder()
             .bucketName(BucketName.of(storageInformationDTO.getBucketName()))
-            .blobId(blobFactory.from(storageInformationDTO.getBlobId()));
+            .blobId(blobFactory.parse(storageInformationDTO.getBlobId()));
     }
 
     public DeletedMessage toDomainObject(DeletedMessageWithStorageInformationDTO.DeletedMessageDTO deletedMessageDTO) throws AddressException {

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
@@ -31,7 +31,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
@@ -118,7 +118,7 @@ class DeletedMessageVaultHookTest {
         messageVault = new BlobStoreDeletedMessageVault(new RecordingMetricFactory(), new MemoryDeletedMessageMetadataVault(),
             BlobStoreFactory.builder()
                 .blobStoreDAO(blobStoreDAO)
-                .blobIdFactory(new HashBlobId.Factory())
+                .blobIdFactory(new PlainBlobId.Factory())
                 .defaultBucketName()
                 .passthrough(), blobStoreDAO, new BucketNameGenerator(clock), clock,
             VaultConfiguration.ENABLED_DEFAULT);

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
@@ -39,7 +39,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
@@ -68,7 +68,7 @@ class BlobStoreDeletedMessageVaultTest implements DeletedMessageVaultContract, D
         messageVault = new BlobStoreDeletedMessageVault(metricFactory, new MemoryDeletedMessageMetadataVault(),
             BlobStoreFactory.builder()
                 .blobStoreDAO(blobStoreDAO)
-                .blobIdFactory(new HashBlobId.Factory())
+                .blobIdFactory(new PlainBlobId.Factory())
                 .defaultBucketName()
                 .passthrough(),
             blobStoreDAO, new BucketNameGenerator(clock), clock, VaultConfiguration.ENABLED_DEFAULT);

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationDTOTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/dto/DeletedMessageWithStorageInformationDTOTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.mail.internet.AddressException;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailbox.inmemory.InMemoryId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.vault.metadata.DeletedMessageWithStorageInformation;
@@ -73,7 +73,7 @@ class DeletedMessageWithStorageInformationDTOTest {
             .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
 
         this.converter = new DeletedMessageWithStorageInformationConverter(
-            new HashBlobId.Factory(),
+            new PlainBlobId.Factory(),
             new InMemoryMessageId.Factory(),
             new InMemoryId.Factory());
     }

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/metadata/DeletedMessageVaultMetadataFixture.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/metadata/DeletedMessageVaultMetadataFixture.java
@@ -21,12 +21,12 @@ package org.apache.james.vault.metadata;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.vault.DeletedMessageFixture;
 
 public interface DeletedMessageVaultMetadataFixture {
-    BlobId BLOB_ID = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
-    BlobId BLOB_ID_2 = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
+    BlobId BLOB_ID = new PlainBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
+    BlobId BLOB_ID_2 = new PlainBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
     BucketName BUCKET_NAME = BucketName.of("bucket-2019-06-01");
     BucketName OTHER_BUCKET_NAME = BucketName.of("other");
 

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/metadata/DeletedMessageVaultMetadataFixture.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/metadata/DeletedMessageVaultMetadataFixture.java
@@ -25,8 +25,8 @@ import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.vault.DeletedMessageFixture;
 
 public interface DeletedMessageVaultMetadataFixture {
-    BlobId BLOB_ID = new HashBlobId.Factory().from("05dcb33b-8382-4744-923a-bc593ad84d23");
-    BlobId BLOB_ID_2 = new HashBlobId.Factory().from("05dcb33b-8382-4744-923a-bc593ad84d24");
+    BlobId BLOB_ID = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
+    BlobId BLOB_ID_2 = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
     BucketName BUCKET_NAME = BucketName.of("bucket-2019-06-01");
     BucketName OTHER_BUCKET_NAME = BucketName.of("other");
 

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobId.java
@@ -26,6 +26,8 @@ import com.google.common.io.ByteSource;
 public interface BlobId {
 
     interface Factory {
+        BlobId of(String id);
+
         BlobId forPayload(byte[] payload);
 
         BlobId forPayload(ByteSource payload);

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobId.java
@@ -19,24 +19,13 @@
 
 package org.apache.james.blob.api;
 
-import java.util.UUID;
-
-import com.google.common.io.ByteSource;
-
 public interface BlobId {
 
     interface Factory {
         BlobId of(String id);
 
-        BlobId forPayload(byte[] payload);
-
-        BlobId forPayload(ByteSource payload);
-
+        //FIXME (in later commit) - rename to parse or parseFrom this should only be used for deserialization
         BlobId from(String id);
-
-        default BlobId randomId() {
-            return from(UUID.randomUUID().toString());
-        }
     }
 
     String asString();

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobId.java
@@ -24,8 +24,7 @@ public interface BlobId {
     interface Factory {
         BlobId of(String id);
 
-        //FIXME (in later commit) - rename to parse or parseFrom this should only be used for deserialization
-        BlobId from(String id);
+        BlobId parse(String id);
     }
 
     String asString();

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
@@ -25,6 +25,8 @@ import org.reactivestreams.Publisher;
 
 import com.google.common.io.ByteSource;
 
+import reactor.util.function.Tuple2;
+
 public interface BlobStore {
     String DEFAULT_BUCKET_NAME_QUALIFIER = "defaultBucket";
 
@@ -34,11 +36,22 @@ public interface BlobStore {
         HIGH_PERFORMANCE
     }
 
+    @FunctionalInterface
+    interface BlobIdProvider {
+        Publisher<Tuple2<BlobId, InputStream>> apply(InputStream stream);
+    }
+
     Publisher<BlobId> save(BucketName bucketName, byte[] data, StoragePolicy storagePolicy);
 
     Publisher<BlobId> save(BucketName bucketName, InputStream data, StoragePolicy storagePolicy);
 
     Publisher<BlobId> save(BucketName bucketName, ByteSource data, StoragePolicy storagePolicy);
+
+    Publisher<BlobId> save(BucketName bucketName, byte[] data, BlobIdProvider blobIdProvider, StoragePolicy storagePolicy);
+
+    Publisher<BlobId> save(BucketName bucketName, InputStream data, BlobIdProvider blobIdProvider, StoragePolicy storagePolicy);
+
+    Publisher<BlobId> save(BucketName bucketName, ByteSource data, BlobIdProvider blobIdProvider, StoragePolicy storagePolicy);
 
     default Publisher<BlobId> save(BucketName bucketName, String data, StoragePolicy storagePolicy) {
         return save(bucketName, data.getBytes(StandardCharsets.UTF_8), storagePolicy);

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/HashBlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/HashBlobId.java
@@ -66,9 +66,14 @@ public class HashBlobId implements BlobId {
         }
 
         @Override
-        public HashBlobId from(String id) {
+        public HashBlobId of(String id) {
             Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
             return new HashBlobId(id);
+        }
+
+        @Override
+        public HashBlobId from(String id) {
+            return of(id);
         }
 
         private static BaseEncoding baseEncodingFrom(String encodingType) {

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/HashBlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/HashBlobId.java
@@ -19,51 +19,15 @@
 
 package org.apache.james.blob.api;
 
-import java.io.IOException;
-import java.util.Optional;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.hash.HashCode;
-import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
-import com.google.common.io.ByteSource;
 
+// FIXME (in later commit) use java record
 public class HashBlobId implements BlobId {
-    private static final String HASH_BLOB_ID_ENCODING_TYPE_PROPERTY = "james.blob.id.hash.encoding";
-    private static final BaseEncoding HASH_BLOB_ID_ENCODING_DEFAULT = BaseEncoding.base64Url();
-
     public static class Factory implements BlobId.Factory {
-        private final BaseEncoding baseEncoding;
-
-        public Factory() {
-            this.baseEncoding = Optional.ofNullable(System.getProperty(HASH_BLOB_ID_ENCODING_TYPE_PROPERTY))
-                .map(Factory::baseEncodingFrom)
-                .orElse(HASH_BLOB_ID_ENCODING_DEFAULT);
-        }
-
-        @Override
-        public HashBlobId forPayload(byte[] payload) {
-            Preconditions.checkArgument(payload != null);
-            return base64(Hashing.sha256().hashBytes(payload));
-        }
-
-        @Override
-        public BlobId forPayload(ByteSource payload) {
-            try {
-                return base64(payload.hash(Hashing.sha256()));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        private HashBlobId base64(HashCode hashCode) {
-            byte[] bytes = hashCode.asBytes();
-            return new HashBlobId(baseEncoding.encode(bytes));
-        }
 
         @Override
         public HashBlobId of(String id) {
@@ -74,24 +38,6 @@ public class HashBlobId implements BlobId {
         @Override
         public HashBlobId from(String id) {
             return of(id);
-        }
-
-        private static BaseEncoding baseEncodingFrom(String encodingType) {
-            switch (encodingType) {
-                case "base16":
-                case "hex":
-                    return BaseEncoding.base16();
-                case "base64":
-                    return BaseEncoding.base64();
-                case "base64Url":
-                    return BaseEncoding.base64Url();
-                case "base32":
-                    return BaseEncoding.base32();
-                case "base32Hex":
-                    return BaseEncoding.base32Hex();
-                default:
-                    throw new IllegalArgumentException("Unknown encoding type: " + encodingType);
-            }
         }
     }
 

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/HashBlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/HashBlobId.java
@@ -36,7 +36,7 @@ public class HashBlobId implements BlobId {
         }
 
         @Override
-        public HashBlobId from(String id) {
+        public HashBlobId parse(String id) {
             return of(id);
         }
     }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
@@ -62,7 +62,22 @@ public class MetricableBlobStore implements BlobStore {
 
     @Override
     public Publisher<BlobId> save(BucketName bucketName, ByteSource data, StoragePolicy storagePolicy) {
-        return metricFactory.decoratePublisherWithTimerMetric(SAVE_INPUT_STREAM_TIMER_NAME, blobStoreImpl.save(bucketName, data, storagePolicy));
+        return metricFactory.decoratePublisherWithTimerMetric(SAVE_BYTES_TIMER_NAME, blobStoreImpl.save(bucketName, data, storagePolicy));
+    }
+
+    @Override
+    public Publisher<BlobId> save(BucketName bucketName, byte[] data, BlobIdProvider blobIdProvider, StoragePolicy storagePolicy) {
+        return metricFactory.decoratePublisherWithTimerMetric(SAVE_BYTES_TIMER_NAME, blobStoreImpl.save(bucketName, data, blobIdProvider, storagePolicy));
+    }
+
+    @Override
+    public Publisher<BlobId> save(BucketName bucketName, InputStream data, BlobIdProvider blobIdProvider, StoragePolicy storagePolicy) {
+        return metricFactory.decoratePublisherWithTimerMetric(SAVE_INPUT_STREAM_TIMER_NAME, blobStoreImpl.save(bucketName, data, blobIdProvider, storagePolicy));
+    }
+
+    @Override
+    public Publisher<BlobId> save(BucketName bucketName, ByteSource data, BlobIdProvider blobIdProvider, StoragePolicy storagePolicy) {
+        return metricFactory.decoratePublisherWithTimerMetric(SAVE_INPUT_STREAM_TIMER_NAME, blobStoreImpl.save(bucketName, data, blobIdProvider, storagePolicy));
     }
 
     @Override

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/PlainBlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/PlainBlobId.java
@@ -19,14 +19,10 @@
 
 package org.apache.james.blob.api;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
-// FIXME (in later commit) use java record
-public class PlainBlobId implements BlobId {
+public record PlainBlobId(String id) implements BlobId {
     public static class Factory implements BlobId.Factory {
 
         @Override
@@ -41,37 +37,8 @@ public class PlainBlobId implements BlobId {
         }
     }
 
-    private final String id;
-
-    @VisibleForTesting
-    PlainBlobId(String id) {
-        this.id = id;
-    }
-
     @Override
     public String asString() {
         return id;
-    }
-
-    @Override
-    public final boolean equals(Object obj) {
-        if (obj instanceof PlainBlobId) {
-            PlainBlobId other = (PlainBlobId) obj;
-            return Objects.equal(id, other.id);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hashCode(id);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects
-            .toStringHelper(this)
-            .add("id", id)
-            .toString();
     }
 }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/PlainBlobId.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/PlainBlobId.java
@@ -26,17 +26,17 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 // FIXME (in later commit) use java record
-public class HashBlobId implements BlobId {
+public class PlainBlobId implements BlobId {
     public static class Factory implements BlobId.Factory {
 
         @Override
-        public HashBlobId of(String id) {
+        public PlainBlobId of(String id) {
             Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
-            return new HashBlobId(id);
+            return new PlainBlobId(id);
         }
 
         @Override
-        public HashBlobId parse(String id) {
+        public PlainBlobId parse(String id) {
             return of(id);
         }
     }
@@ -44,7 +44,7 @@ public class HashBlobId implements BlobId {
     private final String id;
 
     @VisibleForTesting
-    HashBlobId(String id) {
+    PlainBlobId(String id) {
         this.id = id;
     }
 
@@ -55,8 +55,8 @@ public class HashBlobId implements BlobId {
 
     @Override
     public final boolean equals(Object obj) {
-        if (obj instanceof HashBlobId) {
-            HashBlobId other = (HashBlobId) obj;
+        if (obj instanceof PlainBlobId) {
+            PlainBlobId other = (PlainBlobId) obj;
             return Objects.equal(id, other.id);
         }
         return false;

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/BlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/BlobStoreContract.java
@@ -156,7 +156,7 @@ public interface BlobStoreContract extends BucketBlobStoreContract {
         BlobStore store = testee();
         BucketName defaultBucketName = store.getDefaultBucketName();
 
-        assertThatThrownBy(() -> Mono.from(store.readBytes(defaultBucketName, blobIdFactory().from("unknown"))).block())
+        assertThatThrownBy(() -> Mono.from(store.readBytes(defaultBucketName, blobIdFactory().parse("unknown"))).block())
             .isExactlyInstanceOf(ObjectNotFoundException.class);
     }
 
@@ -243,7 +243,7 @@ public interface BlobStoreContract extends BucketBlobStoreContract {
         BlobStore store = testee();
         BucketName defaultBucketName = store.getDefaultBucketName();
 
-        assertThatThrownBy(() -> store.read(defaultBucketName, blobIdFactory().from("unknown")).read())
+        assertThatThrownBy(() -> store.read(defaultBucketName, blobIdFactory().parse("unknown")).read())
             .isInstanceOf(ObjectNotFoundException.class);
     }
 

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
@@ -77,7 +77,9 @@ public interface DeduplicationBlobStoreContract {
         BucketName defaultBucketName = store.getDefaultBucketName();
 
         BlobId blobId = Mono.from(store.save(defaultBucketName, new ByteArrayInputStream(SHORT_BYTEARRAY), storagePolicy)).block();
-
-        assertThat(blobId).isEqualTo(blobIdFactory().from("31f7a65e315586ac198bd798b6629ce4903d0899476d5741a9f32e2e521b6a66"));
+        // This fix is ok because it will only affect deduplication, after this change the same content might be assigned a different blobid
+        // and thus might be duplicated in the store. No data can be lost since no api allows for externally deterministic blob id construction
+        // before this change.
+        assertThat(blobId).isEqualTo(blobIdFactory().of("MfemXjFVhqwZi9eYtmKc5JA9CJlHbVdBqfMuLlIbamY="));
     }
 }

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
@@ -24,10 +24,13 @@ import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
 import static org.apache.james.blob.api.BlobStore.StoragePolicy.SIZE_BASED;
 import static org.apache.james.blob.api.BlobStoreContract.SHORT_BYTEARRAY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,6 +50,22 @@ public interface DeduplicationBlobStoreContract {
     BlobStore testee();
 
     BlobId.Factory blobIdFactory();
+
+    BlobStore createBlobStore();
+
+    @BeforeEach
+    default void beforeEach() {
+        System.clearProperty("james.blob.id.hash.encoding");
+    }
+
+    @Test
+    default void deduplicationBlobstoreCreationShouldFailOnInvalidProperty() {
+        System.setProperty("james.blob.id.hash.encoding", "invalid");
+
+        assertThatThrownBy(this::createBlobStore)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unknown encoding type: invalid");
+    }
 
     @ParameterizedTest
     @MethodSource("storagePolicies")

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
@@ -75,7 +75,7 @@ public interface DeduplicationBlobStoreContract {
 
         BlobId blobId = Mono.from(store.save(defaultBucketName, SHORT_STRING, storagePolicy)).block();
 
-        assertThat(blobId).isEqualTo(blobIdFactory().from("MfemXjFVhqwZi9eYtmKc5JA9CJlHbVdBqfMuLlIbamY="));
+        assertThat(blobId).isEqualTo(blobIdFactory().parse("MfemXjFVhqwZi9eYtmKc5JA9CJlHbVdBqfMuLlIbamY="));
     }
 
     @ParameterizedTest
@@ -86,7 +86,7 @@ public interface DeduplicationBlobStoreContract {
 
         BlobId blobId = Mono.from(store.save(defaultBucketName, SHORT_BYTEARRAY, storagePolicy)).block();
 
-        assertThat(blobId).isEqualTo(blobIdFactory().from("MfemXjFVhqwZi9eYtmKc5JA9CJlHbVdBqfMuLlIbamY="));
+        assertThat(blobId).isEqualTo(blobIdFactory().parse("MfemXjFVhqwZi9eYtmKc5JA9CJlHbVdBqfMuLlIbamY="));
     }
 
     @ParameterizedTest

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeduplicationBlobStoreContract.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.ByteArrayInputStream;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,13 +59,18 @@ public interface DeduplicationBlobStoreContract {
         System.clearProperty("james.blob.id.hash.encoding");
     }
 
+    @AfterEach
+    default void afterEach() {
+        System.clearProperty("james.blob.id.hash.encoding");
+    }
+
     @Test
     default void deduplicationBlobstoreCreationShouldFailOnInvalidProperty() {
-        System.setProperty("james.blob.id.hash.encoding", "invalid");
+        System.setProperty("james.blob.id.hash.encoding", "deduplicationBlobstoreCreationShouldFailOnInvalidProperty");
 
         assertThatThrownBy(this::createBlobStore)
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Unknown encoding type: invalid");
+                .hasMessage("Unknown encoding type: deduplicationBlobstoreCreationShouldFailOnInvalidProperty");
     }
 
     @ParameterizedTest

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeleteBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/DeleteBlobStoreContract.java
@@ -55,7 +55,7 @@ public interface DeleteBlobStoreContract {
         BlobStore store = testee();
         BucketName defaultBucketName = store.getDefaultBucketName();
 
-        assertThatCode(() -> Mono.from(store.delete(defaultBucketName, blobIdFactory().randomId())).block())
+        assertThatCode(() -> Mono.from(store.delete(defaultBucketName, blobIdFactory().of("NOT_EXISTING_BLOB_ID"))).block())
             .doesNotThrowAnyException();
     }
 
@@ -115,7 +115,7 @@ public interface DeleteBlobStoreContract {
     @Test
     default void deleteShouldThrowWhenNullBucketName() {
         BlobStore store = testee();
-        assertThatThrownBy(() -> Mono.from(store.delete(null, blobIdFactory().randomId())).block())
+        assertThatThrownBy(() -> Mono.from(store.delete(null, blobIdFactory().of("ANY_BLOB_ID"))).block())
             .isInstanceOf(NullPointerException.class);
     }
 

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/HashBlobIdTest.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/HashBlobIdTest.java
@@ -38,19 +38,19 @@ class HashBlobIdTest {
     @Test
     void fromShouldConstructBlobId() {
         String id = "111";
-        assertThat(BLOB_ID_FACTORY.from(id))
+        assertThat(BLOB_ID_FACTORY.parse(id))
             .isEqualTo(new HashBlobId(id));
     }
 
     @Test
     void fromShouldThrowOnNull() {
-        assertThatThrownBy(() -> BLOB_ID_FACTORY.from(null))
+        assertThatThrownBy(() -> BLOB_ID_FACTORY.parse(null))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void fromShouldThrowOnEmpty() {
-        assertThatThrownBy(() -> BLOB_ID_FACTORY.from(""))
+        assertThatThrownBy(() -> BLOB_ID_FACTORY.parse(""))
             .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/HashBlobIdTest.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/HashBlobIdTest.java
@@ -22,26 +22,13 @@ package org.apache.james.blob.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.charset.StandardCharsets;
-import java.util.stream.Stream;
-
-import org.apache.james.util.ClassLoaderUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class HashBlobIdTest {
 
     private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
-
-    @BeforeEach
-    void beforeEach() {
-        System.clearProperty("james.blob.id.hash.encoding");
-    }
 
     @Test
     void shouldRespectBeanContract() {
@@ -65,62 +52,5 @@ class HashBlobIdTest {
     void fromShouldThrowOnEmpty() {
         assertThatThrownBy(() -> BLOB_ID_FACTORY.from(""))
             .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void forPayloadShouldThrowOnNull() {
-        assertThatThrownBy(() -> BLOB_ID_FACTORY.forPayload((byte[]) null))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void forPayloadShouldHashEmptyArray() {
-        BlobId blobId = BLOB_ID_FACTORY.forPayload(new byte[0]);
-
-        assertThat(blobId.asString()).isEqualTo("47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU=");
-    }
-
-    @Test
-    void forPayloadShouldHashArray() {
-        BlobId blobId = BLOB_ID_FACTORY.forPayload("content".getBytes(StandardCharsets.UTF_8));
-
-        assertThat(blobId.asString()).isEqualTo("7XACtDnprIRfIjV9giusFERzD722AW0-yUMil7nsn3M=");
-    }
-
-
-    @ParameterizedTest
-    @MethodSource("encodingTypeAndExpectedHash")
-    void forPayloadShouldSupportEncodingWhenConfigured(String encoding, String expectedHash) {
-        System.setProperty("james.blob.id.hash.encoding", encoding);
-        BlobId blobId = new HashBlobId.Factory().forPayload("content".getBytes(StandardCharsets.UTF_8));
-        assertThat(blobId.asString()).isEqualTo(expectedHash);
-    }
-
-    static Stream<Arguments> encodingTypeAndExpectedHash() {
-        return Stream.of(
-            Arguments.of("base16", "ED7002B439E9AC845F22357D822BAC1444730FBDB6016D3EC9432297B9EC9F73"),
-            Arguments.of("hex", "ED7002B439E9AC845F22357D822BAC1444730FBDB6016D3EC9432297B9EC9F73"),
-            Arguments.of("base32", "5VYAFNBZ5GWIIXZCGV6YEK5MCRCHGD55WYAW2PWJIMRJPOPMT5ZQ===="),
-            Arguments.of("base64", "7XACtDnprIRfIjV9giusFERzD722AW0+yUMil7nsn3M="),
-            Arguments.of("base64Url", "7XACtDnprIRfIjV9giusFERzD722AW0-yUMil7nsn3M="),
-            Arguments.of("base32", "5VYAFNBZ5GWIIXZCGV6YEK5MCRCHGD55WYAW2PWJIMRJPOPMT5ZQ===="),
-            Arguments.of("base32Hex", "TLO05D1PT6M88NP26LUO4ATC2H2763TTMO0MQFM98CH9FEFCJTPG===="));
-    }
-
-    @Test
-    void newFactoryShouldFailWhenInvalidEncoding() {
-        System.setProperty("james.blob.id.hash.encoding", "invalid");
-        assertThatThrownBy(HashBlobId.Factory::new)
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Unknown encoding type: invalid");
-    }
-
-    @Test
-    void forPayloadShouldCalculateDifferentHashesWhenCraftedSha1Collision() throws Exception {
-        byte[] payload1 = ClassLoaderUtils.getSystemResourceAsByteArray("shattered-1.pdf");
-        byte[] payload2 = ClassLoaderUtils.getSystemResourceAsByteArray("shattered-2.pdf");
-        BlobId blobId1 = BLOB_ID_FACTORY.forPayload(payload1);
-        BlobId blobId2 = BLOB_ID_FACTORY.forPayload(payload2);
-        assertThat(blobId1).isNotEqualTo(blobId2);
     }
 }

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/PlainBlobIdTest.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/PlainBlobIdTest.java
@@ -26,20 +26,20 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-class HashBlobIdTest {
+class PlainBlobIdTest {
 
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
 
     @Test
     void shouldRespectBeanContract() {
-        EqualsVerifier.forClass(HashBlobId.class).verify();
+        EqualsVerifier.forClass(PlainBlobId.class).verify();
     }
 
     @Test
     void fromShouldConstructBlobId() {
         String id = "111";
         assertThat(BLOB_ID_FACTORY.parse(id))
-            .isEqualTo(new HashBlobId(id));
+            .isEqualTo(new PlainBlobId(id));
     }
 
     @Test

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/TestBlobId.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/TestBlobId.java
@@ -21,23 +21,9 @@ package org.apache.james.blob.api;
 
 import java.util.Objects;
 
-import org.apache.commons.lang3.NotImplementedException;
-
-import com.google.common.io.ByteSource;
-
 public class TestBlobId implements BlobId {
 
     public static class Factory implements BlobId.Factory {
-        @Override
-        public BlobId forPayload(byte[] payload) {
-            throw new NotImplementedException("Use from(String) instead");
-        }
-
-        @Override
-        public BlobId forPayload(ByteSource payload) {
-            throw new NotImplementedException("Use from(String) instead");
-        }
-
         @Override
         public BlobId of(String id) {
             return new TestBlobId(id);

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/TestBlobId.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/TestBlobId.java
@@ -39,8 +39,13 @@ public class TestBlobId implements BlobId {
         }
 
         @Override
-        public BlobId from(String id) {
+        public BlobId of(String id) {
             return new TestBlobId(id);
+        }
+
+        @Override
+        public BlobId from(String id) {
+            return of(id);
         }
     }
 

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/TestBlobId.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/TestBlobId.java
@@ -30,7 +30,7 @@ public class TestBlobId implements BlobId {
         }
 
         @Override
-        public BlobId from(String id) {
+        public BlobId parse(String id) {
             return of(id);
         }
     }

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreFactory.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreFactory.java
@@ -21,7 +21,7 @@ package org.apache.james.blob.cassandra;
 
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 
@@ -29,7 +29,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 
 public class CassandraBlobStoreFactory {
     public static BlobStoreFactory.RequireStoringStrategy forTesting(CqlSession session, MetricFactory metricFactory) {
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, session);
         CassandraDefaultBucketDAO defaultBucketDAO = new CassandraDefaultBucketDAO(session, blobIdFactory);
         CassandraBlobStoreDAO blobStoreDAO = new CassandraBlobStoreDAO(defaultBucketDAO, bucketDAO, CassandraConfiguration.DEFAULT_CONFIGURATION, BucketName.DEFAULT, metricFactory);

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBucketDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBucketDAO.java
@@ -183,13 +183,13 @@ public class CassandraBucketDAO {
 
     public Flux<Pair<BucketName, BlobId>> listAll() {
         return cassandraAsyncExecutor.executeRows(listAll.bind())
-            .map(row -> Pair.of(BucketName.of(row.getString(BUCKET)), blobIdFactory.from(row.getString(ID))));
+            .map(row -> Pair.of(BucketName.of(row.getString(BUCKET)), blobIdFactory.parse(row.getString(ID))));
     }
 
     public Flux<BlobId> listAll(BucketName bucketName) {
         return cassandraAsyncExecutor.executeRows(listBucketContent.bind()
                 .setString(BUCKET, bucketName.asString()))
-            .map(row -> blobIdFactory.from(row.getString(ID)));
+            .map(row -> blobIdFactory.parse(row.getString(ID)));
     }
 
     private ByteBuffer rowToData(Row row) {

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraDefaultBucketDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraDefaultBucketDAO.java
@@ -160,7 +160,7 @@ public class CassandraDefaultBucketDAO {
 
     Flux<BlobId> listBlobs() {
         return cassandraAsyncExecutor.executeRows(listBlobs.bind())
-            .map(row -> blobIdFactory.from(row.getString(DefaultBucketBlobParts.ID)));
+            .map(row -> blobIdFactory.parse(row.getString(DefaultBucketBlobParts.ID)));
     }
 
     private ByteBuffer rowToData(Row row) {

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreClOneTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreClOneTest.java
@@ -53,12 +53,13 @@ import com.google.common.base.Strings;
 
 import reactor.core.publisher.Mono;
 
-class CassandraBlobStoreClOneTest implements CassandraBlobStoreContract {
+class CassandraBlobStoreClOneTest implements CassandraBlobStoreContract, DeduplicationBlobStoreContract {
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraBlobModule.MODULE);
 
     private BlobStore testee;
     private CassandraDefaultBucketDAO defaultBucketDAO;
+    private CassandraCluster cassandra;
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
@@ -72,17 +73,17 @@ class CassandraBlobStoreClOneTest implements CassandraBlobStoreContract {
         CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, this.cassandra.getConf());
         defaultBucketDAO = spy(new CassandraDefaultBucketDAO(this.cassandra.getConf(), blobIdFactory));
         CassandraConfiguration cassandraConfiguration = CassandraConfiguration.builder()
-            .blobPartSize(CHUNK_SIZE)
-            .optimisticConsistencyLevel(true)
-            .build();
+                .blobPartSize(CHUNK_SIZE)
+                .optimisticConsistencyLevel(true)
+                .build();
         MetricFactory metricFactory = metricsTestExtension.getMetricFactory();
-        testee = new MetricableBlobStore(
-            metricFactory,
-            BlobStoreFactory.builder()
-                .blobStoreDAO(new CassandraBlobStoreDAO(defaultBucketDAO, bucketDAO, cassandraConfiguration, BucketName.DEFAULT, metricFactory))
-                .blobIdFactory(blobIdFactory)
-                .defaultBucketName()
-                .deduplication());
+        return new MetricableBlobStore(
+                metricFactory,
+                BlobStoreFactory.builder()
+                        .blobStoreDAO(new CassandraBlobStoreDAO(defaultBucketDAO, bucketDAO, cassandraConfiguration, BucketName.DEFAULT, metricFactory))
+                        .blobIdFactory(blobIdFactory)
+                        .defaultBucketName()
+                        .deduplication());
     }
 
     @Override

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreClOneTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreClOneTest.java
@@ -40,9 +40,9 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.DeduplicationBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.ObjectStoreException;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +69,7 @@ class CassandraBlobStoreClOneTest implements CassandraBlobStoreContract, Dedupli
 
     @Override
     public MetricableBlobStore createBlobStore() {
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, this.cassandra.getConf());
         defaultBucketDAO = spy(new CassandraDefaultBucketDAO(this.cassandra.getConf(), blobIdFactory));
         CassandraConfiguration cassandraConfiguration = CassandraConfiguration.builder()
@@ -93,7 +93,7 @@ class CassandraBlobStoreClOneTest implements CassandraBlobStoreContract, Dedupli
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 
     @Override

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreClOneTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreClOneTest.java
@@ -39,6 +39,7 @@ import org.apache.james.backends.cassandra.init.configuration.CassandraConfigura
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.DeduplicationBlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.ObjectStoreException;
@@ -61,9 +62,15 @@ class CassandraBlobStoreClOneTest implements CassandraBlobStoreContract {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
+        this.cassandra = cassandra;
+        this.testee = createBlobStore();
+    }
+
+    @Override
+    public MetricableBlobStore createBlobStore() {
         HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
-        CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, cassandra.getConf());
-        defaultBucketDAO = spy(new CassandraDefaultBucketDAO(cassandra.getConf(), blobIdFactory));
+        CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, this.cassandra.getConf());
+        defaultBucketDAO = spy(new CassandraDefaultBucketDAO(this.cassandra.getConf(), blobIdFactory));
         CassandraConfiguration cassandraConfiguration = CassandraConfiguration.builder()
             .blobPartSize(CHUNK_SIZE)
             .optimisticConsistencyLevel(true)

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreFixture.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreFixture.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 
 public interface CassandraBlobStoreFixture {
     byte[] DATA = "anydata".getBytes(StandardCharsets.UTF_8);
@@ -32,8 +32,8 @@ public interface CassandraBlobStoreFixture {
     int POSITION_2 = 43;
     int NUMBER_OF_CHUNK = 17;
     int NUMBER_OF_CHUNK_2 = 18;
-    BlobId BLOB_ID = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
-    BlobId BLOB_ID_2 = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
+    BlobId BLOB_ID = new PlainBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
+    BlobId BLOB_ID_2 = new PlainBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
     BucketName BUCKET_NAME = BucketName.of("aBucket");
     BucketName BUCKET_NAME_2 = BucketName.of("anotherBucket");
 }

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreFixture.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreFixture.java
@@ -32,8 +32,8 @@ public interface CassandraBlobStoreFixture {
     int POSITION_2 = 43;
     int NUMBER_OF_CHUNK = 17;
     int NUMBER_OF_CHUNK_2 = 18;
-    BlobId BLOB_ID = new HashBlobId.Factory().from("05dcb33b-8382-4744-923a-bc593ad84d23");
-    BlobId BLOB_ID_2 = new HashBlobId.Factory().from("05dcb33b-8382-4744-923a-bc593ad84d24");
+    BlobId BLOB_ID = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d23");
+    BlobId BLOB_ID_2 = new HashBlobId.Factory().parse("05dcb33b-8382-4744-923a-bc593ad84d24");
     BucketName BUCKET_NAME = BucketName.of("aBucket");
     BucketName BUCKET_NAME_2 = BucketName.of("anotherBucket");
 }

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreTest.java
@@ -41,6 +41,7 @@ public class CassandraBlobStoreTest implements CassandraBlobStoreContract, Dedup
 
     private BlobStore testee;
     private CassandraDefaultBucketDAO defaultBucketDAO;
+    private CassandraCluster cassandra;
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
@@ -54,16 +55,16 @@ public class CassandraBlobStoreTest implements CassandraBlobStoreContract, Dedup
         CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, this.cassandra.getConf());
         defaultBucketDAO = spy(new CassandraDefaultBucketDAO(this.cassandra.getConf(), blobIdFactory));
         CassandraConfiguration cassandraConfiguration = CassandraConfiguration.builder()
-            .blobPartSize(CHUNK_SIZE)
-            .build();
+                .blobPartSize(CHUNK_SIZE)
+                .build();
         MetricFactory metricFactory = metricsTestExtension.getMetricFactory();
-        testee = new MetricableBlobStore(
-            metricFactory,
-            BlobStoreFactory.builder()
-                .blobStoreDAO(new CassandraBlobStoreDAO(defaultBucketDAO, bucketDAO, cassandraConfiguration, BucketName.DEFAULT, metricFactory))
-                .blobIdFactory(blobIdFactory)
-                .defaultBucketName()
-                .deduplication());
+        return new MetricableBlobStore(
+                metricFactory,
+                BlobStoreFactory.builder()
+                        .blobStoreDAO(new CassandraBlobStoreDAO(defaultBucketDAO, bucketDAO, cassandraConfiguration, BucketName.DEFAULT, metricFactory))
+                        .blobIdFactory(blobIdFactory)
+                        .defaultBucketName()
+                        .deduplication());
     }
 
     @Override

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreTest.java
@@ -28,8 +28,8 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.DeduplicationBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +51,7 @@ public class CassandraBlobStoreTest implements CassandraBlobStoreContract, Dedup
 
     @Override
     public MetricableBlobStore createBlobStore() {
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, this.cassandra.getConf());
         defaultBucketDAO = spy(new CassandraDefaultBucketDAO(this.cassandra.getConf(), blobIdFactory));
         CassandraConfiguration cassandraConfiguration = CassandraConfiguration.builder()
@@ -74,7 +74,7 @@ public class CassandraBlobStoreTest implements CassandraBlobStoreContract, Dedup
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 
     @Override

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobStoreTest.java
@@ -44,9 +44,15 @@ public class CassandraBlobStoreTest implements CassandraBlobStoreContract, Dedup
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
+        this.cassandra = cassandra;
+        this.testee = createBlobStore();
+    }
+
+    @Override
+    public MetricableBlobStore createBlobStore() {
         HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
-        CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, cassandra.getConf());
-        defaultBucketDAO = spy(new CassandraDefaultBucketDAO(cassandra.getConf(), blobIdFactory));
+        CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, this.cassandra.getConf());
+        defaultBucketDAO = spy(new CassandraDefaultBucketDAO(this.cassandra.getConf(), blobIdFactory));
         CassandraConfiguration cassandraConfiguration = CassandraConfiguration.builder()
             .blobPartSize(CHUNK_SIZE)
             .build();

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBucketDAOTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBucketDAOTest.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -50,7 +50,7 @@ class CassandraBucketDAOTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        testee = new CassandraBucketDAO(new HashBlobId.Factory(), cassandraCluster.getCassandraCluster().getConf());
+        testee = new CassandraBucketDAO(new PlainBlobId.Factory(), cassandraCluster.getCassandraCluster().getConf());
     }
 
     @Test

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraPassTroughBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraPassTroughBlobStoreTest.java
@@ -28,8 +28,8 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.DeleteBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +44,7 @@ public class CassandraPassTroughBlobStoreTest implements DeleteBlobStoreContract
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         CassandraBucketDAO bucketDAO = new CassandraBucketDAO(blobIdFactory, cassandra.getConf());
         defaultBucketDAO = spy(new CassandraDefaultBucketDAO(cassandra.getConf(), blobIdFactory));
         CassandraConfiguration cassandraConfiguration = CassandraConfiguration.builder()
@@ -67,7 +67,7 @@ public class CassandraPassTroughBlobStoreTest implements DeleteBlobStoreContract
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 
     @Override

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/BlobStoreCacheContract.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/BlobStoreCacheContract.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.apache.james.blob.api.BlobId;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public interface BlobStoreCacheContract {
 
     @Test
     default void shouldSaveWhenCacheSmallByteData() {
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
         assertThatCode(Mono.from(testee().cache(blobId, EIGHT_KILOBYTES))::block)
             .doesNotThrowAnyException();
 
@@ -56,7 +57,7 @@ public interface BlobStoreCacheContract {
 
     @Test
     default void shouldReturnExactlyDataWhenRead() {
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
         Mono.from(testee().cache(blobId, EIGHT_KILOBYTES)).block();
 
         byte[] actual = Mono.from(testee().read(blobId)).block();
@@ -65,13 +66,13 @@ public interface BlobStoreCacheContract {
 
     @Test
     default void shouldReturnEmptyWhenReadWithTimeOut() {
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
         Mono.from(testee().cache(blobId, EIGHT_KILOBYTES)).block();
     }
 
     @Test
     default void shouldReturnNothingWhenDelete() {
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
         Mono.from(testee().cache(blobId, EIGHT_KILOBYTES)).block();
         Mono.from(testee().remove(blobId)).block();
 
@@ -81,8 +82,8 @@ public interface BlobStoreCacheContract {
 
     @Test
     default void shouldDeleteExactlyAndReturnNothingWhenDelete() {
-        BlobId blobId = blobIdFactory().randomId();
-        BlobId blobId2 = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
+        BlobId blobId2 = blobIdFactory().of(UUID.randomUUID().toString());
         Mono.from(testee().cache(blobId, EIGHT_KILOBYTES)).block();
         Mono.from(testee().cache(blobId2, EIGHT_KILOBYTES)).block();
         Mono.from(testee().remove(blobId)).block();
@@ -93,7 +94,7 @@ public interface BlobStoreCacheContract {
 
     @Test
     default void shouldReturnDataWhenCacheSmallDataInConfigurationTTL() {
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
         assertThatCode(Mono.from(testee().cache(blobId, EIGHT_KILOBYTES))::block)
             .doesNotThrowAnyException();
 
@@ -103,7 +104,7 @@ public interface BlobStoreCacheContract {
 
     @Test
     default void shouldNotReturnDataWhenCachedSmallDataOutOfConfigurationTTL() {
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
         assertThatCode(Mono.from(testee().cache(blobId, EIGHT_KILOBYTES))::block)
             .doesNotThrowAnyException();
         //add some time after the TTL to avoid threshold effect
@@ -113,7 +114,7 @@ public interface BlobStoreCacheContract {
 
     @Test
     default void readShouldReturnEmptyCachedByteArray() {
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
         byte[] emptyByteArray = new byte[] {};
 
         Mono.from(testee().cache(blobId, emptyByteArray)).block();

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CachedBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CachedBlobStoreTest.java
@@ -46,8 +46,8 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.api.TestBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
@@ -101,7 +101,7 @@ public class CachedBlobStoreTest implements BlobStoreContract {
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 
     @Test

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CachedBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CachedBlobStoreTest.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.UUID;
 
 import jakarta.mail.internet.MimeMessage;
 
@@ -614,7 +615,7 @@ public class CachedBlobStoreTest implements BlobStoreContract {
         @Test
         void metricsShouldNotWorkExceptLatencyWhenReadNonExistingBlob() {
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThatThrownBy(() -> testee.read(DEFAULT_BUCKETNAME, new TestBlobId.Factory().randomId(), HIGH_PERFORMANCE))
+                softly.assertThatThrownBy(() -> testee.read(DEFAULT_BUCKETNAME, new TestBlobId.Factory().of(UUID.randomUUID().toString()), HIGH_PERFORMANCE))
                     .isInstanceOf(ObjectNotFoundException.class);
 
                 softly.assertThat(metricFactory.countFor(BLOBSTORE_CACHED_MISS_COUNT_METRIC_NAME))
@@ -635,7 +636,7 @@ public class CachedBlobStoreTest implements BlobStoreContract {
         @Test
         void metricsShouldNotWorkExceptLatencyWhenReadNonExistingBlobAsBytes() {
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThatThrownBy(() -> Mono.from(testee.readBytes(DEFAULT_BUCKETNAME, new TestBlobId.Factory().randomId(), HIGH_PERFORMANCE)).blockOptional())
+                softly.assertThatThrownBy(() -> Mono.from(testee.readBytes(DEFAULT_BUCKETNAME, new TestBlobId.Factory().of(UUID.randomUUID().toString()), HIGH_PERFORMANCE)).blockOptional())
                     .isInstanceOf(ObjectNotFoundException.class);
 
                 softly.assertThat(metricFactory.countFor(BLOBSTORE_CACHED_MISS_COUNT_METRIC_NAME))

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CassandraBlobStoreCacheTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CassandraBlobStoreCacheTest.java
@@ -22,6 +22,7 @@ import static org.apache.james.backends.cassandra.Scenario.Builder.fail;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
@@ -70,7 +71,7 @@ class CassandraBlobStoreCacheTest implements BlobStoreCacheContract {
             .forever()
             .whenQueryStartsWith("INSERT INTO blob_cache"));
 
-        BlobId blobId = blobIdFactory().randomId();
+        BlobId blobId = blobIdFactory().of(UUID.randomUUID().toString());
 
         assertThatCode(() -> Mono.from(testee.cache(blobId, EIGHT_KILOBYTES)).block())
             .doesNotThrowAnyException();

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CassandraBlobStoreCacheTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/cache/CassandraBlobStoreCacheTest.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.blob.api.BlobId;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -43,11 +43,11 @@ class CassandraBlobStoreCacheTest implements BlobStoreCacheContract {
     private static final Duration _2_SEC_TTL = Duration.ofSeconds(2);
 
     private BlobStoreCache testee;
-    private HashBlobId.Factory blobIdFactory;
+    private PlainBlobId.Factory blobIdFactory;
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        blobIdFactory = new HashBlobId.Factory();
+        blobIdFactory = new PlainBlobId.Factory();
         CassandraCacheConfiguration cacheConfiguration = new CassandraCacheConfiguration.Builder()
             .sizeThresholdInBytes(DEFAULT_THRESHOLD_IN_BYTES)
             .ttl(_2_SEC_TTL)

--- a/server/blob/blob-export-api/src/test/java/org/apache/james/blob/export/api/ExportedFileNamesGeneratorTest.java
+++ b/server/blob/blob-export-api/src/test/java/org/apache/james/blob/export/api/ExportedFileNamesGeneratorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class ExportedFileNamesGeneratorTest {
 
     private static final TestBlobId.Factory BLOB_ID_FACTORY = new TestBlobId.Factory();
-    private static final BlobId BLOB_ID = BLOB_ID_FACTORY.from("blobId");
+    private static final BlobId BLOB_ID = BLOB_ID_FACTORY.parse("blobId");
 
     @Test
     void generateFileNameShouldNotHavePrefixWhenEmptyPrefix() {

--- a/server/blob/blob-export-file/src/test/java/org/apache/james/blob/export/file/LocalFileBlobExportMechanismTest.java
+++ b/server/blob/blob-export-file/src/test/java/org/apache/james/blob/export/file/LocalFileBlobExportMechanismTest.java
@@ -37,8 +37,8 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.ObjectStoreException;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.export.api.FileExtension;
 import org.apache.james.blob.export.file.LocalFileBlobExportMechanism.Configuration;
 import org.apache.james.blob.memory.MemoryBlobStoreFactory;
@@ -68,7 +68,7 @@ class LocalFileBlobExportMechanismTest {
     void setUp(FileSystem fileSystem) throws Exception {
         mailetContext = FakeMailContext.builder().postmaster(MailAddressFixture.POSTMASTER_AT_JAMES).build();
         blobStore = MemoryBlobStoreFactory.builder()
-            .blobIdFactory(new HashBlobId.Factory())
+            .blobIdFactory(new PlainBlobId.Factory())
             .defaultBucketName()
             .passthrough();
 
@@ -140,7 +140,7 @@ class LocalFileBlobExportMechanismTest {
 
     @Test
     void shareShouldFailWhenBlobDoesNotExist() {
-        BlobId blobId = new HashBlobId.Factory().of("NOT_EXISTING_BLOB_ID");
+        BlobId blobId = new PlainBlobId.Factory().of("NOT_EXISTING_BLOB_ID");
 
         assertThatThrownBy(() ->
             testee.blobId(blobId)

--- a/server/blob/blob-export-file/src/test/java/org/apache/james/blob/export/file/LocalFileBlobExportMechanismTest.java
+++ b/server/blob/blob-export-file/src/test/java/org/apache/james/blob/export/file/LocalFileBlobExportMechanismTest.java
@@ -140,7 +140,7 @@ class LocalFileBlobExportMechanismTest {
 
     @Test
     void shareShouldFailWhenBlobDoesNotExist() {
-        BlobId blobId = new HashBlobId.Factory().forPayload("not existing".getBytes(StandardCharsets.UTF_8));
+        BlobId blobId = new HashBlobId.Factory().of("NOT_EXISTING_BLOB_ID");
 
         assertThatThrownBy(() ->
             testee.blobId(blobId)

--- a/server/blob/blob-file/src/main/java/org/apache/james/blob/file/FileBlobStoreDAO.java
+++ b/server/blob/blob-file/src/main/java/org/apache/james/blob/file/FileBlobStoreDAO.java
@@ -216,7 +216,7 @@ public class FileBlobStoreDAO implements BlobStoreDAO {
                 return Files.list(bucketRoot.toPath());
             })
             .flatMapMany(Flux::fromStream)
-            .map(path -> blobIdFactory.from(path.getFileName().toString()))
+            .map(path -> blobIdFactory.parse(path.getFileName().toString()))
             .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreDAOTest.java
+++ b/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreDAOTest.java
@@ -21,7 +21,7 @@ package org.apache.james.blob.file;
 
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BlobStoreDAOContract;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -32,7 +32,7 @@ class FileBlobStoreDAOTest implements BlobStoreDAOContract {
 
     @BeforeEach
     void setUp() throws Exception {
-        blobStore = new FileBlobStoreDAO(FileSystemImpl.forTesting(), new HashBlobId.Factory());
+        blobStore = new FileBlobStoreDAO(FileSystemImpl.forTesting(), new PlainBlobId.Factory());
     }
 
     @Override

--- a/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreGCAlgorithmTest.java
+++ b/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreGCAlgorithmTest.java
@@ -20,7 +20,7 @@
 package org.apache.james.blob.file;
 
 import org.apache.james.blob.api.BlobStoreDAO;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.server.blob.deduplication.BloomFilterGCAlgorithmContract;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +31,7 @@ public class FileBlobStoreGCAlgorithmTest implements BloomFilterGCAlgorithmContr
 
     @BeforeEach
     public void beforeEach() throws Exception {
-        blobStoreDAO = new FileBlobStoreDAO(FileSystemImpl.forTesting(), new HashBlobId.Factory());
+        blobStoreDAO = new FileBlobStoreDAO(FileSystemImpl.forTesting(), new PlainBlobId.Factory());
     }
 
     @Override

--- a/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStorePassThroughTest.java
+++ b/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStorePassThroughTest.java
@@ -22,15 +22,15 @@ package org.apache.james.blob.file;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.DeleteBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.MetricableBlobStoreContract;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.junit.jupiter.api.BeforeEach;
 
 public class FileBlobStorePassThroughTest implements DeleteBlobStoreContract, MetricableBlobStoreContract {
 
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private BlobStore blobStore;
 
     @BeforeEach

--- a/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreTest.java
+++ b/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreTest.java
@@ -22,14 +22,14 @@ package org.apache.james.blob.file;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.DeduplicationBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.MetricableBlobStoreContract;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.junit.jupiter.api.BeforeEach;
 
 public class FileBlobStoreTest implements MetricableBlobStoreContract, DeduplicationBlobStoreContract {
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private BlobStore blobStore;
 
     @BeforeEach

--- a/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreTest.java
+++ b/server/blob/blob-file/src/test/java/org/apache/james/blob/file/FileBlobStoreTest.java
@@ -34,11 +34,16 @@ public class FileBlobStoreTest implements MetricableBlobStoreContract, Deduplica
 
     @BeforeEach
     void setUp() {
+        blobStore = createBlobStore();
+    }
+
+    @Override
+    public MetricableBlobStore createBlobStore() {
         FileSystemImpl fileSystem = FileSystemImpl.forTesting();
-        blobStore = new MetricableBlobStore(metricsTestExtension.getMetricFactory(), new FileBlobStoreFactory(fileSystem).builder()
-            .blobIdFactory(BLOB_ID_FACTORY)
-            .defaultBucketName()
-            .deduplication());
+        return new MetricableBlobStore(metricsTestExtension.getMetricFactory(), new FileBlobStoreFactory(fileSystem).builder()
+                .blobIdFactory(BLOB_ID_FACTORY)
+                .defaultBucketName()
+                .deduplication());
     }
 
     @Override

--- a/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStorePassThroughTest.java
+++ b/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStorePassThroughTest.java
@@ -22,14 +22,14 @@ package org.apache.james.blob.memory;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.DeleteBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.MetricableBlobStoreContract;
+import org.apache.james.blob.api.PlainBlobId;
 import org.junit.jupiter.api.BeforeEach;
 
 public class MemoryBlobStorePassThroughTest implements DeleteBlobStoreContract, MetricableBlobStoreContract {
 
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private BlobStore blobStore;
 
     @BeforeEach

--- a/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStoreTest.java
+++ b/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStoreTest.java
@@ -22,13 +22,13 @@ package org.apache.james.blob.memory;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.DeduplicationBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.MetricableBlobStoreContract;
+import org.apache.james.blob.api.PlainBlobId;
 import org.junit.jupiter.api.BeforeEach;
 
 public class MemoryBlobStoreTest implements MetricableBlobStoreContract, DeduplicationBlobStoreContract {
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private BlobStore blobStore;
 
     @BeforeEach

--- a/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStoreTest.java
+++ b/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStoreTest.java
@@ -33,10 +33,15 @@ public class MemoryBlobStoreTest implements MetricableBlobStoreContract, Dedupli
 
     @BeforeEach
     void setUp() {
-        blobStore = new MetricableBlobStore(metricsTestExtension.getMetricFactory(), MemoryBlobStoreFactory.builder()
-            .blobIdFactory(BLOB_ID_FACTORY)
-            .defaultBucketName()
-            .deduplication());
+        blobStore = createBlobStore();
+    }
+
+    @Override
+    public MetricableBlobStore createBlobStore() {
+        return new MetricableBlobStore(metricsTestExtension.getMetricFactory(), MemoryBlobStoreFactory.builder()
+                .blobIdFactory(BLOB_ID_FACTORY)
+                .defaultBucketName()
+                .deduplication());
     }
 
     @Override

--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -377,7 +377,7 @@ public class S3BlobStoreDAO implements BlobStoreDAO {
         return Flux.from(client.listObjectsV2Paginator(builder -> builder.bucket(bucketName.asString())))
             .flatMapIterable(ListObjectsV2Response::contents)
             .map(S3Object::key)
-            .map(blobIdFactory::from)
+            .map(blobIdFactory::parse)
             .onErrorResume(e -> e.getCause() instanceof NoSuchBucketException, e -> Flux.empty())
             .onErrorResume(NoSuchBucketException.class, e -> Flux.empty());
     }

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3DeDuplicationBlobStoreTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3DeDuplicationBlobStoreTest.java
@@ -22,6 +22,7 @@ package org.apache.james.blob.objectstorage.aws;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
+import org.apache.james.blob.api.DeduplicationBlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3DeDuplicationBlobStoreTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3DeDuplicationBlobStoreTest.java
@@ -28,7 +28,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.DeduplicationBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
@@ -66,7 +66,7 @@ class S3DeDuplicationBlobStoreTest implements BlobStoreContract, DeduplicationBl
                 .region(dockerAwsS3.dockerAwsS3().region())
                 .build();
 
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         s3ClientFactory = new S3ClientFactory(s3Configuration, new RecordingMetricFactory(), new NoopGaugeRegistry());
         s3BlobStoreDAO = new S3BlobStoreDAO(s3ClientFactory, s3Configuration, blobIdFactory);
 
@@ -101,7 +101,7 @@ class S3DeDuplicationBlobStoreTest implements BlobStoreContract, DeduplicationBl
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 
 }

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3MinioTest.java
@@ -29,14 +29,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BlobStoreDAOContract;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.TestBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
@@ -48,7 +45,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -119,17 +115,5 @@ public class S3MinioTest implements BlobStoreDAOContract {
     void saveShouldWorkWhenValidBlobId() {
         Mono.from(testee.save(TEST_BUCKET_NAME, TEST_BLOB_ID, SHORT_BYTEARRAY)).block();
         assertThat(Mono.from(testee.readBytes(TEST_BUCKET_NAME, TEST_BLOB_ID)).block()).isEqualTo(SHORT_BYTEARRAY);
-    }
-
-    @Test
-    void saveShouldWorkForAllPayloadsWithHash() {
-        Flux.range(0, 1000)
-            .concatMap(i -> {
-                byte[] payload = RandomStringUtils.random(128).getBytes(StandardCharsets.UTF_8);
-                BlobId blobId = new HashBlobId.Factory().forPayload(payload);
-                return testee.save(TEST_BUCKET_NAME, blobId, payload);
-            })
-            .then()
-            .block();
     }
 }

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3NamespaceTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3NamespaceTest.java
@@ -23,7 +23,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
@@ -52,7 +52,7 @@ class S3NamespaceTest implements BlobStoreContract {
             .defaultBucketName(BucketName.of("namespace"))
             .build();
 
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         s3ClientFactory = new S3ClientFactory(s3Configuration, new RecordingMetricFactory(), new NoopGaugeRegistry());
         s3BlobStoreDAO = new S3BlobStoreDAO(s3ClientFactory, s3Configuration, blobIdFactory);
 
@@ -80,6 +80,6 @@ class S3NamespaceTest implements BlobStoreContract {
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 }

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PassThroughBlobStoreTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PassThroughBlobStoreTest.java
@@ -22,7 +22,7 @@ package org.apache.james.blob.objectstorage.aws;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
@@ -52,7 +52,7 @@ class S3PassThroughBlobStoreTest implements BlobStoreContract {
             .region(dockerAwsS3.dockerAwsS3().region())
             .build();
 
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         s3ClientFactory = new S3ClientFactory(s3Configuration, new RecordingMetricFactory(), new NoopGaugeRegistry());
         s3BlobStoreDAO = new S3BlobStoreDAO(s3ClientFactory, s3Configuration, blobIdFactory);
 
@@ -80,7 +80,7 @@ class S3PassThroughBlobStoreTest implements BlobStoreContract {
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 
 }

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixAndNamespaceTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixAndNamespaceTest.java
@@ -24,7 +24,7 @@ import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.DeduplicationBlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
@@ -61,7 +61,7 @@ class S3PrefixAndNamespaceTest implements BlobStoreContract, DeduplicationBlobSt
                 .bucketPrefix("prefix")
                 .build();
 
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         s3ClientFactory = new S3ClientFactory(s3Configuration, new RecordingMetricFactory(), new NoopGaugeRegistry());
         s3BlobStoreDAO = new S3BlobStoreDAO(s3ClientFactory, s3Configuration, blobIdFactory);
 
@@ -85,6 +85,6 @@ class S3PrefixAndNamespaceTest implements BlobStoreContract, DeduplicationBlobSt
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 }

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixAndNamespaceTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixAndNamespaceTest.java
@@ -23,6 +23,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.DeduplicationBlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PrefixTest.java
@@ -22,7 +22,7 @@ package org.apache.james.blob.objectstorage.aws;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
@@ -51,7 +51,7 @@ class S3PrefixTest implements BlobStoreContract {
             .bucketPrefix("prefix")
             .build();
 
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         s3ClientFactory = new S3ClientFactory(s3Configuration, new RecordingMetricFactory(), new NoopGaugeRegistry());
         s3BlobStoreDAO = new S3BlobStoreDAO(s3ClientFactory, s3Configuration, blobIdFactory);
 
@@ -79,6 +79,6 @@ class S3PrefixTest implements BlobStoreContract {
 
     @Override
     public BlobId.Factory blobIdFactory() {
-        return new HashBlobId.Factory();
+        return new PlainBlobId.Factory();
     }
 }

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithm.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithm.java
@@ -274,7 +274,7 @@ public class BloomFilterGCAlgorithm {
     private Mono<Result> gc(BloomFilter<CharSequence> bloomFilter, BucketName bucketName, Context context, int deletionWindowSize) {
         return Flux.from(blobStoreDAO.listBlobs(bucketName))
             .doOnNext(blobId -> context.incrementBlobCount())
-            .flatMap(blobId -> Mono.fromCallable(() -> generationAwareBlobIdFactory.from(blobId.asString())))
+            .flatMap(blobId -> Mono.fromCallable(() -> generationAwareBlobIdFactory.parse(blobId.asString())))
             .filter(blobId -> !blobId.inActiveGeneration(generationAwareBlobIdConfiguration, now))
             .filter(blobId -> !bloomFilter.mightContain(salt + blobId.asString()))
             .window(deletionWindowSize)

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
@@ -127,7 +127,7 @@ public class GenerationAwareBlobId implements BlobId {
         }
 
         @Override
-        public GenerationAwareBlobId from(String id) {
+        public GenerationAwareBlobId parse(String id) {
             int separatorIndex1 = id.indexOf('_');
             if (separatorIndex1 == -1 || separatorIndex1 == id.length() - 1) {
                 return decorateWithoutGeneration(id);
@@ -138,13 +138,13 @@ public class GenerationAwareBlobId implements BlobId {
             }
             int family = Integer.parseInt(id.substring(0, separatorIndex1));
             int generation = Integer.parseInt(id.substring(separatorIndex1 + 1, separatorIndex2));
-            BlobId wrapped = delegate.from(id.substring(separatorIndex2 + 1));
+            BlobId wrapped = delegate.parse(id.substring(separatorIndex2 + 1));
 
             return new GenerationAwareBlobId(generation, family, wrapped);
         }
 
         private GenerationAwareBlobId decorateWithoutGeneration(String id) {
-            return new GenerationAwareBlobId(NO_GENERATION, NO_FAMILY, delegate.from(id));
+            return new GenerationAwareBlobId(NO_GENERATION, NO_FAMILY, delegate.parse(id));
         }
 
         private GenerationAwareBlobId decorate(BlobId blobId) {

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
@@ -133,6 +133,11 @@ public class GenerationAwareBlobId implements BlobId {
         }
 
         @Override
+        public GenerationAwareBlobId of(String id) {
+            return decorate(delegate.of(id));
+        }
+
+        @Override
         public GenerationAwareBlobId from(String id) {
             int separatorIndex1 = id.indexOf('_');
             if (separatorIndex1 == -1 || separatorIndex1 == id.length() - 1) {

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
@@ -32,7 +32,6 @@ import org.apache.james.util.DurationParser;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import com.google.common.io.ByteSource;
 
 public class GenerationAwareBlobId implements BlobId {
 
@@ -123,16 +122,6 @@ public class GenerationAwareBlobId implements BlobId {
         }
 
         @Override
-        public GenerationAwareBlobId forPayload(byte[] payload) {
-            return decorate(delegate.forPayload(payload));
-        }
-
-        @Override
-        public GenerationAwareBlobId forPayload(ByteSource payload) {
-            return decorate(delegate.forPayload(payload));
-        }
-
-        @Override
         public GenerationAwareBlobId of(String id) {
             return decorate(delegate.of(id));
         }
@@ -152,11 +141,6 @@ public class GenerationAwareBlobId implements BlobId {
             BlobId wrapped = delegate.from(id.substring(separatorIndex2 + 1));
 
             return new GenerationAwareBlobId(generation, family, wrapped);
-        }
-
-        @Override
-        public GenerationAwareBlobId randomId() {
-            return decorate(delegate.randomId());
         }
 
         private GenerationAwareBlobId decorateWithoutGeneration(String id) {

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BlobGCTaskSerializationTest.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BlobGCTaskSerializationTest.java
@@ -31,7 +31,7 @@ import org.apache.james.JsonSerializationVerifier;
 import org.apache.james.blob.api.BlobReferenceSource;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.json.JsonGenericSerializer;
 import org.apache.james.util.ClassLoaderUtils;
 import org.apache.james.utils.UpdatableTickingClock;
@@ -53,7 +53,7 @@ class BlobGCTaskSerializationTest {
         blobReferenceSources = ImmutableSet.of(mock(BlobReferenceSource.class));
         clock = new UpdatableTickingClock(Instant.parse("2007-12-03T10:15:30.00Z"));
         generationAwareBlobIdConfiguration = GenerationAwareBlobId.Configuration.DEFAULT;
-        generationAwareBlobIdFactory = new GenerationAwareBlobId.Factory(clock, new HashBlobId.Factory(), generationAwareBlobIdConfiguration);
+        generationAwareBlobIdFactory = new GenerationAwareBlobId.Factory(clock, new PlainBlobId.Factory(), generationAwareBlobIdConfiguration);
     }
 
     @Test

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithmContract.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithmContract.java
@@ -235,7 +235,7 @@ public interface BloomFilterGCAlgorithmContract {
     default void gcShouldHandlerErrorWhenException() {
         when(BLOB_REFERENCE_SOURCE.listReferencedBlobs()).thenReturn(Flux.empty());
         BlobStoreDAO blobStoreDAO = mock(BlobStoreDAO.class);
-        BlobId blobId = GENERATION_AWARE_BLOB_ID_FACTORY.randomId();
+        BlobId blobId = GENERATION_AWARE_BLOB_ID_FACTORY.of(UUID.randomUUID().toString());
         when(blobStoreDAO.listBlobs(DEFAULT_BUCKET)).thenReturn(Flux.just(blobId));
         when(blobStoreDAO.delete(ArgumentMatchers.eq(DEFAULT_BUCKET), any(Collection.class))).thenReturn(Mono.error(new RuntimeException("test")));
 

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithmContract.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/BloomFilterGCAlgorithmContract.java
@@ -39,8 +39,8 @@ import org.apache.james.blob.api.BlobReferenceSource;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.server.blob.deduplication.BloomFilterGCAlgorithm.Context;
 import org.apache.james.server.blob.deduplication.BloomFilterGCAlgorithm.Context.Snapshot;
 import org.apache.james.task.Task;
@@ -57,7 +57,7 @@ import reactor.core.publisher.Mono;
 
 public interface BloomFilterGCAlgorithmContract {
 
-    HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     ZonedDateTime NOW = ZonedDateTime.parse("2015-10-30T16:12:00Z");
     BucketName DEFAULT_BUCKET = BucketName.of("default");
     GenerationAwareBlobId.Configuration GENERATION_AWARE_BLOB_ID_CONFIGURATION = GenerationAwareBlobId.Configuration.DEFAULT;

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobIdTest.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobIdTest.java
@@ -75,7 +75,7 @@ class GenerationAwareBlobIdTest {
         void previousBlobIdsShouldBeParsable() {
             String blobIdString = delegate.of("abc").asString();
 
-            GenerationAwareBlobId actual = testee.from(blobIdString);
+            GenerationAwareBlobId actual = testee.parse(blobIdString);
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(0);
@@ -88,7 +88,7 @@ class GenerationAwareBlobIdTest {
         void noFamilyShouldBeParsable() {
             String blobIdString = "0_0_" + delegate.of("abc").asString();
 
-            GenerationAwareBlobId actual = testee.from(blobIdString);
+            GenerationAwareBlobId actual = testee.parse(blobIdString);
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(0);
@@ -101,7 +101,7 @@ class GenerationAwareBlobIdTest {
         void generationBlobIdShouldBeParsable() {
             String blobIdString = "12_126_" + delegate.of("abc").asString();
 
-            GenerationAwareBlobId actual = testee.from(blobIdString);
+            GenerationAwareBlobId actual = testee.parse(blobIdString);
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(12);
@@ -114,12 +114,12 @@ class GenerationAwareBlobIdTest {
         void wrappedBlobIdCanContainSeparator() {
             String blobIdString = "12_126_ab_c";
 
-            GenerationAwareBlobId actual = testee.from(blobIdString);
+            GenerationAwareBlobId actual = testee.parse(blobIdString);
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(12);
                 soft.assertThat(actual.getGeneration()).isEqualTo(126L);
-                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.from("ab_c"));
+                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.parse("ab_c"));
             });
         }
 
@@ -133,12 +133,12 @@ class GenerationAwareBlobIdTest {
             "_abc"
         })
         void fromShouldFallbackWhenNotApplicable(String blobIdString) {
-            GenerationAwareBlobId actual = testee.from(blobIdString);
+            GenerationAwareBlobId actual = testee.parse(blobIdString);
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(0);
                 soft.assertThat(actual.getGeneration()).isEqualTo(0L);
-                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.from(blobIdString));
+                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.parse(blobIdString));
             });
         }
 
@@ -146,13 +146,13 @@ class GenerationAwareBlobIdTest {
         class Failures {
             @Test
             void emptyShouldFail() {
-                assertThatThrownBy(() -> testee.from(""))
+                assertThatThrownBy(() -> testee.parse(""))
                     .isInstanceOf(IllegalArgumentException.class);
             }
 
             @Test
             void nullShouldFailShouldFail() {
-                assertThatThrownBy(() -> testee.from(null))
+                assertThatThrownBy(() -> testee.parse(null))
                     .isInstanceOf(NullPointerException.class);
             }
 
@@ -167,7 +167,7 @@ class GenerationAwareBlobIdTest {
                 "1_-1_abc",
             })
             void fromShouldFallbackWhenNotApplicable(String blobIdString) {
-                assertThatThrownBy(() -> testee.from(blobIdString))
+                assertThatThrownBy(() -> testee.parse(blobIdString))
                     .isInstanceOf(IllegalArgumentException.class);
             }
         }
@@ -183,14 +183,14 @@ class GenerationAwareBlobIdTest {
 
         @Test
         void asStringShouldIntegrateFamilyAndGeneration() {
-            BlobId blobId = new GenerationAwareBlobId(23, 456, delegate.from("abc"));
+            BlobId blobId = new GenerationAwareBlobId(23, 456, delegate.parse("abc"));
 
             assertThat(blobId.asString()).isEqualTo("456_23_abc");
         }
 
         @Test
         void asStringShouldReturnDelegateForZeroFamily() {
-            BlobId blobId = new GenerationAwareBlobId(0, 0, delegate.from("abc"));
+            BlobId blobId = new GenerationAwareBlobId(0, 0, delegate.parse("abc"));
 
             assertThat(blobId.asString()).isEqualTo("abc");
         }
@@ -201,14 +201,14 @@ class GenerationAwareBlobIdTest {
             "abc"
         })
         void asStringShouldRevertFromString(String blobIdString) {
-            GenerationAwareBlobId blobId = testee.from(blobIdString);
+            GenerationAwareBlobId blobId = testee.parse(blobIdString);
 
             assertThat(blobId.asString()).isEqualTo(blobIdString);
         }
 
         @Test
         void noGenerationShouldNeverBeInActiveGeneration() {
-            GenerationAwareBlobId blobId = new GenerationAwareBlobId(0, 0, delegate.from("abc"));
+            GenerationAwareBlobId blobId = new GenerationAwareBlobId(0, 0, delegate.parse("abc"));
 
             assertThat(blobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW)).isFalse();
         }

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobIdTest.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobIdTest.java
@@ -106,7 +106,7 @@ class GenerationAwareBlobIdTest {
     class BlobIdParsing {
         @Test
         void previousBlobIdsShouldBeParsable() {
-            String blobIdString = delegate.forPayload("abc".getBytes()).asString();
+            String blobIdString = delegate.of("abc").asString();
 
             GenerationAwareBlobId actual = testee.from(blobIdString);
 
@@ -119,27 +119,27 @@ class GenerationAwareBlobIdTest {
 
         @Test
         void noFamilyShouldBeParsable() {
-            String blobIdString = "0_0_" + delegate.forPayload("abc".getBytes()).asString();
+            String blobIdString = "0_0_" + delegate.of("abc").asString();
 
             GenerationAwareBlobId actual = testee.from(blobIdString);
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(0);
                 soft.assertThat(actual.getGeneration()).isEqualTo(0L);
-                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.forPayload("abc".getBytes()));
+                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.of("abc"));
             });
         }
 
         @Test
         void generationBlobIdShouldBeParsable() {
-            String blobIdString = "12_126_" + delegate.forPayload("abc".getBytes()).asString();
+            String blobIdString = "12_126_" + delegate.of("abc").asString();
 
             GenerationAwareBlobId actual = testee.from(blobIdString);
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(12);
                 soft.assertThat(actual.getGeneration()).isEqualTo(126L);
-                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.forPayload("abc".getBytes()));
+                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.of("abc"));
             });
         }
 
@@ -248,14 +248,14 @@ class GenerationAwareBlobIdTest {
 
         @Test
         void inActiveGenerationShouldReturnTrueWhenSameDate() {
-            GenerationAwareBlobId blobId = testee.forPayload("abc".getBytes());
+            GenerationAwareBlobId blobId = testee.of("abc");
 
             assertThat(blobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW)).isTrue();
         }
 
         @Test
         void inActiveGenerationShouldReturnTrueWhenInTheFuture() {
-            GenerationAwareBlobId blobId = testee.forPayload("abc".getBytes());
+            GenerationAwareBlobId blobId = testee.of("abc");
 
             assertThat(blobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW.minus(60, ChronoUnit.DAYS)))
                 .isTrue();
@@ -263,7 +263,7 @@ class GenerationAwareBlobIdTest {
 
         @Test
         void inActiveGenerationShouldReturnTrueForAtLeastOneMoreMonth() {
-            GenerationAwareBlobId blobId = testee.forPayload("abc".getBytes());
+            GenerationAwareBlobId blobId = testee.of("abc");
 
             assertThat(blobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW.plus(30, ChronoUnit.DAYS)))
                 .isTrue();
@@ -271,7 +271,7 @@ class GenerationAwareBlobIdTest {
 
         @Test
         void inActiveGenerationShouldReturnFalseAfterTwoMonth() {
-            GenerationAwareBlobId blobId = testee.forPayload("abc".getBytes());
+            GenerationAwareBlobId blobId = testee.of("abc");
 
             assertThat(blobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW.plus(60, ChronoUnit.DAYS)))
                 .isFalse();

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobIdTest.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobIdTest.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.james.blob.api.BlobId;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.utils.UpdatableTickingClock;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +49,7 @@ class GenerationAwareBlobIdTest {
 
     @BeforeEach
     void setUp() {
-        delegate = new HashBlobId.Factory();
+        delegate = new PlainBlobId.Factory();
         clock = new UpdatableTickingClock(NOW);
         testee = new GenerationAwareBlobId.Factory(clock, delegate, GenerationAwareBlobId.Configuration.DEFAULT);
     }

--- a/server/blob/mail-store/src/test/java/org/apache/james/blob/mail/MimeMessageStoreTest.java
+++ b/server/blob/mail-store/src/test/java/org/apache/james/blob/mail/MimeMessageStoreTest.java
@@ -29,8 +29,8 @@ import jakarta.mail.internet.MimeMessage;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.memory.MemoryBlobStoreFactory;
 import org.apache.james.core.builder.MimeMessageBuilder;
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 class MimeMessageStoreTest {
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
 
     private Store<MimeMessage, MimeMessagePartsId> testee;
     private BlobStore blobStore;

--- a/server/blob/mail-store/src/test/java/org/apache/james/blob/mail/MimeMessageStoreTest.java
+++ b/server/blob/mail-store/src/test/java/org/apache/james/blob/mail/MimeMessageStoreTest.java
@@ -105,8 +105,8 @@ class MimeMessageStoreTest {
     @Test
     void deleteShouldNotThrowWhenCalledOnNonExistingData() throws Exception {
         MimeMessagePartsId parts = MimeMessagePartsId.builder()
-            .headerBlobId(BLOB_ID_FACTORY.randomId())
-            .bodyBlobId(BLOB_ID_FACTORY.randomId())
+            .headerBlobId(BLOB_ID_FACTORY.of("NON_EXISTING_HEADER_BLOB_ID"))
+            .bodyBlobId(BLOB_ID_FACTORY.of("NON_EXISTING_BODY_BLOB_ID"))
             .build();
 
         assertThatCode(() -> Mono.from(testee.delete(parts)).block())

--- a/server/container/guice/blob/api/src/main/java/org/apache/james/modules/mailbox/BlobStoreAPIModule.java
+++ b/server/container/guice/blob/api/src/main/java/org/apache/james/modules/mailbox/BlobStoreAPIModule.java
@@ -21,18 +21,17 @@ package org.apache.james.modules.mailbox;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
+import org.apache.james.blob.api.PlainBlobId;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 
 public class BlobStoreAPIModule extends AbstractModule {
-
     @Override
     protected void configure() {
-        bind(HashBlobId.Factory.class).in(Scopes.SINGLETON);
-        bind(BlobId.Factory.class).to(HashBlobId.Factory.class);
+        bind(PlainBlobId.Factory.class).in(Scopes.SINGLETON);
+        bind(BlobId.Factory.class).to(PlainBlobId.Factory.class);
 
         bind(MetricableBlobStore.class).in(Scopes.SINGLETON);
         bind(BlobStore.class).to(MetricableBlobStore.class);

--- a/server/container/guice/blob/deduplication-gc/src/main/java/org/apache/james/modules/blobstore/BlobDeduplicationGCModule.java
+++ b/server/container/guice/blob/deduplication-gc/src/main/java/org/apache/james/modules/blobstore/BlobDeduplicationGCModule.java
@@ -29,8 +29,8 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobReferenceSource;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreDAO;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.modules.blobstore.server.BlobRoutesModules;
 import org.apache.james.server.blob.deduplication.BlobGCTaskAdditionalInformationDTO;
 import org.apache.james.server.blob.deduplication.BlobGCTaskDTO;
@@ -57,7 +57,7 @@ public class BlobDeduplicationGCModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(HashBlobId.Factory.class).in(Scopes.SINGLETON);
+        bind(PlainBlobId.Factory.class).in(Scopes.SINGLETON);
         bind(BlobId.Factory.class).to(GenerationAwareBlobId.Factory.class);
 
         bind(MetricableBlobStore.class).in(Scopes.SINGLETON);
@@ -68,7 +68,7 @@ public class BlobDeduplicationGCModule extends AbstractModule {
 
     @Singleton
     @Provides
-    public GenerationAwareBlobId.Factory generationAwareBlobIdFactory(Clock clock, HashBlobId.Factory delegate, GenerationAwareBlobId.Configuration configuration) {
+    public GenerationAwareBlobId.Factory generationAwareBlobIdFactory(Clock clock, PlainBlobId.Factory delegate, GenerationAwareBlobId.Configuration configuration) {
         return new GenerationAwareBlobId.Factory(clock, delegate, configuration);
     }
 

--- a/server/container/guice/blob/memory/src/main/java/org/apache/james/modules/BlobMemoryModule.java
+++ b/server/container/guice/blob/memory/src/main/java/org/apache/james/modules/BlobMemoryModule.java
@@ -23,7 +23,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.server.blob.deduplication.DeDuplicationBlobStore;
 
@@ -35,8 +35,8 @@ public class BlobMemoryModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(HashBlobId.Factory.class).in(Scopes.SINGLETON);
-        bind(BlobId.Factory.class).to(HashBlobId.Factory.class);
+        bind(PlainBlobId.Factory.class).in(Scopes.SINGLETON);
+        bind(BlobId.Factory.class).to(PlainBlobId.Factory.class);
 
         bind(DeDuplicationBlobStore.class).in(Scopes.SINGLETON);
         bind(BlobStore.class).to(DeDuplicationBlobStore.class);

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/mailbox/DistributedDeletedMessageVaultDeletionCallback.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/mailbox/DistributedDeletedMessageVaultDeletionCallback.java
@@ -148,8 +148,8 @@ public class DistributedDeletedMessageVaultDeletionCallback implements DeleteMes
                 internalDate,
                 size,
                 hasAttachments,
-                blobIdFactory.from(headerId),
-                blobIdFactory.from(bodyId));
+                blobIdFactory.parse(headerId),
+                blobIdFactory.parse(bodyId));
         }
     }
 

--- a/server/container/guice/mailrepository-blob/src/main/java/org/apache/james/modules/mailrepository/BlobstoreMailRepositoryModule.java
+++ b/server/container/guice/mailrepository-blob/src/main/java/org/apache/james/modules/mailrepository/BlobstoreMailRepositoryModule.java
@@ -19,10 +19,13 @@
 
 package org.apache.james.modules.mailrepository;
 
+import jakarta.inject.Named;
+
 import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
 import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreDAO;
-import org.apache.james.blob.mail.MimeMessageStore;
+import org.apache.james.blob.api.BucketName;
 import org.apache.james.mailrepository.api.MailRepositoryFactory;
 import org.apache.james.mailrepository.api.MailRepositoryStore;
 import org.apache.james.mailrepository.api.Protocol;
@@ -52,8 +55,9 @@ public class BlobstoreMailRepositoryModule extends AbstractModule {
     @ProvidesIntoSet()
     public MailRepositoryFactory blobMailRepository(BlobStoreDAO blobStore,
                                                     BlobId.Factory blobIdFactory,
-                                                    MimeMessageStore.Factory mimeFactory) {
-        return new BlobMailRepositoryFactory(blobStore, blobIdFactory, mimeFactory);
+                                                    @Named(BlobStore.DEFAULT_BUCKET_NAME_QUALIFIER) BucketName defaultBucketName
+                                                    ) {
+        return new BlobMailRepositoryFactory(blobStore, blobIdFactory, defaultBucketName);
     }
 
 }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/upload/UploadDAO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/upload/UploadDAO.java
@@ -216,7 +216,7 @@ public class UploadDAO {
 
     private Function<Row, UploadRepresentation> rowToUploadRepresentation() {
         return row -> new UploadRepresentation(UploadId.from(row.getUuid(ID)),
-            blobIdFactory.from(row.getString(BLOB_ID)),
+            blobIdFactory.parse(row.getString(BLOB_ID)),
             ContentType.of(row.getString(CONTENT_TYPE)),
             row.getLong(SIZE),
             Username.of(row.getString(USER)),

--- a/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraJMAPCurrentUploadUsageCalculatorTest.java
+++ b/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraJMAPCurrentUploadUsageCalculatorTest.java
@@ -26,7 +26,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.components.CassandraMutualizedQuotaModule;
 import org.apache.james.backends.cassandra.components.CassandraQuotaCurrentValueDao;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.jmap.api.upload.JMAPCurrentUploadUsageCalculator;
 import org.apache.james.jmap.api.upload.JMAPCurrentUploadUsageCalculatorContract;
@@ -49,7 +49,7 @@ public class CassandraJMAPCurrentUploadUsageCalculatorTest implements JMAPCurren
     private void setup() {
         Clock clock = Clock.systemUTC();
         uploadRepository = new CassandraUploadRepository(new UploadDAO(cassandraCluster.getCassandraCluster().getConf(),
-            new HashBlobId.Factory()), new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.of("default"), new HashBlobId.Factory()),
+            new PlainBlobId.Factory()), new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.of("default"), new PlainBlobId.Factory()),
             clock);
         uploadUsageRepository = new CassandraUploadUsageRepository(new CassandraQuotaCurrentValueDao(cassandraCluster.getCassandraCluster().getConf()));
         jmapCurrentUploadUsageCalculator = new JMAPCurrentUploadUsageCalculator(uploadRepository, uploadUsageRepository);

--- a/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraUploadRepositoryTest.java
+++ b/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraUploadRepositoryTest.java
@@ -23,7 +23,7 @@ import java.time.Clock;
 
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.jmap.api.model.UploadId;
 import org.apache.james.jmap.api.upload.UploadRepository;
@@ -44,7 +44,7 @@ class CassandraUploadRepositoryTest implements UploadRepositoryContract {
     void setUp() {
         Clock clock = Clock.systemUTC();
         testee = new CassandraUploadRepository(new UploadDAO(cassandra.getCassandraCluster().getConf(),
-            new HashBlobId.Factory()), new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.of("default"), new HashBlobId.Factory()),
+            new PlainBlobId.Factory()), new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.of("default"), new PlainBlobId.Factory()),
             clock);
     }
 

--- a/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraUploadServiceTest.java
+++ b/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/upload/CassandraUploadServiceTest.java
@@ -27,7 +27,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.components.CassandraMutualizedQuotaModule;
 import org.apache.james.backends.cassandra.components.CassandraQuotaCurrentValueDao;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.jmap.api.upload.UploadRepository;
 import org.apache.james.jmap.api.upload.UploadService;
@@ -51,8 +51,8 @@ class CassandraUploadServiceTest implements UploadServiceContract {
     @BeforeEach
     void setUp(CassandraCluster cassandraCluster) {
         Clock clock = Clock.systemUTC();
-        uploadRepository = new CassandraUploadRepository(new UploadDAO(cassandraCluster.getConf(), new HashBlobId.Factory()), new DeDuplicationBlobStore(new MemoryBlobStoreDAO(),
-            BucketName.of("default"), new HashBlobId.Factory()), clock);
+        uploadRepository = new CassandraUploadRepository(new UploadDAO(cassandraCluster.getConf(), new PlainBlobId.Factory()), new DeDuplicationBlobStore(new MemoryBlobStoreDAO(),
+            BucketName.of("default"), new PlainBlobId.Factory()), clock);
         uploadUsageRepository = new CassandraUploadUsageRepository(new CassandraQuotaCurrentValueDao(cassandraCluster.getConf()));
         testee = new UploadServiceDefaultImpl(uploadRepository, uploadUsageRepository, UploadServiceContract.TEST_CONFIGURATION());
     }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryJMAPCurrentUploadUsageCalculatorTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryJMAPCurrentUploadUsageCalculatorTest.java
@@ -23,7 +23,7 @@ import java.time.Clock;
 
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.jmap.api.upload.JMAPCurrentUploadUsageCalculator;
 import org.apache.james.jmap.api.upload.JMAPCurrentUploadUsageCalculatorContract;
@@ -40,7 +40,7 @@ public class InMemoryJMAPCurrentUploadUsageCalculatorTest implements JMAPCurrent
 
     @BeforeEach
     private void setup() {
-        BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, new HashBlobId.Factory());
+        BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, new PlainBlobId.Factory());
         uploadRepository = new InMemoryUploadRepository(blobStore, Clock.systemUTC());
         uploadUsageRepository = new InMemoryUploadUsageRepository();
         jmapCurrentUploadUsageCalculator = new JMAPCurrentUploadUsageCalculator(uploadRepository, uploadUsageRepository);

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryUploadRepositoryTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryUploadRepositoryTest.java
@@ -23,7 +23,7 @@ import java.time.Clock;
 
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.jmap.api.upload.UploadRepository;
 import org.apache.james.jmap.api.upload.UploadRepositoryContract;
@@ -36,7 +36,7 @@ public class InMemoryUploadRepositoryTest implements UploadRepositoryContract {
 
     @BeforeEach
     void setUp() {
-        BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, new HashBlobId.Factory());
+        BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, new PlainBlobId.Factory());
         testee = new InMemoryUploadRepository(blobStore, Clock.systemUTC());
     }
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryUploadServiceTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/upload/InMemoryUploadServiceTest.java
@@ -23,7 +23,7 @@ import java.time.Clock;
 
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.jmap.api.upload.UploadRepository;
 import org.apache.james.jmap.api.upload.UploadService;
@@ -41,7 +41,7 @@ public class InMemoryUploadServiceTest implements UploadServiceContract {
 
     @BeforeEach
     void setUp() {
-        BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, new HashBlobId.Factory());
+        BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, new PlainBlobId.Factory());
         uploadRepository = new InMemoryUploadRepository(blobStore, Clock.systemUTC());
         uploadUsageRepository = new InMemoryUploadUsageRepository();
         testee = new UploadServiceDefaultImpl(uploadRepository, uploadUsageRepository, UploadServiceContract.TEST_CONFIGURATION());

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -338,14 +338,14 @@ public interface MailRepositoryContract {
     @Test
     default void retrieveShouldReturnNullWhenKeyWasRemoved() throws Exception {
         MailRepository testee = retrieveRepository();
-        testee.store(createMail(MAIL_1));
+        var mailKey = testee.store(createMail(MAIL_1));
 
-        testee.remove(MAIL_1);
+        testee.remove(mailKey);
 
         assertThat(retrieveRepository().list())
                 .toIterable()
-                .doesNotContain(MAIL_1);
-        assertThat(retrieveRepository().retrieve(MAIL_1)).isNull();
+                .doesNotContain(mailKey);
+        assertThat(retrieveRepository().retrieve(mailKey)).isNull();
     }
 
     @Test

--- a/server/mailrepository/mailrepository-blob/src/main/scala/org/apache/james/mailrepository/blob/BlobMailRepository.scala
+++ b/server/mailrepository/mailrepository-blob/src/main/scala/org/apache/james/mailrepository/blob/BlobMailRepository.scala
@@ -189,7 +189,7 @@ class BlobMailRepository(val mailMetaDataBlobStore: BlobStore,
 
   @throws[MessagingException]
   override def retrieve(key: MailKey): Mail = {
-    mailMetadataStore.read(MailPartsId(mailMetadataBlobIdFactory.from(key.asString())))
+    mailMetadataStore.read(MailPartsId(mailMetadataBlobIdFactory.parse(key.asString())))
       .flatMap {
         case (mail, mimeMessagePartsId) => mimeMessageStore.read(mimeMessagePartsId).map { mimeMessage =>
           mail.setMessage(mimeMessage)
@@ -204,7 +204,7 @@ class BlobMailRepository(val mailMetaDataBlobStore: BlobStore,
   // FIXME - on supprime les metadata mais pas les mimeMessages associés ?
   @throws[MessagingException]
   override def remove(key: MailKey): Unit = {
-    Mono.from(mailMetadataStore.delete( MailPartsId(mailMetadataBlobIdFactory.from(key.asString())))).block()
+    Mono.from(mailMetadataStore.delete( MailPartsId(mailMetadataBlobIdFactory.parse(key.asString())))).block()
   }
   // FIXME - on supprime les metadata mais pas les mimeMessages associés ?
   @throws[MessagingException]

--- a/server/mailrepository/mailrepository-blob/src/main/scala/org/apache/james/mailrepository/blob/BlobMailRepositoryFactory.scala
+++ b/server/mailrepository/mailrepository-blob/src/main/scala/org/apache/james/mailrepository/blob/BlobMailRepositoryFactory.scala
@@ -31,8 +31,8 @@ class MailRepositoryBlobIdFactory(
                                    url: MailRepositoryUrl
                                  ) extends BlobId.Factory {
   // Must wrap the default BlobId factory but inject a MailRepositoryUrl dependant prefix
-  override def from(id: String): BlobId =
-    blobIdFactory.from(id)
+  override def parse(id: String): BlobId =
+    blobIdFactory.parse(id)
 
   override def of(id: String): BlobId =
     blobIdFactory.of(url.getPath.subPath(id).asString())

--- a/server/mailrepository/mailrepository-blob/src/main/scala/org/apache/james/mailrepository/blob/MailMetadata.scala
+++ b/server/mailrepository/mailrepository-blob/src/main/scala/org/apache/james/mailrepository/blob/MailMetadata.scala
@@ -89,8 +89,8 @@ private[blob] case class MailMetadata(
 
   def mimePartsId(implicit blobIdFactory: BlobId.Factory): MimeMessagePartsId =
     MimeMessagePartsId.builder()
-      .headerBlobId(blobIdFactory.from(headerBlobId))
-      .bodyBlobId(blobIdFactory.from(bodyBlobId))
+      .headerBlobId(blobIdFactory.parse(headerBlobId))
+      .bodyBlobId(blobIdFactory.parse(bodyBlobId))
       .build()
 
 }

--- a/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/BlobMailRepositoryTest.java
+++ b/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/BlobMailRepositoryTest.java
@@ -43,13 +43,13 @@ class BlobMailRepositoryTest implements MailRepositoryContract {
     void setup() {
         blobIdFactory = new HashBlobId.Factory();
         blobStore = new MemoryBlobStoreDAO();
-        var mimeMessageBlobStore  = MemoryBlobStoreFactory.builder()
+        var mimeMessageBlobStore = MemoryBlobStoreFactory.builder()
                 .blobIdFactory(blobIdFactory)
                 .defaultBucketName()
                 .passthrough();
         mimeMessageStoreFactory = new MimeMessageStore.Factory(mimeMessageBlobStore);
-        MailRepositoryPath path = MailRepositoryPath.from("/foo");
-        blobMailRepositoryFactory = new BlobMailRepositoryFactory(blobStore, blobIdFactory, mimeMessageStoreFactory);
+        MailRepositoryPath path = MailRepositoryPath.from("var/mail/error");
+        blobMailRepositoryFactory = new BlobMailRepositoryFactory(blobStore, blobIdFactory, mimeMessageBlobStore.getDefaultBucketName());
         blobMailRepository = buildBlobMailRepository(path);
     }
 

--- a/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/BlobMailRepositoryTest.java
+++ b/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/BlobMailRepositoryTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.mailrepository.blob;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.blob.memory.MemoryBlobStoreFactory;
@@ -34,14 +34,14 @@ import org.junit.jupiter.api.BeforeEach;
 class BlobMailRepositoryTest implements MailRepositoryContract {
 
     private MailRepository blobMailRepository;
-    private HashBlobId.Factory blobIdFactory;
+    private PlainBlobId.Factory blobIdFactory;
     private MemoryBlobStoreDAO blobStore;
     private MimeMessageStore.Factory mimeMessageStoreFactory;
     private BlobMailRepositoryFactory blobMailRepositoryFactory;
 
     @BeforeEach
     void setup() {
-        blobIdFactory = new HashBlobId.Factory();
+        blobIdFactory = new PlainBlobId.Factory();
         blobStore = new MemoryBlobStoreDAO();
         var mimeMessageBlobStore = MemoryBlobStoreFactory.builder()
                 .blobIdFactory(blobIdFactory)

--- a/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/MailRepositoryBlobIdFactoryTest.java
+++ b/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/MailRepositoryBlobIdFactoryTest.java
@@ -22,7 +22,7 @@ package org.apache.james.mailrepository.blob;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.blob.api.BlobId;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailrepository.api.MailRepositoryPath;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.mailrepository.api.Protocol;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class MailRepositoryBlobIdFactoryTest {
     static String MAIL_REPOSITORY_PATH = "/var/mail/error";
 
-    BlobId.Factory blobIdFactory = new HashBlobId.Factory();
+    BlobId.Factory blobIdFactory = new PlainBlobId.Factory();
     MailRepositoryUrl url = MailRepositoryUrl.fromPathAndProtocol(
             new Protocol("blob"),
             MailRepositoryPath.from(MAIL_REPOSITORY_PATH)

--- a/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/MailRepositoryBlobIdFactoryTest.java
+++ b/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/MailRepositoryBlobIdFactoryTest.java
@@ -48,11 +48,11 @@ class MailRepositoryBlobIdFactoryTest {
     }
 
     @Test
-    void fromShouldNotRelocateBlobIdUnderTheMailRepositoryPath() {
+    void parseShouldNotRelocateBlobIdUnderTheMailRepositoryPath() {
         var id = MAIL_REPOSITORY_PATH + "/" + "0c222abb-d115-4a88-9fbe-e65e951301f6";
         MailRepositoryBlobIdFactory factory = new MailRepositoryBlobIdFactory(blobIdFactory, url);
 
-        BlobId actual = factory.from(id);
+        BlobId actual = factory.parse(id);
 
         assertThat(actual.asString()).isEqualTo(id);
     }

--- a/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/MailRepositoryBlobIdFactoryTest.java
+++ b/server/mailrepository/mailrepository-blob/src/test/java/org/apache/james/mailrepository/blob/MailRepositoryBlobIdFactoryTest.java
@@ -1,0 +1,61 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailrepository.blob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.mailrepository.api.MailRepositoryPath;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.mailrepository.api.Protocol;
+import org.junit.jupiter.api.Test;
+
+class MailRepositoryBlobIdFactoryTest {
+    static String MAIL_REPOSITORY_PATH = "/var/mail/error";
+
+    BlobId.Factory blobIdFactory = new HashBlobId.Factory();
+    MailRepositoryUrl url = MailRepositoryUrl.fromPathAndProtocol(
+            new Protocol("blob"),
+            MailRepositoryPath.from(MAIL_REPOSITORY_PATH)
+    );
+
+    @Test
+    void ofShouldRelocateBlobIdUnderTheMailRepositoryPath() {
+        var id = "0c222abb-d115-4a88-9fbe-e65e951301f6";
+        MailRepositoryBlobIdFactory factory = new MailRepositoryBlobIdFactory(blobIdFactory, url);
+
+        BlobId actual = factory.of(id);
+
+        assertThat(actual.asString()).isEqualTo(MAIL_REPOSITORY_PATH + "/" + id);
+    }
+
+    @Test
+    void fromShouldNotRelocateBlobIdUnderTheMailRepositoryPath() {
+        var id = MAIL_REPOSITORY_PATH + "/" + "0c222abb-d115-4a88-9fbe-e65e951301f6";
+        MailRepositoryBlobIdFactory factory = new MailRepositoryBlobIdFactory(blobIdFactory, url);
+
+        BlobId actual = factory.from(id);
+
+        assertThat(actual.asString()).isEqualTo(id);
+    }
+
+
+}

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDaoV2.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDaoV2.java
@@ -261,8 +261,8 @@ public class CassandraMailRepositoryMailDaoV2 {
             .addAttributes(toAttributes(rawAttributes));
 
         return new MailDTO(mailBuilder,
-            blobIdFactory.from(row.getString(HEADER_BLOB_ID)),
-            blobIdFactory.from(row.getString(BODY_BLOB_ID)));
+            blobIdFactory.parse(row.getString(HEADER_BLOB_ID)),
+            blobIdFactory.parse(row.getString(BODY_BLOB_ID)));
     }
 
     private List<Attribute> toAttributes(Map<String, String> rowAttributes) {
@@ -314,8 +314,8 @@ public class CassandraMailRepositoryMailDaoV2 {
     Flux<BlobId> listBlobs() {
         return executor.executeRows(litBlobs.bind())
             .flatMapIterable(row -> List.of(
-                blobIdFactory.from(row.getString(HEADER_BLOB_ID)),
-                blobIdFactory.from(row.getString(BODY_BLOB_ID))
+                blobIdFactory.parse(row.getString(HEADER_BLOB_ID)),
+                blobIdFactory.parse(row.getString(BODY_BLOB_ID))
             ));
     }
 

--- a/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAOTest.java
+++ b/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAOTest.java
@@ -70,8 +70,8 @@ class CassandraMailRepositoryMailDAOTest {
 
     @Test
     void storeShouldAcceptMailWithOnlyName() throws Exception {
-        BlobId blobIdBody = BLOB_ID_FACTORY.from("blobHeader");
-        BlobId blobIdHeader = BLOB_ID_FACTORY.from("blobBody");
+        BlobId blobIdBody = BLOB_ID_FACTORY.parse("blobHeader");
+        BlobId blobIdHeader = BLOB_ID_FACTORY.parse("blobBody");
 
         testee.store(URL,
             FakeMail.builder()
@@ -93,8 +93,8 @@ class CassandraMailRepositoryMailDAOTest {
 
     @Test
     void removeShouldDeleteMailMetaData() throws Exception {
-        BlobId blobIdBody = BLOB_ID_FACTORY.from("blobHeader");
-        BlobId blobIdHeader = BLOB_ID_FACTORY.from("blobBody");
+        BlobId blobIdBody = BLOB_ID_FACTORY.parse("blobHeader");
+        BlobId blobIdHeader = BLOB_ID_FACTORY.parse("blobBody");
 
         testee.store(URL,
             FakeMail.builder()
@@ -118,8 +118,8 @@ class CassandraMailRepositoryMailDAOTest {
 
     @Test
     void readShouldReturnAllMailMetadata() throws Exception {
-        BlobId blobIdBody = BLOB_ID_FACTORY.from("blobHeader");
-        BlobId blobIdHeader = BLOB_ID_FACTORY.from("blobBody");
+        BlobId blobIdBody = BLOB_ID_FACTORY.parse("blobHeader");
+        BlobId blobIdHeader = BLOB_ID_FACTORY.parse("blobBody");
         String errorMessage = "error message";
         String state = "state";
         String remoteAddr = "remoteAddr";
@@ -176,8 +176,8 @@ class CassandraMailRepositoryMailDAOTest {
 
     @Test
     void blobReferencesShouldAllAddedValues() throws Exception {
-        BlobId blobIdBody = BLOB_ID_FACTORY.from("blobHeader");
-        BlobId blobIdHeader = BLOB_ID_FACTORY.from("blobBody");
+        BlobId blobIdBody = BLOB_ID_FACTORY.parse("blobHeader");
+        BlobId blobIdHeader = BLOB_ID_FACTORY.parse("blobBody");
         String state = "state";
         AttributeName attributeName = AttributeName.of("att1");
         List<AttributeValue<?>> attributeValue = ImmutableList.of(AttributeValue.of("value1"), AttributeValue.of("value2"));
@@ -196,8 +196,8 @@ class CassandraMailRepositoryMailDAOTest {
             blobIdBody)
             .block();
 
-        BlobId blobIdBody2 = BLOB_ID_FACTORY.from("blobHeader2");
-        BlobId blobIdHeader2 = BLOB_ID_FACTORY.from("blobBody2");
+        BlobId blobIdBody2 = BLOB_ID_FACTORY.parse("blobHeader2");
+        BlobId blobIdHeader2 = BLOB_ID_FACTORY.parse("blobBody2");
 
         testee.store(URL,
             FakeMail.builder()

--- a/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryTest.java
+++ b/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryTest.java
@@ -29,7 +29,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.BlobTables;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class CassandraMailRepositoryTest {
     static final MailRepositoryUrl URL = MailRepositoryUrl.from("proto://url");
-    static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
 
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(

--- a/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryWithFakeImplementationsTest.java
+++ b/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryWithFakeImplementationsTest.java
@@ -30,7 +30,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.BlobTables;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
@@ -55,7 +55,7 @@ class CassandraMailRepositoryWithFakeImplementationsTest {
             CassandraSchemaVersionModule.MODULE));
 
     private static final MailRepositoryUrl URL = MailRepositoryUrl.from("proto://url");
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
 
 
     CassandraMailRepository cassandraMailRepository;

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesServiceTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesServiceTest.java
@@ -31,7 +31,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
 import org.apache.james.mailbox.MessageUid;
@@ -78,7 +78,7 @@ public class MetaDataFixInconsistenciesServiceTest {
     private static final ModSeq MOD_SEQ_2 = ModSeq.of(2L);
     private static final String CONTENT_MESSAGE = "CONTENT 123 BLA BLA";
 
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
+    private static final PlainBlobId HEADER_BLOB_ID_1 = new PlainBlobId.Factory().of("abc");
     private static final CassandraMessageMetadata MESSAGE_1 = CassandraMessageMetadata.builder()
         .ids(ComposedMessageIdWithMetaData.builder()
             .composedMessageId(new ComposedMessageId(MAILBOX_ID, MESSAGE_ID_1, MESSAGE_UID_1))
@@ -161,7 +161,7 @@ public class MetaDataFixInconsistenciesServiceTest {
         pop3MetadataStore = new CassandraPop3MetadataStore(cassandra.getConf());
         imapUidDAO = new CassandraMessageIdToImapUidDAO(
             cassandra.getConf(),
-            new HashBlobId.Factory(),
+            new PlainBlobId.Factory(),
             CassandraConfiguration.DEFAULT_CONFIGURATION);
 
         cassandraMessageDAOV3 = new CassandraMessageDAOV3(
@@ -169,7 +169,7 @@ public class MetaDataFixInconsistenciesServiceTest {
             cassandra.getTypesProvider(),
             CassandraBlobStoreFactory.forTesting(cassandra.getConf(), new RecordingMetricFactory())
                 .passthrough(),
-            new HashBlobId.Factory());
+            new PlainBlobId.Factory());
         testee = new MetaDataFixInconsistenciesService(imapUidDAO, pop3MetadataStore, cassandraMessageDAOV3);
     }
 

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesServiceTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesServiceTest.java
@@ -78,7 +78,7 @@ public class MetaDataFixInconsistenciesServiceTest {
     private static final ModSeq MOD_SEQ_2 = ModSeq.of(2L);
     private static final String CONTENT_MESSAGE = "CONTENT 123 BLA BLA";
 
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
     private static final CassandraMessageMetadata MESSAGE_1 = CassandraMessageMetadata.builder()
         .ids(ComposedMessageIdWithMetaData.builder()
             .composedMessageId(new ComposedMessageId(MAILBOX_ID, MESSAGE_ID_1, MESSAGE_UID_1))

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/BlobRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/BlobRoutesTest.java
@@ -44,8 +44,8 @@ import org.apache.james.blob.api.BlobReferenceSource;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.json.DTOConverter;
 import org.apache.james.server.blob.deduplication.BlobGCTaskAdditionalInformationDTO;
@@ -76,7 +76,7 @@ import reactor.core.publisher.Mono;
 
 class BlobRoutesTest {
     private static final String BASE_PATH = "/blobs";
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private static final ZonedDateTime TIMESTAMP = ZonedDateTime.parse("2015-10-30T16:12:00Z");
     private static final BucketName DEFAULT_BUCKET = BucketName.of("default");
     private static final GenerationAwareBlobId.Configuration GENERATION_AWARE_BLOB_ID_CONFIGURATION = GenerationAwareBlobId.Configuration.DEFAULT;

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/JmapUploadRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/JmapUploadRoutesTest.java
@@ -38,7 +38,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.UploadId;
@@ -99,10 +99,10 @@ class JmapUploadRoutesTest {
         clock = new UpdatableTickingClock(TIMESTAMP.toInstant());
         blobStore = new PassThroughBlobStore(new MemoryBlobStoreDAO(),
             BucketName.of("default"),
-            new HashBlobId.Factory());
+            new PlainBlobId.Factory());
 
         cassandraUploadRepository = new CassandraUploadRepository(new UploadDAO(cassandraCluster.getCassandraCluster().getConf(),
-            new HashBlobId.Factory()), blobStore, clock);
+            new PlainBlobId.Factory()), blobStore, clock);
 
         JsonTransformer jsonTransformer = new JsonTransformer();
         TasksRoutes tasksRoutes = new TasksRoutes(taskManager, jsonTransformer, DTOConverter.of(UploadCleanupTaskAdditionalInformationDTO.SERIALIZATION_MODULE));

--- a/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
@@ -75,7 +75,7 @@ import java.util.stream.Stream;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.export.api.BlobExportMechanism;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.core.Domain;
@@ -177,12 +177,12 @@ class DeletedMessagesVaultRoutesTest {
     private DeletedMessageZipper zipper;
     private MemoryUsersRepository usersRepository;
     private ExportService exportService;
-    private HashBlobId.Factory blobIdFactory;
+    private PlainBlobId.Factory blobIdFactory;
     private UpdatableTickingClock clock;
 
     @BeforeEach
     void beforeEach() throws Exception {
-        blobIdFactory = new HashBlobId.Factory();
+        blobIdFactory = new PlainBlobId.Factory();
         MemoryBlobStoreDAO blobStoreDAO = new MemoryBlobStoreDAO();
         blobStore = spy(BlobStoreFactory.builder()
             .blobStoreDAO(blobStoreDAO)

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExportServiceTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExportServiceTest.java
@@ -189,9 +189,9 @@ class ExportServiceTest {
         String blobId = fileName.substring(fileName.lastIndexOf("-") + 1);
 
         SoftAssertions.assertSoftly(softly -> {
-            assertThatThrownBy(() -> testSystem.blobStore.read(testSystem.blobStore.getDefaultBucketName(), FACTORY.from(blobId)))
+            assertThatThrownBy(() -> testSystem.blobStore.read(testSystem.blobStore.getDefaultBucketName(), FACTORY.parse(blobId)))
                 .isInstanceOf(ObjectNotFoundException.class);
-            assertThatThrownBy(() -> testSystem.blobStore.read(testSystem.blobStore.getDefaultBucketName(), FACTORY.from(blobId)))
+            assertThatThrownBy(() -> testSystem.blobStore.read(testSystem.blobStore.getDefaultBucketName(), FACTORY.parse(blobId)))
                 .hasMessage(String.format("blob '%s' not found in bucket '%s'", blobId, testSystem.blobStore.getDefaultBucketName().asString()));
         });
     }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExportServiceTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExportServiceTest.java
@@ -35,8 +35,8 @@ import java.io.InputStream;
 import jakarta.mail.MessagingException;
 
 import org.apache.james.blob.api.BlobId;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.export.api.FileExtension;
 import org.apache.james.blob.export.file.FileSystemExtension;
 import org.apache.james.core.Domain;
@@ -72,7 +72,7 @@ class ExportServiceTest {
         "testmail";
     private static final String TWELVE_MEGABYTES_STRING = Strings.repeat("0123456789\r\n", 1024 * 1024);
     private static final String FILE_PREFIX = "mailbox-backup-";
-    private static final BlobId.Factory FACTORY = new HashBlobId.Factory();
+    private static final BlobId.Factory FACTORY = new PlainBlobId.Factory();
 
     private ExportService testee;
     private ExportServiceTestSystem testSystem;

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExportServiceTestSystem.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/ExportServiceTestSystem.java
@@ -26,7 +26,7 @@ import java.net.UnknownHostException;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.export.api.BlobExportMechanism;
 import org.apache.james.blob.export.file.LocalFileBlobExportMechanism;
 import org.apache.james.blob.memory.MemoryBlobStoreFactory;
@@ -58,7 +58,7 @@ public class ExportServiceTestSystem {
     public static final Username CEDRIC = Username.fromLocalPartWithDomain("cedric", DOMAIN);
     public static final String PASSWORD = "password";
     private static final String JAMES_HOST = "james-host";
-    private static final BlobId.Factory FACTORY = new HashBlobId.Factory();
+    private static final BlobId.Factory FACTORY = new PlainBlobId.Factory();
 
     final FakeMailContext mailetContext;
     final InMemoryMailboxManager mailboxManager;

--- a/server/protocols/webadmin/webadmin-pop3/src/test/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-pop3/src/test/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesRoutesTest.java
@@ -35,7 +35,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
 import org.apache.james.json.DTOConverter;
@@ -119,7 +119,7 @@ class Pop3MetaDataFixInconsistenciesRoutesTest {
     private static final String CONTENT_MESSAGE = "CONTENT 123 BLA BLA";
     private static final ModSeq MOD_SEQ_1 = ModSeq.of(1L);
     private static final ModSeq MOD_SEQ_2 = ModSeq.of(2L);
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
+    private static final PlainBlobId HEADER_BLOB_ID_1 = new PlainBlobId.Factory().of("abc");
     private static final CassandraMessageMetadata MESSAGE_1 = CassandraMessageMetadata.builder()
         .ids(ComposedMessageIdWithMetaData.builder()
             .composedMessageId(new ComposedMessageId(MAILBOX_ID, MESSAGE_ID_1, MESSAGE_UID_1))
@@ -178,7 +178,7 @@ class Pop3MetaDataFixInconsistenciesRoutesTest {
         Pop3MetadataStore pop3MetadataStore = new CassandraPop3MetadataStore(cassandra.getConf());
         imapUidDAO = new CassandraMessageIdToImapUidDAO(
             cassandra.getConf(),
-            new HashBlobId.Factory(),
+            new PlainBlobId.Factory(),
             CassandraConfiguration.DEFAULT_CONFIGURATION);
 
         cassandraMessageDAOV3 = new CassandraMessageDAOV3(
@@ -186,7 +186,7 @@ class Pop3MetaDataFixInconsistenciesRoutesTest {
             cassandra.getTypesProvider(),
             CassandraBlobStoreFactory.forTesting(cassandra.getConf(), new RecordingMetricFactory())
                 .passthrough(),
-            new HashBlobId.Factory());
+            new PlainBlobId.Factory());
         MetaDataFixInconsistenciesService fixInconsistenciesService = new MetaDataFixInconsistenciesService(imapUidDAO, pop3MetadataStore, cassandraMessageDAOV3);
 
         taskManager = new MemoryTaskManager(new Hostname("foo"));

--- a/server/protocols/webadmin/webadmin-pop3/src/test/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-pop3/src/test/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesRoutesTest.java
@@ -119,7 +119,7 @@ class Pop3MetaDataFixInconsistenciesRoutesTest {
     private static final String CONTENT_MESSAGE = "CONTENT 123 BLA BLA";
     private static final ModSeq MOD_SEQ_1 = ModSeq.of(1L);
     private static final ModSeq MOD_SEQ_2 = ModSeq.of(2L);
-    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().forPayload("abc".getBytes());
+    private static final HashBlobId HEADER_BLOB_ID_1 = new HashBlobId.Factory().of("abc");
     private static final CassandraMessageMetadata MESSAGE_1 = CassandraMessageMetadata.builder()
         .ids(ComposedMessageIdWithMetaData.builder()
             .composedMessageId(new ComposedMessageId(MAILBOX_ID, MESSAGE_ID_1, MESSAGE_UID_1))

--- a/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/MailMetadata.scala
+++ b/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/MailMetadata.scala
@@ -85,8 +85,8 @@ private[pulsar] case class MailMetadata(enqueueId: String,
 
   def partsId(implicit blobIdFactory: BlobId.Factory): MimeMessagePartsId =
     MimeMessagePartsId.builder()
-      .headerBlobId(blobIdFactory.from(headerBlobId))
-      .bodyBlobId(blobIdFactory.from(bodyBlobId))
+      .headerBlobId(blobIdFactory.parse(headerBlobId))
+      .bodyBlobId(blobIdFactory.parse(bodyBlobId))
       .build()
 
 }

--- a/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/PulsarMailQueue.scala
+++ b/server/queue/queue-pulsar/src/main/scala/org/apache/james/queue/pulsar/PulsarMailQueue.scala
@@ -592,8 +592,8 @@ class PulsarMailQueue(
       .collect { case Some(value) => value }
       .flatMapConcat(metadata => {
         val partsId = MimeMessagePartsId.builder()
-          .headerBlobId(blobIdFactory.from(metadata.headerBlobId))
-          .bodyBlobId(blobIdFactory.from(metadata.bodyBlobId))
+          .headerBlobId(blobIdFactory.parse(metadata.headerBlobId))
+          .bodyBlobId(blobIdFactory.parse(metadata.bodyBlobId))
           .build()
         Source.fromPublisher(readMimeMessage(partsId))
           .collect { case Some(message) => message }

--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueFactoryTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueFactoryTest.java
@@ -29,7 +29,7 @@ import org.apache.james.backends.pulsar.DockerPulsarExtension;
 import org.apache.james.backends.pulsar.PulsarClients;
 import org.apache.james.backends.pulsar.PulsarConfiguration;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.blob.mail.MimeMessageStore;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class PulsarMailQueueFactoryTest implements MailQueueFactoryContract<PulsarMailQueue>, ManageableMailQueueFactoryContract<PulsarMailQueue> {
 
     PulsarMailQueueFactory mailQueueFactory;
-    private HashBlobId.Factory blobIdFactory;
+    private PlainBlobId.Factory blobIdFactory;
     private Store<MimeMessage, MimeMessagePartsId> mimeMessageStore;
     private MailQueueItemDecoratorFactory factory;
     private PulsarConfiguration config;
@@ -67,7 +67,7 @@ class PulsarMailQueueFactoryTest implements MailQueueFactoryContract<PulsarMailQ
     void setUp(DockerPulsarExtension.DockerPulsar dockerPulsar, MailQueueMetricExtension.MailQueueMetricTestSystem metricTestSystem) throws PulsarClientException, PulsarAdminException {
         this.metricTestSystem = metricTestSystem;
 
-        blobIdFactory = new HashBlobId.Factory();
+        blobIdFactory = new PlainBlobId.Factory();
 
         MemoryBlobStoreDAO memoryBlobStore = new MemoryBlobStoreDAO();
         PassThroughBlobStore blobStore = new PassThroughBlobStore(memoryBlobStore, BucketName.DEFAULT, blobIdFactory);

--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
@@ -36,7 +36,7 @@ import org.apache.james.backends.pulsar.DockerPulsarExtension;
 import org.apache.james.backends.pulsar.PulsarClients;
 import org.apache.james.backends.pulsar.PulsarConfiguration;
 import org.apache.james.blob.api.BucketName;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.blob.mail.MimeMessageStore;
@@ -78,7 +78,7 @@ public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricCo
     int maxConcurrency = 10;
     PulsarMailQueue mailQueue;
 
-    private HashBlobId.Factory blobIdFactory;
+    private PlainBlobId.Factory blobIdFactory;
     private Store<MimeMessage, MimeMessagePartsId> mimeMessageStore;
     private MailQueueItemDecoratorFactory factory;
     private MailQueueName mailQueueName;
@@ -91,7 +91,7 @@ public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricCo
     @BeforeEach
     void setUp(DockerPulsarExtension.DockerPulsar pulsar, MailQueueMetricExtension.MailQueueMetricTestSystem metricTestSystem) {
         this.metricTestSystem = metricTestSystem;
-        blobIdFactory = new HashBlobId.Factory();
+        blobIdFactory = new PlainBlobId.Factory();
 
         memoryBlobStore = new MemoryBlobStoreDAO();
         PassThroughBlobStore blobStore = new PassThroughBlobStore(memoryBlobStore, BucketName.DEFAULT, blobIdFactory);

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
@@ -198,8 +198,8 @@ class MailReferenceDTO {
 
     MailReference toMailReference(BlobId.Factory blobIdFactory) {
         MimeMessagePartsId messagePartsId = MimeMessagePartsId.builder()
-            .headerBlobId(blobIdFactory.from(headerBlobId))
-            .bodyBlobId(blobIdFactory.from(bodyBlobId))
+            .headerBlobId(blobIdFactory.parse(headerBlobId))
+            .bodyBlobId(blobIdFactory.parse(bodyBlobId))
             .build();
 
         return new MailReference(EnqueueId.ofSerialized(enqueueId), mailMetadata(), messagePartsId);

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
@@ -201,7 +201,7 @@ public class EnqueuedMailsDAO {
     Flux<BlobId> listBlobIds() {
         return executor.executeRows(selectBlobIdsStatement.bind())
             .flatMapIterable(row -> ImmutableList.of(
-                blobFactory.from(row.getString(HEADER_BLOB_ID)),
-                blobFactory.from(row.getString(BODY_BLOB_ID))));
+                blobFactory.parse(row.getString(HEADER_BLOB_ID)),
+                blobFactory.parse(row.getString(BODY_BLOB_ID))));
     }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
@@ -86,8 +86,8 @@ public class EnqueuedMailsDaoUtil {
         Instant timeRangeStart = row.getInstant(TIME_RANGE_START);
         BucketedSlices.BucketId bucketId = BucketedSlices.BucketId.of(row.getInt(BUCKET_ID));
         Instant enqueuedTime = row.getInstant(ENQUEUED_TIME);
-        BlobId headerBlobId = blobFactory.from(row.getString(HEADER_BLOB_ID));
-        BlobId bodyBlobId = blobFactory.from(row.getString(BODY_BLOB_ID));
+        BlobId headerBlobId = blobFactory.parse(row.getString(HEADER_BLOB_ID));
+        BlobId bodyBlobId = blobFactory.parse(row.getString(BODY_BLOB_ID));
         MimeMessagePartsId mimeMessagePartsId = MimeMessagePartsId
             .builder()
             .headerBlobId(headerBlobId)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
@@ -25,7 +25,7 @@ import java.time.Instant;
 
 import jakarta.mail.MessagingException;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.test.FakeMail;
@@ -45,8 +45,8 @@ class EnqueuedItemTest {
         mail = FakeMail.defaultFakeMail();
         enqueuedTime = Instant.now();
         partsId = MimeMessagePartsId.builder()
-                .headerBlobId(new HashBlobId.Factory().parse("headerBlobId"))
-                .bodyBlobId(new HashBlobId.Factory().parse("bodyBlobId"))
+                .headerBlobId(new PlainBlobId.Factory().parse("headerBlobId"))
+                .bodyBlobId(new PlainBlobId.Factory().parse("bodyBlobId"))
                 .build();
     }
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
@@ -45,8 +45,8 @@ class EnqueuedItemTest {
         mail = FakeMail.defaultFakeMail();
         enqueuedTime = Instant.now();
         partsId = MimeMessagePartsId.builder()
-                .headerBlobId(new HashBlobId.Factory().from("headerBlobId"))
-                .bodyBlobId(new HashBlobId.Factory().from("bodyBlobId"))
+                .headerBlobId(new HashBlobId.Factory().parse("headerBlobId"))
+                .bodyBlobId(new HashBlobId.Factory().parse("bodyBlobId"))
                 .build();
     }
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
@@ -28,7 +28,7 @@ import java.util.Date;
 
 import jakarta.mail.MessagingException;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.server.core.MailImpl;
 import org.apache.mailet.Attribute;
@@ -47,7 +47,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 class MailDTOTest {
     static final EnqueueId EN_QUEUE_ID = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
-    static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     static final Date LAST_UPDATED = Date.from(Instant.parse("2016-09-08T14:25:52.000Z"));
 
     private ObjectMapper objectMapper;

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
@@ -114,8 +114,8 @@ class MailDTOTest {
                 .state("state")
                 .build(),
             MimeMessagePartsId.builder()
-                .headerBlobId(BLOB_ID_FACTORY.from("210e7136-ede3-44eb-9495-3ed816d6e23b"))
-                .bodyBlobId(BLOB_ID_FACTORY.from("ef46c026-7819-4048-b562-3a37469191ed"))
+                .headerBlobId(BLOB_ID_FACTORY.parse("210e7136-ede3-44eb-9495-3ed816d6e23b"))
+                .bodyBlobId(BLOB_ID_FACTORY.parse("ef46c026-7819-4048-b562-3a37469191ed"))
                 .build()));
     }
 
@@ -130,8 +130,8 @@ class MailDTOTest {
                 EN_QUEUE_ID,
                 mail,
                 MimeMessagePartsId.builder()
-                    .headerBlobId(BLOB_ID_FACTORY.from("210e7136-ede3-44eb-9495-3ed816d6e23b"))
-                    .bodyBlobId(BLOB_ID_FACTORY.from("ef46c026-7819-4048-b562-3a37469191ed"))
+                    .headerBlobId(BLOB_ID_FACTORY.parse("210e7136-ede3-44eb-9495-3ed816d6e23b"))
+                    .bodyBlobId(BLOB_ID_FACTORY.parse("ef46c026-7819-4048-b562-3a37469191ed"))
                     .build()));
     }
 }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailLoaderTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailLoaderTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 import jakarta.mail.internet.MimeMessage;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.junit.jupiter.api.Test;
@@ -40,7 +40,7 @@ class MailLoaderTest {
         when(store.read(any())).thenReturn(Mono.error(new RuntimeException("Cassandra problem")));
         MailReferenceDTO dto = mock(MailReferenceDTO.class);
         when(dto.toMailReference(any())).thenReturn(mock(MailReference.class));
-        MailLoader loader = new MailLoader(store, new HashBlobId.Factory());
+        MailLoader loader = new MailLoader(store, new PlainBlobId.Factory());
 
         String result = loader.load(dto)
             .thenReturn("continued")

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueConfigurationChangeTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueConfigurationChangeTest.java
@@ -36,7 +36,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.backends.rabbitmq.RabbitMQExtension;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
 import org.apache.james.blob.mail.MimeMessageStore;
@@ -71,7 +71,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.github.fge.lambdas.Throwing;
 
 class RabbitMQMailQueueConfigurationChangeTest {
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private static final int THREE_BUCKET_COUNT = 3;
     private static final int UPDATE_BROWSE_START_PACE = 2;
     private static final Duration ONE_HOUR_SLICE_WINDOW = Duration.ofHours(1);

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -60,7 +60,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.backends.rabbitmq.RabbitMQExtension;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.cassandra.BlobTables;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
@@ -109,7 +109,7 @@ import reactor.rabbitmq.OutboundMessage;
 import reactor.rabbitmq.Sender;
 
 class RabbitMQMailQueueTest {
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private static final int THREE_BUCKET_COUNT = 3;
     private static final int UPDATE_BROWSE_START_PACE = 25;
     private static final Duration ONE_HOUR_SLICE_WINDOW = Duration.ofHours(1);
@@ -398,7 +398,7 @@ class RabbitMQMailQueueTest {
             dequeueMails(emailCount);
 
             // ensure slice 1 was cleaned
-            EnqueuedMailsDAO mailsDAO = new EnqueuedMailsDAO(cassandraCluster.getCassandraCluster().getConf(), new HashBlobId.Factory());
+            EnqueuedMailsDAO mailsDAO = new EnqueuedMailsDAO(cassandraCluster.getCassandraCluster().getConf(), new PlainBlobId.Factory());
             MailQueueName queueName = MailQueueName.fromString(mailQueue.getName().asString());
             Slice slice = Slice.of(currentSliceStartInstant(IN_SLICE_1));
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMqMailQueueFactoryTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMqMailQueueFactoryTest.java
@@ -32,7 +32,7 @@ import java.time.Clock;
 
 import org.apache.james.backends.rabbitmq.RabbitMQExtension;
 import org.apache.james.backends.rabbitmq.RabbitMQManagementAPI;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
@@ -51,7 +51,7 @@ import reactor.rabbitmq.QueueSpecification;
 
 class RabbitMqMailQueueFactoryTest implements MailQueueFactoryContract<RabbitMQMailQueue> {
     private static final String VHOST = "vhost1";
-    private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
 
     @RegisterExtension
     static RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ()

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
@@ -47,8 +47,8 @@ class DeleteConditionTest {
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
     private static final Instant ENQUEUE_TIME = Instant.now();
     private static final MimeMessagePartsId MESSAGE_PARTS_ID = MimeMessagePartsId.builder()
-        .headerBlobId(new HashBlobId.Factory().from("headerBlobId"))
-        .bodyBlobId(new HashBlobId.Factory().from("bodyBlobId"))
+        .headerBlobId(new HashBlobId.Factory().parse("headerBlobId"))
+        .bodyBlobId(new HashBlobId.Factory().parse("bodyBlobId"))
         .build();
 
     @Nested

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.core.MailAddress;
 import org.apache.james.queue.api.ManageableMailQueue;
@@ -47,8 +47,8 @@ class DeleteConditionTest {
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
     private static final Instant ENQUEUE_TIME = Instant.now();
     private static final MimeMessagePartsId MESSAGE_PARTS_ID = MimeMessagePartsId.builder()
-        .headerBlobId(new HashBlobId.Factory().parse("headerBlobId"))
-        .bodyBlobId(new HashBlobId.Factory().parse("bodyBlobId"))
+        .headerBlobId(new PlainBlobId.Factory().parse("headerBlobId"))
+        .bodyBlobId(new PlainBlobId.Factory().parse("bodyBlobId"))
         .build();
 
     @Nested

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
@@ -22,7 +22,7 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 import java.time.Clock;
 import java.util.Optional;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
@@ -35,7 +35,7 @@ public class CassandraMailQueueViewTestFactory {
     public static CassandraMailQueueView.Factory factory(Clock clock, CqlSession session,
                                                          CassandraMailQueueViewConfiguration configuration,
                                                          MimeMessageStore.Factory mimeMessageStoreFactory) {
-        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        PlainBlobId.Factory blobIdFactory = new PlainBlobId.Factory();
 
         EnqueuedMailsDAO enqueuedMailsDao = new EnqueuedMailsDAO(session, blobIdFactory);
         BrowseStartDAO browseStartDao = new BrowseStartDAO(session);

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
@@ -31,7 +31,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.blob.api.BlobId;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
@@ -54,7 +54,7 @@ class EnqueuedMailsDaoTest {
     private static final Instant NOW = Instant.now();
     private static final Slice SLICE_OF_NOW = Slice.of(NOW);
 
-    private static final BlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+    private static final BlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
     private static final BlobId HEADER_BLOB_ID = BLOB_ID_FACTORY.parse("header blob id");
     private static final BlobId BODY_BLOB_ID = BLOB_ID_FACTORY.parse("body blob id");
     private static final MimeMessagePartsId MIME_MESSAGE_PARTS_ID = MimeMessagePartsId.builder()
@@ -71,7 +71,7 @@ class EnqueuedMailsDaoTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        BlobId.Factory blobFactory = new HashBlobId.Factory();
+        BlobId.Factory blobFactory = new PlainBlobId.Factory();
         testee = new EnqueuedMailsDAO(
             cassandra.getConf(),
             blobFactory);

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
@@ -55,8 +55,8 @@ class EnqueuedMailsDaoTest {
     private static final Slice SLICE_OF_NOW = Slice.of(NOW);
 
     private static final BlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
-    private static final BlobId HEADER_BLOB_ID = BLOB_ID_FACTORY.from("header blob id");
-    private static final BlobId BODY_BLOB_ID = BLOB_ID_FACTORY.from("body blob id");
+    private static final BlobId HEADER_BLOB_ID = BLOB_ID_FACTORY.parse("header blob id");
+    private static final BlobId BODY_BLOB_ID = BLOB_ID_FACTORY.parse("body blob id");
     private static final MimeMessagePartsId MIME_MESSAGE_PARTS_ID = MimeMessagePartsId.builder()
         .headerBlobId(HEADER_BLOB_ID)
         .bodyBlobId(BODY_BLOB_ID)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
@@ -49,8 +49,8 @@ class EnqueuedItemWithSlicingContextTest {
                         .build())
                 .enqueuedTime(Instant.now())
                 .mimeMessagePartsId(MimeMessagePartsId.builder()
-                        .headerBlobId(new HashBlobId.Factory().from("headerBlodId"))
-                        .bodyBlobId(new HashBlobId.Factory().from("bodyBlodId"))
+                        .headerBlobId(new HashBlobId.Factory().parse("headerBlodId"))
+                        .bodyBlobId(new HashBlobId.Factory().parse("bodyBlodId"))
                         .build())
                 .build();
         slicingContext = EnqueuedItemWithSlicingContext.SlicingContext.of(BucketedSlices.BucketId.of(1), Instant.now());

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
@@ -25,7 +25,7 @@ import java.time.Instant;
 
 import jakarta.mail.MessagingException;
 
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
@@ -49,8 +49,8 @@ class EnqueuedItemWithSlicingContextTest {
                         .build())
                 .enqueuedTime(Instant.now())
                 .mimeMessagePartsId(MimeMessagePartsId.builder()
-                        .headerBlobId(new HashBlobId.Factory().parse("headerBlodId"))
-                        .bodyBlobId(new HashBlobId.Factory().parse("bodyBlodId"))
+                        .headerBlobId(new PlainBlobId.Factory().parse("headerBlodId"))
+                        .bodyBlobId(new PlainBlobId.Factory().parse("bodyBlodId"))
                         .build())
                 .build();
         slicingContext = EnqueuedItemWithSlicingContext.SlicingContext.of(BucketedSlices.BucketId.of(1), Instant.now());

--- a/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareBlobExportMechanismTest.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareBlobExportMechanismTest.java
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.export.api.BlobExportMechanism;
 import org.apache.james.blob.export.api.FileExtension;
 import org.apache.james.blob.memory.MemoryBlobStoreFactory;
@@ -55,12 +55,12 @@ class LinshareBlobExportMechanismTest {
 
     private BlobStore blobStore;
     private LinshareBlobExportMechanism testee;
-    private HashBlobId.Factory blobIdFactory;
+    private PlainBlobId.Factory blobIdFactory;
     private LinshareAPIForUserTesting user2API;
 
     @BeforeEach
     void setUp() throws Exception {
-        blobIdFactory = new HashBlobId.Factory();
+        blobIdFactory = new PlainBlobId.Factory();
         blobStore = MemoryBlobStoreFactory.builder()
             .blobIdFactory(blobIdFactory)
             .defaultBucketName()

--- a/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareBlobExportMechanismTest.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareBlobExportMechanismTest.java
@@ -109,7 +109,7 @@ class LinshareBlobExportMechanismTest {
 
     @Test
     void exportShouldFailWhenBlobDoesNotExist() {
-        BlobId blobId = blobIdFactory.randomId();
+        BlobId blobId = blobIdFactory.of("NOT_EXISTING_BLOB_ID");
 
         assertThatThrownBy(
             () -> testee.blobId(blobId)


### PR DESCRIPTION
When deploying the initial blob store backed mail repository we quickly encountered issues with `EmptyErrorMailRepositoryHealthCheck` failing despite not having had errors. 

It turned out that our initial implementation stored all the mails from all the mail repositories in the same bucket with nothing to distinguish them. Therefore every `MailRepository` for every `MailRepositoryUrl` listed all the mails from all the urls and the size accounted for all mails stored in all the mail repositories hence making the health check fail as soon as any mail repository contained a mail. 

We managed to work around part of this problem by creating a mime message store with a dedicated blob store every time we created a mail repository for a url (see [`BlobMailRepositoryFactory`](https://github.com/apache/james-project/commit/9dfb5d5408390bc049976a70cbb3f7457e8794ef#diff-24ee66d7dc3eefc5f2493c144d59475af0e3c50d6baa30e6401bee36a8b91d1dR73)). 
Additionally we wrapped the underlying `BlobIdFactory` with our own [`MailRepositoryBlobId`](https://github.com/apache/james-project/commit/9dfb5d5408390bc049976a70cbb3f7457e8794ef#diff-24ee66d7dc3eefc5f2493c144d59475af0e3c50d6baa30e6401bee36a8b91d1dR29) to ensure the id were properly nested under a path matching the mail repository url. 

With this we were able to solve the list and size problems by filtering out items that didn't match the current mail repository url.  

In a future change we intend to extend the `BlobstoreDao` api to allow passing a sub path to the underlying driver. This would allow to avoid iterating over all the items of the bucket only to filter most of them out.

We preferred this over creating buckets for each url because not every bucket provider allows for arbitrary bucket creation and our strategy works even if the urls are eventually stored in different buckets.

We then stumbled upon another problem though I don't remember exactly how. Some parts of james expect that storing the same mail multiple times returns the same `Mailkey`. All previous implementations of mail repository already honor this by computing the mail key as `Mailkey.forMail(mail)` and returning the generated mail key. We added [a test](https://github.com/apache/james-project/commit/bd5b9a67ddfebe86983ce28e38d6952c144ed593#diff-f85ec649d3b197927fd49a26ee0c659a239073e80c8c47b0143136587f19d60eR460) to explicitely document this property.

With the way the `Blobstore` API was designed, it was not possible to compute the `BlobId` externally to the blob store. Therefore it was impossible for a mail repository using the `PassthroughBlobstore` to honor this constraint because the pass through blob store would generate a different random blob id for each save. It was also impossible the `DeduplicationBlobStore` since it hashes the whole mail content, the mail can be mutated (by mailets for instance) and saving the same mail multiple time would thus result in a different blob id if any part of the mail had been mutated in between the 2 saves.

We thus undertook to change the API of the `BlobStore` to allow providing a way to compute a blob id on every call while maintaining retrocompatibility with existing callers. This change is done in [ES-3763 Changes Blobstore api to enable deterministic BlobId generation](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519). You probably want to first have a look at the [`BlobStore`](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519#diff-467d5afd98ab352519efdbbd49d57ecbddb6239083cc6ebf0ed2541b52392cb6) interface. Then see how we propagated these changes to each of the 4 implementations: 
- [`DeduplicationBlobStore`](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519#diff-bd94a7cf5577caebb0f006d85c11b92b8d8d5db210c932ee9aa9c70552f1bfaa)
- [`PassthroughBlobStore`](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519#diff-c87a5eadd2fac4b2593635bc6b5659d13c2b38b490908436277ff987e82f6977)
- [`MetricableBlobStore`](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519#diff-3a0b7b8f7a1d830a2eb7e52a9123f95023e3de1a1984438d8ad040ae2c7deb4d)
- [`CachedBlobStore`](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519#diff-2871b3f2e76630dc9bbb91125230d48fa8cd16d28fe66d9128ff071824c063a3)

Doing so we experimented with using default implementations in the interface, this required exposing a `defaultBlobIdProvider` method in the interface that was then accessible to the whole world. Since we can´t have protected methods in a Java interface we couldn´t hide this implementation detail from the outside world and decided instead to do the implementation in each of the implementors, It makes the `CachedBlobStore` implementation less elegant (it can probably still be improved upon) but we think the benefits of keeping the interface clean are more important. 
Changing this allowed us to clean up the [`BlobId`](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519#diff-9fc865592b15120099aeb6be558096df780843bf64e16dc6989c0fd8a893d335) interface : 
- `forPayload` is only actually useful for the DeduplicationBlobStore, so we moved the implementation to that blob store
- `randomId` is a small helper to wrap a random value in the `BlobId` implementation. It was only used in the [`PassthroughBlobStore`](https://github.com/apache/james-project/commit/dab9488beb7537586458c0d554a52432662e6519#diff-c87a5eadd2fac4b2593635bc6b5659d13c2b38b490908436277ff987e82f6977R92) where it could trivially be replaced in the default blob id provider and in tests. We feel that it is not the `BlobId` interface responsibility to expose this helper. For now we inlined it everywhere but it might make sense to resurrect it on `TestBlobId` ( which could now be a trivial extension of `PlainBlobId`)

We spent quite a bit of time reworking our changes to make them more digestible. 

The PR starts with 2 cleanup commits that eliminate or rationalize many calls to either `forPayload` or to `randomId`
- `forPayload` wad generally used to generate arbitrary blob ids 
- `randomId` calls were inlined, in a few cases randomId was used to provide an arbitrary id, we replaced these with static explicit values as is usually the case in the james codebase,

Then comes the big change to the `BlobStore` API which we discuss extensively above.

The next commit restores a check that used to exist around HashBlobId, it is only relevant to the S3 implementation which has specific contraints on the blob id values (they need to be compatible with url paths) We chose to extend this constraint to all deduplication implementations by adding it to the [`DeduplicationBlobStoreContract`](https://github.com/apache/james-project/commit/87cfdf11edef6dea5739cd5fc966cd37cdb6c5ea#diff-162ecf29eb8300288c33ad95247a50322e59e3b630b095673bc5c4389f35ec0b)

We then use the newly added changes in `BlobMailRepository` in [JAMES-3763 Use Blobstore#save with deterministic BlobId in BlobMailRepository](https://github.com/apache/james-project/commit/559ad062b22a5f391f2552aa2d4a82e52755016a)

The next 3 commits are cleanups : we rename concepts that have changed or been refined and we finish by switching from a POJO to a record. 

Thank you for reading this long message to its conclusion !
