### PR TITLE
JAMES-3693 Rate limiting for Apache James on top of Redis sentinel - introduce docker-compose sample

### DIFF
--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
@@ -88,4 +88,32 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
       RedisConfiguration.from(config)
     }
   }
+
+  it should "parse redisURL when multiple sentinel endpoint" in {
+    val config = new PropertiesConfiguration()
+    config.setListDelimiterHandler(new DefaultListDelimiterHandler(','))
+    config.addProperty("redisURL", "redis-sentinel://secret1@redis-sentinel-1:26379,redis-sentinel-2:26379,redis-sentinel-3:26379?sentinelMasterId=mymaster")
+    config.addProperty("redis.topology", "master-replica")
+
+    val redisConfig: RedisConfiguration = RedisConfiguration.from(config)
+    redisConfig.isInstanceOf[MasterReplicaRedisConfiguration] shouldEqual (true)
+    val redisMasterReplicaRedisConfiguration = redisConfig.asInstanceOf[MasterReplicaRedisConfiguration]
+
+    redisMasterReplicaRedisConfiguration.redisURI.value.size shouldEqual 1
+    redisMasterReplicaRedisConfiguration.redisURI.value.head.toString shouldEqual "redis-sentinel://*******@redis-sentinel-1,redis-sentinel-2,redis-sentinel-3?sentinelMasterId=mymaster"
+  }
+
+  it should "parse redisURL when single sentinel endpoint" in {
+    val config = new PropertiesConfiguration()
+    config.setListDelimiterHandler(new DefaultListDelimiterHandler(','))
+    config.addProperty("redisURL", "redis-sentinel://secret1@redis-sentinel-1:26379?sentinelMasterId=mymaster")
+    config.addProperty("redis.topology", "master-replica")
+
+    val redisConfig: RedisConfiguration = RedisConfiguration.from(config)
+    redisConfig.isInstanceOf[MasterReplicaRedisConfiguration] shouldEqual (true)
+    val redisMasterReplicaRedisConfiguration = redisConfig.asInstanceOf[MasterReplicaRedisConfiguration]
+
+    redisMasterReplicaRedisConfiguration.redisURI.value.size shouldEqual 1
+    redisMasterReplicaRedisConfiguration.redisURI.value.head.toString shouldEqual "redis-sentinel://*******@redis-sentinel-1?sentinelMasterId=mymaster"
+  }
 }

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisSentinelExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisSentinelExtension.java
@@ -83,7 +83,7 @@ public class RedisSentinelExtension implements GuiceModuleTestExtension {
         }
 
         public MasterReplicaRedisConfiguration getRedisConfiguration() {
-            return MasterReplicaRedisConfiguration.from(ImmutableList.of(createRedisSentinelURI(this.stream().toList().subList(0,1)))
+            return MasterReplicaRedisConfiguration.from(ImmutableList.of(createRedisSentinelURI(this))
                     .toArray(String[]::new),
                 ReadFrom.MASTER,
                 OptionConverters.toScala(Optional.empty()),

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/README.md
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/README.md
@@ -1,0 +1,27 @@
+# Rate limiting for Apache James on top of Redis sentinel
+
+## Introduction
+This guide provides step-by-step instructions for deploying a rate limiter for Apache James using Redis Sentinel.
+
+The redis-sentinel in lab environment is structured with 6 nodes:
+- 1 master node (M1)
+- 2 replica nodes (R1, R2)
+- 3 sentinel nodes (S1, S2, S3)
+
+## Configuration file
+- `redis.properties` file sample:
+
+```
+redisURL=redis-sentinel://your_password@redis-sentinel-1:26379,redis-sentinel-2:26379,redis-sentinel-3:26379?sentinelMasterId=mymaster
+redis.topology=master-replica
+```
+
+- Another configuration file of Apache James is similar to the one in the [rate-limiter-redis](../README.adoc) guide.
+
+### How to run 
+
+Run docker-compose with the following command:
+
+```bash
+docker-compose up -d -f docker-compose-with-redis-sentinel.yml
+```

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/master/docker-entrypoint-master.sh
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/master/docker-entrypoint-master.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cp /usr/local/etc/redis/redis.conf.template /usr/local/etc/redis/redis.conf
+chmod 777 /usr/local/etc/redis/redis.conf
+
+redis-server /usr/local/etc/redis/redis.conf

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/master/redis.conf.template
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/master/redis.conf.template
@@ -1,0 +1,3 @@
+loglevel debug
+appendonly yes
+requirepass secret1

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/replica/docker-entrypoint-replica.sh
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/replica/docker-entrypoint-replica.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cp /usr/local/etc/redis/redis.conf.template /usr/local/etc/redis/redis.conf
+chmod 777 /usr/local/etc/redis/redis.conf
+
+redis-server /usr/local/etc/redis/redis.conf

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/replica/redis.conf.template
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/replica/redis.conf.template
@@ -1,0 +1,5 @@
+loglevel debug
+appendonly yes
+replicaof redis-master 6379
+masterauth secret1
+requirepass secret1

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/sentinel/docker-entrypoint-sentinel.sh
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/sentinel/docker-entrypoint-sentinel.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cp /usr/local/etc/redis/sentinel.conf.template /usr/local/etc/redis/sentinel.conf
+chmod 777 /usr/local/etc/redis/sentinel.conf
+
+redis-sentinel /usr/local/etc/redis/sentinel.conf

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/sentinel/sentinel.conf.template
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/config-template/sentinel/sentinel.conf.template
@@ -1,0 +1,9 @@
+port 26379
+loglevel debug
+
+sentinel monitor mymaster redis-master 6379 2
+sentinel auth-pass mymaster secret1
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 10000
+sentinel parallel-syncs mymaster 1
+sentinel resolve-hostnames yes

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/docker-compose-with-redis-sentinel.yml
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/docker-compose-with-redis-sentinel.yml
@@ -1,0 +1,120 @@
+version: '3'
+
+services:
+  redis-master:
+    image: redis:7.2.5
+    container_name: redis-master
+    restart: always
+    ports:
+      - "6379:6379"
+    command: sh /usr/local/etc/redis/docker-entrypoint.sh
+    volumes:
+      - ./config-template/master/redis.conf.template:/usr/local/etc/redis/redis.conf.template
+      - ./config-template/master/docker-entrypoint-master.sh:/usr/local/etc/redis/docker-entrypoint.sh
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping", "|", "grep", "PONG"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    networks:
+      - emaily-net
+
+  redis-replica-1:
+    image: redis:7.2.5
+    container_name: redis-replica-1
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "6380:6379"
+    command: sh /usr/local/etc/redis/docker-entrypoint.sh
+    volumes:
+      - ./config-template/replica/redis.conf.template:/usr/local/etc/redis/redis.conf.template
+      - ./config-template/replica/docker-entrypoint-replica.sh:/usr/local/etc/redis/docker-entrypoint.sh
+    networks:
+      - emaily-net
+
+  redis-replica-2:
+    image: redis:7.2.5
+    container_name: redis-replica-2
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "6381:6379"
+    command: sh /usr/local/etc/redis/docker-entrypoint.sh
+    volumes:
+      - ./config-template/replica/redis.conf.template:/usr/local/etc/redis/redis.conf.template
+      - ./config-template/replica/docker-entrypoint-replica.sh:/usr/local/etc/redis/docker-entrypoint.sh
+    networks:
+      - emaily-net
+
+  sentinel-1:
+    image: redis:7.2.5
+    container_name: sentinel-1
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "26379:26379"
+    command: sh /usr/local/etc/redis/docker-entrypoint.sh
+    volumes:
+      - ./config-template/sentinel/sentinel.conf.template:/usr/local/etc/redis/sentinel.conf.template
+      - ./config-template/sentinel/docker-entrypoint-sentinel.sh:/usr/local/etc/redis/docker-entrypoint.sh
+    networks:
+      - emaily-net
+
+  sentinel-2:
+    image: redis:7.2.5
+    container_name: sentinel-2
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "26380:26379"
+    command: sh /usr/local/etc/redis/docker-entrypoint.sh
+    volumes:
+      - ./config-template/sentinel/sentinel.conf.template:/usr/local/etc/redis/sentinel.conf.template
+      - ./config-template/sentinel/docker-entrypoint-sentinel.sh:/usr/local/etc/redis/docker-entrypoint.sh
+    networks:
+      - emaily-net
+
+  sentinel-3:
+    image: redis:7.2.5
+    container_name: sentinel-3
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "26381:26379"
+    command: sh /usr/local/etc/redis/docker-entrypoint.sh
+    volumes:
+      - ./config-template/sentinel/sentinel.conf.template:/usr/local/etc/redis/sentinel.conf.template
+      - ./config-template/sentinel/docker-entrypoint-sentinel.sh:/usr/local/etc/redis/docker-entrypoint.sh
+    networks:
+      - emaily-net
+
+  james:
+    image: apache/james:memory-latest
+    depends_on:
+      - sentinel-1
+      - sentinel-2
+      - sentinel-3
+    container_name: james
+    hostname: james.local
+    ports:
+      - "8000:8000"
+    command:
+      - --generate-keystore
+    volumes:
+      - ./redis.properties:/root/conf/redis.properties
+      - ../extensions.properties:/root/conf/extensions.properties
+      - ../target/james-server-rate-limiter-redis-jar-with-dependencies.jar:/root/extensions-jars/james-server-rate-limiter-redis.jar
+      - ../mailetcontainer.xml:/root/conf/mailetcontainer.xml
+      - ../healthcheck.properties:/root/conf/healthcheck.properties
+    networks:
+      - emaily-net
+
+networks:
+  emaily-net:
+    driver: bridge

--- a/server/mailet/rate-limiter-redis/docker-compose-sample/redis.properties
+++ b/server/mailet/rate-limiter-redis/docker-compose-sample/redis.properties
@@ -1,0 +1,3 @@
+redisURL=redis-sentinel://secret1@sentinel-1:26379,sentinel-2:26379,sentinel-3:26379?sentinelMasterId=mymaster
+redis.topology=master-replica
+#redis.readFrom=master


### PR DESCRIPTION
Why require commit ? [JAMES-3693 Fixup RedisConfiguration - parsing correct `redisURL` when multiple redis sentinel endpoint](https://github.com/apache/james-project/commit/344a80157059fb18d2830da3c0eaaea6f11ca53c)

The current James configuration uses:
```
config.setListDelimiterHandler(new DefaultListDelimiterHandler(','))
```
Then when give `redisURL` is `redis-sentinel://secret1@redis-sentinel-1:26379,redis-sentinel-2:26379,redis-sentinel-3:26379?sentinelMasterId=mymaster` (multiple sentinel endpoint)
the James configuration parsing is incorrect.
