### PR TITLE
Explicit commit after running reindex

### DIFF
--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
@@ -1351,6 +1351,15 @@ public class LuceneMessageSearchIndex extends ListeningMessageSearchIndex {
     }
 
     @Override
+    public void postReindexing() {
+        try {
+            commit();
+        } catch (IOException e) {
+            throw new RuntimeException("Error while commiting to index", e);
+        }
+    }
+
+    @Override
     public Mono<Flags> retrieveIndexedFlags(Mailbox mailbox, MessageUid uid) {
         return Mono.fromCallable(() -> retrieveFlags(mailbox, uid));
     }

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/DisabledListeningMessageSearchIndex.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/DisabledListeningMessageSearchIndex.java
@@ -74,6 +74,11 @@ public class DisabledListeningMessageSearchIndex extends ListeningMessageSearchI
     }
 
     @Override
+    public void postReindexing() {
+        // do nothing
+    }
+
+    @Override
     public boolean isHandling(Event event) {
         return INTERESTING_EVENTS.contains(event.getClass());
     }

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndex.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndex.java
@@ -274,6 +274,11 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
     }
 
     @Override
+    public void postReindexing() {
+        // no need to explicitly commit after reindexing
+    }
+
+    @Override
     public Mono<Void> reactiveEvent(Event event) {
         MailboxSession systemSession = sessionProvider.createSystemSession(event.getUsername());
         return handleMailboxEvent(event, systemSession, (MailboxEvents.MailboxEvent) event)

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/LazyMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/LazyMessageSearchIndex.java
@@ -104,6 +104,11 @@ public class LazyMessageSearchIndex extends ListeningMessageSearchIndex {
         return index.deleteAll(session, mailboxId);
     }
 
+    @Override
+    public void postReindexing() {
+        index.postReindexing();
+    }
+
     /**
      * Lazy index the mailbox on first search request if it was not indexed before. After indexing is done it delegate the search request to the wrapped
      * {@link MessageSearchIndex}. Be aware that concurrent search requests are blocked on the same "not-yet-indexed" mailbox till it the index process was 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
@@ -61,6 +61,8 @@ import reactor.core.scheduler.Schedulers;
 public abstract class ListeningMessageSearchIndex implements MessageSearchIndex, EventListener.ReactiveGroupEventListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(ListeningMessageSearchIndex.class);
 
+    public abstract void postReindexing();
+
     public interface SearchOverride {
         boolean applicable(SearchQuery searchQuery, MailboxSession session);
 

--- a/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ReIndexerPerformer.java
+++ b/mailbox/tools/indexer/src/main/java/org/apache/mailbox/tools/indexer/ReIndexerPerformer.java
@@ -295,6 +295,7 @@ public class ReIndexerPerformer {
                 .per(Duration.ofSeconds(1))
                 .forOperation(entry -> reIndex(entry, reIndexingContext, runningOptions)))
             .reduce(Task::combine)
+            .doFinally(signalType -> messageSearchIndex.postReindexing())
             .switchIfEmpty(Mono.just(Result.COMPLETED));
     }
 

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -114,6 +114,7 @@ public class CassandraReIndexerImplTest {
         verify(messageSearchIndex).deleteAll(any(MailboxSession.class), any(MailboxId.class));
         verify(messageSearchIndex, times(threadCount * operationCount))
             .add(any(MailboxSession.class), any(Mailbox.class),any(MailboxMessage.class));
+        verify(messageSearchIndex).postReindexing();
         verifyNoMoreInteractions(messageSearchIndex);
     }
 

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/ReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/ReIndexerImplTest.java
@@ -87,6 +87,7 @@ public class ReIndexerImplTest {
 
         verify(messageSearchIndex).deleteAll(any(MailboxSession.class), mailboxCaptor1.capture());
         verify(messageSearchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+        verify(messageSearchIndex).postReindexing();
         verifyNoMoreInteractions(messageSearchIndex);
 
         assertThat(mailboxCaptor1.getValue()).satisfies(capturedMailboxId -> assertThat(capturedMailboxId).isEqualTo(mailboxId));
@@ -113,6 +114,7 @@ public class ReIndexerImplTest {
 
         verify(messageSearchIndex).deleteAll(any(MailboxSession.class), mailboxCaptor1.capture());
         verify(messageSearchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+        verify(messageSearchIndex).postReindexing();
         verifyNoMoreInteractions(messageSearchIndex);
 
         assertThat(mailboxCaptor1.getValue()).satisfies(capturedMailboxId -> assertThat(capturedMailboxId).isEqualTo(mailboxId));
@@ -139,6 +141,7 @@ public class ReIndexerImplTest {
 
         verify(messageSearchIndex).deleteAll(any(MailboxSession.class), mailboxCaptor1.capture());
         verify(messageSearchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+        verify(messageSearchIndex).postReindexing();
         verifyNoMoreInteractions(messageSearchIndex);
 
         assertThat(mailboxCaptor1.getValue()).satisfies(capturedMailboxId -> assertThat(capturedMailboxId).isEqualTo(mailboxId));
@@ -231,6 +234,7 @@ public class ReIndexerImplTest {
 
         verify(messageSearchIndex).deleteAll(any(MailboxSession.class), mailboxIdCaptor.capture());
         verify(messageSearchIndex).add(any(MailboxSession.class), mailboxCaptor.capture(), messageCaptor.capture());
+        verify(messageSearchIndex).postReindexing();
         verifyNoMoreInteractions(messageSearchIndex);
 
         assertThat(mailboxCaptor.getValue()).satisfies(mailbox -> assertThat(mailbox.getMailboxId()).isEqualTo(mailboxId));
@@ -262,6 +266,7 @@ public class ReIndexerImplTest {
 
         verify(messageSearchIndex).retrieveIndexedFlags(any(), any());
         verify(messageSearchIndex).add(any(MailboxSession.class), mailboxCaptor.capture(), messageCaptor.capture());
+        verify(messageSearchIndex).postReindexing();
         verifyNoMoreInteractions(messageSearchIndex);
 
         assertThat(mailboxCaptor.getValue()).satisfies(mailbox -> assertThat(mailbox.getMailboxId()).isEqualTo(mailboxId));
@@ -280,6 +285,7 @@ public class ReIndexerImplTest {
         ArgumentCaptor<MailboxId> mailboxCaptor = ArgumentCaptor.forClass(MailboxId.class);
 
         verify(messageSearchIndex).deleteAll(any(MailboxSession.class), mailboxCaptor.capture());
+        verify(messageSearchIndex).postReindexing();
         verifyNoMoreInteractions(messageSearchIndex);
 
         assertThat(mailboxCaptor.getValue()).satisfies(capturedMailboxId -> assertThat(capturedMailboxId).isEqualTo(mailboxId));

--- a/server/container/guice/memory/src/main/java/org/apache/james/FakeMessageSearchIndex.java
+++ b/server/container/guice/memory/src/main/java/org/apache/james/FakeMessageSearchIndex.java
@@ -81,6 +81,11 @@ public class FakeMessageSearchIndex extends ListeningMessageSearchIndex {
     }
 
     @Override
+    public void postReindexing() {
+        throw new NotImplementedException("not implemented");
+    }
+
+    @Override
     public Flux<MessageUid> doSearch(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
         throw new NotImplementedException("not implemented");
     }

--- a/server/container/guice/opensearch/src/main/java/org/apache/james/SearchModuleChooser.java
+++ b/server/container/guice/opensearch/src/main/java/org/apache/james/SearchModuleChooser.java
@@ -103,6 +103,11 @@ public class SearchModuleChooser {
         }
 
         @Override
+        public void postReindexing() {
+            throw new NotImplementedException("not implemented");
+        }
+
+        @Override
         public Flux<MessageUid> doSearch(MailboxSession session, Mailbox mailbox, SearchQuery searchQuery) throws MailboxException {
             throw new NotImplementedException("not implemented");
         }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -704,6 +704,7 @@ class MailboxesRoutesTest {
 
                 verify(searchIndex).deleteAll(any(MailboxSession.class), mailboxIdCaptor.capture());
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+                verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 
                 assertThat(mailboxIdCaptor.getValue()).matches(capturedMailboxId -> capturedMailboxId.equals(mailboxId));
@@ -1127,6 +1128,7 @@ class MailboxesRoutesTest {
 
                 verify(searchIndex).deleteAll(any(MailboxSession.class), mailboxIdCaptor.capture());
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+                verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 
                 assertThat(mailboxIdCaptor.getValue()).matches(capturedMailboxId -> capturedMailboxId.equals(mailboxId));
@@ -1623,6 +1625,7 @@ class MailboxesRoutesTest {
                 ArgumentCaptor<MailboxMessage> messageCaptor = ArgumentCaptor.forClass(MailboxMessage.class);
                 ArgumentCaptor<Mailbox> mailboxCaptor = ArgumentCaptor.forClass(Mailbox.class);
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor.capture(), messageCaptor.capture());
+                verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 
                 assertThat(mailboxCaptor.getValue()).matches(mailbox -> mailbox.getMailboxId().equals(mailboxId));

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -2071,6 +2071,7 @@ class UserMailboxesRoutesTest {
 
                 verify(searchIndex).deleteAll(any(MailboxSession.class), mailboxIdCaptor.capture());
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+                verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 
                 assertThat(mailboxIdCaptor.getValue()).matches(capturedMailboxId -> capturedMailboxId.equals(mailboxId));


### PR DESCRIPTION
As per mailinglist:

>>    should we finish the operation with the explicit "commit" operation?
> +1
> 
> We could add a `postReindexing()` method for search indexes which commits for Lucene and noop for Opensearch + scanning.
> 
> Then calling it in reindexing task would be a no brainer.
> 
> Do you think you can contribute this?--
> 
> Best regards,
> 
> Benoit TELLIER