### PR TITLE
JAMES-4054 Fix remove X-SMIME-Status header in mailetcontainer.xml

### DIFF
--- a/server/apps/cassandra-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/cassandra-app/sample-configuration/mailetcontainer.xml
@@ -70,7 +70,11 @@
             </matcher>
 
             <mailet match="All" class="RemoveMimeHeader">
-                <name>bcc,X-SMIME-Status</name>
+                <name>bcc</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>X-SMIME-Status</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
             <mailet match="All" class="RecipientRewriteTable">

--- a/server/apps/distributed-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/distributed-app/sample-configuration/mailetcontainer.xml
@@ -70,7 +70,11 @@
             </matcher>
 
             <mailet match="All" class="RemoveMimeHeader">
-                <name>bcc,X-SMIME-Status</name>
+                <name>bcc</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>X-SMIME-Status</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
             <mailet match="All" class="RecipientRewriteTable">

--- a/server/apps/distributed-pop3-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/distributed-pop3-app/sample-configuration/mailetcontainer.xml
@@ -72,6 +72,10 @@
                 <name>bcc</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>X-SMIME-Status</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>rrt-error</errorProcessor>
             </mailet>

--- a/server/apps/jpa-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/jpa-app/sample-configuration/mailetcontainer.xml
@@ -72,6 +72,10 @@
                 <name>bcc</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>X-SMIME-Status</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>rrt-error</errorProcessor>
             </mailet>

--- a/server/apps/jpa-smtp-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/jpa-smtp-app/sample-configuration/mailetcontainer.xml
@@ -70,6 +70,10 @@
                 <name>bcc</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>X-SMIME-Status</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
             <mailet match="All" class="RecipientRewriteTable" />
             <mailet match="HostIsLocal" class="ToProcessor">
                 <processor>local-address-error</processor>

--- a/server/apps/memory-app/sample-configuration/mailetcontainer.xml
+++ b/server/apps/memory-app/sample-configuration/mailetcontainer.xml
@@ -70,7 +70,11 @@
             </matcher>
 
             <mailet match="All" class="RemoveMimeHeader">
-                <name>bcc,X-SMIME-Status</name>
+                <name>bcc</name>
+                <onMailetException>ignore</onMailetException>
+            </mailet>
+            <mailet match="All" class="RemoveMimeHeader">
+                <name>X-SMIME-Status</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
             <mailet match="All" class="RecipientRewriteTable">


### PR DESCRIPTION
MailetContainerModule seems to check that RemoveMimeHeader with the parameter name strictly equal to `bcc` is present. If not, it crashes james startup. 

That would create issues during next release I think and this is the fix.

Why do we do such a strict checkup btw does somebody now? sound absurd to me.