### PR TITLE
JAMES-4060: Fix UID FETCH command failing on empty mailbox

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/streaming/InputStreamContent.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/streaming/InputStreamContent.java
@@ -86,4 +86,13 @@ public final class InputStreamContent implements Content {
                 return m.getBodyContentReactive();
         }
     }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("InputStreamContent{");
+        sb.append("m=").append(m);
+        sb.append(", type=").append(type);
+        sb.append('}');
+        return sb.toString();
+    }
 }

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Fetch.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Fetch.java
@@ -47,6 +47,13 @@ public abstract class Fetch implements ImapTestConstants {
     }
     
     @Test
+    public void testFetchAllEmptyMailboxUS() throws Exception {
+        simpleScriptedTestProtocol
+            .withLocale(Locale.US)
+            .run("FetchAllEmptyMailbox");
+    }
+
+    @Test
     public void testFetchEnvelopeUS() throws Exception {
         simpleScriptedTestProtocol
             .withLocale(Locale.US)

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/FetchAllEmptyMailbox.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/FetchAllEmptyMailbox.test
@@ -1,0 +1,45 @@
+################################################################
+# Licensed to the Apache Software Foundation (ASF) under one   #
+# or more contributor license agreements.  See the NOTICE file #
+# distributed with this work for additional information        #
+# regarding copyright ownership.  The ASF licenses this file   #
+# to you under the Apache License, Version 2.0 (the            #
+# "License"); you may not use this file except in compliance   #
+# with the License.  You may obtain a copy of the License at   #
+#                                                              #
+#   http://www.apache.org/licenses/LICENSE-2.0                 #
+#                                                              #
+# Unless required by applicable law or agreed to in writing,   #
+# software distributed under the License is distributed on an  #
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       #
+# KIND, either express or implied.  See the License for the    #
+# specific language governing permissions and limitations      #
+# under the License.                                           #
+################################################################
+# Fetch All messages from empty mailbox
+
+C: b1 CREATE box
+S: b1 OK \[MAILBOXID \(.*\)\] CREATE completed.
+
+C: b2 SELECT box
+S: \* OK \[MAILBOXID \(.+\)\] Ok
+S: \* FLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\Seen\)
+S: \* 0 EXISTS
+S: \* 0 RECENT
+S: \* OK \[UIDVALIDITY \d+\].*
+S: \* OK \[PERMANENTFLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\\Seen( \\\*)?\)\].*
+S: \* OK \[HIGHESTMODSEQ \d+\].*
+S: \* OK \[UIDNEXT 1\].*
+S: b2 OK \[READ-WRITE\] SELECT completed.
+
+C: b3 FETCH 1:* (UID)
+S: b3 OK FETCH completed.
+
+C: b4 FETCH *:* (UID)
+S: b4 OK FETCH completed.
+
+C: b5 FETCH * (UID)
+S: b5 OK FETCH completed.
+
+
+

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
@@ -38,6 +38,14 @@ S: \* 2 FETCH \(UID 3\)
 S: \* 3 FETCH \(UID 4\)
 S: a2 OK FETCH completed.
 
+C: a21 FETCH * (UID)
+S: \* 3 FETCH \(UID 4\)
+S: a21 OK FETCH completed.
+
+C: a22 FETCH *:* (UID)
+S: \* 3 FETCH \(UID 4\)
+S: a22 OK FETCH completed.
+
 #UID fetch
 C: a UID FETCH 2:3 (INTERNALDATE)
 S: \* 1 FETCH \(INTERNALDATE "[^"]*" UID 2\)

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
@@ -32,6 +32,12 @@ S: \* 2 FETCH \(UID 3\)
 S: \* 3 FETCH \(UID 4\)
 S: a OK FETCH completed.
 
+C: a2 FETCH 1:* (UID)
+S: \* 1 FETCH \(UID 2\)
+S: \* 2 FETCH \(UID 3\)
+S: \* 3 FETCH \(UID 4\)
+S: a2 OK FETCH completed.
+
 #UID fetch
 C: a UID FETCH 2:3 (INTERNALDATE)
 S: \* 1 FETCH \(INTERNALDATE "[^"]*" UID 2\)
@@ -77,6 +83,24 @@ S: a OK SEARCH completed.
 # Cleanup
 C: a1 DELETE copied
 S: a1 OK DELETE completed.
+
+C: b1 CREATE box
+S: b1 OK \[MAILBOXID \(.*\)\] CREATE completed.
+
+C: b2 SELECT box
+S: \* OK \[MAILBOXID \(.+\)\] Ok
+S: \* FLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\Seen\)
+S: \* 0 EXISTS
+S: \* 0 RECENT
+S: \* OK \[UIDVALIDITY \d+\].*
+S: \* OK \[PERMANENTFLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\\Seen( \\\*)?\)\].*
+S: \* OK \[HIGHESTMODSEQ \d+\].*
+S: \* OK \[UIDNEXT 1\].*
+S: b2 OK \[READ-WRITE\] SELECT completed.
+
+C: b3 FETCH 1:* (UID)
+S: b3 OK FETCH completed.
+
 
 
 

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
@@ -101,6 +101,9 @@ S: b2 OK \[READ-WRITE\] SELECT completed.
 C: b3 FETCH 1:* (UID)
 S: b3 OK FETCH completed.
 
+C: b4 UID FETCH 1:* (UID)
+S: b4 OK FETCH completed.
+
 
 
 

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Uid.test
@@ -98,12 +98,11 @@ S: \* OK \[HIGHESTMODSEQ \d+\].*
 S: \* OK \[UIDNEXT 1\].*
 S: b2 OK \[READ-WRITE\] SELECT completed.
 
-C: b3 FETCH 1:* (UID)
+C: b3 UID FETCH 1:* (UID)
 S: b3 OK FETCH completed.
 
-C: b4 UID FETCH 1:* (UID)
+C: b4 UID FETCH *:* (UID)
 S: b4 OK FETCH completed.
 
-
-
-
+C: b5 UID FETCH * (UID)
+S: b5 OK FETCH completed.

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/Tag.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/Tag.java
@@ -21,7 +21,6 @@ package org.apache.james.imap.api;
 
 import java.util.Objects;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 public class Tag {

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/Tag.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/Tag.java
@@ -53,8 +53,6 @@ public class Tag {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("value", value)
-            .toString();
+        return value;
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -75,7 +75,6 @@ public class DefaultImapDecoder implements ImapDecoder {
     }
 
     private ImapMessage decodeCommandTagged(ImapRequestLineReader request, Tag tag, ImapSession session) {
-        LOGGER.debug("Got <tag>: {}", tag);
         try {
             String commandName = request.atom();
             return decodeCommandNamed(request, tag, commandName, session);
@@ -110,7 +109,6 @@ public class DefaultImapDecoder implements ImapDecoder {
     }
 
     private ImapMessage decodeCommandNamed(ImapRequestLineReader request, Tag tag, String commandName, ImapSession session) {
-        LOGGER.debug("Got <command>: {}", commandName);
         ImapCommandParser command = imapCommands.getParser(commandName);
         if (command == null) {
             LOGGER.info("Missing command implementation for commmand {}", commandName);
@@ -121,6 +119,7 @@ public class DefaultImapDecoder implements ImapDecoder {
         if (count == null || (int) count > 0) {
             session.setAttribute(INVALID_COMMAND_COUNT, 0);
         }
+        LOGGER.trace("Processing {} {} {}", tag.asString(), commandName, message.toString());
         return message;
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -119,7 +119,7 @@ public class DefaultImapDecoder implements ImapDecoder {
         if (count == null || (int) count > 0) {
             session.setAttribute(INVALID_COMMAND_COUNT, 0);
         }
-        LOGGER.trace("Processing {} {} {}", tag, commandName, message);
+        LOGGER.trace("Processing {} {} {} [{}] ", tag, commandName, message, session.getUserName());
         return message;
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -119,7 +119,7 @@ public class DefaultImapDecoder implements ImapDecoder {
         if (count == null || (int) count > 0) {
             session.setAttribute(INVALID_COMMAND_COUNT, 0);
         }
-        LOGGER.trace("Processing {} {} {}", tag.asString(), commandName, message.toString());
+        LOGGER.trace("Processing {} {} {}", tag, commandName, message);
         return message;
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -31,6 +31,7 @@ import org.apache.james.imap.decode.ImapCommandParser;
 import org.apache.james.imap.decode.ImapCommandParserFactory;
 import org.apache.james.imap.decode.ImapDecoder;
 import org.apache.james.imap.decode.ImapRequestLineReader;
+import org.apache.james.util.MDCStructuredLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,7 +120,12 @@ public class DefaultImapDecoder implements ImapDecoder {
         if (count == null || (int) count > 0) {
             session.setAttribute(INVALID_COMMAND_COUNT, 0);
         }
-        LOGGER.trace("Processing {} {} {} [{}] ", tag, commandName, message, session.getUserName());
+        // Avoid cost of initializing MDC locally
+        if (LOGGER.isTraceEnabled()) {
+            new MDCStructuredLogger(LOGGER)
+                    .field("username", String.valueOf(session.getUserName()))
+                    .log(logger -> logger.trace("Processing {} {} {} ", tag, commandName, message));
+        }
         return message;
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/UidCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/UidCommandParser.java
@@ -61,7 +61,6 @@ public class UidCommandParser extends AbstractImapCommandParser {
         if (!(helperCommand instanceof AbstractUidCommandParser)) {
             throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Invalid UID command: '" + commandName + "'");
         }
-        LOGGER.debug("Got <command>: UID {}", commandName);
         final AbstractUidCommandParser uidEnabled = (AbstractUidCommandParser) helperCommand;
         return uidEnabled.decode(request, tag, true, session);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/request/AbstractImapRequest.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/request/AbstractImapRequest.java
@@ -52,4 +52,11 @@ public abstract class AbstractImapRequest implements ImapRequest {
         return tag;
     }
 
+    @Override
+    public String toString() {
+        return "AbstractImapRequest{" +
+                "tag=" + getTag() +
+                ", command=" + getCommand() +
+                '}';
+    }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/response/ImmutableStatusResponse.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/response/ImmutableStatusResponse.java
@@ -24,8 +24,6 @@ import org.apache.james.imap.api.Tag;
 import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponse;
 
-import com.google.common.base.MoreObjects;
-
 /**
  * Immutable status response. Suitable for unpooled usage.
  */

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/response/ImmutableStatusResponse.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/response/ImmutableStatusResponse.java
@@ -24,6 +24,8 @@ import org.apache.james.imap.api.Tag;
 import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponse;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * Immutable status response. Suitable for unpooled usage.
  */
@@ -68,8 +70,7 @@ public class ImmutableStatusResponse implements StatusResponse {
         return command;
     }
 
-    @Override
-    public String toString() {
+    public String asString() {
         final StringBuilder sb = new StringBuilder();
         if (getResponseCode() != null) {
             sb.append(' ').append(getResponseCode());
@@ -87,5 +88,16 @@ public class ImmutableStatusResponse implements StatusResponse {
             sb.append(' ').append(getCommand());
         }
         return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("responseCode", responseCode)
+                .add("serverResponseType", serverResponseType)
+                .add("tag", tag)
+                .add("textKey", textKey)
+                .add("command", command)
+                .toString();
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/response/ImmutableStatusResponse.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/response/ImmutableStatusResponse.java
@@ -72,12 +72,22 @@ public class ImmutableStatusResponse implements StatusResponse {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("responseCode", responseCode)
-            .add("serverResponseType", serverResponseType)
-            .add("tag", tag)
-            .add("textKey", textKey)
-            .add("command", command)
-            .toString();
+        final StringBuilder sb = new StringBuilder();
+        if (getResponseCode() != null) {
+            sb.append(' ').append(getResponseCode());
+        }
+        if (getServerResponseType() != null) {
+            sb.append(' ').append(getServerResponseType());
+        }
+        if (getTag() != null) {
+            sb.append(' ').append(getTag());
+        }
+        if (getTextKey() != null) {
+            sb.append(' ').append(getTextKey());
+        }
+        if (getCommand() != null) {
+            sb.append(' ').append(getCommand());
+        }
+        return sb.toString();
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/response/UnpooledStatusResponseFactory.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/response/UnpooledStatusResponseFactory.java
@@ -36,7 +36,7 @@ public class UnpooledStatusResponseFactory extends AbstractStatusResponseFactory
     @Override
     protected StatusResponse createResponse(Type type, Tag tag, ImapCommand command, HumanReadableText displayTextKey, ResponseCode code) {
         var response = new ImmutableStatusResponse(type, tag, command, displayTextKey, code);
-        LOGGER.trace("Created IMAP response: {}", response);
+        LOGGER.trace("Created IMAP response: {}",  response);
         return response;
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/response/UnpooledStatusResponseFactory.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/response/UnpooledStatusResponseFactory.java
@@ -26,12 +26,18 @@ import org.apache.james.imap.api.message.response.StatusResponse;
 import org.apache.james.imap.api.message.response.StatusResponse.ResponseCode;
 import org.apache.james.imap.api.message.response.StatusResponse.Type;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UnpooledStatusResponseFactory extends AbstractStatusResponseFactory implements StatusResponseFactory {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnpooledStatusResponseFactory.class);
+
     @Override
     protected StatusResponse createResponse(Type type, Tag tag, ImapCommand command, HumanReadableText displayTextKey, ResponseCode code) {
-        return new ImmutableStatusResponse(type, tag, command, displayTextKey, code);
+        var response = new ImmutableStatusResponse(type, tag, command, displayTextKey, code);
+        LOGGER.trace("Created IMAP response: {}", response);
+        return response;
     }
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/response/UnpooledStatusResponseFactory.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/response/UnpooledStatusResponseFactory.java
@@ -35,9 +35,7 @@ public class UnpooledStatusResponseFactory extends AbstractStatusResponseFactory
 
     @Override
     protected StatusResponse createResponse(Type type, Tag tag, ImapCommand command, HumanReadableText displayTextKey, ResponseCode code) {
-        var response = new ImmutableStatusResponse(type, tag, command, displayTextKey, code);
-        LOGGER.trace("Created IMAP response: {}",  response);
-        return response;
+        return new ImmutableStatusResponse(type, tag, command, displayTextKey, code);
     }
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -444,14 +444,10 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
 
     private MessageRange msnRangeToMessageRange(SelectedMailbox selected, long lowVal, long highVal)
             throws MessageRangeException {
-        // Take care of "*" and "*:*" values by return the last message in
+        // Take care of "*", "1:*" and "*:*" values by return the last message in
         // the mailbox. See IMAP-289
-        if (lowVal == Long.MAX_VALUE && highVal == Long.MAX_VALUE) {
-            Optional<MessageUid> last = selected.getLastUid();
-            if (!last.isPresent()) {
-                throw new MessageRangeException("Mailbox is empty");
-            }
-            return last.get().toRange();
+        if ((lowVal == Long.MAX_VALUE || lowVal == 1) && highVal == Long.MAX_VALUE) {
+            return MessageRange.all();
         }
 
         MessageUid lowUid = msnlowValToUid(selected, lowVal);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -444,9 +444,11 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
 
     private MessageRange msnRangeToMessageRange(SelectedMailbox selected, long lowVal, long highVal)
             throws MessageRangeException {
-        // Take care of "*", "1:*" and "*:*" values by return the last message in
-        // the mailbox. See IMAP-289
-        if ((lowVal == Long.MAX_VALUE || lowVal == 1) && highVal == Long.MAX_VALUE) {
+        if (lowVal == Long.MAX_VALUE && highVal == Long.MAX_VALUE) {
+            // Take care of "*" and "*:*" values by returning the last message in the mailbox. See IMAP-289
+            return selected.getLastUid().map(MessageRange::one).orElseGet(MessageRange::all);
+        } else if (lowVal == 1 && highVal == Long.MAX_VALUE) {
+            // Take care of "1:*" values by returning all messages in the mailbox. See IMAP-289
             return MessageRange.all();
         }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
@@ -128,6 +128,7 @@ public class StatusProcessor extends AbstractMailboxProcessor<StatusRequest> imp
                     if (response.getHighestModSeq() != null) {
                         condstoreEnablingCommand(session, responder, metaData, false);
                     }
+                    LOGGER.trace("Status on mailbox named {}, response: {}", mailbox, response);
                     responder.respond(response);
                 }));
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
@@ -128,7 +128,6 @@ public class StatusProcessor extends AbstractMailboxProcessor<StatusRequest> imp
                     if (response.getHighestModSeq() != null) {
                         condstoreEnablingCommand(session, responder, metaData, false);
                     }
-                    LOGGER.trace("Status on mailbox named {}, response: {}", mailbox, response);
                     responder.respond(response);
                 }));
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/ContentBodyElement.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/ContentBodyElement.java
@@ -62,4 +62,12 @@ class ContentBodyElement implements BodyElement {
     public InputStream getInputStream() throws IOException {
         return content.getInputStream();
     }
+
+    @Override
+    public String toString() {
+        return "ContentBodyElement{" +
+                "name='" + getName() + '\'' +
+                ", content=" + content +
+                '}';
+    }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -201,9 +201,6 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
         List<MessageRange> ranges = new ArrayList<>();
 
         for (IdRange range : request.getIdSet()) {
-            if (session.getSelected().getLastUid().isEmpty()) {
-                continue;
-            }
             Optional<MessageRange> messageSet = messageRange(session.getSelected(), range, request.isUseUids());
             if (messageSet.isPresent()) {
                 MessageRange normalizedMessageSet = normalizeMessageRange(selected, messageSet.orElse(null));

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -201,10 +201,12 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
         List<MessageRange> ranges = new ArrayList<>();
 
         for (IdRange range : request.getIdSet()) {
-            MessageRange messageSet = messageRange(session.getSelected(), range, request.isUseUids())
-                .orElseThrow(() -> new MessageRangeException(range.getFormattedString() + " is an invalid range"));
-            if (messageSet != null) {
-                MessageRange normalizedMessageSet = normalizeMessageRange(selected, messageSet);
+            if (session.getSelected().getLastUid().isEmpty()) {
+                continue;
+            }
+            Optional<MessageRange> messageSet = messageRange(session.getSelected(), range, request.isUseUids());
+            if (messageSet.isPresent()) {
+                MessageRange normalizedMessageSet = normalizeMessageRange(selected, messageSet.orElse(null));
                 MessageRange batchedMessageSet = MessageRange.range(normalizedMessageSet.getUidFrom(), normalizedMessageSet.getUidTo());
                 ranges.add(batchedMessageSet);
             }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -220,7 +220,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
             LOGGER.info("Connection established from {}", address.getAddress().getHostAddress());
             imapConnectionsMetric.increment();
 
-            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel());
+            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
             ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
             // write hello to client
             response.untagged().message("OK").message(hello).end();
@@ -286,7 +286,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
         }
     }
 
-    private static String retrieveUsername(ImapSession imapSession) {
+    static String retrieveUsername(ImapSession imapSession) {
         return Optional.ofNullable(imapSession)
             .flatMap(session -> Optional.ofNullable(session.getUserName()))
             .map(Username::asString)
@@ -324,7 +324,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                 // command length."
                 //
                 // See also JAMES-1190
-                ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel());
+                ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
                 ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
                 response.untaggedResponse(ImapConstants.BAD + " failed. Maximum command line length exceeded");
                 response.flush();
@@ -350,7 +350,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
     private void manageRejectedException(ChannelHandlerContext ctx, ReactiveThrottler.RejectedException cause) throws IOException {
         if (cause.getImapMessage() instanceof AbstractImapRequest) {
             AbstractImapRequest req = (AbstractImapRequest) cause.getImapMessage();
-            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel());
+            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
             ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
             new ResponseEncoder(encoder, response)
                 .respond(new ImmutableStatusResponse(StatusResponse.Type.NO, req.getTag(), req.getCommand(),
@@ -404,7 +404,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
             linearalizer.isExecutingRequest.set(true);
         }
 
-        ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel());
+        ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
         ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
         writer.setFlushCallback(response::flush);
         ImapMessage message = (ImapMessage) msg;

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -220,7 +220,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
             LOGGER.info("Connection established from {}", address.getAddress().getHostAddress());
             imapConnectionsMetric.increment();
 
-            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
+            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel(), imapsession);
             ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
             // write hello to client
             response.untagged().message("OK").message(hello).end();
@@ -324,7 +324,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                 // command length."
                 //
                 // See also JAMES-1190
-                ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
+                ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel(), imapSession);
                 ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
                 response.untaggedResponse(ImapConstants.BAD + " failed. Maximum command line length exceeded");
                 response.flush();
@@ -349,8 +349,9 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
 
     private void manageRejectedException(ChannelHandlerContext ctx, ReactiveThrottler.RejectedException cause) throws IOException {
         if (cause.getImapMessage() instanceof AbstractImapRequest) {
+            ImapSession imapSession = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
             AbstractImapRequest req = (AbstractImapRequest) cause.getImapMessage();
-            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
+            ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel(), imapSession);
             ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
             new ResponseEncoder(encoder, response)
                 .respond(new ImmutableStatusResponse(StatusResponse.Type.NO, req.getTag(), req.getCommand(),
@@ -404,7 +405,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
             linearalizer.isExecutingRequest.set(true);
         }
 
-        ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx);
+        ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel(), session);
         ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
         writer.setFlushCallback(response::flush);
         ImapMessage message = (ImapMessage) msg;


### PR DESCRIPTION
(ref: https://issues.apache.org/jira/browse/JAMES-4060, https://www.mail-archive.com/server-dev@james.apache.org/msg74362.html)
(followup to https://github.com/apache/james-project/pull/2385 #2385)

* extending testcase to include `UID FETCH`
* fix the issue by ignoring range retrieval when the inbox is empty
* improvements to debug logs (compacting DefaultImapDecoder logs to single entry; add missing `toString()` and simplify toString in `ImmutableStatusResponse`):

Log afterwards looks nicer/cleaner IMHO (it's not perfect as it's mostly parsed data but gives more information about request-response chatter):
```
17:14:05.268 [DEBUG] o.a.j.m.p.ProtocolSession - C: b1 CREATE box
17:14:05.268 [TRACE] o.a.j.i.d.m.DefaultImapDecoder - Processing b1 CREATE CreateRequest{mailboxName=box}
17:14:05.268 [DEBUG] o.a.j.m.s.StoreMailboxManager - createMailbox #private:imapuser:box
17:14:05.269 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  MAILBOXID OK b1 completed. CREATE
17:14:05.269 [DEBUG] o.a.j.m.p.ProtocolSession - S: b1 OK [MAILBOXID (4)] CREATE completed.
17:14:05.269 [DEBUG] o.a.j.m.p.ProtocolSession - C: b2 SELECT box
17:14:05.270 [TRACE] o.a.j.i.d.m.DefaultImapDecoder - Processing b2 SELECT SelectRequest{mailboxName=box, condstore=false, lastKnownUidValidity=UidValidity{UNKNOWN}, knownModSeq=null, uidSet=null, knownUidSet=null, knownSequenceSet=null}
17:14:05.270 [DEBUG] o.a.j.m.s.StoreMailboxManager - Loaded mailbox #private:imapuser:box
17:14:05.272 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  MAILBOXID OK Ok
17:14:05.272 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  UIDVALIDITY OK UIDs valid
17:14:05.272 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  PERMANENTFLAGS OK Limited
17:14:05.272 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  HIGHESTMODSEQ OK Highest
17:14:05.272 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  UIDNEXT OK Predicted next UID
17:14:05.272 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  READ-WRITE OK b2 completed. SELECT
17:14:05.272 [DEBUG] o.a.j.m.p.ProtocolSession - S: * OK [MAILBOXID (4)] Ok
17:14:05.272 [DEBUG] o.a.j.m.p.ProtocolSession - S: * FLAGS (\Answered \Deleted \Draft \Flagged \Seen)
17:14:05.272 [DEBUG] o.a.j.m.p.ProtocolSession - S: * 0 EXISTS
17:14:05.272 [DEBUG] o.a.j.m.p.ProtocolSession - S: * 0 RECENT
17:14:05.272 [DEBUG] o.a.j.m.p.ProtocolSession - S: * OK [UIDVALIDITY 277573197] UIDs valid
17:14:05.273 [DEBUG] o.a.j.m.p.ProtocolSession - S: * OK [PERMANENTFLAGS (\Answered \Deleted \Draft \Flagged \Seen \*)] Limited
17:14:05.273 [DEBUG] o.a.j.m.p.ProtocolSession - S: * OK [HIGHESTMODSEQ 0] Highest
17:14:05.273 [DEBUG] o.a.j.m.p.ProtocolSession - S: * OK [UIDNEXT 1] Predicted next UID
17:14:05.273 [DEBUG] o.a.j.m.p.ProtocolSession - S: b2 OK [READ-WRITE] SELECT completed.
17:14:05.273 [DEBUG] o.a.j.m.p.ProtocolSession - C: b3 FETCH 1:* (UID)
17:14:05.273 [TRACE] o.a.j.i.d.m.DefaultImapDecoder - Processing b3 FETCH FetchRequest{useUids=false, idSet=[IdRange ( 1->9223372036854775807 )], fetch=FetchData{items=[UID], setSeen=false, bodyElements=[], changedSince=-1, vanished=false}}
17:14:05.273 [DEBUG] o.a.j.m.s.StoreMailboxManager - Loaded mailbox 4 #private:imapuser:box
17:14:05.273 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  OK b3 completed. FETCH
17:14:05.273 [DEBUG] o.a.j.m.p.ProtocolSession - S: b3 OK FETCH completed.
17:14:05.273 [DEBUG] o.a.j.m.p.ProtocolSession - C: b4 UID FETCH 1:* (UID)
17:14:05.274 [TRACE] o.a.j.i.d.m.DefaultImapDecoder - Processing b4 UID FetchRequest{useUids=true, idSet=[IdRange ( 1->9223372036854775807 )], fetch=FetchData{items=[UID], setSeen=false, bodyElements=[], changedSince=-1, vanished=false}}
17:14:05.274 [DEBUG] o.a.j.m.s.StoreMailboxManager - Loaded mailbox 4 #private:imapuser:box
17:14:05.274 [TRACE] o.a.j.i.m.r.UnpooledStatusResponseFactory - Created IMAP response:  OK b4 completed. FETCH
17:14:05.274 [DEBUG] o.a.j.m.p.ProtocolSession - S: b4 OK FETCH completed.
```