### PR TITLE
[FIX] DeletedMessage size could be zero

### DIFF
--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessage.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessage.java
@@ -172,7 +172,7 @@ public class DeletedMessage {
     public DeletedMessage(MessageId messageId, List<MailboxId> originMailboxes, Username owner,
                           ZonedDateTime deliveryDate, ZonedDateTime deletionDate, MaybeSender sender, List<MailAddress> recipients,
                           Optional<String> subject, boolean hasAttachment, long size) {
-        Preconditions.checkArgument(size > 0, "'size' is required to be a strictly positive number");
+        Preconditions.checkArgument(size >= 0, "'size' is required to be a non negative number");
 
         this.messageId = messageId;
         this.originMailboxes = originMailboxes;

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageTest.java
@@ -34,6 +34,7 @@ import static org.apache.mailet.base.MailAddressFixture.RECIPIENT1;
 import static org.apache.mailet.base.MailAddressFixture.RECIPIENT2;
 import static org.apache.mailet.base.MailAddressFixture.SENDER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.core.MaybeSender;
@@ -73,16 +74,15 @@ class DeletedMessageTest {
     }
 
     @Test
-    void buildShouldThrowWhenPassingZeroSize() {
-        assertThatThrownBy(() -> SIZE_STAGE.size(0L).build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("'size' is required to be a strictly positive number");
+    void buildShouldNotThrowWhenPassingZeroSize() {
+        assertThatCode(() -> SIZE_STAGE.size(0L).build())
+            .doesNotThrowAnyException();
     }
 
     @Test
     void buildShouldThrowWhenPassingNegativeSize() {
         assertThatThrownBy(() -> SIZE_STAGE.size(-1L).build())
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("'size' is required to be a strictly positive number");
+            .hasMessage("'size' is required to be a non negative number");
     }
 }


### PR DESCRIPTION
cf: https://github.com/linagora/james-project/issues/5252

DeletedMessage' size was indeed zero in one of our customer envs.

```
java.lang.IllegalArgumentException: 'size' is required to be a strictly positive number
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:143)
	at org.apache.james.vault.DeletedMessage.<init>(DeletedMessage.java:175)
	at org.apache.james.vault.DeletedMessage$Builder$FinalStage.build(DeletedMessage.java:150)
	at org.apache.james.vault.metadata.DeletedMessageVaultDeletionCallback.lambda$forMessage$2(DeletedMessageVaultDeletionCallback.java:89)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:132)
	at reactor.core.publisher.MonoUsing$MonoUsingSubscriber.onNext(MonoUsing.java:231)
	at reactor.core.publisher.MonoUsing$MonoUsingSubscriber.onNext(MonoUsing.java:231)
	at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:122)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79)
	at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:122)
	at reactor.core.publisher.MonoPublishOn$PublishOnSubscriber.run(MonoPublishOn.java:181)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

```
admin@cqlsh:xxxx> select fullcontentoctets from messageidtable WHERE mailboxid = 33ffdde0-4e88-11ef-a191-57867848886b;

 fullcontentoctets
-------------------
                 0
             93449
             89585
            143591
```
