### PR TITLE
JAMES-4059 MailetContainerModule should not do a strict check on RemoveMimeHeader with bcc name param

### DIFF
--- a/docs/modules/servers/pages/distributed/configure/jvm.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jvm.adoc
@@ -105,10 +105,11 @@ Ex in `jvm.properties`
 
 == Disable mailet container check at James startup
 
-James is doing a check on startup making sure that the `bcc` header is being removed via
+James is doing checks on startup for validating mailet container configuration against a set of
+business rules, for instance making sure that the `bcc` header is being removed via
 `RemoveMimeHeader` mailet in the mail processing pipeline defined in `mailetcontainer.xml` file.
 
-It could be useful for some administrators that know what they are doing to disable such a check
+It could be useful for some administrators that know what they are doing to disable such checks
 during James startup.
 
 Optional. Boolean. Defaults to true.

--- a/docs/modules/servers/pages/distributed/configure/jvm.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jvm.adoc
@@ -103,3 +103,18 @@ Ex in `jvm.properties`
 # james.reactor.inputstream.prefetch=4
 ----
 
+== Disable mailet container check at James startup
+
+James is doing a check on startup making sure that the `bcc` header is being removed via
+`RemoveMimeHeader` mailet in the mail processing pipeline defined in `mailetcontainer.xml` file.
+
+It could be useful for some administrators that know what they are doing to disable such a check
+during James startup.
+
+Optional. Boolean. Defaults to true.
+
+Ex in `jvm.properties`
+----
+james.mailet.container.check.enabled=false
+----
+To disable the mailet container check at James startup.

--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -66,3 +66,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # Whether James should unzip JWTs. Default to false
 # james.jwt.zip.allow=false
+
+# Enable/disable mailet container check at James startup. Defaults to true.
+# james.mailet.container.check.enabled=true

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -82,3 +82,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # Prefetch to use in Reactor to stream convertions (S3 => InputStream). Default to 1.
 # Higher values will tend to block less often at the price of higher memory consumptions.
 # james.reactor.inputstream.prefetch=4
+
+# Enable/disable mailet container check at James startup. Defaults to true.
+# james.mailet.container.check.enabled=true

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -56,3 +56,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # Whether James should unzip JWTs. Default to false
 # james.jwt.zip.allow=false
+
+# Enable/disable mailet container check at James startup. Defaults to true.
+# james.mailet.container.check.enabled=true

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -54,3 +54,6 @@ openjpa.Multithreaded=true
 
 # Whether James should unzip JWTs. Default to false
 # james.jwt.zip.allow=false
+
+# Enable/disable mailet container check at James startup. Defaults to true.
+# james.mailet.container.check.enabled=true

--- a/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/jvm.properties
@@ -54,3 +54,6 @@ openjpa.Multithreaded=true
 
 # Whether James should unzip JWTs. Default to false
 # james.jwt.zip.allow=false
+
+# Enable/disable mailet container check at James startup. Defaults to true.
+# james.mailet.container.check.enabled=true

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -56,3 +56,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # Whether James should unzip JWTs. Default to false
 # james.jwt.zip.allow=false
+
+# Enable/disable mailet container check at James startup. Defaults to true.
+# james.mailet.container.check.enabled=true

--- a/server/apps/scaling-pulsar-smtp/sample-configuration/jvm.properties
+++ b/server/apps/scaling-pulsar-smtp/sample-configuration/jvm.properties
@@ -46,3 +46,6 @@
 
 # Whether James should unzip JWTs. Default to false
 # james.jwt.zip.allow=false
+
+# Enable/disable mailet container check at James startup. Defaults to true.
+# james.mailet.container.check.enabled=true

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
@@ -86,7 +86,7 @@ public class MailetContainerModule extends AbstractModule {
         "transport",
         All.class,
         RemoveMimeHeader.class,
-        pair -> pair.getMailet().getMailetConfig().getInitParameter("name").contains("bcc"),
+        pair -> Arrays.asList(pair.getMailet().getMailetConfig().getInitParameter("name").split(",")).contains("bcc"),
         "Should be configured to remove Bcc header");
 
     @Override

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
@@ -85,7 +85,7 @@ public class MailetContainerModule extends AbstractModule {
         "transport",
         All.class,
         RemoveMimeHeader.class,
-        pair -> pair.getMailet().getMailetConfig().getInitParameter("name").equals("bcc"),
+        pair -> pair.getMailet().getMailetConfig().getInitParameter("name").contains("bcc"),
         "Should be configured to remove Bcc header");
 
     @Override

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
@@ -80,6 +80,7 @@ import com.google.inject.multibindings.ProvidesIntoSet;
 public class MailetContainerModule extends AbstractModule {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MailetContainerModule.class);
+    private static final boolean MAILET_CONTAINER_CHECK_ENABLED = Boolean.parseBoolean(System.getProperty("james.mailet.container.check.enabled", "true"));
 
     public static final ProcessorsCheck.Impl BCC_Check = new ProcessorsCheck.Impl(
         "transport",
@@ -114,7 +115,10 @@ public class MailetContainerModule extends AbstractModule {
         initialisationOperations.addBinding().to(MailetModuleInitializationOperation.class);
 
         Multibinder<ProcessorsCheck> transportProcessorChecks = Multibinder.newSetBinder(binder(), ProcessorsCheck.class);
-        transportProcessorChecks.addBinding().toInstance(BCC_Check);
+
+        if (MAILET_CONTAINER_CHECK_ENABLED) {
+            transportProcessorChecks.addBinding().toInstance(BCC_Check);
+        }
     }
 
     @Provides

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
@@ -115,10 +115,7 @@ public class MailetContainerModule extends AbstractModule {
         initialisationOperations.addBinding().to(MailetModuleInitializationOperation.class);
 
         Multibinder<ProcessorsCheck> transportProcessorChecks = Multibinder.newSetBinder(binder(), ProcessorsCheck.class);
-
-        if (MAILET_CONTAINER_CHECK_ENABLED) {
-            transportProcessorChecks.addBinding().toInstance(BCC_Check);
-        }
+        transportProcessorChecks.addBinding().toInstance(BCC_Check);
     }
 
     @Provides
@@ -183,7 +180,9 @@ public class MailetContainerModule extends AbstractModule {
         @Override
         public void initModule() throws Exception {
             configureProcessors();
-            checkProcessors();
+            if (MAILET_CONTAINER_CHECK_ENABLED) {
+                checkProcessors();
+            }
         }
 
         private void configureProcessors() throws Exception {

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/MailetContainerModule.java
@@ -86,7 +86,7 @@ public class MailetContainerModule extends AbstractModule {
         "transport",
         All.class,
         RemoveMimeHeader.class,
-        pair -> Arrays.asList(pair.getMailet().getMailetConfig().getInitParameter("name").split(",")).contains("bcc"),
+        pair -> Arrays.asList(pair.getMailet().getMailetConfig().getInitParameter("name").toLowerCase().split(",")).contains("bcc"),
         "Should be configured to remove Bcc header");
 
     @Override

--- a/server/container/guice/protocols/jmap/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
+++ b/server/container/guice/protocols/jmap/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
@@ -219,5 +219,19 @@ class MailetPreconditionTest {
             assertThatThrownBy(() -> MailetContainerModule.BCC_Check.check(pairs))
                 .isInstanceOf(ConfigurationException.class);
         }
+
+        @Test
+        void bccMailetCheckShouldNotThrowOnValidInsensitivePair() throws Exception {
+            RemoveMimeHeader removeMimeHeader = new RemoveMimeHeader();
+            removeMimeHeader.init(FakeMailetConfig.builder()
+                .mailetName(BCC)
+                .mailetContext(MAILET_CONTEXT)
+                .setProperty("name", "BcC")
+                .build());
+
+            ImmutableMultimap<String, MatcherMailetPair> pairs = ImmutableMultimap.of("transport", new MatcherMailetPair(new All(), removeMimeHeader));
+            assertThatCode(() -> MailetContainerModule.BCC_Check.check(pairs))
+                .doesNotThrowAnyException();
+        }
     }
 }

--- a/server/container/guice/protocols/jmap/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
+++ b/server/container/guice/protocols/jmap/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
@@ -191,5 +191,19 @@ class MailetPreconditionTest {
             assertThatCode(() -> MailetContainerModule.BCC_Check.check(pairs))
                 .doesNotThrowAnyException();
         }
+
+        @Test
+        void bccMailetCheckShouldNotThrowOnValidPairWithOtherNames() throws Exception {
+            RemoveMimeHeader removeMimeHeader = new RemoveMimeHeader();
+            removeMimeHeader.init(FakeMailetConfig.builder()
+                .mailetName(BCC)
+                .mailetContext(MAILET_CONTEXT)
+                .setProperty("name", "header1,bcc,header2")
+                .build());
+
+            ImmutableMultimap<String, MatcherMailetPair> pairs = ImmutableMultimap.of("transport", new MatcherMailetPair(new All(), removeMimeHeader));
+            assertThatCode(() -> MailetContainerModule.BCC_Check.check(pairs))
+                .doesNotThrowAnyException();
+        }
     }
 }

--- a/server/container/guice/protocols/jmap/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
+++ b/server/container/guice/protocols/jmap/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
@@ -205,5 +205,19 @@ class MailetPreconditionTest {
             assertThatCode(() -> MailetContainerModule.BCC_Check.check(pairs))
                 .doesNotThrowAnyException();
         }
+
+        @Test
+        void bccMailetCheckShouldThrowOnInvalidNameWithPairIncluded() throws Exception {
+            RemoveMimeHeader removeMimeHeader = new RemoveMimeHeader();
+            removeMimeHeader.init(FakeMailetConfig.builder()
+                .mailetName(BCC)
+                .mailetContext(MAILET_CONTEXT)
+                .setProperty("name", "x-bcc-bug")
+                .build());
+
+            ImmutableMultimap<String, MatcherMailetPair> pairs = ImmutableMultimap.of("transport", new MatcherMailetPair(new All(), removeMimeHeader));
+            assertThatThrownBy(() -> MailetContainerModule.BCC_Check.check(pairs))
+                .isInstanceOf(ConfigurationException.class);
+        }
     }
 }


### PR DESCRIPTION
I hesitated adding a test for the jvm property commit as it's a bit tricky for james startup

Maybe in memory-app with some alternative conf files in resources? Or just not necessary? 