### PR TITLE
JAMES-4066 EHLO should accept alphanumeric hostname

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
@@ -102,7 +102,13 @@ public class EhloCmdHandler extends AbstractHookableCmdHandler<HeloHook> impleme
             // Guava tries parsing IPv6 if and only if wrapped by []
             || InetAddresses.isUriInetAddress("[" + removeEmIPV6Prefix(hostname) + "]")
             || InternetDomainName.isValid(hostname)
-            || emClientCompatibility(hostname);
+            || emClientCompatibility(hostname)
+            || isAlphanumeric(hostname);
+    }
+
+    // CF JAMES-4046 https://issues.apache.org/jira/projects/JAMES/issues/JAMES-4066
+    private boolean isAlphanumeric(String hostname) {
+        return hostname.matches("^[a-zA-Z0-9]+$");
     }
 
     // CF JAMES-4040 IPv6v4-full https://datatracker.ietf.org/doc/html/rfc5321

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
@@ -37,6 +37,7 @@ import org.apache.james.protocols.smtp.hook.HookResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -108,7 +109,11 @@ public class EhloCmdHandler extends AbstractHookableCmdHandler<HeloHook> impleme
 
     // CF JAMES-4046 https://issues.apache.org/jira/projects/JAMES/issues/JAMES-4066
     private boolean isAlphanumeric(String hostname) {
-        return hostname.matches("^[a-zA-Z0-9]+$");
+        return !hostname.isEmpty() &&
+            CharMatcher.inRange('a', 'z')
+                .or(CharMatcher.inRange('A', 'Z'))
+                .or(CharMatcher.inRange('0', '9'))
+                .matchesAllOf(hostname);
     }
 
     // CF JAMES-4040 IPv6v4-full https://datatracker.ietf.org/doc/html/rfc5321

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
@@ -58,6 +58,9 @@ public class EhloCmdHandler extends AbstractHookableCmdHandler<HeloHook> impleme
     private static final List<String> ESMTP_FEATURES = ImmutableList.of("PIPELINING", "ENHANCEDSTATUSCODES", "8BITMIME");
     private static final Response DOMAIN_ADDRESS_REQUIRED = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG) + " Domain address required: " + COMMAND_NAME).immutable();
     private static final Logger LOGGER = LoggerFactory.getLogger(EhloCmdHandler.class);
+    private static final CharMatcher ALPHANUMERIC_MATCHER = CharMatcher.inRange('a', 'z')
+        .or(CharMatcher.inRange('A', 'Z'))
+        .or(CharMatcher.inRange('0', '9'));
 
     private List<EhloExtension> ehloExtensions;
 
@@ -109,11 +112,7 @@ public class EhloCmdHandler extends AbstractHookableCmdHandler<HeloHook> impleme
 
     // CF JAMES-4046 https://issues.apache.org/jira/projects/JAMES/issues/JAMES-4066
     private boolean isAlphanumeric(String hostname) {
-        return !hostname.isEmpty() &&
-            CharMatcher.inRange('a', 'z')
-                .or(CharMatcher.inRange('A', 'Z'))
-                .or(CharMatcher.inRange('0', '9'))
-                .matchesAllOf(hostname);
+        return !hostname.isEmpty() && ALPHANUMERIC_MATCHER.matchesAllOf(hostname);
     }
 
     // CF JAMES-4040 IPv6v4-full https://datatracker.ietf.org/doc/html/rfc5321

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -1424,6 +1424,20 @@ public class SMTPServerTest {
     }
 
     @Test
+    void ehloShouldAcceptAlphanumericHostname() throws Exception {
+        smtpConfiguration.setAuthorizedAddresses("128.0.0.1/8");
+        smtpConfiguration.setAuthorizingAnnounce();
+        init(smtpConfiguration);
+
+        SMTPClient smtpProtocol = new SMTPClient();
+        InetSocketAddress bindedAddress = testSystem.getBindedAddress();
+        smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+
+        smtpProtocol.sendCommand("ehlo", "7kO2OrE");
+        assertThat(smtpProtocol.getReplyString()).contains("250");
+    }
+
+    @Test
     public void testAuthSendMailFromDomainAlias() throws Exception {
         smtpConfiguration.setAuthorizedAddresses("128.0.0.1/8");
         smtpConfiguration.setAuthorizingAnnounce();


### PR DESCRIPTION
Postfix indeed supports alphanumeric hostname

```
hp@hp-quanth:~$ telnet localhost 41055
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
220 incoming.upn.integration-open-paas.org ESMTP Postfix (Ubuntu) EHLO 7kO2OrE
250-incoming.upn.integration-open-paas.org
```