### PR TITLE
James: unset JAVA_TOOL_OPTIONS env variable when running james-cli

### DIFF
--- a/server/apps/cassandra-app/src/main/scripts/james-cli
+++ b/server/apps/cassandra-app/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"

--- a/server/apps/distributed-app/src/main/scripts/james-cli
+++ b/server/apps/distributed-app/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"

--- a/server/apps/distributed-pop3-app/src/main/scripts/james-cli
+++ b/server/apps/distributed-pop3-app/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"

--- a/server/apps/jpa-app/src/main/scripts/james-cli
+++ b/server/apps/jpa-app/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"

--- a/server/apps/jpa-smtp-app/src/main/scripts/james-cli
+++ b/server/apps/jpa-smtp-app/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"

--- a/server/apps/memory-app/src/main/scripts/james-cli
+++ b/server/apps/memory-app/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"

--- a/server/apps/scaling-pulsar-smtp/src/main/scripts/james-cli
+++ b/server/apps/scaling-pulsar-smtp/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"

--- a/server/apps/webadmin-cli/james-cli
+++ b/server/apps/webadmin-cli/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -jar target/james-cli.jar "$@"


### PR DESCRIPTION
GIVEN I run james-cli in kubernetes
THEN the pod crashes and reboots

Because the james-cli runs JVM it catches the environment variables set by James. As such it always pretouch 3GB of RAM. When added to memory consumed by James it exceeds the limit and pod get's OOM-killed.