### PR TITLE
[JAMES-3696] fix broken tests

### DIFF
--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -30,8 +30,8 @@
     <artifactId>apache-james-backends-pulsar</artifactId>
     <name>Apache James :: Backends Common :: Pulsar</name>
     <properties>
-        <pulsar-client.version>2.11.0</pulsar-client.version>
-        <clever-cloud.pulsar4s.version>2.9.1</clever-cloud.pulsar4s.version>
+        <pulsar-client.version>3.3.1</pulsar-client.version>
+        <clever-cloud.pulsar4s.version>2.10.0</clever-cloud.pulsar4s.version>
         <pekko-stream.version>1.0.2</pekko-stream.version>
     </properties>
 

--- a/backends-common/pulsar/src/test/java/org/apache/james/backends/pulsar/DockerPulsarExtension.java
+++ b/backends-common/pulsar/src/test/java/org/apache/james/backends/pulsar/DockerPulsarExtension.java
@@ -57,7 +57,7 @@ public class DockerPulsarExtension implements GuiceModuleTestExtension {
 
     @Inject
     public DockerPulsarExtension() {
-        container = new PulsarContainer(DEFAULT_IMAGE_NAME.withTag("3.3.0"))
+        container = new PulsarContainer(DEFAULT_IMAGE_NAME.withTag("3.3.1"))
                 .withLogConsumer(DockerPulsarExtension::displayDockerLog);
     }
 

--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
@@ -31,6 +31,7 @@ import org.apache.activemq.ActiveMQPrefetchPolicy;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.commons.io.FileUtils;
 import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.junit.categories.Unstable;
 import org.apache.james.metrics.api.GaugeRegistry;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.queue.api.DelayedManageableMailQueueContract;
@@ -155,6 +156,17 @@ public class ActiveMQMailQueueBlobTest implements DelayedManageableMailQueueCont
     @Disabled("JAMES-3687 Delayed deletes are buggy")
     public void delayedEmailsShouldBeDeletedWhenMixedWithOtherEmails() {
 
+    }
+
+    @Tag(Unstable.TAG)
+    @Test
+    @Override
+    public void browseShouldNotFailWhenConcurrentClearWhenIterating() throws Exception {
+        // This test used to pass because the assertion did not actually check anything
+        // it used Iterators.consumingIterator which only wraps the underlying iterator without
+        // actually consuming it. When replaced with an actual consumption this implementation started
+        // failing.
+        DelayedManageableMailQueueContract.super.browseShouldNotFailWhenConcurrentClearWhenIterating();
     }
 
     @Test

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedManageableMailQueueContract.java
@@ -123,11 +123,11 @@ public interface DelayedManageableMailQueueContract extends DelayedMailQueueCont
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Recipient, RECIPIENT2.asString());
 
-        awaitRemove();
-
-        assertThat(getManageableMailQueue().browse()).toIterable()
-                .extracting(mail -> mail.getMail().getName())
-                .containsExactly("name2");
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse()).toIterable()
+                        .extracting(mail -> mail.getMail().getName())
+                        .containsExactly("name2")
+        );
     }
 
     @Test

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,10 +42,12 @@ import jakarta.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.junit.categories.Unstable;
 import org.apache.mailet.Attribute;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.MailAddressFixture;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,7 +56,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -217,7 +219,7 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         Flux.from(getManageableMailQueue().deQueue());
 
-        assertThatCode(() ->  Iterators.consumingIterator(items)).doesNotThrowAnyException();
+        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
     }
 
     @Test
@@ -266,7 +268,7 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         Flux.from(getManageableMailQueue().deQueue());
 
-        assertThatCode(() ->  Iterators.consumingIterator(items)).doesNotThrowAnyException();
+        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
     }
 
     @Test
@@ -307,7 +309,7 @@ public interface ManageableMailQueueContract extends MailQueueContract {
             .name("name4")
             .build());
 
-        assertThatCode(() ->  Iterators.consumingIterator(items)).doesNotThrowAnyException();
+        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
     }
 
     @Test
@@ -352,7 +354,7 @@ public interface ManageableMailQueueContract extends MailQueueContract {
             .name("name2")
             .build());
 
-        assertThatCode(() ->  Iterators.consumingIterator(items)).doesNotThrowAnyException();
+        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
     }
 
     @Test
@@ -392,7 +394,7 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().clear();
 
-        assertThatCode(() ->  Iterators.consumingIterator(items)).doesNotThrowAnyException();
+        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
     }
 
     @Test
@@ -432,7 +434,7 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().flush();
 
-        assertThatCode(() ->  Iterators.consumingIterator(items)).doesNotThrowAnyException();
+        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
     }
 
     @Test
@@ -474,7 +476,7 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         awaitRemove();
 
-        assertThatCode(() ->  Iterators.consumingIterator(items)).doesNotThrowAnyException();
+        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
     }
 
     @Test
@@ -736,6 +738,15 @@ public interface ManageableMailQueueContract extends MailQueueContract {
         assertThat(getManageableMailQueue().browse()).toIterable()
             .extracting(mail -> mail.getMail().getName())
             .containsExactly("name2");
+    }
+
+    default <T> int consumeIterator(Iterator<T> iterator) {
+        var i = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            i++;
+        }
+        return i;
     }
 
 }

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import jakarta.mail.MessagingException;
@@ -42,12 +43,10 @@ import jakarta.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
-import org.apache.james.junit.categories.Unstable;
 import org.apache.mailet.Attribute;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.MailAddressFixture;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,10 +60,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface ManageableMailQueueContract extends MailQueueContract {
-
-    default void awaitRemove() {
-
-    }
 
     ManageableMailQueue getManageableMailQueue();
 
@@ -459,24 +454,27 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
     @Test
     default void browseShouldNotFailWhenConcurrentRemoveWhenIterating() throws Exception {
-        enQueue(defaultMail()
-            .name("name1")
-            .build());
-        enQueue(defaultMail()
-            .name("name2")
-            .build());
-        enQueue(defaultMail()
-            .name("name3")
-            .build());
+        // We use a large number of emails so that the probability of the remove being propagated
+        // through the queue is high enough that the test is not flaky.
+        IntStream.range(0, 100).forEach(
+                Throwing.intConsumer(i ->
+                        enQueue(defaultMail()
+                                .name("name" + i)
+                                .build())
+                ).sneakyThrow()
+        );
 
         ManageableMailQueue.MailQueueIterator items = getManageableMailQueue().browse();
-        items.next();
+        items.next();// we consume 1 here
 
-        getManageableMailQueue().remove(ManageableMailQueue.Type.Name, "name2");
+        getManageableMailQueue().remove(ManageableMailQueue.Type.Name, "name98"); // we remove 1 here
 
-        awaitRemove();
 
-        assertThatCode(() ->  consumeIterator(items)).doesNotThrowAnyException();
+        assertThatCode(
+                // the remove may or may not be applied to an already started iterator
+                // as long as it doesn't make the iterator crash
+                () -> assertThat(consumeIterator(items)).isGreaterThanOrEqualTo(98).isLessThan(100)
+        ).doesNotThrowAnyException();
     }
 
     @Test
@@ -551,13 +549,13 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Name, "name2");
 
-        awaitRemove();
-
-        assertThat(getManageableMailQueue().browse())
-            .toIterable()
-            .extracting(ManageableMailQueue.MailQueueItemView::getMail)
-            .extracting(Mail::getName)
-            .containsExactly("name1");
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .extracting(ManageableMailQueue.MailQueueItemView::getMail)
+                        .extracting(Mail::getName)
+                        .containsExactly("name1")
+        );
     }
 
     @Test
@@ -573,13 +571,13 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Sender, OTHER_AT_LOCAL.asString());
 
-        awaitRemove();
-
-        assertThat(getManageableMailQueue().browse())
-            .toIterable()
-            .extracting(ManageableMailQueue.MailQueueItemView::getMail)
-            .extracting(Mail::getName)
-            .containsExactly("name2");
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .extracting(ManageableMailQueue.MailQueueItemView::getMail)
+                        .extracting(Mail::getName)
+                        .containsExactly("name2")
+        );
     }
 
     @Test
@@ -595,13 +593,13 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Recipient, RECIPIENT2.asString());
 
-        awaitRemove();
-
-        assertThat(getManageableMailQueue().browse())
-            .toIterable()
-            .extracting(ManageableMailQueue.MailQueueItemView::getMail)
-            .extracting(Mail::getName)
-            .containsExactly("name1");
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .extracting(ManageableMailQueue.MailQueueItemView::getMail)
+                        .extracting(Mail::getName)
+                        .containsExactly("name1")
+        );
     }
 
     static Stream<Arguments> removeByRecipientShouldRemoveSpecificEmailWhenMultipleRecipients() throws AddressException {
@@ -630,13 +628,13 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Recipient, toRemove.asString());
 
-        awaitRemove();
-
-        assertThat(getManageableMailQueue().browse())
-            .toIterable()
-            .extracting(ManageableMailQueue.MailQueueItemView::getMail)
-            .extracting(Mail::getName)
-            .containsExactly("name2");
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .extracting(ManageableMailQueue.MailQueueItemView::getMail)
+                        .extracting(Mail::getName)
+                        .containsExactly("name2")
+        );
     }
 
     @Test
@@ -693,7 +691,13 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Name, "name1");
 
-        awaitRemove();
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .extracting(ManageableMailQueue.MailQueueItemView::getMail)
+                        .extracting(Mail::getName)
+                        .doesNotContain("name1")
+        );
 
         assertThat(Flux.from(getManageableMailQueue().deQueue()).blockFirst().getMail().getName())
             .isEqualTo("name2");
@@ -709,7 +713,11 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Recipient, MailAddressFixture.RECIPIENT1.asString());
 
-        awaitRemove();
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .isEmpty()
+        );
 
         enQueue(defaultMail()
             .name("name2")
@@ -729,7 +737,12 @@ public interface ManageableMailQueueContract extends MailQueueContract {
 
         getManageableMailQueue().remove(ManageableMailQueue.Type.Recipient, MailAddressFixture.RECIPIENT1.asString());
 
-        awaitRemove();
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .isEmpty()
+        );
+
 
         enQueue(defaultMail()
             .name("name2")

--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
@@ -41,7 +41,6 @@ import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
-import org.apache.james.junit.categories.Unstable;
 import org.apache.james.queue.api.DelayedMailQueueContract;
 import org.apache.james.queue.api.DelayedManageableMailQueueContract;
 import org.apache.james.queue.api.MailQueue;
@@ -61,7 +60,6 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -71,7 +69,6 @@ import com.sksamuel.pulsar4s.ConsumerMessage;
 import reactor.core.publisher.Flux;
 import scala.jdk.javaapi.OptionConverters;
 
-@Tag(Unstable.TAG)
 @ExtendWith(DockerPulsarExtension.class)
 public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricContract, ManageableMailQueueContract, DelayedMailQueueContract, DelayedManageableMailQueueContract {
 
@@ -108,15 +105,6 @@ public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricCo
         mailQueue.close();
         system.terminate();
         pulsarClients.stop();
-    }
-
-    @Override
-    public void awaitRemove() {
-        try {
-            Thread.sleep(50);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override
@@ -272,13 +260,13 @@ public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricCo
         //this won't delete the mail from the store until we try a dequeue
         getManageableMailQueue().remove(ManageableMailQueue.Type.Name, "name2");
 
-        awaitRemove();
-
-        assertThat(getManageableMailQueue().browse())
-                .toIterable()
-                .extracting(ManageableMailQueue.MailQueueItemView::getMail)
-                .extracting(Mail::getName)
-                .containsExactly("name1", "name3");
+        Awaitility.await().untilAsserted(() ->
+                assertThat(getManageableMailQueue().browse())
+                        .toIterable()
+                        .extracting(ManageableMailQueue.MailQueueItemView::getMail)
+                        .extracting(Mail::getName)
+                        .containsExactly("name1", "name3")
+        );
 
         Flux.from(getMailQueue().deQueue()).take(2).doOnNext(Throwing.consumer(x -> x.done(MailQueue.MailQueueItem.CompletionStatus.SUCCESS))).blockLast();
         Awaitility.await().untilAsserted(this::assertThatStoreIsEmpty);


### PR DESCRIPTION
When I tried to start working on the flaky test I ran the `PulsarMailqueueTest` suite and one of the tests failed. Using `git bisect` I was able to trace it back to the introduction of the deadletter policy a while ago and yet all the pipelines were ok on the CI. 
I looked into the `unstable-test` stage and in develocity but couldn't find any trace of the `PulsarMailqueueTest` suite being executed. 

Doing local tests I realized that when the whole class is tagged, for some reason, the suite will not be executed, neither in the normal test stage or in the `unstable-test` stage. This does not only affect `PulsarMailQueueTest`. See my attempt at fixing the underlying problem in https://github.com/apache/james-project/pull/2417

This PR focuses on resolving the flakyness of the pulsar mailqueue tests by : 
- Fixing the currently broken test
- Changing the way we assert to allow for an asychronous distribution of removal filters.

Doing so led Matthieu and I to discover another issue in the `ManageableMailQueueContract` : several tests assertions were verifying exactly nothing. We fixed that in the 3rd commit of this PR (https://github.com/apache/james-project/pull/2416/commits/a7541825528f08484f885b15000205dd06eb9a13 as I write this). Doing so raised a failing test case for the `ActiveMQMailQueueBlobTest`
