### PR TITLE
[devscout] adds implementation notes on ManageableMailQueue and PulsarMailQueue

### DIFF
--- a/server/queue/queue-api/src/main/java/org/apache/james/queue/api/ManageableMailQueue.java
+++ b/server/queue/queue-api/src/main/java/org/apache/james/queue/api/ManageableMailQueue.java
@@ -31,6 +31,20 @@ import reactor.core.publisher.Mono;
 
 /**
  * {@link MailQueue} which is manageable
+ *
+ * <h3>Implementation notes:</h3>
+ * <p>{@link ManageableMailQueue#remove}:</p>
+ * <ul>
+ *     <li><b>MUST</b> be eventually consistent</li>
+ *     <li><b>CAN</b> be immediately consistent</li>
+ * </ul>
+ *
+ * <p>{@link ManageableMailQueue#browse()}</p>
+ * <ul>
+ *  <li><b>MUST</b> tolerate other threads changing the content in the actual queue</li>
+ *  <li><b>CAN</b> return queue items that have been removed or dequeued since the browse has started.
+ *  This can happen in snapshot-based implementations (the snapshot is fixed before the removal or dequeue) or in
+ *  eventually consistent distributed implementations</li>
  */
 public interface ManageableMailQueue extends MailQueue {
 

--- a/server/queue/queue-pulsar/README.adoc
+++ b/server/queue/queue-pulsar/README.adoc
@@ -1,0 +1,32 @@
+= Apache James Pulsar MailQueue
+
+This project offers an implementation of the james mailqueue backed by https://pulsar.apache.org/[apache pulsar].
+
+== Overview
+
+This implementation honors both
+
+- MailQueue
+- ManageableMailQueue.
+
+== Implementation notes
+=== Reactive
+
+The implementation is built on top of reactive streams and is therefore natively reactive. The blocking dequeue semantics are achieved by an explicit await on the reactive version of the method.
+
+=== Storage
+
+Pulsar is not well suited to store arbitrarily large messages. Since email sizes can quickly inflate, especially with attachments, we chose to store the actual content of the mail in a blob storage of some kind, while only storing metadata in Pulsar.
+
+When browsing or dequeueing, the implementation will fetch the corresponding blob and combine it with the necessary metadata to rebuild the whole mail.
+
+The initial implementation stores both MimeMessage and headers in separate storages. This can definitely be improved to store the whole blob in one place and simplify the read logic (both dequeue and browse)
+
+=== Remove
+
+We chose to implement the storage and distribution of the removals through a mechanism of filters which are themselves distributed through pulsar. This choice means that this implementation is only eventually consistent on removals and not strongly consistent.
+
+=== Browse
+
+The iterator for browse is dynamically backed by the pulsar queue it pulls items from the queue as they are asked applying any removal filters as needed.
+This means that dequeued items will not be returned by the iterator even if the iterator was retrieved before the dequeue happens. It also means that once filters have reached eventual consistency they will automatically apply to the ongoing iterator.


### PR DESCRIPTION
This serves to clarify implementation details that can affect the semantics of some operations.

i couldn't really find a better place than the javadoc of the `ManageableMailQueue` to put this in. 

I did write the following in `server/queue/queue-api/README.adoc`
```README.adoc
= Apache James MailQueue projects

The James MailQueue project provies the queue/spool mechanism used in the Apache James project.
The james-server-queue-api defines 2 levels of APIs which can be implemented to provide such spool mechanism
basic and manageable.

== Overview

The main API contracts are:

- MailQueue
- ManageableMailQueue

== MailQueue

This contract includes the most basic semantics for the queue mechanism:

- enqueue
- dequeue

Both operations are exposed in a blocking and a reactive flavor.


== ManageableMailQueue

This contract enhances the basic semantics of MailQueue to offer management services:

- browse
- flush
- clear
- remove


[NOTE]
.ManageableMailQueue#remove
====
- **MUST** be eventually consistent
- **CAN** be strongly consistent
====

[NOTE]
.ManageableMailQueue#browse
====
- **MUST** tolerate concurrent changes in the underlying queue while the MailQueueIterator is being consumed
- **CAN** return stale items (removed or dequeud) since the operation has started. This can happen for snapshot-based implementations that have captured a copy of the data or in distributed implementations relying on eventual consistency
====
```

but the implementation notes of the MailQueue itself are in the javadoc rather than in a readme so I decided against including this file in the PR.

I also added some design considerations and choices that went into the pulsar mailqueue implementation.