### PR TITLE
[JAMES-4064] switch pulsarmailqueue filter topics to non durable subscriptions

### DIFF
--- a/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
+++ b/server/queue/queue-pulsar/src/test/java/org/apache/james/queue/pulsar/PulsarMailQueueTest.java
@@ -212,6 +212,8 @@ public class PulsarMailQueueTest implements MailQueueContract, MailQueueMetricCo
         Awaitility.await().untilAsserted(() ->
                 assertThat(Flux.merge(Flux.from(secondQueue.deQueue()), Flux.from(getManageableMailQueue().deQueue())).blockFirst().getMail().getName())
                         .isEqualTo("namez"));
+
+        secondQueue.close();
     }
 
     @Test


### PR DESCRIPTION
As discussed in the issue, filter topics need to use unique subscription names to fetch all applicable filters upon restart. 

At the moment we use durable subscriptions which means that these subscriptions accumulate across restarts on the pulsar side, eventually reaching the limit of allowed subscriptions per topic. 

Alternatives
- We could try to be good citizens and delete the subscriptions but there is no guarantee that the process terminates properly and does the cleanup
- We could use another kind of UUID which is strictly incremental and or includes a timestamp, allowing to build a safe cleanup script, but it would be difficult to run automatically in a safe way. 
- We could expose the filter subscription names of the active nodes to make sure the cleanup script doesn't accidentally delete currently used subscriptions
 
In this PR I propose to use the [non-durable](https://pulsar.apache.org/docs/3.3.x/concepts-messaging/#what-is-a-subscription-mode) subscriptions of Pulsar which seem to me to be the safest and cleanest solution to this issue,
