### PR TITLE
JAMES-4077 - Introduce james-server-guice-lucene module & replace it to JPAJamesServerMain

### DIFF
--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -110,6 +110,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-lucene</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-mailbox</artifactId>
         </dependency>
         <dependency>

--- a/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/apps/jpa-app/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -31,6 +31,7 @@ import org.apache.james.modules.mailbox.DefaultEventModule;
 import org.apache.james.modules.mailbox.JPAMailboxModule;
 import org.apache.james.modules.mailbox.LuceneSearchMailboxModule;
 import org.apache.james.modules.mailbox.MemoryDeadLetterModule;
+import org.apache.james.modules.mailbox.ReIndexingTaskSerializationModule;
 import org.apache.james.modules.protocols.IMAPServerModule;
 import org.apache.james.modules.protocols.LMTPServerModule;
 import org.apache.james.modules.protocols.ManageSieveServerModule;
@@ -88,6 +89,7 @@ public class JPAJamesServerMain implements JamesServerMain {
         new JPADataModule(),
         new JPAMailboxModule(),
         new MailboxModule(),
+        new ReIndexingTaskSerializationModule(),
         new LuceneSearchMailboxModule(),
         new NoJwtModule(),
         new RawPostDequeueDecoratorModule(),

--- a/server/container/guice/lucene/pom.xml
+++ b/server/container/guice/lucene/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/server/container/guice/lucene/pom.xml
+++ b/server/container/guice/lucene/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>james-server-guice</artifactId>
+        <version>3.9.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>james-server-guice-lucene</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache James :: Server :: Lucene - guice modules</name>
+    <description>Guice injections for the Lucene engine</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-lucene</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/server/container/guice/lucene/src/main/java/org/apache/james/modules/mailbox/LuceneMemorySearchMailboxModule.java
+++ b/server/container/guice/lucene/src/main/java/org/apache/james/modules/mailbox/LuceneMemorySearchMailboxModule.java
@@ -21,38 +21,18 @@ package org.apache.james.modules.mailbox;
 
 import java.io.IOException;
 
-import org.apache.james.events.EventListener;
-import org.apache.james.filesystem.api.FileSystem;
-import org.apache.james.mailbox.lucene.search.LuceneMessageSearchIndex;
-import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
-import org.apache.james.mailbox.store.search.MessageSearchIndex;
+import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.FSDirectory;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.google.inject.multibindings.Multibinder;
 
-public class LuceneSearchMailboxModule extends AbstractModule {
-
-    @Override
-    protected void configure() {
-        install(new ReIndexingTaskSerializationModule());
-
-        bind(LuceneMessageSearchIndex.class).in(Scopes.SINGLETON);
-        bind(MessageSearchIndex.class).to(LuceneMessageSearchIndex.class);
-        bind(ListeningMessageSearchIndex.class).to(LuceneMessageSearchIndex.class);
-
-        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class)
-            .addBinding()
-            .to(LuceneMessageSearchIndex.class);
-    }
+public class LuceneMemorySearchMailboxModule extends AbstractModule {
 
     @Provides
     @Singleton
-    Directory provideDirectory(FileSystem fileSystem) throws IOException {
-        return FSDirectory.open(fileSystem.getBasedir().toPath());
+    Directory provideDirectory() throws IOException {
+        return new ByteBuffersDirectory();
     }
 }

--- a/server/container/guice/lucene/src/main/java/org/apache/james/modules/mailbox/LuceneSearchMailboxModule.java
+++ b/server/container/guice/lucene/src/main/java/org/apache/james/modules/mailbox/LuceneSearchMailboxModule.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import java.io.IOException;
+
+import org.apache.james.events.EventListener;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.mailbox.lucene.search.LuceneMessageSearchIndex;
+import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
+import org.apache.james.mailbox.store.search.MessageSearchIndex;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+
+public class LuceneSearchMailboxModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(LuceneMessageSearchIndex.class).in(Scopes.SINGLETON);
+        bind(MessageSearchIndex.class).to(LuceneMessageSearchIndex.class);
+        bind(ListeningMessageSearchIndex.class).to(LuceneMessageSearchIndex.class);
+
+        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class)
+            .addBinding()
+            .to(LuceneMessageSearchIndex.class);
+    }
+
+    @Provides
+    @Singleton
+    Directory provideDirectory(FileSystem fileSystem) throws IOException {
+        return FSDirectory.open(fileSystem.getBasedir().toPath());
+    }
+}

--- a/server/container/guice/pom.xml
+++ b/server/container/guice/pom.xml
@@ -46,6 +46,7 @@
         <module>distributed</module>
         <module>jmx</module>
         <module>jpa-common</module>
+        <module>lucene</module>
         <module>mailbox</module>
         <module>mailbox-jpa</module>
         <module>mailbox-plugin-deleted-messages-vault</module>
@@ -138,6 +139,11 @@
             <dependency>
                 <groupId>${james.groupId}</groupId>
                 <artifactId>james-server-guice-lmtp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
+                <artifactId>james-server-guice-lucene</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Currently [LuceneSearchMailboxModule.java](https://github.com/apache/james-project/compare/master...vttranlina:guice_lucene?expand=1#diff-9d43f98c587435fb4cb72d364e81779eb6a9babd234348bf32a1788193526753) was located in mailbox-jpa

To allow for options beyond "jpa," 
I propose  `<artifactId>james-server-guice-lucene</artifactId>`

