### PR TITLE
URLEncoding for subaddressing

### DIFF
--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
@@ -26,7 +26,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/ACLProbeImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/ACLProbeImpl.java
@@ -31,6 +31,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxACL.ACLCommand;
 import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.probe.ACLProbe;
 import org.apache.james.utils.GuiceProbe;
@@ -60,9 +61,9 @@ public class ACLProbeImpl implements GuiceProbe, ACLProbe {
         mailboxManager.applyRightsCommand(mailboxPath, command, mailboxSession);
     }
 
-    public void executeCommand(MailboxPath mailboxPath, ACLCommand command) throws MailboxException {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
-        mailboxManager.applyRightsCommand(mailboxPath, command, mailboxSession);
+    public void executeCommand(MailboxId mailboxId, Username ownerUser, ACLCommand command) throws MailboxException {
+        MailboxSession mailboxSession = mailboxManager.createSystemSession(ownerUser);
+        mailboxManager.applyRightsCommand(mailboxId, command, mailboxSession);
     }
 
     @Override

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SubAddressingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SubAddressingTest.java
@@ -222,17 +222,15 @@ class SubAddressingTest {
                         .asAddition());
 
         sendSubAddressedMail(TARGETED_MAILBOX_ENCODED);
-        awaitAtMostOneMinute.until(() -> jamesServer.getProbe(MailboxProbeImpl.class)
-                .searchMessage(MultimailboxesSearchQuery.from(SearchQuery.builder().build()).build(), RECIPIENT, 1)
-                .size() == 1);
 
+        int LOAD_LIMIT = 1;
         awaitAtMostOneMinute.until(() -> jamesServer.getProbe(MailboxProbeImpl.class)
                 .searchMessage(MultimailboxesSearchQuery
                         .from(SearchQuery.builder().build())
                         .inMailboxes(targetMailboxId)
                         .build(),
                     RECIPIENT,
-                    1)
+                    LOAD_LIMIT)
                 .size() == 1);
     }
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SubAddressingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SubAddressingTest.java
@@ -223,14 +223,14 @@ class SubAddressingTest {
 
         sendSubAddressedMail(TARGETED_MAILBOX_ENCODED);
 
-        int LOAD_LIMIT = 1;
+        int loadLimit = 1;
         awaitAtMostOneMinute.until(() -> jamesServer.getProbe(MailboxProbeImpl.class)
                 .searchMessage(MultimailboxesSearchQuery
                         .from(SearchQuery.builder().build())
                         .inMailboxes(targetMailboxId)
                         .build(),
                     RECIPIENT,
-                    LOAD_LIMIT)
+                    loadLimit)
                 .size() == 1);
     }
 


### PR DESCRIPTION
this is the very beginning of the implementation of URLEncoding for subaddressing.
right now, i can't manage to write the integration test correctly: even using the probe instead of IMAP commands, the creation of a mailbox with a name containing a space is rejected: `java.lang.RuntimeException: AAAC BAD CREATE failed. Illegal encoding.`...

side note: i was unsure of what to do with the checkstyle issue in TikaTextExtractorTest, i committed it separately.