### PR TITLE
[FIX] Add missing commons codec dependency

### DIFF
--- a/backends-common/cassandra/pom.xml
+++ b/backends-common/cassandra/pom.xml
@@ -68,12 +68,10 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/backends-common/opensearch/pom.xml
+++ b/backends-common/opensearch/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>throwing-lambdas</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
         </dependency>

--- a/event-bus/cassandra/pom.xml
+++ b/event-bus/cassandra/pom.xml
@@ -56,11 +56,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/event-sourcing/event-store-cassandra/pom.xml
+++ b/event-sourcing/event-store-cassandra/pom.xml
@@ -79,11 +79,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-scala-extensions_${scala.base}</artifactId>
         </dependency>

--- a/mailbox/cassandra/pom.xml
+++ b/mailbox/cassandra/pom.xml
@@ -180,11 +180,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>

--- a/mailbox/plugin/deleted-messages-vault-cassandra/pom.xml
+++ b/mailbox/plugin/deleted-messages-vault-cassandra/pom.xml
@@ -81,11 +81,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/mailbox/plugin/quota-mailing-cassandra/pom.xml
+++ b/mailbox/plugin/quota-mailing-cassandra/pom.xml
@@ -130,11 +130,6 @@
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>

--- a/mpt/impl/imap-mailbox/cassandra/pom.xml
+++ b/mpt/impl/imap-mailbox/cassandra/pom.xml
@@ -96,11 +96,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/mpt/impl/managesieve/cassandra/pom.xml
+++ b/mpt/impl/managesieve/cassandra/pom.xml
@@ -30,7 +30,6 @@
 
     <name>Apache James :: MPT :: ManageSieve :: Cassandra</name>
 
-
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -54,11 +53,5 @@
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
 </project>

--- a/mpt/impl/smtp/cassandra-rabbitmq-object-storage/pom.xml
+++ b/mpt/impl/smtp/cassandra-rabbitmq-object-storage/pom.xml
@@ -116,10 +116,5 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/mpt/impl/smtp/cassandra/pom.xml
+++ b/mpt/impl/smtp/cassandra/pom.xml
@@ -84,10 +84,5 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/server/apps/cassandra-app/pom.xml
+++ b/server/apps/cassandra-app/pom.xml
@@ -260,11 +260,6 @@
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/server/apps/distributed-app/pom.xml
+++ b/server/apps/distributed-app/pom.xml
@@ -321,11 +321,6 @@
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/server/apps/distributed-pop3-app/pom.xml
+++ b/server/apps/distributed-pop3-app/pom.xml
@@ -312,11 +312,6 @@
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/server/blob/blob-cassandra/pom.xml
+++ b/server/blob/blob-cassandra/pom.xml
@@ -80,11 +80,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/server/data/data-cassandra/pom.xml
+++ b/server/data/data-cassandra/pom.xml
@@ -96,11 +96,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <scope>test</scope>

--- a/server/data/data-jmap-cassandra/pom.xml
+++ b/server/data/data-jmap-cassandra/pom.xml
@@ -110,11 +110,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>

--- a/server/mailrepository/mailrepository-cassandra/pom.xml
+++ b/server/mailrepository/mailrepository-cassandra/pom.xml
@@ -87,11 +87,6 @@
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/pom.xml
@@ -121,11 +121,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>pulsar</artifactId>
             <scope>test</scope>

--- a/server/queue/queue-rabbitmq/pom.xml
+++ b/server/queue/queue-rabbitmq/pom.xml
@@ -155,11 +155,6 @@
             <artifactId>amqp-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>

--- a/server/task/task-distributed/pom.xml
+++ b/server/task/task-distributed/pom.xml
@@ -123,11 +123,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Encountered on a customer install...

```
test_james20_pub | Exception in thread "OpenSearch-driver-1" java.lang.NoClassDefFoundError: org/apache/commons/codec/binary/Base64
test_james20_pub |      at org.apache.http.impl.auth.BasicScheme.authenticate(BasicScheme.java:166)
test_james20_pub |      at org.apache.http.impl.auth.HttpAuthenticator.doAuth(HttpAuthenticator.java:233)
test_james20_pub |      at org.apache.http.impl.auth.HttpAuthenticator.generateAuthResponse(HttpAuthenticator.java:213)
test_james20_pub |      at org.apache.http.impl.nio.client.MainClientExec.generateRequest(MainClientExec.java:224)
test_james20_pub |      at org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl.generateRequest(DefaultClientExchangeHandlerImpl.java:135)
test_james20_pub |      at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.requestReady(HttpAsyncRequestExecutor.java:193)
test_james20_pub |      at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.connected(HttpAsyncRequestExecutor.java:134)
test_james20_pub |      at org.apache.http.impl.nio.client.InternalIODispatch.onConnected(InternalIODispatch.java:69)
test_james20_pub |      at org.apache.http.impl.nio.client.InternalIODispatch.onConnected(InternalIODispatch.java:40)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractIODispatch.connected(AbstractIODispatch.java:73)
test_james20_pub |      at org.apache.http.impl.nio.reactor.BaseIOReactor.sessionCreated(BaseIOReactor.java:246)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractIOReactor.processNewChannels(AbstractIOReactor.java:429)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:287)
test_james20_pub |      at org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:104)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:591)
test_james20_pub |      at java.base/java.lang.Thread.run(Unknown Source)
test_james20_pub | Caused by: java.lang.ClassNotFoundException: org.apache.commons.codec.binary.Base64
test_james20_pub |      at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
test_james20_pub |      at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
test_james20_pub |      at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
test_james20_pub |      ... 16 more
test_james20_pub | 14:26:25.498 [ERROR] o.a.h.i.n.c.InternalHttpAsyncClient - user: sessionId: proxy: I/O reactor terminated abnormally
test_james20_pub | java.lang.ClassNotFoundException: org.apache.commons.codec.binary.Base64
test_james20_pub |      at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
test_james20_pub |      at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
test_james20_pub |      at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
test_james20_pub |      ... 16 common frames omitted
test_james20_pub | Wrapped by: java.lang.NoClassDefFoundError: org/apache/commons/codec/binary/Base64
test_james20_pub |      at org.apache.http.impl.auth.BasicScheme.authenticate(BasicScheme.java:166)
test_james20_pub |      at org.apache.http.impl.auth.HttpAuthenticator.doAuth(HttpAuthenticator.java:233)
test_james20_pub |      at org.apache.http.impl.auth.HttpAuthenticator.generateAuthResponse(HttpAuthenticator.java:213)
test_james20_pub |      at org.apache.http.impl.nio.client.MainClientExec.generateRequest(MainClientExec.java:224)
test_james20_pub |      at org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl.generateRequest(DefaultClientExchangeHandlerImpl.java:135)
test_james20_pub |      at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.requestReady(HttpAsyncRequestExecutor.java:193)
test_james20_pub |      at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.connected(HttpAsyncRequestExecutor.java:134)
test_james20_pub |      at org.apache.http.impl.nio.client.InternalIODispatch.onConnected(InternalIODispatch.java:69)
test_james20_pub |      at org.apache.http.impl.nio.client.InternalIODispatch.onConnected(InternalIODispatch.java:40)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractIODispatch.connected(AbstractIODispatch.java:73)
test_james20_pub |      at org.apache.http.impl.nio.reactor.BaseIOReactor.sessionCreated(BaseIOReactor.java:246)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractIOReactor.processNewChannels(AbstractIOReactor.java:429)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:287)
test_james20_pub |      at org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:104)
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:591)
test_james20_pub |      ... 1 common frames omitted
test_james20_pub | Wrapped by: org.apache.http.nio.reactor.IOReactorException: I/O dispatch worker terminated abnormally
test_james20_pub |      at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor.execute(AbstractMultiworkerIOReactor.java:359)
test_james20_pub |      at org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager.execute(PoolingNHttpClientConnectionManager.java:221)
test_james20_pub |      at org.apache.http.impl.nio.client.CloseableHttpAsyncClientBase$1.run(CloseableHttpAsyncClientBase.java:64)
test_james20_pub |      at java.base/java.lang.Thread.run(Unknown Source)
```