### PR TITLE
Update RedisSentinelExtension to switch BindMode to READ_ONLY

### DIFF
--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
@@ -94,7 +94,7 @@ public class RedisClusterExtension implements GuiceModuleTestExtension {
             .withNetworkAliases(alias)
             .withClasspathResourceMapping("redis_cluster.conf",
                 "/usr/local/etc/redis/redis.conf",
-                BindMode.READ_WRITE)
+                BindMode.READ_ONLY)
             .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1)
                 .withStartupTimeout(Duration.ofMinutes(2)));
 

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisMasterReplicaExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisMasterReplicaExtension.java
@@ -199,13 +199,13 @@ public class RedisMasterReplicaExtension implements GuiceModuleTestExtension {
         if (tlsEnabled) {
             genericContainer.withClasspathResourceMapping("certificate.crt",
                     "/etc/redis/certificate.crt",
-                    BindMode.READ_WRITE)
+                    BindMode.READ_ONLY)
                 .withClasspathResourceMapping("private.key",
                     "/etc/redis/private.key",
-                    BindMode.READ_WRITE)
+                    BindMode.READ_ONLY)
                 .withClasspathResourceMapping("rootCA.crt",
                     "/etc/redis/rootCA.crt",
-                    BindMode.READ_WRITE);
+                    BindMode.READ_ONLY);
             if (isSlave) {
                 genericContainer.withCommand(TLS_REPLICA_COMMAND);
             } else {

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisSentinelExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisSentinelExtension.java
@@ -239,13 +239,13 @@ public class RedisSentinelExtension implements GuiceModuleTestExtension {
         if (tlsEnabled) {
             genericContainer.withClasspathResourceMapping("certificate.crt",
                     "/etc/redis/certificate.crt",
-                    BindMode.READ_WRITE)
+                    BindMode.READ_ONLY)
                 .withClasspathResourceMapping("private.key",
                     "/etc/redis/private.key",
-                    BindMode.READ_WRITE)
+                    BindMode.READ_ONLY)
                 .withClasspathResourceMapping("rootCA.crt",
                     "/etc/redis/rootCA.crt",
-                    BindMode.READ_WRITE);
+                    BindMode.READ_ONLY);
             if (isSlave) {
                 genericContainer.withCommand(TLS_REPLICA_COMMAND);
             } else {
@@ -272,20 +272,20 @@ public class RedisSentinelExtension implements GuiceModuleTestExtension {
         if (tlsEnabled) {
             genericContainer.withClasspathResourceMapping("sentinel_tls.conf",
                     "/etc/redis/sentinel.conf",
-                    BindMode.READ_WRITE)
+                    BindMode.READ_ONLY)
                 .withClasspathResourceMapping("certificate.crt",
                     "/etc/redis/certificate.crt",
-                    BindMode.READ_WRITE)
+                    BindMode.READ_ONLY)
                 .withClasspathResourceMapping("private.key",
                     "/etc/redis/private.key",
-                    BindMode.READ_WRITE)
+                    BindMode.READ_ONLY)
                 .withClasspathResourceMapping("rootCA.crt",
                     "/etc/redis/rootCA.crt",
-                    BindMode.READ_WRITE);
+                    BindMode.READ_ONLY);
         } else {
             genericContainer.withClasspathResourceMapping("sentinel.conf",
                 "/etc/redis/sentinel.conf",
-                BindMode.READ_WRITE);
+                BindMode.READ_ONLY);
         }
         return genericContainer;
     }

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisTLSExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisTLSExtension.java
@@ -72,13 +72,13 @@ public class RedisTLSExtension implements GuiceModuleTestExtension {
         .withCommand(START_SERVER_COMMAND)
         .withClasspathResourceMapping("certificate.crt",
             "/etc/redis/certificate.crt",
-            BindMode.READ_WRITE)
+            BindMode.READ_ONLY)
         .withClasspathResourceMapping("private.key",
             "/etc/redis/private.key",
-            BindMode.READ_WRITE)
+            BindMode.READ_ONLY)
         .withClasspathResourceMapping("rootCA.crt",
             "/etc/redis/rootCA.crt",
-            BindMode.READ_WRITE)
+            BindMode.READ_ONLY)
         .withNetworkAliases("redis")
         .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1)
             .withStartupTimeout(Duration.ofMinutes(2)));


### PR DESCRIPTION
Somehow testcontainers erase the content of binding files when READ_WRITE mode is used