### PR TITLE
posting right in JMAP for subaddressing

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -5866,7 +5866,7 @@ trait MailboxSetMethodContract {
          |                "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
          |                "update": {
          |                    "${mailboxId.serialize}": {
-         |                      "sharedWith/${ANDRE.asString()}": ["p"]
+         |                      "sharedWith/${ANDRE.asString()}": ["x"]
          |                    }
          |                }
          |           },
@@ -5902,7 +5902,7 @@ trait MailboxSetMethodContract {
          |                "notUpdated": {
          |                    "${mailboxId.serialize}": {
          |                        "type": "invalidArguments",
-         |                        "description": "Specified value do not match the expected JSON format: List(((0),List(JsonValidationError(List(Unknown right 'p'),List()))))",
+         |                        "description": "Specified value do not match the expected JSON format: List(((0),List(JsonValidationError(List(Unknown right 'x'),List()))))",
          |                        "properties": [
          |                            "sharedWith/andre@domain.tld"
          |                        ]

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/rights.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/rights.mdown
@@ -39,6 +39,7 @@ The following `Right`s are defined:
  - `"w"` Write: the user can alter the Keywords of messages contained in this Mailbox, except the `$Seen` keyword
  - `"s"` Seen: the user can alter the `$Seen` keyword of messages contained in this Mailbox
  - `"e"` Expunge: the user can mark Email as Expunged in this Mailbox. This action is not achievable using JMAP.
+ - `"p"` Post: the user can send an Email to this Mailbox. This is used with the identifier `anyone` in the context of subaddressing.
 
 `UserRights` is an array of `Right`, representing the actions a user can perform on a mailbox.
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Rights.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Rights.scala
@@ -67,8 +67,9 @@ object Right {
   val Seen = Right(JavaRight.WriteSeenFlag)
   val DeleteMessages = Right(JavaRight.DeleteMessages)
   val Write = Right(JavaRight.Write)
+  val Post = Right(JavaRight.Post)
 
-  private val allRights = Seq(Administer, Expunge, Insert, Lookup, Read, Seen, DeleteMessages, Write)
+  private val allRights = Seq(Administer, Expunge, Insert, Lookup, Read, Seen, DeleteMessages, Write, Post)
 
   def forRight(right: JavaRight): Option[Right] = allRights.find(_.right.equals(right))
 

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
@@ -82,7 +82,7 @@ class RightsTest extends AnyWordSpec with Matchers {
     }
     "filter out unknown rights" in {
       val acl = new JavaMailboxACL(Map(
-        EntryKey.createUserEntryKey(USERNAME) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aetok")).asJava)
+        EntryKey.createUserEntryKey(USERNAME) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aetxk")).asJava)
 
       Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USERNAME, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages)))
     }

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
@@ -54,6 +54,9 @@ class RightsTest extends AnyWordSpec with Matchers {
     "recognise 't'" in {
       Right.forChar('t') must be(Some(Right.DeleteMessages))
     }
+    "recognise 'p'" in {
+      Right.forChar('p') must be(Some(Right.Post))
+    }
     "return empty when unknown" in {
       Right.forChar('k') must be(None)
     }
@@ -79,7 +82,7 @@ class RightsTest extends AnyWordSpec with Matchers {
     }
     "filter out unknown rights" in {
       val acl = new JavaMailboxACL(Map(
-        EntryKey.createUserEntryKey(USERNAME) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aetpk")).asJava)
+        EntryKey.createUserEntryKey(USERNAME) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aetok")).asJava)
 
       Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USERNAME, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages)))
     }


### PR DESCRIPTION
i am tackling [the step 4 of this issue](https://issues.apache.org/jira/browse/JAMES-3945), that is, adding JMAP support for subaddressing

in order to allow subaddressing or not for a specific mailbox, there is the need for a `p` (`posting`) right, that can be granted to the identifier `anyone`