### PR TITLE
[ENHANCEMENT] MDC for IMAP parsing logs

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/base/AbstractImapCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/base/AbstractImapCommandParser.java
@@ -71,7 +71,7 @@ public abstract class AbstractImapCommandParser implements ImapCommandParser {
             try {
                 return decode(request, tag, session);
             } catch (DecodingException e) {
-                LOGGER.debug("Cannot parse protocol ", e);
+                LOGGER.info("Cannot parse protocol ", e);
                 return statusResponseFactory.taggedBad(tag, command, e.getKey());
             }
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/base/AbstractImapCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/base/AbstractImapCommandParser.java
@@ -71,7 +71,7 @@ public abstract class AbstractImapCommandParser implements ImapCommandParser {
             try {
                 return decode(request, tag, session);
             } catch (DecodingException e) {
-                LOGGER.info("Cannot parse protocol ", e);
+                session.withMDC(() -> LOGGER.info("Cannot parse protocol ", e));
                 return statusResponseFactory.taggedBad(tag, command, e.getKey());
             }
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -70,7 +70,7 @@ public class DefaultImapDecoder implements ImapDecoder {
             Tag tag = request.tag();
             return decodeCommandTagged(request, tag, session);
         } catch (DecodingException e) {
-            LOGGER.debug("Cannot parse tag", e);
+            session.withMDC(() -> LOGGER.debug("Cannot parse tag", e));
             return unknownCommand(null, session);
         }
     }
@@ -80,7 +80,7 @@ public class DefaultImapDecoder implements ImapDecoder {
             String commandName = request.atom();
             return decodeCommandNamed(request, tag, commandName, session);
         } catch (DecodingException e) {
-            LOGGER.info("Error during initial request parsing", e);
+            session.withMDC(() -> LOGGER.info("Error during initial request parsing", e));
             return unknownCommand(tag, session);
         }
     }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/HAProxyMessageHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/HAProxyMessageHandler.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.imapserver.netty;
 
-import static org.apache.james.imapserver.netty.ImapChannelUpstreamHandler.MDC_KEY;
+import static org.apache.james.imap.api.process.ImapSession.MDC_KEY;
 
 import java.net.InetSocketAddress;
 import java.util.Set;

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPMDCContext.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPMDCContext.java
@@ -23,8 +23,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Optional;
 
-import org.apache.james.core.Username;
-import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.protocols.netty.ProtocolMDCContextFactory;
 import org.apache.james.util.MDCBuilder;
 
@@ -70,14 +68,5 @@ public class IMAPMDCContext {
             return address.getHostName();
         }
         return remoteAddress.toString();
-    }
-
-    public static MDCBuilder from(ImapSession imapSession) {
-        return MDCBuilder.create()
-            .addToContext(MDCBuilder.USER, Optional.ofNullable(imapSession.getUserName())
-                .map(Username::asString)
-                .orElse(""))
-            .addToContextIfPresent("selectedMailbox", Optional.ofNullable(imapSession.getSelected())
-                .map(selectedMailbox -> selectedMailbox.getMailboxId().serialize()));
     }
 }


### PR DESCRIPTION
Design choices:

 - For performance reasons do not set up the MDC for each and every parsing attempt. Doing it upon parsing errors is likely enough, and prevent costs associated with MDC management.
 - Centralize management of the MDC into the IMAP session. This avoids coupling the parsers to the transport layer by preventing constant duplication.
 - And finally this meant also managing user and selected mailbox in a statefull manner. This unsure the MDC from the IMAP session can be used straight away...