### PR TITLE
[IMPROVEMENT] mock-smtp-server (parameters without values)

### DIFF
--- a/server/mailet/mock-smtp-server/pom.xml
+++ b/server/mailet/mock-smtp-server/pom.xml
@@ -123,12 +123,12 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:11-jre-jammy</image>
+                        <image>eclipse-temurin:21-jre-jammy</image>
                     </from>
                     <to>
                         <image>linagora/mock-smtp-server</image>
                         <tags>
-                            <tag>0.6</tag>
+                            <tag>0.7</tag>
                         </tags>
                     </to>
                     <container>

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/HTTPConfigurationServer.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/HTTPConfigurationServer.java
@@ -99,6 +99,7 @@ public class HTTPConfigurationServer {
     static final String VERSION = "/version";
     static final String SMTP_MAILS = "/smtpMails";
     static final String SMTP_MAILS_COUNT = "/smtpMailsCount";
+    static final String JSON_SERIALIZATION_ERROR_MESSAGE = "Could not serialize JSON ";
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .registerModule(new Jdk8Module())
@@ -156,7 +157,7 @@ public class HTTPConfigurationServer {
                 .header(CONTENT_TYPE, APPLICATION_JSON)
                 .sendString(Mono.just(OBJECT_MAPPER.writeValueAsString(mockSmtpBehaviors)));
         } catch (JsonProcessingException e) {
-            LOGGER.error("Could not serialize JSON", e);
+            LOGGER.error(JSON_SERIALIZATION_ERROR_MESSAGE, e);
             return res.status(INTERNAL_SERVER_ERROR).send();
         }
     }
@@ -169,7 +170,7 @@ public class HTTPConfigurationServer {
                 .header(CONTENT_TYPE, APPLICATION_JSON)
                 .sendString(Mono.just(OBJECT_MAPPER.writeValueAsString(extensions)));
         } catch (JsonProcessingException e) {
-            LOGGER.error("Could not serialize JSON", e);
+            LOGGER.error(JSON_SERIALIZATION_ERROR_MESSAGE, e);
             return res.status(INTERNAL_SERVER_ERROR).send();
         }
     }
@@ -225,7 +226,7 @@ public class HTTPConfigurationServer {
                     .header(CONTENT_TYPE, APPLICATION_JSON)
                     .sendString(Mono.just(OBJECT_MAPPER.writeValueAsString(mailsRemoved)));
         } catch (JsonProcessingException e) {
-            LOGGER.error("Could not serialize JSON", e);
+            LOGGER.error(JSON_SERIALIZATION_ERROR_MESSAGE, e);
             return res.status(INTERNAL_SERVER_ERROR).send();
         }
     }
@@ -238,7 +239,7 @@ public class HTTPConfigurationServer {
                 .header(CONTENT_TYPE, APPLICATION_JSON)
                 .sendString(Mono.just(OBJECT_MAPPER.writeValueAsString(mails)));
         } catch (JsonProcessingException e) {
-            LOGGER.error("Could not serialize JSON", e);
+            LOGGER.error(JSON_SERIALIZATION_ERROR_MESSAGE, e);
             return res.status(INTERNAL_SERVER_ERROR).send();
         }
     }
@@ -251,7 +252,7 @@ public class HTTPConfigurationServer {
                     .header(CONTENT_TYPE, APPLICATION_JSON)
                     .sendString(Mono.just(OBJECT_MAPPER.writeValueAsString(count)));
         } catch (JsonProcessingException e) {
-            LOGGER.error("Could not serialize JSON", e);
+            LOGGER.error(JSON_SERIALIZATION_ERROR_MESSAGE, e);
             return res.status(INTERNAL_SERVER_ERROR).send();
         }
     }

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Condition.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Condition.java
@@ -104,8 +104,7 @@ public interface Condition {
 
         @Override
         public final boolean equals(Object o) {
-            if (o instanceof OperatorCondition) {
-                OperatorCondition condition = (OperatorCondition) o;
+            if (o instanceof OperatorCondition condition) {
 
                 return Objects.equals(this.operator, condition.operator)
                     && Objects.equals(this.matchingValue, condition.matchingValue);

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Mails.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Mails.java
@@ -40,8 +40,7 @@ public class Mails {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof Mails) {
-            Mails that = (Mails) o;
+        if (o instanceof Mails that) {
 
             return Objects.equals(this.mailList, that.mailList);
         }

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/MockSMTPBehavior.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/MockSMTPBehavior.java
@@ -55,8 +55,7 @@ public class MockSMTPBehavior {
 
         @Override
         public final boolean equals(Object o) {
-            if (o instanceof NumberOfAnswersPolicy) {
-                NumberOfAnswersPolicy that = (NumberOfAnswersPolicy) o;
+            if (o instanceof NumberOfAnswersPolicy that) {
 
                 return Objects.equals(this.numberOfAnswers, that.numberOfAnswers);
             }
@@ -147,8 +146,7 @@ public class MockSMTPBehavior {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof MockSMTPBehavior) {
-            MockSMTPBehavior that = (MockSMTPBehavior) o;
+        if (o instanceof MockSMTPBehavior that) {
 
             return Objects.equals(this.smtpCommand, that.smtpCommand)
                 && Objects.equals(this.condition, that.condition)

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/MockSMTPBehaviorInformation.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/MockSMTPBehaviorInformation.java
@@ -132,8 +132,7 @@ public class MockSMTPBehaviorInformation {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof MockSMTPBehaviorInformation) {
-            MockSMTPBehaviorInformation that = (MockSMTPBehaviorInformation) o;
+        if (o instanceof MockSMTPBehaviorInformation that) {
 
             return Objects.equals(this.behavior, that.behavior)
                 && Objects.equals(this.remainingAnswersCounter(), that.remainingAnswersCounter());

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/MockSmtpBehaviors.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/MockSmtpBehaviors.java
@@ -47,8 +47,7 @@ public class MockSmtpBehaviors {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof MockSmtpBehaviors) {
-            MockSmtpBehaviors that = (MockSmtpBehaviors) o;
+        if (o instanceof MockSmtpBehaviors that) {
 
             return Objects.equals(this.behaviorList, that.behaviorList);
         }

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Response.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/Response.java
@@ -102,8 +102,7 @@ public class Response {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof Response) {
-            Response response = (Response) o;
+        if (o instanceof Response response) {
 
             return Objects.equals(this.code, response.code)
                 && Objects.equals(this.message, response.message);

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/SMTPExtension.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/SMTPExtension.java
@@ -46,8 +46,7 @@ public class SMTPExtension {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof SMTPExtension) {
-            SMTPExtension that = (SMTPExtension) o;
+        if (o instanceof SMTPExtension that) {
 
             return Objects.equals(this.name, that.name);
         }

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/SMTPExtensions.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/model/SMTPExtensions.java
@@ -45,8 +45,7 @@ public class SMTPExtensions {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof SMTPExtensions) {
-            SMTPExtensions that = (SMTPExtensions) o;
+        if (o instanceof SMTPExtensions that) {
 
             return Objects.equals(this.smtpExtensions, that.smtpExtensions);
         }

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/testing/MockSmtpServerExtension.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/testing/MockSmtpServerExtension.java
@@ -46,7 +46,7 @@ public class MockSmtpServerExtension implements AfterEachCallback, BeforeAllCall
 
         DockerMockSmtp() {
             mockSmtpServer = DockerContainer.fromName(Images.MOCK_SMTP_SERVER)
-                .withLogConsumer(outputFrame -> LOGGER.debug("MockSMTP: " + outputFrame.getUtf8String()))
+                .withLogConsumer(outputFrame -> LOGGER.debug("MockSMTP: {}", outputFrame.getUtf8String()))
                 .withExposedPorts(25, 8000)
                 .waitingFor(Wait.forLogMessage(".*Mock SMTP server started.*", 1))
                 .withName("james-testing-mock-smtp-server-" + UUID.randomUUID());

--- a/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/MockSMTPServerTest.java
+++ b/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/MockSMTPServerTest.java
@@ -224,8 +224,8 @@ class MockSMTPServerTest {
                     .name("REQUIRETLS")
                     .build())
                 .addMailParameter(Mail.Parameter.builder()
-                        .name("SMTPUTF8")
-                        .build())
+                    .name("SMTPUTF8")
+                    .build())
                 .from(new MailAddress(BOB))
                 .addRecipientMailAddress(new MailAddress(ALICE))
                 .build();

--- a/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/MockSMTPServerTest.java
+++ b/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/MockSMTPServerTest.java
@@ -200,7 +200,7 @@ class MockSMTPServerTest {
             try {
                 smtpClient.connect("localhost", mockServer.getPort().getValue());
                 smtpClient.ehlo("localhost");
-                smtpClient.mail("<bob@james.org> MT-PRIORITY=3 RET=HDRS ENVID=gabouzomeuh");
+                smtpClient.mail("<bob@james.org> MT-PRIORITY=3 REQUIRETLS RET=HDRS SMTPUTF8 ENVID=gabouzomeuh");
                 smtpClient.rcpt("<alice@james.org>");
                 smtpClient.sendShortMessageData("A short message...");
             } finally {
@@ -220,6 +220,12 @@ class MockSMTPServerTest {
                     .name("MT-PRIORITY")
                     .value("3")
                     .build())
+                .addMailParameter(Mail.Parameter.builder()
+                    .name("REQUIRETLS")
+                    .build())
+                .addMailParameter(Mail.Parameter.builder()
+                        .name("SMTPUTF8")
+                        .build())
                 .from(new MailAddress(BOB))
                 .addRecipientMailAddress(new MailAddress(ALICE))
                 .build();


### PR DESCRIPTION
Hello! 
I think the mock-smtp-server needs tweaking to improve the integration testing work, he must accept a specific list of parameters without values. Like for example for a `REQUIRETLS` parameter in a task: 
[JAMES-3823](https://issues.apache.org/jira/projects/JAMES/issues/JAMES-3823?filter=allopenissues)
[#2460](https://github.com/apache/james-project/pull/2460)
