### PR TITLE
refactor and test the use of the `anyone` keyword when sharing with JMAP

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
@@ -375,15 +375,19 @@ public class MailboxACL {
         }
 
         public static EntryKey createUserEntryKey(Username name) {
-            return new EntryKey(name.asString(), NameType.user, POSITIVE_KEY);
-        }
-
-        public static EntryKey createNegativeUserEntryKey(Username name) {
-            return new EntryKey(name.asString(), NameType.user, NEGATIVE_KEY);
+            return createUserEntryKey(name.asString());
         }
 
         public static EntryKey createUserEntryKey(Username name, boolean negative) {
-            return new EntryKey(name.asString(), NameType.user, negative);
+            return createUserEntryKey(name.asString(), negative);
+        }
+
+        public static EntryKey createUserEntryKey(String name) {
+            return createUserEntryKey(name, POSITIVE_KEY);
+        }
+
+        public static EntryKey createUserEntryKey(String name, boolean negative) {
+            return new EntryKey(name, NameType.user, negative);
         }
 
         private final String name;

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/ACLProbeImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/ACLProbeImpl.java
@@ -46,18 +46,20 @@ public class ACLProbeImpl implements GuiceProbe, ACLProbe {
     }
 
     @Override
-    public void replaceRights(MailboxPath mailboxPath, String targetUser, Rfc4314Rights rights) throws MailboxException {
+    public void replaceRights(MailboxPath mailboxPath, String targetIdentifier, Rfc4314Rights rights) throws MailboxException {
         MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
 
-        ACLCommand command = MailboxACL.command().forUser(Username.of(targetUser)).rights(rights).asReplacement();
+        MailboxACL.EntryKey targetEntryKey = MailboxACL.EntryKey.deserialize(targetIdentifier);
+        ACLCommand command = MailboxACL.command().key(targetEntryKey).rights(rights).asReplacement();
         mailboxManager.applyRightsCommand(mailboxPath, command, mailboxSession);
     }
 
     @Override
-    public void addRights(MailboxPath mailboxPath, String targetUser, Rfc4314Rights rights) throws MailboxException {
+    public void addRights(MailboxPath mailboxPath, String targetIdentifier, Rfc4314Rights rights) throws MailboxException {
         MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
-        ACLCommand command = MailboxACL.command().forUser(Username.of(targetUser)).rights(rights).asAddition();
 
+        MailboxACL.EntryKey targetEntryKey = MailboxACL.EntryKey.deserialize(targetIdentifier);
+        ACLCommand command = MailboxACL.command().key(targetEntryKey).rights(rights).asReplacement();
         mailboxManager.applyRightsCommand(mailboxPath, command, mailboxSession);
     }
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -5919,7 +5919,7 @@ trait MailboxSetMethodContract {
          |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
          |      "notUpdated": {
          |        "${mailboxId.serialize}": {
-         |          "type": "invalidPatch",
+         |          "type": "invalidArguments",
          |          "description": "Domain parts ASCII chars must be a-z A-Z 0-9 - or _"
          |        }
          |      }

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -5929,6 +5929,162 @@ trait MailboxSetMethodContract {
   }
 
   @Test
+  def partialRightsUpdateShouldCorrectlyHandleAnyoneKeyword(server: GuiceJamesServer): Unit = {
+    val path = MailboxPath.forUser(BOB, "mailbox")
+    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)
+
+    val request =
+      s"""
+         |{
+         |   "using": [ "urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail", "urn:apache:james:params:jmap:mail:shares" ],
+         |   "methodCalls": [
+         |       [
+         |           "Mailbox/set",
+         |           {
+         |                "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |                "update": {
+         |                    "${mailboxId.serialize}": {
+         |                      "sharedWith/anyone": ["p"]
+         |                    }
+         |                }
+         |           },
+         |    "c1"
+         |       ],
+         |       ["Mailbox/get",
+         |         {
+         |           "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |           "properties": ["id", "rights"],
+         |           "ids": ["${mailboxId.serialize}"]
+         |          },
+         |       "c2"]
+         |   ]
+         |}
+         |""".stripMargin
+
+    val response = `given`
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .body(request)
+    .when
+      .post
+    .`then`
+      .log().ifValidationFails()
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract
+      .body
+      .asString
+
+    assertThatJson(response)
+      .whenIgnoringPaths("methodResponses[0][1].newState", "methodResponses[0][1].oldState",
+        "methodResponses[1][1].state")
+      .isEqualTo(
+        s"""{
+           |  "sessionState": "${SESSION_STATE.value}",
+           |  "methodResponses": [
+           |    ["Mailbox/set", {
+           |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+           |      "updated": {
+           |        "${mailboxId.serialize}": {}
+           |      }
+           |    }, "c1"],
+           |    ["Mailbox/get", {
+           |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+           |      "list": [{
+           |        "id": "${mailboxId.serialize}",
+           |        "rights": {
+           |          "anyone": ["p"]
+           |        }
+           |      }],
+           |      "notFound": []
+           |    }, "c2"]
+           |  ]
+           |}""".stripMargin)
+
+    assertThat(server.getProbe(classOf[ACLProbeImpl]).retrieveRights(path)
+      .getEntries)
+      .containsKey(MailboxACL.ANYONE_KEY)
+  }
+
+  @Test
+  def resetRightsUpdateShouldCorrectlyHandleAnyoneKeyword(server: GuiceJamesServer): Unit = {
+    val path = MailboxPath.forUser(BOB, "mailbox")
+    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)
+
+    val request =
+      s"""
+         |{
+         |   "using": [ "urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail", "urn:apache:james:params:jmap:mail:shares" ],
+         |   "methodCalls": [
+         |       [
+         |           "Mailbox/set",
+         |           {
+         |                "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |                "update": {
+         |                    "${mailboxId.serialize}": {
+         |                      "sharedWith": {
+         |                        "anyone":["p"]
+         |                      }
+         |                    }
+         |                }
+         |           },
+         |    "c1"
+         |       ],
+         |       ["Mailbox/get",
+         |         {
+         |           "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |           "properties": ["id", "rights"],
+         |           "ids": ["${mailboxId.serialize}"]
+         |          },
+         |       "c2"]
+         |   ]
+         |}
+         |""".stripMargin
+
+    val response = `given`
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .body(request)
+      .when
+      .post
+      .`then`
+      .log().ifValidationFails()
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract
+      .body
+      .asString
+
+    assertThatJson(response)
+      .whenIgnoringPaths("methodResponses[0][1].newState", "methodResponses[0][1].oldState",
+        "methodResponses[1][1].state")
+      .isEqualTo(
+        s"""{
+           |  "sessionState": "${SESSION_STATE.value}",
+           |  "methodResponses": [
+           |    ["Mailbox/set", {
+           |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+           |      "updated": {
+           |        "${mailboxId.serialize}": {}
+           |      }
+           |    }, "c1"],
+           |    ["Mailbox/get", {
+           |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+           |      "list": [{
+           |        "id": "${mailboxId.serialize}",
+           |        "rights": {
+           |          "anyone": ["p"]
+           |        }
+           |      }],
+           |      "notFound": []
+           |    }, "c2"]
+           |  ]
+           |}""".stripMargin)
+
+    assertThat(server.getProbe(classOf[ACLProbeImpl]).retrieveRights(path)
+      .getEntries)
+      .containsKey(MailboxACL.ANYONE_KEY)
+  }
+
+  @Test
   def partialRightsUpdateShouldFailWhenInvalidRights(server: GuiceJamesServer): Unit = {
     val path = MailboxPath.forUser(BOB, "mailbox")
     val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
@@ -24,7 +24,6 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.refineV
 import eu.timepit.refined.types.string.NonEmptyString
-import org.apache.james.core.Username
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.Id.Id
 import org.apache.james.jmap.core.Properties.toProperties
@@ -34,6 +33,7 @@ import org.apache.james.jmap.json.MailboxSerializer
 import org.apache.james.jmap.mail.MailboxName.MailboxName
 import org.apache.james.jmap.mail.MailboxPatchObject.MailboxPatchObjectKey
 import org.apache.james.jmap.method.{MailboxCreationParseException, SetRequest, WithAccountId}
+import org.apache.james.mailbox.model.MailboxACL.EntryKey
 import org.apache.james.mailbox.model.{MailboxId, MailboxACL => JavaMailboxACL}
 import org.apache.james.mailbox.{MailboxSession, Role}
 import play.api.libs.json.{JsBoolean, JsError, JsNull, JsObject, JsString, JsSuccess, JsValue}
@@ -136,7 +136,7 @@ case class MailboxPatchObject(value: Map[String, JsValue]) {
       }).headOption
 
     val partialRightsUpdates: Seq[SharedWithPartialUpdate] = asUpdatedIterable.flatMap(x => x match {
-      case scala.Right(SharedWithPartialUpdate(username, rights)) => Some(SharedWithPartialUpdate(username, rights))
+      case scala.Right(SharedWithPartialUpdate(entryKey, rights)) => Some(SharedWithPartialUpdate(entryKey, rights))
       case _ => None
     }).toSeq
 
@@ -290,15 +290,15 @@ object SharedWithPartialUpdate {
   def parse(serializer: MailboxSerializer, capabilities: Set[CapabilityIdentifier])
            ( property: String, newValue: JsValue): Either[PatchUpdateValidationException, Update] =
     if (capabilities.contains(CapabilityIdentifier.JAMES_SHARES)) {
-      parseUsername(property)
-        .flatMap(username => parseRights(newValue, property, serializer)
-          .map(rights => SharedWithPartialUpdate(username, rights)))
+      parseEntryKey(property)
+        .flatMap(entryKey => parseRights(newValue, property, serializer)
+          .map(rights => SharedWithPartialUpdate(entryKey, rights)))
     } else {
       MailboxPatchObject.notFound(property)
     }
 
-  def parseUsername(property: String): Either[PatchUpdateValidationException, Username] = try {
-    scala.Right(Username.of(property.substring(MailboxPatchObject.sharedWithPrefix.length)))
+  def parseEntryKey(property: String): Either[PatchUpdateValidationException, EntryKey] = try {
+    scala.Right(EntryKey.deserialize(property.substring(MailboxPatchObject.sharedWithPrefix.length)))
   } catch {
     case e: Exception => Left(InvalidPropertyException(property, e.getMessage))
   }
@@ -336,8 +336,8 @@ sealed trait Update
 case class NameUpdate(newName: String) extends Update
 case class SharedWithResetUpdate(rights: Rights) extends Update
 case class IsSubscribedUpdate(isSubscribed: Option[IsSubscribed]) extends Update
-case class SharedWithPartialUpdate(username: Username, rights: Rfc4314Rights) extends Update {
-  def asACLCommand(): JavaMailboxACL.ACLCommand = JavaMailboxACL.command().forUser(username).rights(rights.asJava).asReplacement()
+case class SharedWithPartialUpdate(entryKey: EntryKey, rights: Rfc4314Rights) extends Update {
+  def asACLCommand(): JavaMailboxACL.ACLCommand = JavaMailboxACL.command().key(entryKey).rights(rights.asJava).asReplacement()
 }
 
 class PatchUpdateValidationException() extends IllegalArgumentException

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
@@ -29,7 +29,7 @@ import org.apache.james.jmap.json.MailboxSerializer
 import org.apache.james.jmap.mail.{InvalidPatchException, InvalidPropertyException, InvalidUpdateException, MailboxGet, MailboxPatchObject, MailboxSetRequest, MailboxSetResponse, MailboxUpdateResponse, NameUpdate, ParentIdUpdate, ServerSetPropertyException, UnparsedMailboxId, UnsupportedPropertyUpdatedException, ValidatedMailboxPatchObject}
 import org.apache.james.jmap.method.MailboxSetUpdatePerformer.{MailboxUpdateFailure, MailboxUpdateResult, MailboxUpdateResults, MailboxUpdateSuccess}
 import org.apache.james.mailbox.MailboxManager.{MailboxSearchFetchType, RenameOption}
-import org.apache.james.mailbox.exception.{InsufficientRightsException, MailboxExistsException, MailboxNameException, MailboxNotFoundException}
+import org.apache.james.mailbox.exception.{DifferentDomainException, InsufficientRightsException, MailboxExistsException, MailboxNameException, MailboxNotFoundException}
 import org.apache.james.mailbox.model.search.{MailboxQuery, PrefixedWildcard}
 import org.apache.james.mailbox.model.{MailboxId, MailboxPath}
 import org.apache.james.mailbox.{MailboxManager, MailboxSession, MessageManager, Role, SubscriptionManager}
@@ -87,6 +87,9 @@ object MailboxSetUpdatePerformer {
       case e: IllegalArgumentException =>
         LOGGER.info("Illegal argument in Mailbox/set update", e)
         SetError.invalidArguments(SetErrorDescription(e.getMessage), None)
+      case e: DifferentDomainException =>
+        LOGGER.info("Invalid arguments in Mailbox/set update", e)
+        SetError.invalidArguments(SetErrorDescription("Invalid arguments in Mailbox/set update: different domains"), None)
       case e =>
         LOGGER.error("Failed to update mailbox", e)
         SetError.serverFail(SetErrorDescription(e.getMessage))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetUpdatePerformer.scala
@@ -255,7 +255,7 @@ class MailboxSetUpdatePerformer @Inject()(serializer: MailboxSerializer,
           .action("Mailbox/set update")
           .parameters(() => ImmutableMap.of("loggedInUser", mailboxSession.getLoggedInUser.toScala.map(_.asString()).getOrElse(""),
             "delegator", mailboxSession.getUser.asString(),
-            "delegatee", partialUpdate.username.asString(),
+            "delegatee", partialUpdate.entryKey.getName,
             "mailboxId", mailboxId.serialize(),
             "rights", partialUpdate.rights.asJava.serialize()))
           .log("JMAP mailbox shared.")),

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/MailboxSerializationTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/MailboxSerializationTest.scala
@@ -21,11 +21,12 @@ package org.apache.james.jmap.json
 
 import eu.timepit.refined.auto._
 import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
-import org.apache.james.core.{Domain, Username}
+import org.apache.james.core.Domain
 import org.apache.james.jmap.json.MailboxSerializationTest.MAILBOX
 import org.apache.james.jmap.mail.MailboxName.MailboxName
 import org.apache.james.jmap.mail.{IsSubscribed, Mailbox, MailboxNamespace, MailboxRights, MayAddItems, MayCreateChild, MayDelete, MayReadItems, MayRemoveItems, MayRename, MaySetKeywords, MaySetSeen, MaySubmit, PersonalNamespace, Quota, QuotaId, QuotaRoot, Quotas, Right, Rights, SortOrder, TotalEmails, TotalThreads, UnreadEmails, UnreadThreads, Value}
 import org.apache.james.mailbox.Role
+import org.apache.james.mailbox.model.MailboxACL.EntryKey
 import org.apache.james.mailbox.model.{MailboxId, TestId}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -56,8 +57,8 @@ object MailboxSerializationTest {
     maySubmit = MaySubmit(false)
   )
 
-  private val RIGHTS: Rights = Rights.of(Username.of("bob"), Seq(Right.Expunge, Right.Lookup))
-    .append(Username.of("alice"), Seq(Right.Read, Right.Write))
+  private val RIGHTS: Rights = Rights.of(EntryKey.createUserEntryKey("bob"), Seq(Right.Expunge, Right.Lookup))
+    .append(EntryKey.createUserEntryKey("alice"), Seq(Right.Read, Right.Write))
 
   private val QUOTAS = Quotas(Map(
     QuotaId(QuotaRoot("quotaRoot", None)) -> Quota(Map(

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
@@ -29,8 +29,9 @@ import scala.jdk.CollectionConverters._
 
 class RightsTest extends AnyWordSpec with Matchers {
   val NEGATIVE = true
-  val USERNAME: Username = Username.of("user")
-  val OTHER_USERNAME: Username = Username.of("otherUser")
+  val USER: String = "user"
+  val USER_ENTRYKEY: EntryKey = EntryKey.createUserEntryKey(USER)
+  val OTHER_USER_ENTRYKEY: EntryKey = EntryKey.createUserEntryKey("otherUser")
 
   "Right ofCharacter" should  {
     "recognise 'a'" in {
@@ -70,21 +71,21 @@ class RightsTest extends AnyWordSpec with Matchers {
     }
     "filter out negative users" in {
       val acl = new JavaMailboxACL(Map(
-        EntryKey.createUserEntryKey(USERNAME, NEGATIVE) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aet")).asJava)
+        EntryKey.createUserEntryKey(USER, NEGATIVE) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aet")).asJava)
 
       Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.EMPTY)
     }
     "accept users" in {
       val acl = new JavaMailboxACL(Map(
-        EntryKey.createUserEntryKey(USERNAME) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aet")).asJava)
+        USER_ENTRYKEY -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aet")).asJava)
 
-      Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USERNAME, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages)))
+      Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USER_ENTRYKEY, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages)))
     }
     "filter out unknown rights" in {
       val acl = new JavaMailboxACL(Map(
-        EntryKey.createUserEntryKey(USERNAME) -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aetxk")).asJava)
+        USER_ENTRYKEY -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aetxk")).asJava)
 
-      Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USERNAME, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages)))
+      Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USER_ENTRYKEY, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages)))
     }
   }
   "To ACL" should  {
@@ -92,11 +93,11 @@ class RightsTest extends AnyWordSpec with Matchers {
       Rights.EMPTY.toMailboxAcl.asJava must be(new JavaMailboxACL())
     }
     "return acl conversion" in {
-      val user1 = Username.of("user1")
-      val user2 = Username.of("user2")
+      val user1 = EntryKey.createUserEntryKey("user1")
+      val user2 = EntryKey.createUserEntryKey("user2")
       val expected = new JavaMailboxACL(Map(
-          EntryKey.createUserEntryKey(user1) -> new JavaRfc4314Rights(JavaRight.Administer, JavaRight.DeleteMessages),
-          EntryKey.createUserEntryKey(user2) -> new JavaRfc4314Rights(JavaRight.PerformExpunge, JavaRight.Lookup))
+          user1 -> new JavaRfc4314Rights(JavaRight.Administer, JavaRight.DeleteMessages),
+          user2 -> new JavaRfc4314Rights(JavaRight.PerformExpunge, JavaRight.Lookup))
         .asJava)
       val jmapPojo = Rights.of(user1, Seq(Right.Administer, Right.DeleteMessages))
         .append(user2, Seq(Right.Expunge, Right.Lookup))
@@ -106,72 +107,72 @@ class RightsTest extends AnyWordSpec with Matchers {
   }
   "Remove entries" should  {
     "return empty when empty" in {
-      Rights.EMPTY.removeEntriesFor(USERNAME) must be(Rights.EMPTY)
+      Rights.EMPTY.removeEntriesFor(USER_ENTRYKEY) must be(Rights.EMPTY)
     }
     "return empty when only user" in {
-      Rights.of(USERNAME, Right.Lookup)
-        .removeEntriesFor(USERNAME) must be(Rights.EMPTY)
+      Rights.of(USER_ENTRYKEY, Right.Lookup)
+        .removeEntriesFor(USER_ENTRYKEY) must be(Rights.EMPTY)
     }
     "only remove specified users" in {
-      val expected = Rights.of(OTHER_USERNAME, Right.Lookup)
+      val expected = Rights.of(OTHER_USER_ENTRYKEY, Right.Lookup)
 
-      Rights.of(USERNAME, Right.Lookup)
-        .append(OTHER_USERNAME, Right.Lookup)
-        .removeEntriesFor(USERNAME) must be(expected)
+      Rights.of(USER_ENTRYKEY, Right.Lookup)
+        .append(OTHER_USER_ENTRYKEY, Right.Lookup)
+        .removeEntriesFor(USER_ENTRYKEY) must be(expected)
     }
   }
   "mayAddItems" should  {
     "return empty when no user" in {
-      Rights.EMPTY.mayAddItems(USERNAME) must be(NotApplicable)
+      Rights.EMPTY.mayAddItems(USER_ENTRYKEY) must be(NotApplicable)
     }
     "return false when no insert right" in {
-      Rights.of(USERNAME, Seq(Right.Administer, Right.Expunge, Right.Lookup, Right.DeleteMessages, Right.Read, Right.Seen, Right.Write))
-        .mayAddItems(USERNAME) must be(NotApplicable)
+      Rights.of(USER_ENTRYKEY, Seq(Right.Administer, Right.Expunge, Right.Lookup, Right.DeleteMessages, Right.Read, Right.Seen, Right.Write))
+        .mayAddItems(USER_ENTRYKEY) must be(NotApplicable)
     }
     "return true when insert right" in {
-      Rights.of(USERNAME, Right.Insert)
-        .mayAddItems(USERNAME) must be(Applicable)
+      Rights.of(USER_ENTRYKEY, Right.Insert)
+        .mayAddItems(USER_ENTRYKEY) must be(Applicable)
     }
   }
   "mayReadItems" should  {
     "return empty when no user" in {
-      Rights.EMPTY.mayReadItems(USERNAME) must be(NotApplicable)
+      Rights.EMPTY.mayReadItems(USER_ENTRYKEY) must be(NotApplicable)
     }
     "return false when no read right" in {
-      Rights.of(USERNAME, Seq(Right.Administer, Right.Expunge, Right.Lookup, Right.DeleteMessages, Right.Administer, Right.Seen, Right.Write))
-        .mayReadItems(USERNAME) must be(NotApplicable)
+      Rights.of(USER_ENTRYKEY, Seq(Right.Administer, Right.Expunge, Right.Lookup, Right.DeleteMessages, Right.Administer, Right.Seen, Right.Write))
+        .mayReadItems(USER_ENTRYKEY) must be(NotApplicable)
     }
     "return true when read right" in {
-      Rights.of(USERNAME, Right.Read)
-        .mayReadItems(USERNAME) must be(Applicable)
+      Rights.of(USER_ENTRYKEY, Right.Read)
+        .mayReadItems(USER_ENTRYKEY) must be(Applicable)
     }
   }
   "mayRemoveItems" should  {
     "return empty when no user" in {
-      Rights.EMPTY.mayRemoveItems(USERNAME) must be(NotApplicable)
+      Rights.EMPTY.mayRemoveItems(USER_ENTRYKEY) must be(NotApplicable)
     }
     "return false when no delete right" in {
-      Rights.of(USERNAME, Seq(Right.Administer, Right.Expunge, Right.Lookup, Right.Read, Right.Administer, Right.Seen, Right.Write))
-        .mayRemoveItems(USERNAME) must be(NotApplicable)
+      Rights.of(USER_ENTRYKEY, Seq(Right.Administer, Right.Expunge, Right.Lookup, Right.Read, Right.Administer, Right.Seen, Right.Write))
+        .mayRemoveItems(USER_ENTRYKEY) must be(NotApplicable)
     }
     "return true when delete right" in {
-      Rights.of(USERNAME, Right.DeleteMessages)
-        .mayRemoveItems(USERNAME) must be(Applicable)
+      Rights.of(USER_ENTRYKEY, Right.DeleteMessages)
+        .mayRemoveItems(USER_ENTRYKEY) must be(Applicable)
     }
   }
   "mayRename" should  {
     "return unsupported" in {
-      Rights.EMPTY.mayRename(USERNAME) must be(Unsupported)
+      Rights.EMPTY.mayRename(USER_ENTRYKEY) must be(Unsupported)
     }
   }
   "mayDelete" should  {
     "return unsupported" in {
-      Rights.EMPTY.mayDelete(USERNAME) must be(Unsupported)
+      Rights.EMPTY.mayDelete(USER_ENTRYKEY) must be(Unsupported)
     }
   }
   "mayCreateChild" should  {
     "return unsupported" in {
-      Rights.EMPTY.mayCreateChild(USERNAME) must be(Unsupported)
+      Rights.EMPTY.mayCreateChild(USER_ENTRYKEY) must be(Unsupported)
     }
   }
 }


### PR DESCRIPTION
tackling [issue #5314](https://github.com/linagora/james-project/issues/5314)