### PR TITLE
[MAILET] Allow chaining composite matcher

### DIFF
--- a/docs/modules/servers/partials/configure/mailetcontainer.adoc
+++ b/docs/modules/servers/partials/configure/mailetcontainer.adoc
@@ -39,20 +39,31 @@ instead.
 
 == The Mailet Tag
 
-Consider the following simple *mailet* tag:</p>
+The mailet tag has two required attributes, condition tag and *class* tag.
 
-[source,xml]
-....
-<mailet match="RemoteAddrNotInNetwork=127.0.0.1" class="ToProcessor">
-    <processor>spam</processor>
-</mailet>
-....
+The condition tag need to be one of these tag:
 
-The mailet tag has two required attributes, *match* and *class*.
-
-The *match* attribute is set to the value of the specific Matcher class to be instantiated with a an
+- The *match* attribute is set to the value of the specific Matcher class to be instantiated with a an
 optional argument.  If present, the argument is separated from the Matcher class name by an '='.  Semantic
 interpretation of the argument is left to the particular mailet.
+  Example:
+
+    [source,xml]
+    ....
+    <mailet match="RemoteAddrNotInNetwork=127.0.0.1" class="ToProcessor">
+        <processor>spam</processor>
+    </mailet>
+    ....
+
+- The *notmatch* attribute inverts the according Matcher condition.
+  Example:
+
+    [source,xml]
+    ....
+    <mailet notmatch="RemoteAddrInNetwork=127.0.0.1" class="ToProcessor">
+        <processor>spam</processor>
+    </mailet>
+    ....
 
 The *class* attribute is set to the value of the Mailet class that is to be instantiated.
 

--- a/server/apps/memory-app/src/test/resources/mailetcontainer.xml
+++ b/server/apps/memory-app/src/test/resources/mailetcontainer.xml
@@ -52,8 +52,8 @@
             </mailet>
         </processor>
 
-
-        <processor state="transport" enableJmx="false">
+        <!-- Dummy processor to test chaining composite matchers-->
+        <processor state="dummy" enableJmx="false">
             <matcher name="relay-allowed" match="org.apache.james.mailetcontainer.impl.matchers.Or">
                 <matcher match="SMTPAuthSuccessful"/>
                 <matcher match="SMTPIsAuthNetwork"/>
@@ -67,6 +67,9 @@
                 <matcher notmatch="relay-allowed"/>
             </matcher>
             <mailet notmatch="chaining-not-matcher" class="org.apache.james.transport.mailets.debug.Counter"/>
+        </processor>
+
+        <processor state="transport" enableJmx="false">
             <mailet match="SMTPAuthSuccessful" class="SetMimeHeader">
                 <name>X-UserIsAuth</name>
                 <value>true</value>

--- a/server/apps/memory-app/src/test/resources/mailetcontainer.xml
+++ b/server/apps/memory-app/src/test/resources/mailetcontainer.xml
@@ -54,6 +54,15 @@
 
 
         <processor state="transport" enableJmx="false">
+            <matcher name="relay-allowed" match="org.apache.james.mailetcontainer.impl.matchers.Or">
+                <matcher match="SMTPAuthSuccessful"/>
+                <matcher match="SMTPIsAuthNetwork"/>
+                <matcher match="SentByMailet"/>
+                <matcher match="org.apache.james.jmap.mailet.SentByJmap"/>
+            </matcher>
+            <matcher name="chaining-matcher" match="org.apache.james.mailetcontainer.impl.matchers.Not">
+                <matcher match="relay-allowed"/>
+            </matcher>
             <mailet match="SMTPAuthSuccessful" class="SetMimeHeader">
                 <name>X-UserIsAuth</name>
                 <value>true</value>

--- a/server/apps/memory-app/src/test/resources/mailetcontainer.xml
+++ b/server/apps/memory-app/src/test/resources/mailetcontainer.xml
@@ -66,6 +66,7 @@
             <matcher name="chaining-not-matcher" match="org.apache.james.mailetcontainer.impl.matchers.Not">
                 <matcher notmatch="relay-allowed"/>
             </matcher>
+            <mailet notmatch="chaining-not-matcher" class="org.apache.james.transport.mailets.debug.Counter"/>
             <mailet match="SMTPAuthSuccessful" class="SetMimeHeader">
                 <name>X-UserIsAuth</name>
                 <value>true</value>

--- a/server/apps/memory-app/src/test/resources/mailetcontainer.xml
+++ b/server/apps/memory-app/src/test/resources/mailetcontainer.xml
@@ -63,6 +63,9 @@
             <matcher name="chaining-matcher" match="org.apache.james.mailetcontainer.impl.matchers.Not">
                 <matcher match="relay-allowed"/>
             </matcher>
+            <matcher name="chaining-not-matcher" match="org.apache.james.mailetcontainer.impl.matchers.Not">
+                <matcher notmatch="relay-allowed"/>
+            </matcher>
             <mailet match="SMTPAuthSuccessful" class="SetMimeHeader">
                 <name>X-UserIsAuth</name>
                 <value>true</value>

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
@@ -232,7 +232,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
                 // if no matcher is configured throw an Exception
                 throw new ConfigurationException("Please configure only match or nomatch per mailet");
             } else if (matcherName != null) {
-                matcher = matcherLoader.getMatcher(createMatcherConfig(matcherName));
+                matcher = loadMatcher(compMap, matcherName);
                 if (matcher instanceof CompositeMatcher) {
                     CompositeMatcher compMatcher = (CompositeMatcher) matcher;
 
@@ -295,13 +295,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
                     // if no matcher is configured throw an Exception
                     throw new ConfigurationException("Please configure only match or nomatch per mailet");
                 } else if (matcherName != null) {
-                    // try to load from compositeMatchers first
-                    matcher = compositeMatchers.get(matcherName);
-                    if (matcher == null) {
-                        // no composite Matcher found, try to load it via
-                        // MatcherLoader
-                        matcher = matcherLoader.getMatcher(createMatcherConfig(matcherName));
-                    }
+                    matcher = loadMatcher(compositeMatchers, matcherName);
                 } else if (invertedMatcherName != null) {
                     // no composite Matcher found, try to load it via MatcherLoader
                     matcher = matcherLoader.getMatcher(createMatcherConfig(invertedMatcherName));
@@ -341,6 +335,18 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
                 throw new ConfigurationException("Unable to load Mailet or Matcher");
             }
         }
+    }
+
+    private Matcher loadMatcher(Map<String, Matcher> compositeMatchers, String matcherName) throws MessagingException {
+        Matcher matcher;
+        // try to load from compositeMatchers first
+        matcher = compositeMatchers.get(matcherName);
+        if (matcher == null) {
+            // no composite Matcher found, try to load it via
+            // MatcherLoader
+            matcher = matcherLoader.getMatcher(createMatcherConfig(matcherName));
+        }
+        return matcher;
     }
 
     /**

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import jakarta.annotation.PostConstruct;
@@ -54,6 +55,7 @@ import org.apache.mailet.base.MatcherInverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -336,16 +338,9 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
         }
     }
 
-    private Matcher loadMatcher(Map<String, Matcher> compositeMatchers, String matcherName) throws MessagingException {
-        Matcher matcher;
-        // try to load from compositeMatchers first
-        matcher = compositeMatchers.get(matcherName);
-        if (matcher == null) {
-            // no composite Matcher found, try to load it via
-            // MatcherLoader
-            matcher = matcherLoader.getMatcher(createMatcherConfig(matcherName));
-        }
-        return matcher;
+    private Matcher loadMatcher(Map<String, Matcher> compositeMatchers, String matcherName) {
+        return Optional.ofNullable(compositeMatchers.get(matcherName))
+            .orElseGet(Throwing.supplier(() -> matcherLoader.getMatcher(createMatcherConfig(matcherName))));
     }
 
     /**

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
@@ -242,7 +242,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
                     }
                 }
             } else if (invertedMatcherName != null) {
-                Matcher m = matcherLoader.getMatcher(createMatcherConfig(invertedMatcherName));
+                Matcher m = loadMatcher(compMap, invertedMatcherName);
                 if (m instanceof CompositeMatcher) {
                     CompositeMatcher compMatcher = (CompositeMatcher) m;
 

--- a/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
+++ b/server/mailet/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
@@ -297,8 +297,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
                 } else if (matcherName != null) {
                     matcher = loadMatcher(compositeMatchers, matcherName);
                 } else if (invertedMatcherName != null) {
-                    // no composite Matcher found, try to load it via MatcherLoader
-                    matcher = matcherLoader.getMatcher(createMatcherConfig(invertedMatcherName));
+                    matcher = loadMatcher(compositeMatchers, invertedMatcherName);
                     matcher = new MatcherInverter(matcher);
 
                 } else {

--- a/server/mailet/mailetcontainer-impl/src/test/java/org/apache/james/mailetcontainer/impl/matchers/InvertMatcherWithCompositeMatcherTest.java
+++ b/server/mailet/mailetcontainer-impl/src/test/java/org/apache/james/mailetcontainer/impl/matchers/InvertMatcherWithCompositeMatcherTest.java
@@ -1,0 +1,158 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailetcontainer.impl.matchers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.server.core.MailImpl;
+import org.apache.mailet.Mail;
+import org.apache.mailet.Matcher;
+import org.apache.mailet.base.MatcherInverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InvertMatcherWithCompositeMatcherTest {
+    private And andTestee;
+    private Not notTestee;
+    private Or orTestee;
+    private Matcher matcher1;
+    private Matcher matcher2;
+    private Mail mail;
+    private MailAddress recipient1;
+    private MailAddress recipient2;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        matcher1 = mock(Matcher.class);
+        matcher2 = mock(Matcher.class);
+
+        andTestee = new And();
+        notTestee = new Not();
+        orTestee = new Or();
+
+        recipient1 = new MailAddress("1@apahe.org");
+        recipient2 = new MailAddress("2@apache.org");
+        mail = MailImpl.builder().name("name")
+            .addRecipients(recipient1, recipient2)
+            .build();
+    }
+
+    @Test
+    void invertMatchOfAnAndCompositeMatcher() throws Exception {
+        //  <matcher name="invert-of-an-and-matcher" notmatch="org.apache.james.mailetcontainer.impl.matchers.And">
+        //     <matcher match="matcher1"/>
+        //     <matcher match="matcher2"/>
+        //  </matcher>
+
+        when(matcher1.match(mail)).thenReturn(List.of(recipient1, recipient2));
+        when(matcher2.match(mail)).thenReturn(List.of(recipient1, recipient2));
+        andTestee.add(matcher1);
+        andTestee.add(matcher2);
+        MatcherInverter inverterMatcher = new MatcherInverter(andTestee);
+
+        assertThat(inverterMatcher.match(mail)).isNull();
+    }
+
+    @Test
+    void invertMatchOfAnAndCompositeMatcherTwoNonMatchCase() throws Exception {
+        //  <matcher name="invert-of-an-and-matcher" notmatch="org.apache.james.mailetcontainer.impl.matchers.And">
+        //     <matcher match="matcher1"/>
+        //     <matcher match="matcher2"/>
+        //  </matcher>
+
+        when(matcher1.match(mail)).thenReturn(List.of());
+        when(matcher2.match(mail)).thenReturn(List.of());
+        andTestee.add(matcher1);
+        andTestee.add(matcher2);
+        MatcherInverter inverterMatcher = new MatcherInverter(andTestee);
+
+        assertThat(inverterMatcher.match(mail)).containsExactlyInAnyOrder(recipient1, recipient2);
+    }
+
+    @Test
+    void invertMatchOfANotCompositeMatcher() throws Exception {
+        //  <matcher name="invert-of-a-not-matcher" notmatch="org.apache.james.mailetcontainer.impl.matchers.Not">
+        //     <matcher match="matcher1"/>
+        //     <matcher match="matcher2"/>
+        //  </matcher>
+
+        when(matcher1.match(mail)).thenReturn(List.of(recipient1));
+        when(matcher2.match(mail)).thenReturn(List.of(recipient2));
+        notTestee.add(matcher1);
+        notTestee.add(matcher2);
+        MatcherInverter inverterMatcher = new MatcherInverter(notTestee);
+
+        assertThat(inverterMatcher.match(mail)).containsExactlyInAnyOrder(recipient1, recipient2);
+    }
+
+    @Test
+    void invertMatchOfANotCompositeMatcherTwoNonMatchCase() throws Exception {
+        //  <matcher name="invert-of-a-not-matcher" notmatch="org.apache.james.mailetcontainer.impl.matchers.Not">
+        //     <matcher match="matcher1"/>
+        //     <matcher match="matcher2"/>
+        //  </matcher>
+
+        when(matcher1.match(mail)).thenReturn(List.of());
+        when(matcher2.match(mail)).thenReturn(List.of());
+        notTestee.add(matcher1);
+        notTestee.add(matcher2);
+        MatcherInverter inverterMatcher = new MatcherInverter(notTestee);
+
+        assertThat(inverterMatcher.match(mail)).isNull();
+    }
+
+    @Test
+    void invertMatchOfAnOrCompositeMatcher() throws Exception {
+        //  <matcher name="invert-of-a-or-matcher" notmatch="org.apache.james.mailetcontainer.impl.matchers.Or">
+        //     <matcher match="matcher1"/>
+        //     <matcher match="matcher2"/>
+        //  </matcher>
+
+        when(matcher1.match(mail)).thenReturn(List.of(recipient1));
+        when(matcher2.match(mail)).thenReturn(List.of(recipient2));
+        orTestee.add(matcher1);
+        orTestee.add(matcher2);
+        MatcherInverter inverterMatcher = new MatcherInverter(orTestee);
+
+        assertThat(inverterMatcher.match(mail)).isNull();
+    }
+
+    @Test
+    void invertMatchOfAnOrCompositeMatcherTwoNonMatchCase() throws Exception {
+        //  <matcher name="invert-of-a-or-matcher" notmatch="org.apache.james.mailetcontainer.impl.matchers.Or">
+        //     <matcher match="matcher1"/>
+        //     <matcher match="matcher2"/>
+        //  </matcher>
+
+        when(matcher1.match(mail)).thenReturn(List.of());
+        when(matcher2.match(mail)).thenReturn(List.of());
+        orTestee.add(matcher1);
+        orTestee.add(matcher2);
+        MatcherInverter inverterMatcher = new MatcherInverter(orTestee);
+
+        assertThat(inverterMatcher.match(mail)).containsExactlyInAnyOrder(recipient1, recipient2);
+    }
+
+}


### PR DESCRIPTION
```
<matcher name="relay-allowed" match="org.apache.james.mailetcontainer.impl.matchers.Or">
    <matcher match="SMTPAuthSuccessful"/>
    <matcher match="SMTPIsAuthNetwork"/>
    <matcher match="SentByMailet"/>
    <matcher match="org.apache.james.jmap.mailet.SentByJmap"/>
</matcher>
<matcher name="should-check-spam" match="org.apache.james.mailetcontainer.impl.matchers.Not">
    <matcher match="relay-allowed"/>
</matcher>
```
was not possible before.

Loading the matcher from composite matchers collection also, not only using class loader solves the issue.