### PR TITLE
IMAP - IDLE Command - Add test cases when authenticated state

### DIFF
--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -2198,6 +2198,44 @@ class IMAPServerTest {
         }
 
         @Test
+        void idleShouldAllowedWhenAuthenticatedState() throws Exception {
+            // Given an authenticated user
+            clientConnection.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
+            readBytes(clientConnection);
+
+            // When IDLE command is issued (Authenticated state)
+            clientConnection.write(ByteBuffer.wrap(("a3 IDLE\r\n").getBytes(StandardCharsets.UTF_8)));
+
+            // Then the server should respond Idling response
+            Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+                assertThat(readStringUntil(clientConnection, s -> s.contains("+ Idling")))
+                    .isNotNull());
+        }
+
+        @Test
+        void idleShouldDoNothingResponseWhenAuthenticatedStateAndHasNewMessages() throws Exception {
+            // Given an authenticated user
+            clientConnection.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
+            readBytes(clientConnection);
+
+            // When IDLE command is issued (Authenticated state)
+            clientConnection.write(ByteBuffer.wrap(("a3 IDLE\r\n").getBytes(StandardCharsets.UTF_8)));
+            readStringUntil(clientConnection, s -> s.contains("+ Idling"));
+
+            // And a new message is appended
+            inbox.appendMessage(MessageManager.AppendCommand.builder().build("h: value\r\n\r\nbody".getBytes()), mailboxSession);
+
+            ImmutableList.Builder<String> listenerResult = ImmutableList.builder();
+            Mono.fromCallable(() -> new String(readBytes(clientConnection), StandardCharsets.US_ASCII))
+                .doOnNext(listenerResult::add)
+                .subscribeOn(Schedulers.boundedElastic()).subscribe();
+
+            Thread.sleep(200);
+            // Then the server should not send any response
+            assertThat(listenerResult.build()).isEmpty();
+        }
+
+        @Test
         void idleShouldSendInitialContinuation() throws Exception {
             clientConnection.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
             readBytes(clientConnection);


### PR DESCRIPTION
- According to RFC 2177, IDLE is supported in the authenticated state, but it doesn't specify detailed behavior. Currently, James simply returns an idling state without any responding when new messages, similar to other mail services like Cyrus and Gmail.