### PR TITLE
[CNB] JAMES-4088 Ensure IMAP SELECT EXIST response is up to date

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxCounterCorrector.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxCounterCorrector.java
@@ -1,0 +1,41 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
+
+public interface MailboxCounterCorrector {
+    Logger LOGGER = LoggerFactory.getLogger(MailboxCounterCorrector.class);
+
+    MailboxCounterCorrector DEFAULT = id -> {
+        try {
+            LOGGER.warn("Invalid counter for {}", id.getMailboxEntity().getMailboxId().serialize());
+            return Mono.empty();
+        } catch (MailboxException e) {
+            throw new RuntimeException(e);
+        }
+    };
+
+    Mono<Void> fixCountersFor(MessageManager mailbox);
+}

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxCounterCorrector.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxCounterCorrector.java
@@ -19,23 +19,11 @@
 
 package org.apache.james.mailbox;
 
-import org.apache.james.mailbox.exception.MailboxException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import reactor.core.publisher.Mono;
 
 public interface MailboxCounterCorrector {
-    Logger LOGGER = LoggerFactory.getLogger(MailboxCounterCorrector.class);
 
-    MailboxCounterCorrector DEFAULT = id -> {
-        try {
-            LOGGER.warn("Invalid counter for {}", id.getMailboxEntity().getMailboxId().serialize());
-            return Mono.empty();
-        } catch (MailboxException e) {
-            throw new RuntimeException(e);
-        }
-    };
+    MailboxCounterCorrector DEFAULT = id -> Mono.empty();
 
     Mono<Void> fixCountersFor(MessageManager mailbox);
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/CassandraMailboxCounterCorrector.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/CassandraMailboxCounterCorrector.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.mailbox.MailboxCounterCorrector;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.exception.MailboxException;
+
+import reactor.core.publisher.Mono;
+
+public class CassandraMailboxCounterCorrector implements MailboxCounterCorrector {
+    private final RecomputeMailboxCountersService service;
+
+    @Inject
+    public CassandraMailboxCounterCorrector(RecomputeMailboxCountersService service) {
+        this.service = service;
+    }
+
+    @Override
+    public Mono<Void> fixCountersFor(MessageManager mailbox) {
+        try {
+            return service.recomputeMailboxCounter(new RecomputeMailboxCountersService.Context(),
+                    mailbox.getMailboxEntity(),
+                    RecomputeMailboxCountersService.Options.trustMessageProjection())
+                .then();
+        } catch (MailboxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -395,6 +395,8 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
         responder.respond(new ExistsResponse(realMessageCount));
 
         if (messageCount != realMessageCount) {
+            LOGGER.warn("Invalid counter for {}, was {} and should have been {}", selectedMailbox.getMessageManager().getId().serialize(),
+                messageCount, realMessageCount);
             mailboxCounterCorrector.fixCountersFor(selectedMailbox.getMessageManager())
                 .subscribeOn(Schedulers.parallel())
                 .subscribe();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessor.java
@@ -34,6 +34,7 @@ import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.processor.base.AbstractProcessor;
 import org.apache.james.imap.processor.base.ImapResponseMessageProcessor;
 import org.apache.james.imap.processor.fetch.FetchProcessor;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.quota.QuotaManager;
@@ -55,6 +56,7 @@ public class DefaultProcessor implements ImapProcessor {
                                                        MailboxTyper mailboxTyper,
                                                        QuotaManager quotaManager,
                                                        QuotaRootResolver quotaRootResolver,
+                                                       MailboxCounterCorrector mailboxCounterCorrector,
                                                        MetricFactory metricFactory) {
         PathConverter.Factory pathConverterFactory = PathConverter.Factory.DEFAULT;
 
@@ -76,7 +78,7 @@ public class DefaultProcessor implements ImapProcessor {
         builder.add(new AuthenticateProcessor(mailboxManager, statusResponseFactory, metricFactory, pathConverterFactory));
         builder.add(new ExpungeProcessor(mailboxManager, statusResponseFactory, metricFactory));
         builder.add(new ReplaceProcessor(mailboxManager, statusResponseFactory, metricFactory, pathConverterFactory));
-        builder.add(new ExamineProcessor(mailboxManager, eventBus, statusResponseFactory, metricFactory, pathConverterFactory));
+        builder.add(new ExamineProcessor(mailboxManager, eventBus, statusResponseFactory, metricFactory, pathConverterFactory, mailboxCounterCorrector));
         builder.add(new AppendProcessor(mailboxManager, statusResponseFactory, metricFactory, pathConverterFactory));
         builder.add(new StoreProcessor(mailboxManager, statusResponseFactory, metricFactory));
         builder.add(new NoopProcessor(mailboxManager, statusResponseFactory, metricFactory));
@@ -87,7 +89,7 @@ public class DefaultProcessor implements ImapProcessor {
         builder.add(new XListProcessor(mailboxManager, statusResponseFactory, mailboxTyper, metricFactory, subscriptionManager, pathConverterFactory));
         builder.add(new ListProcessor<>(mailboxManager, statusResponseFactory, metricFactory, subscriptionManager, statusProcessor, mailboxTyper, pathConverterFactory));
         builder.add(new SearchProcessor(mailboxManager, statusResponseFactory, metricFactory));
-        builder.add(new SelectProcessor(mailboxManager, eventBus, statusResponseFactory, metricFactory, pathConverterFactory));
+        builder.add(new SelectProcessor(mailboxManager, eventBus, statusResponseFactory, metricFactory, pathConverterFactory, mailboxCounterCorrector));
         builder.add(new NamespaceProcessor(mailboxManager, statusResponseFactory, metricFactory, new NamespaceSupplier.Default()));
         builder.add(new FetchProcessor(mailboxManager, statusResponseFactory, metricFactory));
         builder.add(new StartTLSProcessor(statusResponseFactory));

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ExamineProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ExamineProcessor.java
@@ -30,6 +30,7 @@ import org.apache.james.imap.api.message.UidRange;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.ExamineRequest;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
@@ -38,8 +39,8 @@ public class ExamineProcessor extends AbstractSelectionProcessor<ExamineRequest>
 
     @Inject
     public ExamineProcessor(MailboxManager mailboxManager, EventBus eventBus, StatusResponseFactory statusResponseFactory,
-                            MetricFactory metricFactory, PathConverter.Factory pathConverterFactory) {
-        super(ExamineRequest.class, mailboxManager, statusResponseFactory, pathConverterFactory, true, metricFactory, eventBus);
+                            MetricFactory metricFactory, PathConverter.Factory pathConverterFactory, MailboxCounterCorrector mailboxCounterCorrector) {
+        super(ExamineRequest.class, mailboxManager, statusResponseFactory, pathConverterFactory, true, metricFactory, eventBus, mailboxCounterCorrector);
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SelectProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SelectProcessor.java
@@ -30,6 +30,7 @@ import org.apache.james.imap.api.message.UidRange;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.SelectRequest;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
@@ -38,8 +39,8 @@ public class SelectProcessor extends AbstractSelectionProcessor<SelectRequest> {
 
     @Inject
     public SelectProcessor(MailboxManager mailboxManager, EventBus eventBus, StatusResponseFactory statusResponseFactory,
-                           MetricFactory metricFactory, PathConverter.Factory pathConverterFactory) {
-        super(SelectRequest.class, mailboxManager, statusResponseFactory, pathConverterFactory, false, metricFactory, eventBus);
+                           MetricFactory metricFactory, PathConverter.Factory pathConverterFactory, MailboxCounterCorrector mailboxCounterCorrector) {
+        super(SelectRequest.class, mailboxManager, statusResponseFactory, pathConverterFactory, false, metricFactory, eventBus, mailboxCounterCorrector);
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/main/DefaultImapProcessorFactory.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/main/DefaultImapProcessorFactory.java
@@ -27,6 +27,7 @@ import org.apache.james.imap.api.process.MailboxTyper;
 import org.apache.james.imap.message.response.UnpooledStatusResponseFactory;
 import org.apache.james.imap.processor.DefaultProcessor;
 import org.apache.james.imap.processor.base.UnknownRequestProcessor;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.quota.QuotaManager;
@@ -48,7 +49,7 @@ public class DefaultImapProcessorFactory {
         UnknownRequestProcessor unknownRequestImapProcessor = new UnknownRequestProcessor(statusResponseFactory);
 
         return DefaultProcessor.createDefaultProcessor(unknownRequestImapProcessor, mailboxManager,
-            eventBus, subscriptionManager, statusResponseFactory, mailboxTyper, quotaManager, quotaRootResolver, metricFactory);
+            eventBus, subscriptionManager, statusResponseFactory, mailboxTyper, quotaManager, quotaRootResolver, MailboxCounterCorrector.DEFAULT, metricFactory);
     }
 
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/AbstractSelectionProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/AbstractSelectionProcessorTest.java
@@ -31,6 +31,7 @@ import org.apache.james.imap.api.message.UidRange;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.SelectedMailbox;
 import org.apache.james.imap.main.PathConverter;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.metrics.api.MetricFactory;
@@ -46,7 +47,8 @@ public class AbstractSelectionProcessorTest {
         EventBus eventBus = null;
         StatusResponseFactory statusResponseFactory = null;
         MetricFactory metricFactory = null;
-        testee = new SelectProcessor(mailboxManager, eventBus, statusResponseFactory, metricFactory, PathConverter.Factory.DEFAULT);
+        MailboxCounterCorrector mailboxCounterCorrector = null;
+        testee = new SelectProcessor(mailboxManager, eventBus, statusResponseFactory, metricFactory, PathConverter.Factory.DEFAULT, mailboxCounterCorrector);
     }
 
     @Test

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SelectProcessorTest.java
@@ -41,6 +41,7 @@ import org.apache.james.imap.main.ResponseEncoder;
 import org.apache.james.imap.message.request.AbstractMailboxSelectionRequest;
 import org.apache.james.imap.message.request.SelectRequest;
 import org.apache.james.imap.message.response.UnpooledStatusResponseFactory;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
@@ -66,11 +67,13 @@ class SelectProcessorTest {
         InMemoryIntegrationResources integrationResources = InMemoryIntegrationResources.defaultResources();
 
         mailboxManager = integrationResources.getMailboxManager();
+        MailboxCounterCorrector mailboxCounterCorrector = null;
         testee = new SelectProcessor(mailboxManager,
             integrationResources.getEventBus(),
             new UnpooledStatusResponseFactory(),
             new RecordingMetricFactory(),
-            PathConverter.Factory.DEFAULT);
+            PathConverter.Factory.DEFAULT,
+            mailboxCounterCorrector);
 
         mailboxSession = mailboxManager.createSystemSession(Username.of("bob"));
         mailboxManager.createMailbox(MailboxPath.inbox(BOB), mailboxSession);

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
@@ -55,6 +55,7 @@ import org.apache.james.mailbox.AttachmentContentLoader;
 import org.apache.james.mailbox.AttachmentIdFactory;
 import org.apache.james.mailbox.AttachmentManager;
 import org.apache.james.mailbox.Authenticator;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MessageIdManager;
@@ -89,6 +90,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
 import org.apache.james.mailbox.cassandra.mail.CassandraUserMailboxRightsDAO;
 import org.apache.james.mailbox.cassandra.mail.MessageBlobReferenceSource;
 import org.apache.james.mailbox.cassandra.mail.eventsourcing.acl.ACLModule;
+import org.apache.james.mailbox.cassandra.mail.task.CassandraMailboxCounterCorrector;
 import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
 import org.apache.james.mailbox.cassandra.modules.CassandraAnnotationModule;
 import org.apache.james.mailbox.cassandra.modules.CassandraApplicableFlagsModule;
@@ -180,6 +182,7 @@ public class CassandraMailboxModule extends AbstractModule {
         bind(UserRepositoryAuthenticator.class).in(Scopes.SINGLETON);
         bind(EmailChangeRepositoryDAO.class).in(Scopes.SINGLETON);
         bind(MailboxChangeRepositoryDAO.class).in(Scopes.SINGLETON);
+        bind(CassandraMailboxCounterCorrector.class).in(Scopes.SINGLETON);
 
         bind(ReIndexerImpl.class).in(Scopes.SINGLETON);
         bind(MessageIdReIndexerImpl.class).in(Scopes.SINGLETON);
@@ -211,6 +214,7 @@ public class CassandraMailboxModule extends AbstractModule {
         bind(RightManager.class).to(StoreRightManager.class);
         bind(SessionProvider.class).to(SessionProviderImpl.class);
         bind(AttachmentContentLoader.class).to(AttachmentManager.class);
+        bind(MailboxCounterCorrector.class).to(CassandraMailboxCounterCorrector.class);
 
         bind(Limit.class).annotatedWith(Names.named(CassandraEmailChangeRepository.LIMIT_NAME)).toInstance(Limit.of(256));
         bind(Limit.class).annotatedWith(Names.named(CassandraMailboxChangeRepository.LIMIT_NAME)).toInstance(Limit.of(256));

--- a/server/container/guice/mailbox-jpa/src/main/java/org/apache/james/modules/mailbox/JPAMailboxModule.java
+++ b/server/container/guice/mailbox-jpa/src/main/java/org/apache/james/modules/mailbox/JPAMailboxModule.java
@@ -33,6 +33,7 @@ import org.apache.james.mailbox.AttachmentContentLoader;
 import org.apache.james.mailbox.AttachmentIdFactory;
 import org.apache.james.mailbox.Authenticator;
 import org.apache.james.mailbox.Authorizator;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.SessionProvider;
@@ -120,6 +121,7 @@ public class JPAMailboxModule extends AbstractModule {
         bind(MailboxACLResolver.class).to(UnionMailboxACLResolver.class);
         bind(AttachmentIdFactory.class).to(StringBackedAttachmentIdFactory.class);
         bind(AttachmentContentLoader.class).to(JPAAttachmentContentLoader.class);
+        bind(MailboxCounterCorrector.class).toInstance(MailboxCounterCorrector.DEFAULT);
 
         bind(ReIndexer.class).to(ReIndexerImpl.class);
         

--- a/server/container/guice/memory/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
+++ b/server/container/guice/memory/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.AttachmentIdFactory;
 import org.apache.james.mailbox.AttachmentManager;
 import org.apache.james.mailbox.Authenticator;
 import org.apache.james.mailbox.Authorizator;
+import org.apache.james.mailbox.MailboxCounterCorrector;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MessageIdManager;
@@ -131,6 +132,7 @@ public class MemoryMailboxModule extends AbstractModule {
         bind(AttachmentContentLoader.class).to(AttachmentManager.class);
 
         bind(DeletedMessageMetadataVault.class).to(MemoryDeletedMessageMetadataVault.class);
+        bind(MailboxCounterCorrector.class).toInstance(MailboxCounterCorrector.DEFAULT);
 
         bind(InMemoryMailboxSessionMapperFactory.class).in(Scopes.SINGLETON);
         bind(InMemoryModSeqProvider.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
This is critical for Mail User Agent like Apple mail relying on MSN FETCH for resynchronisation. Outdated counters, meant to be expected with Cassandra implementation would lead to terminal errors aborting mail resynchronisation.

Instead, use the content of the just loaded selected mailbox, accurate and piggyback counter asynchronous correction as needed.