### PR TITLE
JAMES-3893 Identity routes should not return 500 code when invalid username

### DIFF
--- a/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
@@ -326,6 +326,68 @@ public abstract class WebAdminServerIntegrationTest {
             .body("message", is("Default identity can not be found"));
     }
 
+    @Test
+    void getIdentitiesOfInvalidUserShouldReturnBadRequest() {
+        given()
+            .get(String.format("/users/%s/identities?default=true", "John Doe"))
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void createIdentitiesForInvalidUserShouldReturnBadRequest() {
+        given()
+            .body("{\n" +
+                "  \"name\": \"create name 1\",\n" +
+                "  \"email\": \"bob@domain.tld\",\n" +
+                "  \"textSignature\": \"create textSignature1\",\n" +
+                "  \"htmlSignature\": \"create htmlSignature1\",\n" +
+                "  \"sortOrder\": 99,\n" +
+                "  \"bcc\": [\n" +
+                "    {\n" +
+                "      \"name\": \"create bcc 1\",\n" +
+                "      \"email\": \"create_boss_bcc_1@domain.tld\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"replyTo\": [\n" +
+                "    {\n" +
+                "      \"name\": \"create replyTo 1\",\n" +
+                "      \"email\": \"create_boss1@domain.tld\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}")
+            .post(String.format("/users/%s/identities", "John Doe"))
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void updateIdentitiesForInvalidUserShouldReturnBadRequest() {
+        given()
+            .body("{\n" +
+                "  \"name\": \"create name 1\",\n" +
+                "  \"email\": \"bob@domain.tld\",\n" +
+                "  \"textSignature\": \"create textSignature1\",\n" +
+                "  \"htmlSignature\": \"create htmlSignature1\",\n" +
+                "  \"sortOrder\": 99,\n" +
+                "  \"bcc\": [\n" +
+                "    {\n" +
+                "      \"name\": \"create bcc 1\",\n" +
+                "      \"email\": \"create_boss_bcc_1@domain.tld\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"replyTo\": [\n" +
+                "    {\n" +
+                "      \"name\": \"create replyTo 1\",\n" +
+                "      \"email\": \"create_boss1@domain.tld\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}")
+            .put(String.format("/users/%s/identities/b1c924a3-5b86-44fa-a036-77825ec0e3e6", "John Doe"))
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
     // Immutable
     @Test
     void validateHealthChecksShouldReturnOk() {


### PR DESCRIPTION
Calling `POST /users/John Doe/identities` yields 500 Internal Server Error:
```java
java.lang.IllegalStateException: null
	at com.google.common.base.Preconditions.checkState(Preconditions.java:499)
	at org.apache.james.core.Username.asMailAddress(Username.java:129)
	at com.github.fge.lambdas.functions.FunctionChainer.lambda$sneakyThrow$49(FunctionChainer.java:74)
	at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onNext(FluxMap.java:208)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.tryEmitScalar(FluxFlatMap.java:492)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:424)
	at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:122)
	at reactor.core.publisher.FluxExpand$ExpandBreathSubscriber.onNext(FluxExpand.java:118)
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2571)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2367)
	at reactor.core.publisher.FluxExpand$ExpandBreathSubscriber.onSubscribe(FluxExpand.java:112)
	at reactor.core.publisher.FluxJust.subscribe(FluxJust.java:68)
	at reactor.core.publisher.Flux.subscribe(Flux.java:8840)
	at reactor.core.publisher.FluxExpand$ExpandBreathSubscriber.drainQueue(FluxExpand.java:179)
	at reactor.core.publisher.FluxExpand.subscribeOrReturn(FluxExpand.java:71)
	at reactor.core.publisher.Flux.subscribe(Flux.java:8825)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:430)
	at reactor.core.publisher.FluxArray$ArraySubscription.slowPath(FluxArray.java:126)
	at reactor.core.publisher.FluxArray$ArraySubscription.request(FluxArray.java:99)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onSubscribe(FluxFlatMap.java:373)
	at reactor.core.publisher.FluxMerge.subscribe(FluxMerge.java:73)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
	at reactor.core.scala.publisher.SMono.subscribe(SMono.scala:1136)
	at reactor.core.scala.publisher.SMono.subscribe$(SMono.scala:1136)
	at reactor.core.scala.publisher.ReactiveSMono.subscribe(ReactiveSMono.scala:8)
	at reactor.core.publisher.FluxSource.subscribe(FluxSource.java:71)
	at reactor.core.publisher.Flux.subscribe(Flux.java:8840)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:430)
	at reactor.core.publisher.FluxArray$ArraySubscription.slowPath(FluxArray.java:126)
	at reactor.core.publisher.FluxArray$ArraySubscription.request(FluxArray.java:99)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onSubscribe(FluxFlatMap.java:373)
	at reactor.core.publisher.FluxMerge.subscribe(FluxMerge.java:73)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
	at reactor.core.scala.publisher.SMono.subscribe(SMono.scala:1136)
	at reactor.core.scala.publisher.SMono.subscribe$(SMono.scala:1136)
	at reactor.core.scala.publisher.ReactiveSMono.subscribe(ReactiveSMono.scala:8)
	at reactor.core.publisher.MonoFromPublisher.subscribe(MonoFromPublisher.java:64)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
	at reactor.core.scala.publisher.SMono.subscribe(SMono.scala:1136)
	at reactor.core.scala.publisher.SMono.subscribe$(SMono.scala:1136)
	at reactor.core.scala.publisher.ReactiveSMono.subscribe(ReactiveSMono.scala:8)
	at reactor.core.publisher.MonoFromPublisher.subscribe(MonoFromPublisher.java:64)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
	at reactor.core.publisher.Mono.block(Mono.java:1778)
	at org.apache.james.webadmin.data.jmap.UserIdentityRoutes.createIdentity(UserIdentityRoutes.java:128)
	at spark.RouteImpl$1.handle(RouteImpl.java:72)
	at spark.http.matching.Routes.execute(Routes.java:61)
	at spark.http.matching.MatcherFilter.doFilter(MatcherFilter.java:134)
	at spark.embeddedserver.jetty.JettyHandler.doHandle(JettyHandler.java:50)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1598)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:516)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
	at java.base/java.lang.Thread.run(Unknown Source)
	Suppressed: java.lang.Exception: #block terminated with an error
		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
		at reactor.core.publisher.Mono.block(Mono.java:1779)
		... 24 common frames omitted
```

