### PR TITLE
JAMES-3945 advertize that subaddressing is supported

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
@@ -107,7 +107,7 @@ object CustomMethodContract {
       |    "urn:apache:james:params:jmap:mail:identity:sortorder": {},
       |    "urn:apache:james:params:jmap:delegation": {},
       |    "$CUSTOM": {"custom": "property"},
-      |    "urn:apache:james:params:jmap:mail:shares": {},
+      |    "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
       |    "urn:ietf:params:jmap:vacationresponse":{},
       |    "urn:ietf:params:jmap:mdn":{}
       |  },
@@ -147,7 +147,7 @@ object CustomMethodContract {
       |        "urn:ietf:params:jmap:quota": {},
       |        "urn:apache:james:params:jmap:mail:identity:sortorder": {},
       |        "urn:apache:james:params:jmap:delegation": {},
-      |        "urn:apache:james:params:jmap:mail:shares": {},
+      |        "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
       |        "$CUSTOM": {"custom": "property"},
       |        "urn:ietf:params:jmap:vacationresponse":{},
       |        "urn:ietf:params:jmap:mdn":{}

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/DisabledCapabilityContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/DisabledCapabilityContract.scala
@@ -62,7 +62,7 @@ object DisabledCapabilityContract {
       |    "urn:ietf:params:jmap:quota": {},
       |    "urn:apache:james:params:jmap:mail:identity:sortorder": {},
       |    "urn:apache:james:params:jmap:delegation": {},
-      |    "urn:apache:james:params:jmap:mail:shares": {},
+      |    "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
       |    "urn:ietf:params:jmap:vacationresponse":{},
       |    "urn:ietf:params:jmap:mdn":{}
       |  },
@@ -94,7 +94,7 @@ object DisabledCapabilityContract {
       |        "urn:ietf:params:jmap:quota": {},
       |        "urn:apache:james:params:jmap:mail:identity:sortorder": {},
       |        "urn:apache:james:params:jmap:delegation": {},
-      |        "urn:apache:james:params:jmap:mail:shares": {},
+      |        "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
       |        "urn:ietf:params:jmap:vacationresponse":{},
       |        "urn:ietf:params:jmap:mdn":{}
       |      }

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailSubmissionSetMethodFutureReleaseContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailSubmissionSetMethodFutureReleaseContract.scala
@@ -82,7 +82,7 @@ case object EmailSubmissionSetMethodFutureReleaseContract {
       |    "urn:ietf:params:jmap:quota": {},
       |    "urn:apache:james:params:jmap:mail:identity:sortorder": {},
       |    "urn:apache:james:params:jmap:delegation": {},
-      |    "urn:apache:james:params:jmap:mail:shares": {},
+      |    "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
       |    "urn:ietf:params:jmap:vacationresponse":{},
       |    "urn:ietf:params:jmap:mdn":{}
       |  },
@@ -122,7 +122,7 @@ case object EmailSubmissionSetMethodFutureReleaseContract {
       |        "urn:ietf:params:jmap:quota": {},
       |        "urn:apache:james:params:jmap:mail:identity:sortorder": {},
       |        "urn:apache:james:params:jmap:delegation": {},
-      |        "urn:apache:james:params:jmap:mail:shares": {},
+      |        "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
       |        "urn:ietf:params:jmap:vacationresponse":{},
       |        "urn:ietf:params:jmap:mdn":{}
       |      }

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
@@ -72,7 +72,7 @@ object SessionRoutesContract {
                          |    "urn:ietf:params:jmap:quota": {},
                          |    "urn:apache:james:params:jmap:mail:identity:sortorder": {},
                          |    "urn:apache:james:params:jmap:delegation": {},
-                         |    "urn:apache:james:params:jmap:mail:shares": {},
+                         |    "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
                          |    "urn:ietf:params:jmap:vacationresponse":{},
                          |    "urn:ietf:params:jmap:mdn":{}
                          |  },
@@ -112,7 +112,7 @@ object SessionRoutesContract {
                          |        "urn:ietf:params:jmap:quota": {},
                          |        "urn:apache:james:params:jmap:mail:identity:sortorder": {},
                          |        "urn:apache:james:params:jmap:delegation": {},
-                         |        "urn:apache:james:params:jmap:mail:shares": {},
+                         |        "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
                          |        "urn:ietf:params:jmap:vacationresponse":{},
                          |        "urn:ietf:params:jmap:mdn":{}
                          |      }
@@ -260,7 +260,7 @@ trait SessionRoutesContract {
                    |                    "i;unicode-casemap"
                    |                ]
                    |            },
-                   |            "urn:apache:james:params:jmap:mail:shares": {},
+                   |            "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
                    |            "urn:ietf:params:jmap:vacationresponse": {},
                    |            "urn:ietf:params:jmap:mail": {
                    |                "maxMailboxesPerEmail": 10000000,
@@ -309,7 +309,7 @@ trait SessionRoutesContract {
                    |                    "i;unicode-casemap"
                    |                ]
                    |            },
-                   |            "urn:apache:james:params:jmap:mail:shares": {},
+                   |            "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
                    |            "urn:ietf:params:jmap:vacationresponse": {},
                    |            "urn:ietf:params:jmap:mail": {
                    |                "maxMailboxesPerEmail": 10000000,

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/rights.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/mail/rights.mdown
@@ -21,6 +21,14 @@ If specified, behavioral changes and additional fields defined hereafter MUST ap
 
 If unspecified no additional fields to the Mailbox object are returned, and the behaviour needs to be exactly the one of `urn:ietf:params:jmap:mail`.
 
+## Addition to the capability object
+
+Servers supporting *subaddressing* need to advertise it through the session capabilities by adding the following field to the `urn:apache:james:params:jmap:mail:shares` capability object:
+
+- `subaddressingSupported`: *true*
+
+If this field is not present, then it should be assumed that subaddressing is NOT supported.
+
 ## Addition to existing data types
 
 The following data types are defined:

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capability.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capability.scala
@@ -317,7 +317,7 @@ case object DelegationCapabilityFactory extends CapabilityFactory {
 }
 
 final case class SharesCapabilityProperties() extends CapabilityProperties {
-  override def jsonify(): JsObject = Json.obj()
+  override def jsonify(): JsObject = Json.obj("subaddressingSupported" -> true)
 }
 
 case object SharesCapabilityFactory extends CapabilityFactory {

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/SessionSerializationTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/SessionSerializationTest.scala
@@ -145,7 +145,7 @@ class SessionSerializationTest extends AnyWordSpec with Matchers {
           |      "mayCreateTopLevelMailbox": true
           |    },
           |    "urn:apache:james:params:jmap:mail:quota":{},
-          |    "urn:apache:james:params:jmap:mail:shares":{},
+          |    "urn:apache:james:params:jmap:mail:shares":{"subaddressingSupported":true},
           |    "urn:ietf:params:jmap:vacationresponse":{}
           |  },
           |  "accounts": {

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/SessionRoutesTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/SessionRoutesTest.scala
@@ -162,7 +162,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |    "urn:apache:james:params:jmap:delegation": {},
                          |    "urn:apache:james:params:jmap:mail:quota": {},
                          |    "urn:ietf:params:jmap:quota": {},
-                         |    "urn:apache:james:params:jmap:mail:shares": {},
+                         |    "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
                          |    "urn:ietf:params:jmap:vacationresponse":{}
                          |  },
                          |  "accounts" : {
@@ -201,7 +201,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |        "urn:ietf:params:jmap:quota": {},
                          |        "urn:apache:james:params:jmap:mail:identity:sortorder": {},
                          |        "urn:apache:james:params:jmap:delegation": {},
-                         |        "urn:apache:james:params:jmap:mail:shares": {},
+                         |        "urn:apache:james:params:jmap:mail:shares": {"subaddressingSupported":true},
                          |        "urn:ietf:params:jmap:vacationresponse":{}
                          |      }
                          |    }


### PR DESCRIPTION
[jira JAMES-3945 ticket for subaddressing](https://issues.apache.org/jira/browse/JAMES-3945)

subaddressing has now been implemented on the backend side, but not fully deployed. we need to have the frontend automatically detect if the backend supports subaddressing or not.

thus i modified the `urn:apache:james:params:jmap:mail:shares` capability to add a `subaddressingSupported` property (boolean). if this property is not defined, then the frontend should assume it is not supported.