### PR TITLE
[FIX] Domain validation should be more informative - Fixup message

### DIFF
--- a/core/src/main/java/org/apache/james/core/Domain.java
+++ b/core/src/main/java/org/apache/james/core/Domain.java
@@ -56,7 +56,7 @@ public class Domain implements Serializable {
 
         String domainWithoutBrackets = removeBrackets(domain);
         Preconditions.checkArgument(PART_CHAR_MATCHER.matchesAllOf(domainWithoutBrackets),
-            "Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {}", domain);
+            "Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in %s", domain);
 
         int pos = 0;
         int nextDot = domainWithoutBrackets.indexOf('.');

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -5924,7 +5924,7 @@ trait MailboxSetMethodContract {
          |      "notUpdated": {
          |        "${mailboxId.serialize}": {
          |          "type": "invalidArguments",
-         |          "description": "Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [invalid@domain.tld]"
+         |          "description": "Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in invalid@domain.tld"
          |        }
          |      }
          |    }, "c1"]

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DLPConfigurationRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DLPConfigurationRoutesTest.java
@@ -329,7 +329,7 @@ class DLPConfigurationRoutesTest {
                 .body("statusCode", is(HttpStatus.BAD_REQUEST_400))
                 .body("type", is("InvalidArgument"))
                 .body("message", is("Invalid arguments supplied in the user request"))
-                .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [dr@strange.com]"));
+                .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in dr@strange.com"));
         }
 
         @Test
@@ -646,7 +646,7 @@ class DLPConfigurationRoutesTest {
                 .body("statusCode", is(HttpStatus.BAD_REQUEST_400))
                 .body("type", is("InvalidArgument"))
                 .body("message", is("Invalid arguments supplied in the user request"))
-                .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [dr@strange.com]"));
+                .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in dr@strange.com"));
         }
     }
 
@@ -859,7 +859,7 @@ class DLPConfigurationRoutesTest {
                 .body("statusCode", is(HttpStatus.BAD_REQUEST_400))
                 .body("type", is("InvalidArgument"))
                 .body("message", is("Invalid arguments supplied in the user request"))
-                .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [dr@strange.com]"));
+                .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in dr@strange.com"));
         }
     }
     

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/MappingRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/MappingRoutesTest.java
@@ -640,7 +640,7 @@ class MappingRoutesTest {
         .body("statusCode", is(400))
         .body("type", is("InvalidArgument"))
         .body("message", is("Invalid arguments supplied in the user request"))
-        .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [domain@domain.tld]"));
+        .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in domain@domain.tld"));
     }
 
     @Test

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RecomputeUserFastViewProjectionItemsRequestToTaskTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RecomputeUserFastViewProjectionItemsRequestToTaskTest.java
@@ -242,7 +242,7 @@ class RecomputeUserFastViewProjectionItemsRequestToTaskTest {
             .body("statusCode", is(400))
             .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
             .body("message", is("Invalid arguments supplied in the user request"))
-            .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [bad@bad]"));
+            .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in bad@bad"));
     }
 
     @Test

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -1577,7 +1577,7 @@ class UserMailboxesRoutesTest {
                     .body("statusCode", Matchers.is(400))
                     .body("type", Matchers.is("InvalidArgument"))
                     .body("message", Matchers.is("Invalid arguments supplied in the user request"))
-                    .body("details", Matchers.is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [bad@bad]"));
+                    .body("details", Matchers.is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in bad@bad"));
             }
         }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/MailboxesExportRequestToTaskTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/MailboxesExportRequestToTaskTest.java
@@ -178,7 +178,7 @@ class MailboxesExportRequestToTaskTest {
             .body("statusCode", is(400))
             .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
             .body("message", is("Invalid arguments supplied in the user request"))
-            .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [bad@bad]"));
+            .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in bad@bad"));
     }
 
     @Test

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/SubscribeAllRequestToTaskTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/service/SubscribeAllRequestToTaskTest.java
@@ -176,7 +176,7 @@ class SubscribeAllRequestToTaskTest {
             .body("statusCode", is(400))
             .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
             .body("message", is("Invalid arguments supplied in the user request"))
-            .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in {} [bad@bad]"));
+            .body("details", is("Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in bad@bad"));
     }
 
     @Test


### PR DESCRIPTION
ref: 980d3144e9a0be6258d9570c04b9351231536aaf

- Fix mistake placeholder `%s` vs `{}`