### PR TITLE
[FIX] Ability to split emails with large recipient counts

### DIFF
--- a/docs/modules/servers/partials/MailToAllUsers.adoc
+++ b/docs/modules/servers/partials/MailToAllUsers.adoc
@@ -1,12 +1,6 @@
 === MailToAllUsers
 
-A mailet that helps to email to all users in the system. The emails are sent in batches to manage
-the load. The first batch is sent directly, while the remaining batches are sent asynchronously.
-
-==== Configuration parameters
-
-*batchSize*::
-The number of recipients to include in each batch. Optional, default to 100.
+A mailet that helps to email to all users in the system.
 
 ==== Sample configuration
 
@@ -16,9 +10,7 @@ The number of recipients to include in each batch. Optional, default to 100.
     <matcher match="SenderIs=admin@gov.org"/>
     <matcher match="RecipientIs=all@gov.org"/>
 </matcher>
-<mailet match="notify-matcher" class="MailToAllUsers">
-    <batchSize>100</batchSize>
-</mailet>
+<mailet match="notify-matcher" class="MailToAllUsers"/>
 ----
 
 

--- a/docs/modules/servers/partials/SplitMail.adoc
+++ b/docs/modules/servers/partials/SplitMail.adoc
@@ -1,0 +1,16 @@
+=== MailToAllUsers
+
+A mailet to split email with too much recipients. The first batch is sent directly, while the remaining batches are sent asynchronously.
+The batch size can be configured via the <b>batchSize</b> parameter (optional, defaults to 100).
+
+==== Sample configuration
+
+[source,xml]
+----
+<mailet match="notify-matcher" class="SplitMail">
+  <batchSize>100</batchSize>
+</mailet>
+----
+
+
+

--- a/docs/modules/servers/partials/SplitMail.adoc
+++ b/docs/modules/servers/partials/SplitMail.adoc
@@ -1,4 +1,4 @@
-=== MailToAllUsers
+=== SplitMail
 
 A mailet to split email with too much recipients. The first batch is sent directly, while the remaining batches are sent asynchronously.
 The batch size can be configured via the <b>batchSize</b> parameter (optional, defaults to 100).

--- a/docs/modules/servers/partials/configure/mailets.adoc
+++ b/docs/modules/servers/partials/configure/mailets.adoc
@@ -45,6 +45,8 @@ include::partial$MailAttributesListToMimeHeaders.adoc[]
 
 include::partial$MailAttributesToMimeHeaders.adoc[]
 
+include::partial$MailToAllUsers.adoc[]
+
 include::partial$MetricsMailet.adoc[]
 
 include::partial$MimeDecodingMailet.adoc[]
@@ -96,6 +98,8 @@ include::partial$SMIMESign.adoc[]
 include::partial$SpamAssassin.adoc[]
 
 include::partial$StripAttachment.adoc[]
+
+include::partial$SplitMail.adoc[]
 
 include::partial$TextCalendarBodyToAttachment.adoc[]
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SplitMail.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SplitMail.java
@@ -1,0 +1,115 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import jakarta.mail.MessagingException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.lifecycle.api.LifecycleUtil;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+import org.reactivestreams.Publisher;
+
+import com.github.fge.lambdas.Throwing;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+
+/**
+ * A mailet to split email with too much recipients. The first batch is sent directly, while the remaining batches are sent asynchronously.
+ * The batch size can be configured via the <b>batchSize</b> parameter (optional, defaults to 100).
+ *
+ * <h3>Configuration</h3>
+ * <pre><code>
+ * {@code
+ * <matcher name="notify-matcher" match="org.apache.james.mailetcontainer.impl.matchers.And">
+ *     <matcher match="SenderIs=admin@gov.org"/>
+ *     <matcher match="RecipientIs=all@gov.org"/>
+ * </matcher>
+ * <mailet match="notify-matcher" class="SplitMail">
+ *     <batchSize>100</batchSize>
+ * </mailet>
+ * }
+ * </code></pre>
+ *
+ */
+public class SplitMail extends GenericMailet {
+    private static final int DEFAULT_BATCH_SIZE = 100;
+    private int batchSize;
+
+    @Override
+    public void init() throws MessagingException {
+        batchSize = Integer.parseInt(Optional.ofNullable(getInitParameter("batchSize"))
+            .orElse(String.valueOf(DEFAULT_BATCH_SIZE)));
+    }
+
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        if (mail.getRecipients().stream().count() > batchSize) {
+            Flux.fromIterable(mail.getRecipients())
+                .window(batchSize)
+                .index()
+                .flatMap(sendMail(mail))
+                .then()
+                .block();
+        }
+    }
+
+    private Function<Tuple2<Long, Flux<MailAddress>>, Publisher<Void>> sendMail(Mail mail) {
+        return tuple -> {
+            boolean firstBatch = tuple.getT1() == 0;
+            if (firstBatch) {
+                return sendMailToFirstRecipientsBatchDirectly(mail, tuple.getT2());
+            }
+            return sendMailToRemainingRecipientsBatchAsynchronously(mail, tuple.getT2());
+        };
+    }
+
+    private Mono<Void> sendMailToFirstRecipientsBatchDirectly(Mail mail, Flux<MailAddress> firstRecipientsBatch) {
+        return firstRecipientsBatch
+            .collectList()
+            .flatMap(recipients -> Mono.fromRunnable(() -> mail.setRecipients(recipients)))
+            .then();
+    }
+
+    private Mono<Void> sendMailToRemainingRecipientsBatchAsynchronously(Mail mail, Flux<MailAddress> remainingRecipientsBatch) {
+        return remainingRecipientsBatch
+            .collectList()
+            .flatMap(recipients -> Mono.fromRunnable(Throwing.runnable(() -> {
+                Mail duplicateMail = mail.duplicate();
+                try {
+                    duplicateMail.setRecipients(recipients);
+                    getMailetContext().sendMail(duplicateMail);
+                } finally {
+                    LifecycleUtil.dispose(duplicateMail);
+                }
+            })))
+            .then();
+    }
+
+    @Override
+    public String getMailetName() {
+        return "SplitMail";
+    }
+}

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SplitMailTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SplitMailTest.java
@@ -1,0 +1,122 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.core.Username;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMailContext;
+import org.apache.mailet.base.test.FakeMailetConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import jakarta.mail.MessagingException;
+
+class SplitMailTest {
+    private static final Username USER_1 = Username.of("user1@gov.org");
+    private static final Username USER_2 = Username.of("user2@gov.org");
+    private static final Username USER_3 = Username.of("user3@gov.org");
+    private static final Username USER_4 = Username.of("user4@gov.org");
+    private static final Username USER_5 = Username.of("user5@gov.org");
+
+    private FakeMailContext mailetContext;
+    private SplitMail splitMail;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mailetContext = FakeMailContext.defaultContext();
+        splitMail = new SplitMail();
+        splitMail.init(FakeMailetConfig.builder()
+            .mailetContext(mailetContext)
+            .setProperty("batchSize", "2")
+            .build());
+    }
+
+    @Test
+    void firstUsersBatchShouldBeSentDirectlyWhenExactlyBatchSize() throws Exception {
+        Mail originalMail = createMail();
+        originalMail.setRecipients(ImmutableList.of(USER_1.asMailAddress(),
+            USER_2.asMailAddress()));
+
+        splitMail.service(originalMail);
+
+        assertThat(originalMail.getRecipients())
+            .containsExactlyInAnyOrder(USER_1.asMailAddress(), USER_2.asMailAddress());
+    }
+
+    @Test
+    void firstUsersBatchShouldBeSentDirectly() throws Exception {
+        Mail originalMail = createMail();
+        originalMail.setRecipients(ImmutableList.of(USER_1.asMailAddress(),
+            USER_2.asMailAddress(),
+            USER_3.asMailAddress(),
+            USER_4.asMailAddress()));
+
+        splitMail.service(originalMail);
+
+        assertThat(originalMail.getRecipients())
+            .containsExactlyInAnyOrder(USER_1.asMailAddress(), USER_2.asMailAddress());
+    }
+
+    @Test
+    void remainingUsersBatchesShouldBeSentAsync() throws Exception {
+        Mail originalMail = createMail();
+        originalMail.setRecipients(ImmutableList.of(USER_1.asMailAddress(),
+            USER_2.asMailAddress(),
+            USER_3.asMailAddress(),
+            USER_4.asMailAddress()));
+
+        splitMail.service(originalMail);
+
+        assertThat(mailetContext.getSentMails().getFirst().getRecipients())
+            .containsExactly(USER_3.asMailAddress(), USER_4.asMailAddress());
+    }
+
+    @Test
+    void remainingUsersBatchesShouldBeSentAsyncInSeveralBatches() throws Exception {
+        Mail originalMail = createMail();
+        originalMail.setRecipients(ImmutableList.of(USER_1.asMailAddress(),
+            USER_2.asMailAddress(),
+            USER_3.asMailAddress(),
+            USER_4.asMailAddress(),
+            USER_5.asMailAddress()));
+
+        splitMail.service(originalMail);
+
+        assertThat(mailetContext.getSentMails())
+            .hasSize(2)
+            .allMatch(mail -> mail.getRecipients().size() <= 2);
+    }
+
+    private Mail createMail() throws MessagingException {
+        return FakeMail.builder()
+            .name("name")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setSender("admin@gov.org")
+                .setSubject("Hi all")
+                .addToRecipient("all@gov.org"))
+            .recipient("all@gov.org")
+            .build();
+    }
+}

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SplitMailTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SplitMailTest.java
@@ -21,6 +21,8 @@ package org.apache.james.transport.mailets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.mail.MessagingException;
+
 import org.apache.james.core.Username;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.mailet.Mail;
@@ -29,9 +31,8 @@ import org.apache.mailet.base.test.FakeMailContext;
 import org.apache.mailet.base.test.FakeMailetConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
-import jakarta.mail.MessagingException;
+import com.google.common.collect.ImmutableList;
 
 class SplitMailTest {
     private static final Username USER_1 = Username.of("user1@gov.org");


### PR DESCRIPTION
 - I suspect James could struggle in distributed version to distribute very large count of recipients To this end, splitting email would help.
 - This is a default Postfix behaviour.

 The code snippet is extracted from MailToAllUsers mailet.