### PR TITLE
JAMES-2586 Add index for thread table

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresThreadModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresThreadModule.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.postgres.mail.dao;
 
+import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.HASH_MIME_MESSAGE_ID_INDEX;
 import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.MESSAGE_ID_INDEX;
 import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.TABLE;
 import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.THREAD_ID_INDEX;
@@ -62,11 +63,16 @@ public interface PostgresThreadModule {
         PostgresIndex THREAD_ID_INDEX = PostgresIndex.name("thread_thread_id_index")
             .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
                 .on(TABLE_NAME, USERNAME, THREAD_ID));
+
+        PostgresIndex HASH_MIME_MESSAGE_ID_INDEX = PostgresIndex.name("thread_has_mime_message_id_index")
+            .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
+                .on(TABLE_NAME, USERNAME, HASH_MIME_MESSAGE_ID));
     }
 
     PostgresModule MODULE = PostgresModule.builder()
         .addTable(TABLE)
         .addIndex(MESSAGE_ID_INDEX)
         .addIndex(THREAD_ID_INDEX)
+        .addIndex(HASH_MIME_MESSAGE_ID_INDEX)
         .build();
 }


### PR DESCRIPTION
The performance test reveals that the query on the `thread` table is take time:
```sql
select
  thread_id,
  hash_base_subject
from thread
where (
  username = $1
  and hash_mime_message_id in (
    $2, $3
  )
)
```

before
![image](https://github.com/user-attachments/assets/04a2b8ed-88f6-47ad-865d-4e3ed51583f1)

After
![image](https://github.com/user-attachments/assets/3480f711-ab31-4ec3-9cf7-4eb165aed205)
