### PR TITLE
Revert "JAMES-2586 Add index for thread table"

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresThreadModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresThreadModule.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.mailbox.postgres.mail.dao;
 
-import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.HASH_MIME_MESSAGE_ID_INDEX;
 import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.MESSAGE_ID_INDEX;
 import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.TABLE;
 import static org.apache.james.mailbox.postgres.mail.dao.PostgresThreadModule.PostgresThreadTable.THREAD_ID_INDEX;
@@ -63,16 +62,11 @@ public interface PostgresThreadModule {
         PostgresIndex THREAD_ID_INDEX = PostgresIndex.name("thread_thread_id_index")
             .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
                 .on(TABLE_NAME, USERNAME, THREAD_ID));
-
-        PostgresIndex HASH_MIME_MESSAGE_ID_INDEX = PostgresIndex.name("thread_has_mime_message_id_index")
-            .createIndexStep((dsl, indexName) -> dsl.createIndexIfNotExists(indexName)
-                .on(TABLE_NAME, USERNAME, HASH_MIME_MESSAGE_ID));
     }
 
     PostgresModule MODULE = PostgresModule.builder()
         .addTable(TABLE)
         .addIndex(MESSAGE_ID_INDEX)
         .addIndex(THREAD_ID_INDEX)
-        .addIndex(HASH_MIME_MESSAGE_ID_INDEX)
         .build();
 }


### PR DESCRIPTION
This reverts commit 194832f1ba30df2ef260e7f64c9b4fc020709fea.

No argumentation, no analysis whatsoever
mean time is still lower on the second run
APPEND is SIGNIFICANTLY slower.

Please revert and analysis more.