### PR TITLE
[POC] Improve MinIO support

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/quota/QuotaChangeNotifier.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/quota/QuotaChangeNotifier.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.quota;
+
+import org.apache.james.core.Domain;
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
+
+public interface QuotaChangeNotifier {
+    QuotaChangeNotifier NOOP = new QuotaChangeNotifier() {
+        @Override
+        public Publisher<Void> notifyUpdate(QuotaRoot quotaRoot) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Publisher<Void> notifyUpdate(Domain domain) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Publisher<Void> notifyGlobalUpdate() {
+            return Mono.empty();
+        }
+    };
+
+    Publisher<Void> notifyUpdate(QuotaRoot quotaRoot);
+
+    Publisher<Void> notifyUpdate(Domain domain);
+
+    Publisher<Void> notifyGlobalUpdate();
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManagerV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManagerV2.java
@@ -42,6 +42,7 @@ import org.apache.james.core.quota.QuotaType;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -53,10 +54,12 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
     private static final String GLOBAL_IDENTIFIER = "global";
 
     private final CassandraQuotaLimitDao cassandraQuotaLimitDao;
+    private final QuotaChangeNotifier quotaChangeNotifier;
 
     @Inject
-    public CassandraPerUserMaxQuotaManagerV2(CassandraQuotaLimitDao cassandraQuotaLimitDao) {
+    public CassandraPerUserMaxQuotaManagerV2(CassandraQuotaLimitDao cassandraQuotaLimitDao, QuotaChangeNotifier quotaChangeNotifier) {
         this.cassandraQuotaLimitDao = cassandraQuotaLimitDao;
+        this.quotaChangeNotifier = quotaChangeNotifier;
     }
 
     @Override
@@ -72,7 +75,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
                 .quotaComponent(QuotaComponent.MAILBOX)
                 .quotaType(QuotaType.SIZE)
                 .quotaLimit(QuotaCodec.quotaValueToLong(maxStorageQuota))
-                .build());
+                .build())
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(quotaRoot)));
     }
 
     @Override
@@ -88,7 +92,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
                 .quotaComponent(QuotaComponent.MAILBOX)
                 .quotaType(QuotaType.COUNT)
                 .quotaLimit(QuotaCodec.quotaValueToLong(maxMessageCount))
-                .build());
+                .build())
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(quotaRoot)));
     }
 
     @Override
@@ -104,7 +109,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
                 .quotaComponent(QuotaComponent.MAILBOX)
                 .quotaType(QuotaType.COUNT)
                 .quotaLimit(QuotaCodec.quotaValueToLong(count))
-                .build());
+                .build())
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(domain)));
     }
 
     @Override
@@ -120,7 +126,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
                 .quotaComponent(QuotaComponent.MAILBOX)
                 .quotaType(QuotaType.SIZE)
                 .quotaLimit(QuotaCodec.quotaValueToLong(size))
-                .build());
+                .build())
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(domain)));
     }
 
     @Override
@@ -130,7 +137,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
 
     @Override
     public Mono<Void> removeDomainMaxMessageReactive(Domain domain) {
-        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.DOMAIN, domain.asString(), QuotaType.COUNT));
+        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.DOMAIN, domain.asString(), QuotaType.COUNT))
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(domain)));
     }
 
     @Override
@@ -140,7 +148,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
 
     @Override
     public Mono<Void> removeDomainMaxStorageReactive(Domain domain) {
-        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.DOMAIN, domain.asString(), QuotaType.SIZE));
+        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.DOMAIN, domain.asString(), QuotaType.SIZE))
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(domain)));
     }
 
     @Override
@@ -170,7 +179,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
 
     @Override
     public Mono<Void> removeMaxMessageReactive(QuotaRoot quotaRoot) {
-        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.USER, quotaRoot.getValue(), QuotaType.COUNT));
+        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.USER, quotaRoot.getValue(), QuotaType.COUNT))
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(quotaRoot)));
     }
 
     @Override
@@ -180,7 +190,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
 
     @Override
     public Mono<Void> removeMaxStorageReactive(QuotaRoot quotaRoot) {
-        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.USER, quotaRoot.getValue(), QuotaType.SIZE));
+        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.USER, quotaRoot.getValue(), QuotaType.SIZE))
+            .then(Mono.from(quotaChangeNotifier.notifyUpdate(quotaRoot)));
     }
 
     @Override
@@ -195,7 +206,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
                 .quotaComponent(QuotaComponent.MAILBOX)
                 .quotaType(QuotaType.SIZE)
                 .quotaLimit(QuotaCodec.quotaValueToLong(globalMaxStorage))
-                .build());
+                .build())
+            .then(Mono.from(quotaChangeNotifier.notifyGlobalUpdate()));
     }
 
     @Override
@@ -205,7 +217,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
 
     @Override
     public Mono<Void> removeGlobalMaxStorageReactive() {
-        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.GLOBAL, GLOBAL_IDENTIFIER, QuotaType.SIZE));
+        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.GLOBAL, GLOBAL_IDENTIFIER, QuotaType.SIZE))
+            .then(Mono.from(quotaChangeNotifier.notifyGlobalUpdate()));
     }
 
     @Override
@@ -220,7 +233,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
                 .quotaComponent(QuotaComponent.MAILBOX)
                 .quotaType(QuotaType.COUNT)
                 .quotaLimit(QuotaCodec.quotaValueToLong(globalMaxMessageCount))
-                .build());
+                .build())
+            .then(Mono.from(quotaChangeNotifier.notifyGlobalUpdate()));
     }
 
     @Override
@@ -230,7 +244,8 @@ public class CassandraPerUserMaxQuotaManagerV2 implements MaxQuotaManager {
 
     @Override
     public Mono<Void> removeGlobalMaxMessageReactive() {
-        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.GLOBAL, GLOBAL_IDENTIFIER, QuotaType.COUNT));
+        return cassandraQuotaLimitDao.deleteQuotaLimit(QuotaLimitKey.of(QuotaComponent.MAILBOX, QuotaScope.GLOBAL, GLOBAL_IDENTIFIER, QuotaType.COUNT))
+            .then(Mono.from(quotaChangeNotifier.notifyGlobalUpdate()));
     }
 
     @Override

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.cassandra.quota.CassandraCurrentQuotaManagerV2;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManagerV2;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.mailbox.store.MailboxManagerConfiguration;
 import org.apache.james.mailbox.store.NoMailboxPathLocker;
@@ -115,7 +116,7 @@ public class CassandraMailboxManagerProvider {
             LIMIT_ANNOTATIONS, LIMIT_ANNOTATION_SIZE);
 
         SessionProviderImpl sessionProvider = new SessionProviderImpl(noAuthenticator, noAuthorizator);
-        MaxQuotaManager maxQuotaManager = new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(session));
+        MaxQuotaManager maxQuotaManager = new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(session), QuotaChangeNotifier.NOOP);
         CassandraCurrentQuotaManagerV2 currentQuotaUpdater = new CassandraCurrentQuotaManagerV2(new CassandraQuotaCurrentValueDao(session));
         StoreQuotaManager storeQuotaManager = new StoreQuotaManager(currentQuotaUpdater, maxQuotaManager);
         QuotaRootResolver quotaRootResolver = new DefaultUserQuotaRootResolver(sessionProvider, mapperFactory);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.cassandra.quota.CassandraCurrentQuotaManagerV2;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManagerV2;
 import org.apache.james.mailbox.quota.CurrentQuotaManager;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.store.MailboxManagerConfiguration;
 import org.apache.james.mailbox.store.NoMailboxPathLocker;
@@ -101,7 +102,7 @@ public class CassandraTestSystemFixture {
     }
 
     static MaxQuotaManager createMaxQuotaManager(CassandraCluster cassandra) {
-        return new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(cassandra.getConf()));
+        return new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(cassandra.getConf()), QuotaChangeNotifier.NOOP);
     }
 
     public static CurrentQuotaManager createCurrentQuotaManager(CassandraCluster cassandra) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManagerMigrationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManagerMigrationTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.components.CassandraMutualizedQuotaModule;
+import org.apache.james.backends.cassandra.components.CassandraQuotaLimitDao;
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.apache.james.core.quota.QuotaCountLimit;
@@ -37,6 +38,7 @@ import org.apache.james.mailbox.cassandra.modules.CassandraMailboxQuotaModule;
 import org.apache.james.mailbox.cassandra.quota.migration.CassandraPerUserMaxQuotaManagerMigration;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
 import org.apache.james.mailbox.quota.UserQuotaRootResolver;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.cassandra.CassandraUsersDAO;
@@ -74,7 +76,8 @@ public class CassandraPerUserMaxQuotaManagerMigrationTest {
         usersRepository = new UsersRepositoryImpl<>(domainList, usersDAO);
         Injector testInjector = GuiceUtils.testInjector(cassandraCluster.getCassandraCluster());
         oldMaxQuotaManager = testInjector.getInstance(CassandraPerUserMaxQuotaManagerV1.class);
-        newMaxQuotaManager = testInjector.getInstance(CassandraPerUserMaxQuotaManagerV2.class);
+        newMaxQuotaManager = new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(cassandraCluster.getCassandraCluster().getConf()),
+            QuotaChangeNotifier.NOOP);
         UserQuotaRootResolver userQuotaRootResolver = Mockito.mock(UserQuotaRootResolver.class);
         Mockito.when(userQuotaRootResolver.forUser(USERNAME)).thenReturn(QUOTA_ROOT);
         migration = new CassandraPerUserMaxQuotaManagerMigration(usersRepository,

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManagerV2Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManagerV2Test.java
@@ -26,9 +26,10 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.StatementRecorder;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.components.CassandraMutualizedQuotaModule;
-import org.apache.james.mailbox.cassandra.mail.utils.GuiceUtils;
+import org.apache.james.backends.cassandra.components.CassandraQuotaLimitDao;
 import org.apache.james.mailbox.cassandra.modules.CassandraMailboxQuotaModule;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
 import org.apache.james.mailbox.store.quota.GenericMaxQuotaManagerTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -42,8 +43,8 @@ public class CassandraPerUserMaxQuotaManagerV2Test extends GenericMaxQuotaManage
 
     @Override
     protected MaxQuotaManager provideMaxQuotaManager() {
-        return GuiceUtils.testInjector(cassandraCluster.getCassandraCluster())
-            .getInstance(CassandraPerUserMaxQuotaManagerV2.class);
+        return new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(cassandraCluster.getCassandraCluster().getConf()),
+            QuotaChangeNotifier.NOOP);
     }
 
     @Test

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/DefaultQuotaChangeNotifier.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/DefaultQuotaChangeNotifier.java
@@ -1,0 +1,96 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store.quota;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.events.EventBus;
+import org.apache.james.events.RegistrationKey;
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
+import org.apache.james.mailbox.quota.QuotaManager;
+import org.apache.james.mailbox.store.event.EventFactory;
+import org.reactivestreams.Publisher;
+
+import com.google.common.collect.ImmutableSet;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class DefaultQuotaChangeNotifier implements QuotaChangeNotifier {
+    @FunctionalInterface
+    public interface UsernameSupplier extends Supplier<Flux<Username>> {
+
+    }
+
+    private static final ImmutableSet<RegistrationKey> NO_REGISTRATION_KEYS = ImmutableSet.of();
+
+    private final UsernameSupplier usernameSupplier;
+    private final DefaultUserQuotaRootResolver quotaRootResolver;
+    private final EventBus eventBus;
+    private final QuotaManager quotaManager;
+
+    @Inject
+    public DefaultQuotaChangeNotifier(UsernameSupplier usernameSupplier, DefaultUserQuotaRootResolver quotaRootResolver,
+                                      EventBus eventBus, QuotaManager quotaManager) {
+        this.usernameSupplier = usernameSupplier;
+        this.quotaRootResolver = quotaRootResolver;
+        this.eventBus = eventBus;
+        this.quotaManager = quotaManager;
+    }
+
+    @Override
+    public Publisher<Void> notifyUpdate(QuotaRoot quotaRoot) {
+        Username username = quotaRootResolver.associatedUsername(quotaRoot);
+        return Mono.from(quotaManager.getQuotasReactive(quotaRoot))
+            .flatMap(quotas -> eventBus.dispatch(
+                EventFactory.quotaUpdated()
+                    .randomEventId()
+                    .user(username)
+                    .quotaRoot(quotaRoot)
+                    .quotaCount(quotas.getMessageQuota())
+                    .quotaSize(quotas.getStorageQuota())
+                    .instant(Instant.now())
+                    .build(),
+                NO_REGISTRATION_KEYS));
+    }
+
+    @Override
+    public Publisher<Void> notifyUpdate(Domain domain) {
+        return usernameSupplier.get()
+            .map(quotaRootResolver::forUser)
+            .filter(user -> user.getDomain().map(domain::equals).orElse(false))
+            .concatMap(this::notifyUpdate)
+            .then();
+    }
+
+    @Override
+    public Publisher<Void> notifyGlobalUpdate() {
+        return usernameSupplier.get()
+            .map(quotaRootResolver::forUser)
+            .concatMap(this::notifyUpdate)
+            .then();
+    }
+}

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.cassandra.TestCassandraMailboxSessionMapperFacto
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.quota.CassandraCurrentQuotaManagerV2;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManagerV2;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.mailbox.store.JVMMailboxPathLocker;
 import org.apache.james.mailbox.store.MailboxManagerConfiguration;
@@ -109,7 +110,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
         SessionProviderImpl sessionProvider = new SessionProviderImpl(authenticator, authorizator);
         QuotaRootResolver quotaRootResolver = new DefaultUserQuotaRootResolver(sessionProvider, mapperFactory);
 
-        perUserMaxQuotaManager = new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(session));
+        perUserMaxQuotaManager = new CassandraPerUserMaxQuotaManagerV2(new CassandraQuotaLimitDao(session), QuotaChangeNotifier.NOOP);
         CassandraCurrentQuotaManagerV2 currentQuotaManager = new CassandraCurrentQuotaManagerV2(new CassandraQuotaCurrentValueDao(session));
         StoreQuotaManager quotaManager = new StoreQuotaManager(currentQuotaManager, perUserMaxQuotaManager);
         ListeningCurrentQuotaUpdater quotaUpdater = new ListeningCurrentQuotaUpdater(currentQuotaManager, quotaRootResolver, eventBus, quotaManager);

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/BlobGCTask.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/BlobGCTask.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobReferenceSource;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BucketName;
@@ -150,7 +151,7 @@ public class BlobGCTask implements Task {
 
         @FunctionalInterface
         public interface RequireGenerationAwareBlobIdFactory {
-            RequireGenerationAwareBlobIdConfiguration generationAwareBlobIdFactory(GenerationAwareBlobId.Factory generationAwareBlobIdFactory);
+            RequireGenerationAwareBlobIdConfiguration generationAwareBlobIdFactory(BlobId.Factory generationAwareBlobIdFactory);
         }
 
         @FunctionalInterface
@@ -159,7 +160,7 @@ public class BlobGCTask implements Task {
         }
 
         private final BlobStoreDAO blobStoreDAO;
-        private final GenerationAwareBlobId.Factory generationAwareBlobIdFactory;
+        private final BlobId.Factory generationAwareBlobIdFactory;
         private final GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration;
         private final Set<BlobReferenceSource> blobReferenceSources;
         private final Clock clock;
@@ -168,7 +169,7 @@ public class BlobGCTask implements Task {
         private final double associatedProbability;
         private Optional<Integer> deletionWindowSize;
 
-        public Builder(BlobStoreDAO blobStoreDAO, GenerationAwareBlobId.Factory generationAwareBlobIdFactory,
+        public Builder(BlobStoreDAO blobStoreDAO, BlobId.Factory generationAwareBlobIdFactory,
                        GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration,
                        Set<BlobReferenceSource> blobReferenceSources, Clock clock, BucketName bucketName,
                        int expectedBlobCount, double associatedProbability) {
@@ -223,7 +224,7 @@ public class BlobGCTask implements Task {
 
 
     private final BlobStoreDAO blobStoreDAO;
-    private final GenerationAwareBlobId.Factory generationAwareBlobIdFactory;
+    private final BlobId.Factory generationAwareBlobIdFactory;
     private final GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration;
     private final Set<BlobReferenceSource> blobReferenceSources;
     private final Clock clock;
@@ -235,7 +236,7 @@ public class BlobGCTask implements Task {
 
 
     public BlobGCTask(BlobStoreDAO blobStoreDAO,
-                      GenerationAwareBlobId.Factory generationAwareBlobIdFactory,
+                      BlobId.Factory generationAwareBlobIdFactory,
                       GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration,
                       Set<BlobReferenceSource> blobReferenceSources,
                       BucketName bucketName,

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/BlobGCTaskDTO.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/BlobGCTaskDTO.java
@@ -23,6 +23,7 @@ import java.time.Clock;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobReferenceSource;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.BucketName;
@@ -53,7 +54,7 @@ public class BlobGCTaskDTO implements TaskDTO {
     }
 
     public static TaskDTOModule<BlobGCTask, BlobGCTaskDTO> module(BlobStoreDAO blobStoreDAO,
-                                                                  GenerationAwareBlobId.Factory generationAwareBlobIdFactory,
+                                                                  BlobId.Factory generationAwareBlobIdFactory,
                                                                   GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration,
                                                                   Set<BlobReferenceSource> blobReferenceSources,
                                                                   Clock clock) {

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAware.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAware.java
@@ -1,0 +1,27 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.server.blob.deduplication;
+
+import java.time.Instant;
+
+@FunctionalInterface
+public interface GenerationAware {
+    boolean inActiveGeneration(GenerationAwareBlobId.Configuration configuration, Instant now);
+}

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/GenerationAwareBlobId.java
@@ -33,7 +33,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-public class GenerationAwareBlobId implements BlobId {
+public class GenerationAwareBlobId implements BlobId, GenerationAware {
 
     public static class Configuration {
         public static final Duration DEFAULT_DURATION = Duration.ofDays(30);
@@ -157,7 +157,7 @@ public class GenerationAwareBlobId implements BlobId {
     public static final int NO_FAMILY = 0;
     public static final int NO_GENERATION = 0;
 
-    private static long computeGeneration(Configuration configuration, Instant now) {
+    static long computeGeneration(Configuration configuration, Instant now) {
         return now.getEpochSecond() / configuration.getDuration().toSeconds();
     }
 
@@ -182,6 +182,7 @@ public class GenerationAwareBlobId implements BlobId {
         return family + "_" + generation + "_" + delegate.asString();
     }
 
+    @Override
     public boolean inActiveGeneration(Configuration configuration, Instant now) {
         return configuration.getFamily() == this.family &&
             generation + 1 >= computeGeneration(configuration, now);

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobId.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobId.java
@@ -1,0 +1,160 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.server.blob.deduplication;
+
+import static org.apache.james.server.blob.deduplication.GenerationAwareBlobId.NO_FAMILY;
+import static org.apache.james.server.blob.deduplication.GenerationAwareBlobId.computeGeneration;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.blob.api.BlobId;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+public class MinIOGenerationAwareBlobId implements BlobId, GenerationAware {
+    public static class Factory implements BlobId.Factory {
+        public static final int NO_FAMILY = 0;
+        public static final int NO_GENERATION = 0;
+
+        private final Clock clock;
+        private final GenerationAwareBlobId.Configuration configuration;
+        private final BlobId.Factory delegate;
+
+        @Inject
+        public Factory(Clock clock, GenerationAwareBlobId.Configuration configuration, BlobId.Factory delegate) {
+            this.clock = clock;
+            this.configuration = configuration;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public BlobId parse(String id) {
+            int separatorIndex1 = id.indexOf('/');
+            if (separatorIndex1 == -1 || separatorIndex1 == id.length() - 1) {
+                return decorateWithoutGeneration(id);
+            }
+            int separatorIndex2 = id.indexOf('/', separatorIndex1 + 1);
+            if (separatorIndex2 == -1 || separatorIndex2 == id.length() - 1) {
+                return decorateWithoutGeneration(id);
+            }
+            try {
+                int family = Integer.parseInt(id.substring(0, separatorIndex1));
+                int generation = Integer.parseInt(id.substring(separatorIndex1 + 1, separatorIndex2));
+                String blobIdPart = id.substring(separatorIndex2 + 1);
+                BlobId wrapped = delegate.parse(blobIdPart.charAt(0) + "/" +
+                    blobIdPart.charAt(1) + "/" +
+                    blobIdPart.charAt(2) + "/" +
+                    blobIdPart.charAt(3) + "/" +
+                    blobIdPart.substring(4));
+                return new MinIOGenerationAwareBlobId(generation, family, wrapped);
+            } catch (NumberFormatException e) {
+                return delegate.parse(id.substring(separatorIndex2 + 1));
+            }
+        }
+
+        private GenerationAwareBlobId decorateWithoutGeneration(String id) {
+            return new GenerationAwareBlobId(NO_GENERATION, NO_FAMILY, delegate.parse(id));
+        }
+
+        @Override
+        public BlobId of(String id) {
+            return decorate(delegate.of(id));
+        }
+
+        private MinIOGenerationAwareBlobId decorate(BlobId blobId) {
+            return new MinIOGenerationAwareBlobId(computeGeneration(configuration, clock.instant()),
+                configuration.getFamily(),
+                blobId);
+        }
+    }
+
+    private final long generation;
+    private final int family;
+    private final BlobId delegate;
+
+    @VisibleForTesting
+    MinIOGenerationAwareBlobId(long generation, int family, BlobId delegate) {
+        Preconditions.checkArgument(generation >= 0, "'generation' should not be negative");
+        Preconditions.checkArgument(family >= 0, "'family' should not be negative");
+        this.generation = generation;
+        this.family = family;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String asString() {
+        if (family == NO_FAMILY) {
+            return delegate.asString();
+        }
+        return family + "/" + generation + "/" + delegate.asString();
+    }
+
+    @Override
+    public boolean inActiveGeneration(GenerationAwareBlobId.Configuration configuration, Instant now) {
+        return configuration.getFamily() == this.family &&
+            generation + 1 >= computeGeneration(configuration, now);
+    }
+
+    @VisibleForTesting
+    long getGeneration() {
+        return generation;
+    }
+
+    @VisibleForTesting
+    int getFamily() {
+        return family;
+    }
+
+    @VisibleForTesting
+    BlobId getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (obj instanceof MinIOGenerationAwareBlobId) {
+            MinIOGenerationAwareBlobId other = (MinIOGenerationAwareBlobId) obj;
+            return Objects.equals(generation, other.generation)
+                && Objects.equals(delegate, other.delegate)
+                && Objects.equals(family, other.family);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(generation, family, delegate);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects
+            .toStringHelper(this)
+            .add("generation", generation)
+            .add("delegate", delegate)
+            .toString();
+    }
+}

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobIdTest.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobIdTest.java
@@ -1,0 +1,281 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.server.blob.deduplication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.utils.UpdatableTickingClock;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class MinIOGenerationAwareBlobIdTest {
+    private static final Instant NOW = Instant.parse("2021-08-19T10:15:30.00Z");
+
+    private BlobId.Factory delegate;
+    private MinIOGenerationAwareBlobId.Factory testee;
+
+    @BeforeEach
+    void setUp() {
+        delegate = new PlainBlobId.Factory();
+        UpdatableTickingClock clock = new UpdatableTickingClock(NOW);
+        testee = new MinIOGenerationAwareBlobId.Factory(clock, GenerationAwareBlobId.Configuration.DEFAULT, delegate);
+    }
+
+    @Nested
+    class BlobIdGeneration {
+        @Test
+        void ofShouldGenerateABlobIdOfTheRightGeneration() {
+            String key = "4ccb692e-3efb-40e9-8876-4ecfd51ffd4d";
+            MinIOGenerationAwareBlobId actual = (MinIOGenerationAwareBlobId) testee.of(key);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(actual.getFamily()).isEqualTo(GenerationAwareBlobId.Configuration.DEFAULT.getFamily());
+                soft.assertThat(actual.getGeneration()).isEqualTo(628L);
+                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.of("4/c/c/b/692e-3efb-40e9-8876-4ecfd51ffd4d"));
+            });
+        }
+    }
+
+    @Nested
+    class BlobIdParsing {
+        @Test
+        void asStringValueShouldBeParsable() {
+            String key = UUID.randomUUID().toString();
+            BlobId minioBlobId = testee.of(key);
+            String minioBlobIdAsString = minioBlobId.asString();
+
+            BlobId blobId = testee.parse(minioBlobIdAsString);
+            assertThat(blobId).isEqualTo(minioBlobId);
+        }
+
+        @Test
+        void previousBlobIdsShouldBeParsable() {
+            String blobIdString = delegate.of("abcdef").asString();
+
+            BlobId actual = testee.parse(blobIdString);
+            assertThat(actual)
+                .isInstanceOfSatisfying(GenerationAwareBlobId.class, actualBlobId -> {
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(actualBlobId.getFamily()).isEqualTo(0);
+                        soft.assertThat(actualBlobId.getGeneration()).isEqualTo(0L);
+                        soft.assertThat(actualBlobId.getDelegate().asString()).isEqualTo(blobIdString);
+                    });
+                });
+        }
+
+        @Test
+        void noFamilyShouldBeParsable() {
+            String originalBlobId = "abcdef";
+            String blobIdString = "0/0/" + delegate.of(originalBlobId).asString();
+
+            BlobId actual = testee.parse(blobIdString);
+            assertThat(actual)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId -> {
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(actualBlobId.getFamily()).isEqualTo(0);
+                        soft.assertThat(actualBlobId.getGeneration()).isEqualTo(0L);
+                        soft.assertThat(actualBlobId.getDelegate()).isEqualTo(delegate.of(originalBlobId));
+                    });
+                });
+        }
+
+        @Test
+        void generationBlobIdShouldBeParsable() {
+            String originalBlobId = "abcdef";
+            String blobIdString = "12/126/" + delegate.of(originalBlobId).asString();
+
+            BlobId actual = testee.parse(blobIdString);
+            assertThat(actual)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId -> {
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(actualBlobId.getFamily()).isEqualTo(12);
+                        soft.assertThat(actualBlobId.getGeneration()).isEqualTo(126L);
+                        soft.assertThat(actualBlobId.getDelegate()).isEqualTo(delegate.of(originalBlobId));
+                    });
+                });
+        }
+
+        @Test
+        void wrappedBlobIdCanContainSeparator() {
+            String blobIdString = "12/126/ab/c";
+
+            BlobId actual = testee.parse(blobIdString);
+            assertThat(actual)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId -> {
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(actualBlobId.getFamily()).isEqualTo(12);
+                        soft.assertThat(actualBlobId.getGeneration()).isEqualTo(126L);
+                        soft.assertThat(actualBlobId.getDelegate()).isEqualTo(delegate.of("ab/c"));
+                    });
+                });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "abcdefgh",
+            "abcdefgh/",
+            "1/abcdefgh",
+            "1/2",
+            "1/2/",
+            "/abcdefgh"
+        })
+        void fromShouldFallbackWhenNotApplicable(String blobIdString) {
+            BlobId actual = testee.parse(blobIdString);
+            assertThat(actual)
+                .isInstanceOfSatisfying(GenerationAwareBlobId.class, actualBlobId -> {
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(actualBlobId.getFamily()).isEqualTo(0);
+                        soft.assertThat(actualBlobId.getGeneration()).isEqualTo(0L);
+                        soft.assertThat(actualBlobId.getDelegate()).isEqualTo(delegate.parse(blobIdString));
+                    });
+                });
+        }
+
+        @Nested
+        class Failures {
+            @Test
+            void emptyShouldFail() {
+                assertThatThrownBy(() -> testee.parse(""))
+                    .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void nullShouldFailShouldFail() {
+                assertThatThrownBy(() -> testee.parse(null))
+                    .isInstanceOf(NullPointerException.class);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {
+                "invalid/2/abcdefgh",
+                "1/invalid/abcdefgh",
+                "1//abcdefgh",
+                "//abcdefgh",
+                "/1/abcdefgh",
+                "-1/2/abcdefgh",
+                "1/-1/abcdefgh",
+            })
+            void fromShouldFallbackWhenNotApplicable(String blobIdString) {
+                assertThatCode(() -> testee.parse(blobIdString))
+                    .doesNotThrowAnyException();
+            }
+        }
+    }
+
+    @Nested
+    class BlobIdPojo {
+
+        @Test
+        void shouldMatchPojoContract() {
+            EqualsVerifier.forClass(MinIOGenerationAwareBlobId.class)
+                .verify();
+        }
+
+        @Test
+        void asStringShouldIntegrateFamilyAndGeneration() {
+            BlobId blobId = testee.of("36825033-d835-4490-9f5a-eef120b1e85c");
+
+            assertThat(blobId.asString()).isEqualTo("1/628/3/6/8/2/5033-d835-4490-9f5a-eef120b1e85c");
+        }
+
+        @Test
+        void asStringShouldReturnDelegateForZeroFamily() {
+            BlobId blobId = new MinIOGenerationAwareBlobId(0, 0, delegate.parse("36825033-d835-4490-9f5a-eef120b1e85c"));
+
+            assertThat(blobId.asString()).isEqualTo("36825033-d835-4490-9f5a-eef120b1e85c");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "1/2/a/b/c/d/efgh",
+            "abc",
+            "1/2/abc"
+        })
+        void asStringShouldRevertFromString(String blobIdString) {
+            BlobId blobId = testee.parse(blobIdString);
+
+            assertThat(blobId.asString()).isEqualTo(blobIdString);
+        }
+
+        @Test
+        void noGenerationShouldNeverBeInActiveGeneration() {
+            MinIOGenerationAwareBlobId blobId = new MinIOGenerationAwareBlobId(0, 0, delegate.parse("36825033-d835-4490-9f5a-eef120b1e85c"));
+
+            assertThat(blobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW)).isFalse();
+        }
+
+        @Test
+        void inActiveGenerationShouldReturnTrueWhenSameDate() {
+            BlobId blobId = testee.of("36825033-d835-4490-9f5a-eef120b1e85c");
+
+            assertThat(blobId)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId ->
+                    assertThat(actualBlobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW)).isTrue());
+        }
+
+        @Test
+        void inActiveGenerationShouldReturnTrueWhenInTheFuture() {
+            BlobId blobId = testee.of("36825033-d835-4490-9f5a-eef120b1e85c");
+
+            assertThat(blobId)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId ->
+                    assertThat(actualBlobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW.minus(60, ChronoUnit.DAYS))).isTrue());
+        }
+
+        @Test
+        void inActiveGenerationShouldReturnTrueForAtLeastOneMoreMonth() {
+            BlobId blobId = testee.of("36825033-d835-4490-9f5a-eef120b1e85c");
+            assertThat(blobId)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId ->
+                    assertThat(actualBlobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW.plus(30, ChronoUnit.DAYS))).isTrue());
+        }
+
+        @Test
+        void inActiveGenerationShouldReturnFalseAfterTwoMonth() {
+            BlobId blobId = testee.of("36825033-d835-4490-9f5a-eef120b1e85c");
+
+            assertThat(blobId)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId ->
+                    assertThat(actualBlobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW.plus(60, ChronoUnit.DAYS))).isFalse());
+        }
+
+        @Test
+        void inActiveGenerationShouldReturnFalseWhenDistinctFamily() {
+            MinIOGenerationAwareBlobId blobId = new MinIOGenerationAwareBlobId(628L, 2, delegate.of("36825033-d835-4490-9f5a-eef120b1e85c"));
+
+            assertThat(blobId.inActiveGeneration(GenerationAwareBlobId.Configuration.DEFAULT, NOW.plus(60, ChronoUnit.DAYS)))
+                .isFalse();
+        }
+    }
+}

--- a/server/container/guice/blob/deduplication-gc/src/main/java/org/apache/james/modules/blobstore/BlobDeduplicationGCModule.java
+++ b/server/container/guice/blob/deduplication-gc/src/main/java/org/apache/james/modules/blobstore/BlobDeduplicationGCModule.java
@@ -58,7 +58,6 @@ public class BlobDeduplicationGCModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(PlainBlobId.Factory.class).in(Scopes.SINGLETON);
-        bind(BlobId.Factory.class).to(GenerationAwareBlobId.Factory.class);
 
         bind(MetricableBlobStore.class).in(Scopes.SINGLETON);
         bind(BlobStore.class).to(MetricableBlobStore.class);
@@ -68,7 +67,7 @@ public class BlobDeduplicationGCModule extends AbstractModule {
 
     @Singleton
     @Provides
-    public GenerationAwareBlobId.Factory generationAwareBlobIdFactory(Clock clock, PlainBlobId.Factory delegate, GenerationAwareBlobId.Configuration configuration) {
+    public BlobId.Factory generationAwareBlobIdFactory(Clock clock, PlainBlobId.Factory delegate, GenerationAwareBlobId.Configuration configuration) {
         return new GenerationAwareBlobId.Factory(clock, delegate, configuration);
     }
 
@@ -85,7 +84,7 @@ public class BlobDeduplicationGCModule extends AbstractModule {
 
     @ProvidesIntoSet
     public TaskDTOModule<? extends Task, ? extends TaskDTO> blobGCTask(BlobStoreDAO blobStoreDAO,
-                                                                       GenerationAwareBlobId.Factory generationAwareBlobIdFactory,
+                                                                       BlobId.Factory generationAwareBlobIdFactory,
                                                                        GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration,
                                                                        Set<BlobReferenceSource> blobReferenceSources,
                                                                        Clock clock) {

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxQuotaLegacyModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxQuotaLegacyModule.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.modules.mailbox;
 
+import org.apache.james.adapter.mailbox.UsersRepositoryUsernameSupplier;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.mailbox.cassandra.quota.CassandraCurrentQuotaManagerV1;
 import org.apache.james.mailbox.cassandra.quota.CassandraCurrentQuotaManagerV2;
@@ -26,6 +27,8 @@ import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManagerV
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManagerV2;
 import org.apache.james.mailbox.quota.CurrentQuotaManager;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
+import org.apache.james.mailbox.store.quota.DefaultQuotaChangeNotifier;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -47,6 +50,11 @@ public class CassandraMailboxQuotaLegacyModule extends AbstractModule {
         bind(MaxQuotaManager.class).to(CassandraPerUserMaxQuotaManagerV1.class);
         bind(MaxQuotaManager.class).annotatedWith(Names.named("old")).to(CassandraPerUserMaxQuotaManagerV1.class);
         bind(MaxQuotaManager.class).annotatedWith(Names.named("new")).to(CassandraPerUserMaxQuotaManagerV2.class);
+
+        bind(UsersRepositoryUsernameSupplier.class).in(Scopes.SINGLETON);
+        bind(DefaultQuotaChangeNotifier.class).in(Scopes.SINGLETON);
+        bind(QuotaChangeNotifier.class).to(DefaultQuotaChangeNotifier.class);
+        bind(DefaultQuotaChangeNotifier.UsernameSupplier.class).to(UsersRepositoryUsernameSupplier.class);
 
         Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
         cassandraDataDefinitions.addBinding().toInstance(org.apache.james.mailbox.cassandra.modules.CassandraMailboxQuotaModule.MODULE);

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxQuotaModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxQuotaModule.java
@@ -19,12 +19,15 @@
 
 package org.apache.james.modules.mailbox;
 
+import org.apache.james.adapter.mailbox.UsersRepositoryUsernameSupplier;
 import org.apache.james.mailbox.cassandra.quota.CassandraCurrentQuotaManagerV2;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManagerV2;
 import org.apache.james.mailbox.cassandra.quota.FakeCassandraCurrentQuotaManager;
 import org.apache.james.mailbox.cassandra.quota.FakeMaxQuotaManager;
 import org.apache.james.mailbox.quota.CurrentQuotaManager;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaChangeNotifier;
+import org.apache.james.mailbox.store.quota.DefaultQuotaChangeNotifier;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -42,5 +45,10 @@ public class CassandraMailboxQuotaModule extends AbstractModule {
         bind(MaxQuotaManager.class).to(CassandraPerUserMaxQuotaManagerV2.class);
         bind(MaxQuotaManager.class).annotatedWith(Names.named("old")).to(FakeMaxQuotaManager.class);
         bind(MaxQuotaManager.class).annotatedWith(Names.named("new")).to(CassandraPerUserMaxQuotaManagerV2.class);
+
+        bind(UsersRepositoryUsernameSupplier.class).in(Scopes.SINGLETON);
+        bind(DefaultQuotaChangeNotifier.class).in(Scopes.SINGLETON);
+        bind(QuotaChangeNotifier.class).to(DefaultQuotaChangeNotifier.class);
+        bind(DefaultQuotaChangeNotifier.UsernameSupplier.class).to(UsersRepositoryUsernameSupplier.class);
     }
 }

--- a/server/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/UsersRepositoryUsernameSupplier.java
+++ b/server/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/UsersRepositoryUsernameSupplier.java
@@ -1,0 +1,42 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.adapter.mailbox;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.store.quota.DefaultQuotaChangeNotifier;
+import org.apache.james.user.api.UsersRepository;
+
+import reactor.core.publisher.Flux;
+
+public class UsersRepositoryUsernameSupplier implements DefaultQuotaChangeNotifier.UsernameSupplier {
+    private final UsersRepository usersRepository;
+
+    @Inject
+    public UsersRepositoryUsernameSupplier(UsersRepository usersRepository) {
+        this.usersRepository = usersRepository;
+    }
+
+    @Override
+    public Flux<Username> get() {
+        return Flux.from(usersRepository.listReactive());
+    }
+}

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/BlobRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/BlobRoutes.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobReferenceSource;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreDAO;
@@ -56,7 +57,7 @@ public class BlobRoutes implements Routes {
     private final BucketName bucketName;
     private final Set<BlobReferenceSource> blobReferenceSources;
     private final GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration;
-    private final GenerationAwareBlobId.Factory generationAwareBlobIdFactory;
+    private final BlobId.Factory generationAwareBlobIdFactory;
 
     @Inject
     public BlobRoutes(TaskManager taskManager,
@@ -66,7 +67,7 @@ public class BlobRoutes implements Routes {
                       @Named(BlobStore.DEFAULT_BUCKET_NAME_QUALIFIER) BucketName defaultBucketName,
                       Set<BlobReferenceSource> blobReferenceSources,
                       GenerationAwareBlobId.Configuration generationAwareBlobIdConfiguration,
-                      GenerationAwareBlobId.Factory generationAwareBlobIdFactory) {
+                      BlobId.Factory generationAwareBlobIdFactory) {
         this.taskManager = taskManager;
         this.jsonTransformer = jsonTransformer;
         this.clock = clock;


### PR DESCRIPTION
Storing all blobs into a single bucket hurts: impossible to run the GC or do S3 administrative operations

(minio underlying model is mapping to OS folders, so Tmail storing all in one bucket litterally creates folders with dozens of millions of files which is a VERY bad idea)

First commit adds a little handy abstraction allowing alternative implems to GenerationAwareBlobId and makes the system more open: NICE.

The second commit could be done in Twake mail if needed though I do know some James users relying on MinIO in the wild out there...
