### PR TITLE
[ENHANCEMENT] mailUserAgent in IMAP MDC - Fixup multiple entries with same key

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdProcessor.java
@@ -45,6 +45,7 @@ import reactor.core.publisher.Mono;
 
 public class IdProcessor extends AbstractMailboxProcessor<IDRequest> implements CapabilityImplementingProcessor {
     public static final String MDC_KEY = "bound_MDC";
+    public static final String MAIL_USER_AGENT_KEY = "mailUserAgent";
     private static final Logger LOGGER = LoggerFactory.getLogger(IdProcessor.class);
     private static final ImmutableList<Capability> CAPABILITIES = ImmutableList.of(Capability.of("ID"));
 
@@ -83,7 +84,10 @@ public class IdProcessor extends AbstractMailboxProcessor<IDRequest> implements 
     private void addMailUserAgentToMDC(ImapSession session, String mailUserAgent) {
         Object maybeMDC = session.getAttribute(MDC_KEY);
         if (maybeMDC instanceof MDCBuilder boundMDC) {
-            MDCBuilder newMDC = boundMDC.addToContext("mailUserAgent", mailUserAgent);
+            if (boundMDC.snapshotContextMap().containsKey(MAIL_USER_AGENT_KEY)) {
+                return;
+            }
+            MDCBuilder newMDC = boundMDC.addToContext(MAIL_USER_AGENT_KEY, mailUserAgent);
             session.setAttribute(MDC_KEY, newMDC);
         }
     }

--- a/server/container/util/src/main/java/org/apache/james/util/MDCBuilder.java
+++ b/server/container/util/src/main/java/org/apache/james/util/MDCBuilder.java
@@ -147,6 +147,10 @@ public class MDCBuilder {
         return contextMap.build();
     }
 
+    public Map<String, String> snapshotContextMap() {
+        return ImmutableMap.copyOf(buildContextMap());
+    }
+
     public <T> T execute(Supplier<T> supplier) {
         return MDCBuilder.withMdc(this, supplier);
     }


### PR DESCRIPTION
If the client send the command `ID` multiple times in the same session, the server will throw an exception:

Eg:
- Client
```
* OK JAMES IMAP4rev1 Server MacBook-Pro.local is ready.
a1 ID NIL
* ID ("name" "Apache James" "version" "3.9.0")
a1 OK ID completed.
a2 ID NIL
* ID ("name" "Apache James" "version" "3.9.0")
a2 OK ID completed.
Connection closed by foreign host.
```
Then server: 
```java
java.lang.IllegalArgumentException: Multiple entries with same key: mailUserAgent=NIL and mailUserAgent=NIL
	at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:382)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.MonoRunnable] :
	reactor.core.publisher.Mono.fromRunnable(Mono.java:702)
	org.apache.james.util.ReactorUtils.lambda$logAsMono$14(ReactorUtils.java:206)
Error has been observed at the following site(s):
	*_____Mono.fromRunnable ⇢ at org.apache.james.util.ReactorUtils.lambda$logAsMono$14(ReactorUtils.java:206)
	*__Mono.deferContextual ⇢ at org.apache.james.util.ReactorUtils.logAsMono(ReactorUtils.java:206)
	*_____________Mono.then ⇢ at org.apache.james.imap.processor.base.AbstractProcessor.processReactive(AbstractProcessor.java:52)
	|_    Mono.contextWrite ⇢ at org.apache.james.imap.processor.base.AbstractProcessor.processReactive(AbstractProcessor.java:53)
	|_        Mono.doOnEach ⇢ at org.apache.james.imapserver.netty.ImapChannelUpstreamHandler.channelRead(ImapChannelUpstreamHandler.java:427)
	|_    Mono.contextWrite ⇢ at org.apache.james.imapserver.netty.ImapChannelUpstreamHandler.channelRead(ImapChannelUpstreamHandler.java:469)
	|_       Mono.doFinally ⇢ at org.apache.james.imapserver.netty.ReactiveThrottler.throttle(ReactiveThrottler.java:105)
	|_       Mono.doOnError ⇢ at org.apache.james.imapserver.netty.ImapChannelUpstreamHandler.channelRead(ImapChannelUpstreamHandler.java:472)
	|_       Mono.doFinally ⇢ at org.apache.james.imapserver.netty.ImapChannelUpstreamHandler.channelRead(ImapChannelUpstreamHandler.java:473)
Original Stack Trace:
		at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:382)
		at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:376)
		at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:249)
		at com.google.common.collect.RegularImmutableMap.fromEntryArrayCheckingBucketOverflow(RegularImmutableMap.java:136)
		at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:98)
		at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:579)
		at com.google.common.collect.ImmutableMap$Builder.buildOrThrow(ImmutableMap.java:607)
		at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:594)
		at org.apache.james.util.MDCBuilder.addToContext(MDCBuilder.java:129)
		at java.base/java.util.stream.ReduceOps$1ReducingSink.accept(ReduceOps.java:80)
		at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
		at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
		at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
		at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
		at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
		at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
		at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
		at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
		at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
		at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:657)
		at org.apache.james.util.ReactorUtils.retrieveMDCBuilder(ReactorUtils.java:235)
		at org.apache.james.util.ReactorUtils.logWithContext(ReactorUtils.java:198)
		at org.apache.james.util.ReactorUtils.lambda$logAsMono$13(ReactorUtils.java:206)
		at reactor.core.publisher.MonoRunnable.subscribe(MonoRunnable.java:49)
		at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:76)
		at reactor.core.publisher.MonoDeferContextual.subscribe(MonoDeferContextual.java:55)
		at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
		at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.subscribeNext(MonoIgnoreThen.java:265)
		at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:51)
		at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
		at reactor.core.publisher.Mono.subscribeWith(Mono.java:4634)
		at reactor.core.publisher.Mono.subscribe(Mono.java:4395)
		at org.apache.james.imapserver.netty.ImapChannelUpstreamHandler.channelRead(ImapChannelUpstreamHandler.java:478)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
		at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
		at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
		at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
		at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
		at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
		at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
		at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
		at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
		at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
		at java.base/java.lang.Thread.run(Thread.java:1583)
```

-> We should check if the `mailUserAgent` key already exists in contextMap before adding it.