### PR TITLE
[FIX] POP3 UserCmdHandler should return error response when invalid username input

### DIFF
--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/UserCmdHandler.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/core/UserCmdHandler.java
@@ -70,9 +70,13 @@ public class UserCmdHandler extends AbstractPOP3CommandHandler implements CapaCa
         LOGGER.trace("USER command received");
         String parameters = request.getArgument();
         if (session.getHandlerState() == POP3Session.AUTHENTICATION_READY && parameters != null) {
-            session.setUsername(Username.of(parameters));
-            session.setHandlerState(POP3Session.AUTHENTICATION_USERSET);
-            return POP3Response.OK;
+            try {
+                session.setUsername(Username.of(parameters));
+                session.setHandlerState(POP3Session.AUTHENTICATION_USERSET);
+                return POP3Response.OK;
+            } catch (IllegalArgumentException e) {
+                return POP3Response.ERR;
+            }
         } else {
             return POP3Response.ERR;
         }

--- a/server/container/util/src/main/java/org/apache/james/util/MDCBuilder.java
+++ b/server/container/util/src/main/java/org/apache/james/util/MDCBuilder.java
@@ -44,6 +44,9 @@ public class MDCBuilder {
             return answerSupplier.get();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }  catch (IllegalArgumentException e) {
+            LOGGER.warn("Got IllegalArgumentException, logging its context", e);
+            throw e;
         } catch (RuntimeException e) {
             LOGGER.error("Got error, logging its context", e);
             throw e;


### PR DESCRIPTION
Was `Error dispatching command for request USER` on `java.lang.IllegalArgumentException: Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in govmu,org`:
```json
{
    "timestamp": "2024-12-10T04:32:03.703Z",
    "level": "ERROR",
    "thread": "pop3server-11",
    "mdc": {
        "charset": "US-ASCII",
        "protocol": "POP3",
        "sessionId": "6fec7ab7",
        "ip": "192.168.43.3"
    },
    "logger": "org.apache.james.protocols.api.handler.CommandDispatcher",
    "message": "Error dispatching command for request USER",
    "context": "default",
    "exception": "java.lang.IllegalArgumentException: Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in govmu,org\n\tat com.google.common.base.Preconditions.checkArgument(Preconditions.java:220)\n\tat org.apache.james.core.Domain.of(Domain.java:58)\n\tat org.apache.james.core.Username.fromLocalPartWithDomain(Username.java:52)\n\tat org.apache.james.core.Username.of(Username.java:46)\n\tat org.apache.james.protocols.pop3.core.UserCmdHandler.user(UserCmdHandler.java:73)\n\tat org.apache.james.protocols.pop3.core.UserCmdHandler.lambda$onCommand$0(UserCmdHandler.java:66)\n\tat org.apache.james.util.MDCBuilder.withMdc(MDCBuilder.java:44)\n\tat org.apache.james.protocols.pop3.core.UserCmdHandler.lambda$onCommand$1(UserCmdHandler.java:61)\n\tat org.apache.james.metrics.api.MetricFactory.decorateSupplierWithTimerMetric(MetricFactory.java:37)\n\tat org.apache.james.protocols.pop3.core.UserCmdHandler.onCommand(UserCmdHandler.java:60)\n\tat org.apache.james.protocols.pop3.core.UserCmdHandler.onCommand(UserCmdHandler.java:42)\n\tat org.apache.james.protocols.api.handler.CommandDispatcher.dispatchCommandHandlers(CommandDispatcher.java:165)\n\tat org.apache.james.protocols.api.handler.CommandDispatcher.onLine(CommandDispatcher.java:142)\n\tat org.apache.james.protocols.netty.BasicChannelInboundHandler.channelRead(BasicChannelInboundHandler.java:195)\n\tat io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)\n\tat io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)\n\tat io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)\n\tat io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)\n\tat io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)\n\tat io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)\n\tat io.netty.channel.AbstractChannelHandlerContext.access$600(AbstractChannelHandlerContext.java:61)\n\tat io.netty.channel.AbstractChannelHandlerContext$7.run(AbstractChannelHandlerContext.java:425)\n\tat io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)\n\tat io.netty.util.concurrent.DefaultEventExecutor.run(DefaultEventExecutor.java:66)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)\n\tat io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n"
}
```