### PR TITLE
[PERF] Email move should send only one JMAP push notification

### DIFF
--- a/docs/modules/servers/partials/configure/jvm.adoc
+++ b/docs/modules/servers/partials/configure/jvm.adoc
@@ -100,6 +100,15 @@ james.jmap.reactor.netty.metrics.enabled=true
 ----
 To enable the metrics.
 
+== Set up JMAP EMail/set range threshold
+
+From which point should range operation be used? Defaults to 3.
+
+Ex in `jvm.properties`:
+----
+james.jmap.email.set.range.threshold=3
+----
+
 == Enable S3 metrics
 
 James supports extracting some S3 client-level metrics e.g. number of connections being used, time to acquire an S3 connection, total time to finish a S3 request...

--- a/event-bus/api/src/main/java/org/apache/james/events/EventListener.java
+++ b/event-bus/api/src/main/java/org/apache/james/events/EventListener.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.events;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.james.util.ReactorUtils;
@@ -26,6 +27,7 @@ import org.reactivestreams.Publisher;
 
 import com.github.fge.lambdas.Throwing;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -35,6 +37,12 @@ public interface EventListener {
 
     interface ReactiveEventListener extends EventListener {
         Publisher<Void> reactiveEvent(Event event);
+
+        default Publisher<Void> reactiveEvent(List<Event> event) {
+            return Flux.fromIterable(event)
+                .concatMap(this::reactiveEvent)
+                .then();
+        }
 
         default void event(Event event) throws Exception {
             Mono.from(reactiveEvent(event))

--- a/event-bus/api/src/main/java/org/apache/james/events/EventListener.java
+++ b/event-bus/api/src/main/java/org/apache/james/events/EventListener.java
@@ -40,6 +40,7 @@ public interface EventListener {
 
         default Publisher<Void> reactiveEvent(List<Event> event) {
             return Flux.fromIterable(event)
+                .filter(this::isHandling)
                 .concatMap(this::reactiveEvent)
                 .then();
         }

--- a/event-bus/api/src/main/java/org/apache/james/events/EventSerializer.java
+++ b/event-bus/api/src/main/java/org/apache/james/events/EventSerializer.java
@@ -32,11 +32,19 @@ public interface EventSerializer {
         return toJson(event).getBytes(StandardCharsets.UTF_8);
     }
 
+    default byte[] toJsonBytes(Collection<Event> event) {
+        return toJson(event).getBytes(StandardCharsets.UTF_8);
+    }
+
     Event asEvent(String serialized);
 
     List<Event> asEvents(String serialized);
 
     default Event fromBytes(byte[] serialized) {
         return asEvent(new String(serialized, StandardCharsets.UTF_8));
+    }
+
+    default List<Event> asEventsFromBytes(byte[] serialized) {
+        return asEvents(new String(serialized, StandardCharsets.UTF_8));
     }
 }

--- a/event-bus/api/src/main/java/org/apache/james/events/EventSerializer.java
+++ b/event-bus/api/src/main/java/org/apache/james/events/EventSerializer.java
@@ -20,15 +20,21 @@
 package org.apache.james.events;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
 
 public interface EventSerializer {
     String toJson(Event event);
+
+    String toJson(Collection<Event> event);
 
     default byte[] toJsonBytes(Event event) {
         return toJson(event).getBytes(StandardCharsets.UTF_8);
     }
 
     Event asEvent(String serialized);
+
+    List<Event> asEvents(String serialized);
 
     default Event fromBytes(byte[] serialized) {
         return asEvent(new String(serialized, StandardCharsets.UTF_8));

--- a/event-bus/api/src/test/java/org/apache/james/events/EventBusTestFixture.java
+++ b/event-bus/api/src/test/java/org/apache/james/events/EventBusTestFixture.java
@@ -24,10 +24,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.james.core.Username;
 
@@ -188,6 +190,21 @@ public interface EventBusTestFixture {
             Event.EventId eventId = Event.EventId.of(UUID.fromString(parts.get(1)));
             Username username = Username.of(Joiner.on("&").join(parts.stream().skip(2).collect(ImmutableList.toImmutableList())));
             return new TestEvent(eventId, username);
+        }
+
+        @Override
+        public String toJson(Collection<Event> event) {
+            return event.stream()
+                .map(this::toJson)
+                .collect(Collectors.joining("^"));
+        }
+
+        @Override
+        public List<Event> asEvents(String serialized) {
+            return Splitter.on('^')
+                .splitToStream(serialized)
+                .map(this::asEvent)
+                .collect(ImmutableList.toImmutableList());
         }
     }
 

--- a/event-bus/in-vm/src/main/java/org/apache/james/events/delivery/InVmEventDelivery.java
+++ b/event-bus/in-vm/src/main/java/org/apache/james/events/delivery/InVmEventDelivery.java
@@ -92,6 +92,9 @@ public class InVmEventDelivery implements EventDelivery {
     }
 
     private Mono<Void> doDeliverToListener(EventListener.ReactiveEventListener listener, List<Event> events) {
+        if (events.stream().noneMatch(listener::isHandling)) {
+            return Mono.empty();
+        }
         return Mono.defer(() -> Mono.from(metricFactory.decoratePublisherWithTimerMetric(timerName(listener),
                 listener.reactiveEvent(events))))
             .contextWrite(context("deliver", buildMDC(listener, events)));

--- a/mailbox/event/json/src/main/scala/org/apache/james/event/json/MailboxEventSerializer.scala
+++ b/mailbox/event/json/src/main/scala/org/apache/james/event/json/MailboxEventSerializer.scala
@@ -401,6 +401,7 @@ class JsonSerialize(mailboxIdFactory: MailboxId.Factory, messageIdFactory: Messa
     def toJson(event: Event): String = Json.toJson(event).toString()
     def toJson(event: Iterable[Event]): String = Json.toJson(event).toString()
     def toJsonBytes(event: Event): Array[Byte] = Json.toBytes(Json.toJson(event))
+    def toJsonBytes(event: Iterable[Event]): Array[Byte] = Json.toBytes(Json.toJson(event))
     def fromJson(json: String): JsResult[Event] = Json.fromJson[Event](Json.parse(json))
     def fromJsonAsEvents(json: String): JsResult[List[Event]] = if (json.startsWith("{")) {
       Json.fromJson[Event](Json.parse(json)).map(event => List(event))
@@ -413,6 +414,7 @@ class JsonSerialize(mailboxIdFactory: MailboxId.Factory, messageIdFactory: Messa
   def toJson(event: JavaEvent): String = eventSerializerPrivateWrapper.toJson(ScalaConverter.toScala(event))
   def toJson(event: util.Collection[JavaEvent]): String = eventSerializerPrivateWrapper.toJson(event.asScala.map(ScalaConverter.toScala))
   def toJsonBytes(event: JavaEvent): Array[Byte] = eventSerializerPrivateWrapper.toJsonBytes(ScalaConverter.toScala(event))
+  def toJsonBytes(event: util.Collection[JavaEvent]): Array[Byte] = eventSerializerPrivateWrapper.toJsonBytes(event.asScala.map(ScalaConverter.toScala))
   def fromJson(json: String): JsResult[JavaEvent] = eventSerializerPrivateWrapper.fromJson(json)
     .map(event => event.toJava)
   def fromJsonAsEvents(json: String): JsResult[List[JavaEvent]] = eventSerializerPrivateWrapper.fromJsonAsEvents(json)
@@ -425,6 +427,8 @@ class MailboxEventSerializer @Inject()(mailboxIdFactory: MailboxId.Factory, mess
   override def toJson(event: JavaEvent): String = jsonSerialize.toJson(event)
 
   override def toJsonBytes(event: JavaEvent): Array[Byte] = jsonSerialize.toJsonBytes(event)
+
+  override def toJsonBytes(event: util.Collection[JavaEvent]): Array[Byte] = jsonSerialize.toJsonBytes(event)
 
   def fromJson(json: String): JsResult[JavaEvent] = jsonSerialize.fromJson(json)
 

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -94,3 +94,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # james.deduplicating.blobstore.thread.switch.threshold=32768
 # Count of octet from which streams are buffered to files and not to memory
 # james.deduplicating.blobstore.file.threshold=10240
+
+# From which point should range operation be used? Defaults to 3.
+# james.jmap.email.set.range.threshold=3

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
@@ -95,7 +95,9 @@ case class JmapEventSerializer @Inject()(stateChangeEventDTOFactory: StateChange
   override def fromBytes(serialized: Array[Byte]): Event = genericSerializer.deserializeFromBytes(serialized)
 
   override def toJson(event: util.Collection[Event]): String = {
-    Preconditions.checkArgument(event.size() == 1, "Not supported for multiple events, please serialize separately")
+    if (event.size() != 1) {
+      throw new IllegalArgumentException("Not supported for multiple events, please serialize separately")
+    }
     toJson(event.iterator().next())
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
@@ -19,11 +19,10 @@
 
 package org.apache.james.jmap.change
 
-import java.util.Optional
 import java.util
+import java.util.Optional
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.api.client.util.Preconditions
 import com.google.common.collect.ImmutableList
 import jakarta.inject.Inject
 import org.apache.james.core.Username

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
@@ -20,8 +20,11 @@
 package org.apache.james.jmap.change
 
 import java.util.Optional
+import java.util
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.google.api.client.util.Preconditions
+import com.google.common.collect.ImmutableList
 import jakarta.inject.Inject
 import org.apache.james.core.Username
 import org.apache.james.events.Event.EventId
@@ -90,4 +93,11 @@ case class JmapEventSerializer @Inject()(stateChangeEventDTOFactory: StateChange
   override def toJsonBytes(event: Event): Array[Byte] =  genericSerializer.serializeToBytes(event)
 
   override def fromBytes(serialized: Array[Byte]): Event = genericSerializer.deserializeFromBytes(serialized)
+
+  override def toJson(event: util.Collection[Event]): String = {
+    Preconditions.checkArgument(event.size() == 1, "Not supported for multiple events, please serialize separately")
+    toJson(event.iterator().next())
+  }
+
+  override def asEvents(serialized: String): util.List[Event] = ImmutableList.of(asEvent(serialized))
 }


### PR DESCRIPTION
Today moving emails triggers 2 JMAP websocket notification: it shall generate a signle one!

Key idea: on the EventBus, I shall be able to publish a list of events.

This will be serialized and transported by rabbit as a list of event. (We can have a configuration parameter to turn on/off this parameter to ease rolling migration). Deserialization will need to handle both list and single events.

It will be executed as a list of events by listeners, with a default implementation to handle the current single event (without breaking change)

MailboxChangeListener will handle the email move in a single pass: process both `Added` and `Expunged` in a single pass and return a single `StateChange`.

See https://github.com/linagora/tmail-flutter/issues/3331