### PR TITLE
JAMES-4093 TrafficShapingConfiguration: change `checkInterval` and `maxDelays` default values to Netty ones

### DIFF
--- a/docs/modules/servers/partials/configure/imap.adoc
+++ b/docs/modules/servers/partials/configure/imap.adoc
@@ -170,8 +170,8 @@ Example:
         <trafficShaping>
             <writeTrafficPerSecond>0</writeTrafficPerSecond>
             <readTrafficPerSecond>0</readTrafficPerSecond>
-            <checkInterval>1</checkInterval>
-            <maxDelays>30</maxDelays>
+            <checkInterval>1000</checkInterval>
+            <maxDelays>15000</maxDelays>
         </trafficShaping>
     </imapserver>
 ....

--- a/docs/modules/servers/partials/operate/webadmin.adoc
+++ b/docs/modules/servers/partials/operate/webadmin.adoc
@@ -4779,7 +4779,7 @@ Will destroy channels belonging to `bob@domain.tld`.
 
 Return code:
 
-- 204: the certificate is reloaded
+- 204: disconnect the user successfully
 
 ==== Disconnecting all users
 
@@ -4791,7 +4791,7 @@ Will close all channels.
 
 Return code:
 
-- 204: the certificate is reloaded
+- 204: disconnect all users successfully
 
 ==== Disconnecting a group of users
 
@@ -4803,7 +4803,7 @@ Will disconnect `badGuy1@domain.tld` and `badGuy2@domain.tld`.
 
 Return code:
 
-- 204: the certificate is reloaded
+- 204: disconnect the users successfully
 - 400: Invalid request
 
 === Listing connected users

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/TrafficShapingConfiguration.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/TrafficShapingConfiguration.java
@@ -19,6 +19,9 @@
 
 package org.apache.james.imapserver.netty;
 
+import static io.netty.handler.traffic.AbstractTrafficShapingHandler.DEFAULT_CHECK_INTERVAL;
+import static io.netty.handler.traffic.AbstractTrafficShapingHandler.DEFAULT_MAX_TIME;
+
 import org.apache.commons.configuration2.Configuration;
 
 import io.netty.handler.traffic.ChannelTrafficShapingHandler;
@@ -28,8 +31,8 @@ public record TrafficShapingConfiguration(long writeLimit, long readLimit, long 
         return new TrafficShapingConfiguration(
             configuration.getLong("writeTrafficPerSecond", 0),
             configuration.getLong("readTrafficPerSecond", 0),
-            configuration.getLong("checkInterval", 30),
-            configuration.getLong("maxDelays", 30));
+            configuration.getLong("checkInterval", DEFAULT_CHECK_INTERVAL),
+            configuration.getLong("maxDelays", DEFAULT_MAX_TIME));
     }
 
     public ChannelTrafficShapingHandler newHandler() {

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/imapserver.xml
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/imapserver.xml
@@ -40,8 +40,8 @@ under the License.
         <trafficShaping>
             <writeTrafficPerSecond>0</writeTrafficPerSecond>
             <readTrafficPerSecond>0</readTrafficPerSecond>
-            <checkInterval>1</checkInterval>
-            <maxDelays>30</maxDelays>
+            <checkInterval>1000</checkInterval>
+            <maxDelays>15000</maxDelays>
         </trafficShaping>
     </imapserver>
     <imapserver enabled="true">

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -4968,7 +4968,7 @@ Will destroy channels belonging to `bob@domain.tld`.
 
 Return code:
 
-- 204: the certificate is reloaded
+- 204: disconnect the user successfully
 
 #### Disconnecting all users
 
@@ -4980,7 +4980,7 @@ Will close all channels.
 
 Return code:
 
-- 204: the certificate is reloaded
+- 204: disconnect all users successfully
 
 #### Disconnecting a group of users
 
@@ -4992,7 +4992,7 @@ Will disconnect `badGuy1@domain.tld` and `badGuy2@domain.tld`.
 
 Return code:
 
-- 204: the certificate is reloaded
+- 204: disconnect the users successfully
 - 400: Invalid request
 
 ### Listing connected users

--- a/src/site/xdoc/server/config-imap4.xml
+++ b/src/site/xdoc/server/config-imap4.xml
@@ -163,8 +163,8 @@
         &lt;trafficShaping&gt;
             &lt;writeTrafficPerSecond&gt;0&lt;/writeTrafficPerSecond&gt;
             &lt;readTrafficPerSecond&gt;0&lt;/readTrafficPerSecond&gt;
-            &lt;checkInterval&gt;1&lt;/checkInterval&gt;
-            &lt;maxDelays&gt;30&lt;/maxDelays&gt;
+            &lt;checkInterval&gt;1000&lt;/checkInterval&gt;
+            &lt;maxDelays&gt;15000&lt;/maxDelays&gt;
         &lt;/trafficShaping&gt;
 &lt;/imapserver&gt;
         </code></pre>


### PR DESCRIPTION
The unit is millisecond, not second.
`checkInterval` 30ms -> likely not performance wise.
`maxDelays` 30ms -> after maximum 30ms, bandwidth throttling ends -> almost no traffic shaping applied with the old default value (TESTED).