### PR TITLE
[devscout] upgrade logback and crowdsec

### DIFF
--- a/docs/modules/servers/partials/operate/logging.adoc
+++ b/docs/modules/servers/partials/operate/logging.adoc
@@ -25,6 +25,18 @@ and link:https://docs.fluentbit.io/[FluentBit] as centralize logging.
 Information about logback configuration can be found
 link:http://logback.qos.ch/manual/configuration.html[here].
 
+It is possible to configure a logback appender to expose structured logging
+as JSON using logback's  `JsonEncoder` like in the following example:
+
+```
+<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+         <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+             <withFormattedMessage>true</withFormattedMessage>
+         </encoder>
+         <immediateFlush>false</immediateFlush>
+</appender>
+```
+
 Note that dedicated formatters can be added to your docker containers :
 
  - Add the corresponding JAR onto the `/root/libs` folder of docker container

--- a/pom.xml
+++ b/pom.xml
@@ -651,7 +651,7 @@
         <lucene.version>9.11.1</lucene.version>
         <jasypt.version>1.9.3</jasypt.version>
         <guice.version>7.0.0</guice.version>
-        <logback.version>1.4.14</logback.version>
+        <logback.version>1.5.12</logback.version>
         <tink.version>1.9.0</tink.version>
         <lettuce.core.version>6.3.2.RELEASE</lettuce.core.version>
         <io.micrometer.core.version>1.13.6</io.micrometer.core.version>
@@ -2075,11 +2075,6 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback.contrib</groupId>
-                <artifactId>logback-json-classic</artifactId>
-                <version>0.1.5</version>
             </dependency>
             <dependency>
                 <groupId>com.beetstra.jutf7</groupId>

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/ProtocolMDCContextFactory.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/ProtocolMDCContextFactory.java
@@ -96,7 +96,6 @@ public interface ProtocolMDCContextFactory {
     static MDCBuilder forSession(ProtocolSession protocolSession) {
         return MDCBuilder.create()
             .addToContext(MDCBuilder.SESSION_ID, protocolSession.getSessionID())
-            .addToContext(MDCBuilder.CHARSET, protocolSession.getCharset().displayName())
             .addToContextIfPresent(MDCBuilder.USER, Optional.ofNullable(protocolSession.getUsername()).map(Username::asString));
     }
 

--- a/server/apps/cassandra-app/pom.xml
+++ b/server/apps/cassandra-app/pom.xml
@@ -248,10 +248,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback.contrib</groupId>
-            <artifactId>logback-json-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.linagora</groupId>
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>

--- a/server/apps/distributed-app/helm-chart/james/configs/logback.xml
+++ b/server/apps/distributed-app/helm-chart/james/configs/logback.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one   
-  or more contributor license agreements.  See the NOTICE file 
-  distributed with this work for additional information        
-  regarding copyright ownership.  The ASF licenses this file   
-  to you under the Apache License, Version 2.0 (the            
-  "License"); you may not use this file except in compliance   
-  with the License.  You may obtain a copy of the License at   
-                                                               
-    http://www.apache.org/licenses/LICENSE-2.0                 
-                                                               
-  Unless required by applicable law or agreed to in writing,   
-  software distributed under the License is distributed on an  
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       
-  KIND, either express or implied.  See the License for the    
-  specific language governing permissions and limitations      
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
   under the License.                                           
  -->
 

--- a/server/apps/distributed-app/pom.xml
+++ b/server/apps/distributed-app/pom.xml
@@ -309,10 +309,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback.contrib</groupId>
-            <artifactId>logback-json-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.linagora</groupId>
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>

--- a/server/apps/distributed-pop3-app/pom.xml
+++ b/server/apps/distributed-pop3-app/pom.xml
@@ -300,10 +300,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback.contrib</groupId>
-            <artifactId>logback-json-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.linagora</groupId>
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>

--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -201,10 +201,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback.contrib</groupId>
-            <artifactId>logback-json-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.linagora</groupId>
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>

--- a/server/apps/jpa-smtp-app/pom.xml
+++ b/server/apps/jpa-smtp-app/pom.xml
@@ -149,10 +149,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback.contrib</groupId>
-            <artifactId>logback-json-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.linagora</groupId>
             <artifactId>logback-elasticsearch-appender</artifactId>
         </dependency>

--- a/server/apps/memory-app/pom.xml
+++ b/server/apps/memory-app/pom.xml
@@ -219,10 +219,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback.contrib</groupId>
-            <artifactId>logback-json-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/server/apps/scaling-pulsar-smtp/pom.xml
+++ b/server/apps/scaling-pulsar-smtp/pom.xml
@@ -159,10 +159,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback.contrib</groupId>
-            <artifactId>logback-json-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/third-party/crowdsec/sample-configuration/logback.xml
+++ b/third-party/crowdsec/sample-configuration/logback.xml
@@ -1,49 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one   
-  or more contributor license agreements.  See the NOTICE file 
-  distributed with this work for additional information        
-  regarding copyright ownership.  The ASF licenses this file   
-  to you under the Apache License, Version 2.0 (the            
-  "License"); you may not use this file except in compliance   
-  with the License.  You may obtain a copy of the License at   
-                                                               
-    http://www.apache.org/licenses/LICENSE-2.0                 
-                                                               
-  Unless required by applicable law or agreed to in writing,   
-  software distributed under the License is distributed on an  
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       
-  KIND, either express or implied.  See the License for the    
-  specific language governing permissions and limitations      
-  under the License.                                           
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
  -->
 
 <configuration>
 
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
 
-        <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
-                <resetJUL>true</resetJUL>
-        </contextListener>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+            <withFormattedMessage>true</withFormattedMessage>
+        </encoder>
+        <immediateFlush>false</immediateFlush>
+    </appender>
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
 
-        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-                        <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
-                                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
-                                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
-
-                                <!-- Importance for handling multiple lines log -->
-                                <appendLineSeparator>true</appendLineSeparator>
-
-                                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-                                        <prettyPrint>false</prettyPrint>
-                                </jsonFormatter>
-                        </layout>
-                </encoder>
-                <immediateFlush>false</immediateFlush>
-        </appender>
-        <root level="WARN">
-                <appender-ref ref="CONSOLE" />
-        </root>
-
-        <logger name="org.apache.james" level="INFO" />
+    <logger name="org.apache.james" level="INFO" />
 </configuration>

--- a/third-party/crowdsec/src/test/resources/crowdsec/parsers/syslog-logs.yaml
+++ b/third-party/crowdsec/src/test/resources/crowdsec/parsers/syslog-logs.yaml
@@ -64,11 +64,11 @@ statics:
   - parsed: mdc_username
     expression: evt.Unmarshaled.message.mdc.username
   - parsed: logger
-    expression: evt.Unmarshaled.message.logger
+    expression: evt.Unmarshaled.message.loggerName
   - parsed: message
-    expression: evt.Unmarshaled.message.message
+    expression: evt.Unmarshaled.message.formattedMessage
   - parsed: context
-    expression: evt.Unmarshaled.message.context
+    expression: ToJsonString(evt.Unmarshaled.message.context)
   - meta: datasource_path
     expression: evt.Line.Src
   - meta: datasource_type

--- a/third-party/crowdsec/src/test/resources/logback-test.xml
+++ b/third-party/crowdsec/src/test/resources/logback-test.xml
@@ -37,23 +37,29 @@
             <maxFileSize>100MB</maxFileSize>
         </triggeringPolicy>
 
-        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
-                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
-                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
-
-                <!-- Importance for handling multiple lines log -->
-                <appendLineSeparator>true</appendLineSeparator>
-
-                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-                    <prettyPrint>false</prettyPrint>
-                </jsonFormatter>
-            </layout>
+        <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+            <withFormattedMessage>true</withFormattedMessage>
         </encoder>
+        <immediateFlush>false</immediateFlush>
     </appender>
     <root level="WARN">
         <appender-ref ref="LOG_FILE" />
+<!--        <appender-ref ref="CONSOLE" />-->
     </root>
 
     <logger name="org.apache.james" level="INFO" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+        </encoder>
+        <immediateFlush>false</immediateFlush>
+        <!-- Disable below block for debug logs mode-->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+    </appender>
+<!--    <logger name="tc" level="INFO" additivity="false">-->
+<!--        <appender-ref ref="CONSOLE"/>-->
+<!--    </logger>-->
 </configuration>


### PR DESCRIPTION
This commit drops the unmaintained logback-classic dependecy and upgrades logback to the latest version.

Logback-classic has a native JsonEncoder (already in the original version). The latest version allows to have the formatted message and to enable/disable any top level field\ by configuration.

This allows using logback's own JSON encoder and get rid ot logback-contrib which is unmaintained to output json ( the repository is archived and the dependencies are quite outdated)

 A side effect was that the format of the Json output changes slightly, I adjusted the samplec configurations for the crowdsec module.

One of the change is a higher resolution for the timestamp, which required raising crowdsec to 1.6.x.

I missed the previous [merge request](https://github.com/apache/james-project/pull/2482) which responds to [JAMES-4083](https://issues.apache.org/jira/browse/JAMES-4083). I discovered this while rebasing on upstream :grimacing: but I feel getting rid of the whole abandoned logback contrib is a better solution so I still propose this change to you.

I adjusted the crowdsec integration tests and I use this setup in my "production" already,

