### PR TITLE
James-4097 Allow disabling same-domain requirement when assigning rights

### DIFF
--- a/docs/modules/servers/partials/configure/jvm.adoc
+++ b/docs/modules/servers/partials/configure/jvm.adoc
@@ -184,5 +184,5 @@ Optional. Boolean. Defaults to false.
 
 Ex in `jvm.properties`
 ----
-james.rights.users.crossdomain=false
+james.rights.crossdomain.allow=false
 ----

--- a/docs/modules/servers/partials/configure/jvm.adoc
+++ b/docs/modules/servers/partials/configure/jvm.adoc
@@ -173,3 +173,16 @@ james.deduplicating.blobstore.thread.switch.threshold=32768
 # Count of octet from which streams are buffered to files and not to memory
 james.deduplicating.blobstore.file.threshold=10240
 ----
+
+== Allow users to have rights for shares of different domain
+
+Typically, preventing users to obtain rights for shares of another domain is a useful security layer.
+However, in multi-tenancy deployments, this can be useful (for example, students might be given access to a shared mailbox
+residing under the @university.edu domain with their @student.university.edu address).
+
+Optional. Boolean. Defaults to false.
+
+Ex in `jvm.properties`
+----
+james.rights.users.crossdomain=false
+----

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
@@ -74,6 +74,10 @@ public class StoreRightManager implements RightManager {
         this.eventBus = eventBus;
     }
 
+    private boolean isCrossDomainAccessAllowed() {
+        return Boolean.parseBoolean(System.getProperty("james.rights.users.crossdomain", "false"));
+    }
+
     @Override
     public boolean hasRight(MailboxPath mailboxPath, Right right, MailboxSession session) throws MailboxException {
         return myRights(mailboxPath, session).contains(right);
@@ -185,7 +189,7 @@ public class StoreRightManager implements RightManager {
     @Override
     public Mono<Void> applyRightsCommandReactive(MailboxPath mailboxPath, ACLCommand mailboxACLCommand, MailboxSession session) {
         return Mono.just(mailboxSessionMapperFactory.getMailboxMapper(session))
-            .doOnNext(Throwing.consumer(mapper -> assertSharesBelongsToUserDomain(mailboxPath.getUser(), mailboxACLCommand)))
+            .doOnNext(Throwing.consumer(mapper -> assertUserHasAccessToShareDomains(mailboxPath.getUser(), mailboxACLCommand)))
             .flatMap(mapper -> mapper.findMailboxByPath(mailboxPath)
                 .doOnNext(Throwing.consumer(mailbox -> assertHaveAccessTo(mailbox, session)))
                 .flatMap(mailbox -> mapper.updateACL(mailbox, mailboxACLCommand)
@@ -211,8 +215,8 @@ public class StoreRightManager implements RightManager {
         applyRightsCommand(mailbox.generateAssociatedPath(), mailboxACLCommand, session);
     }
 
-    private void assertSharesBelongsToUserDomain(Username user, ACLCommand mailboxACLCommand) throws DifferentDomainException {
-        assertSharesBelongsToUserDomain(user, ImmutableMap.of(mailboxACLCommand.getEntryKey(), mailboxACLCommand.getRights()));
+    private void assertUserHasAccessToShareDomains(Username user, ACLCommand mailboxACLCommand) throws DifferentDomainException {
+        assertUserHasAccessToShareDomains(user, ImmutableMap.of(mailboxACLCommand.getEntryKey(), mailboxACLCommand.getRights()));
     }
 
     public boolean isReadWrite(MailboxSession session, Mailbox mailbox, Flags sharedPermanentFlags) {
@@ -263,7 +267,7 @@ public class StoreRightManager implements RightManager {
 
     @Override
     public void setRights(MailboxPath mailboxPath, MailboxACL mailboxACL, MailboxSession session) throws MailboxException {
-        assertSharesBelongsToUserDomain(mailboxPath.getUser(), mailboxACL.getEntries());
+        assertUserHasAccessToShareDomains(mailboxPath.getUser(), mailboxACL.getEntries());
 
         MailboxMapper mapper = mailboxSessionMapperFactory.getMailboxMapper(session);
         block(mapper.findMailboxByPath(mailboxPath)
@@ -285,7 +289,13 @@ public class StoreRightManager implements RightManager {
     }
 
     @VisibleForTesting
-    void assertSharesBelongsToUserDomain(Username user, Map<EntryKey, Rfc4314Rights> entries) throws DifferentDomainException {
+    void assertUserHasAccessToShareDomains(Username user, Map<EntryKey, Rfc4314Rights> entries) throws DifferentDomainException {
+        if (isCrossDomainAccessAllowed()) {
+            // In this case, we impose no limitations.
+            return;
+        }
+
+        // If cross-domain sharing is disabled, a user may only access their own domain.
         if (entries.keySet().stream()
             .filter(entry -> !entry.getNameType().equals(NameType.special))
             .map(EntryKey::getName)
@@ -342,7 +352,7 @@ public class StoreRightManager implements RightManager {
      */
     public Mono<Void> setRightsReactiveWithoutAccessControl(MailboxPath mailboxPath, MailboxACL mailboxACL, MailboxSession session) {
         try {
-            assertSharesBelongsToUserDomain(mailboxPath.getUser(), mailboxACL.getEntries());
+            assertUserHasAccessToShareDomains(mailboxPath.getUser(), mailboxACL.getEntries());
         } catch (DifferentDomainException e) {
             return Mono.error(e);
         }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
@@ -24,18 +24,23 @@ import static org.apache.james.mailbox.fixture.MailboxFixture.BOB;
 import static org.apache.james.mailbox.fixture.MailboxFixture.CEDRIC;
 import static org.apache.james.mailbox.fixture.MailboxFixture.INBOX_ALICE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import jakarta.mail.Flags;
 
 import org.apache.james.core.Username;
+import org.apache.james.events.Event;
 import org.apache.james.events.EventBus;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
+import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.exception.DifferentDomainException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
@@ -65,6 +70,7 @@ class StoreRightManagerTest {
     MailboxSession aliceSession;
     MailboxACLResolver mailboxAclResolver;
     MailboxMapper mockedMailboxMapper;
+    EventBus eventBus;
 
     @BeforeEach
     void setup() {
@@ -72,7 +78,7 @@ class StoreRightManagerTest {
         MailboxSessionMapperFactory mockedMapperFactory = mock(MailboxSessionMapperFactory.class);
         mockedMailboxMapper = mock(MailboxMapper.class);
         mailboxAclResolver = new UnionMailboxACLResolver();
-        EventBus eventBus = mock(EventBus.class);
+        eventBus = mock(EventBus.class);
         when(mockedMapperFactory.getMailboxMapper(aliceSession))
             .thenReturn(mockedMailboxMapper);
 
@@ -259,22 +265,38 @@ class StoreRightManagerTest {
     }
 
     @Test
-    void assertSharesBelongsToUserDomainShouldThrowWhenOneDomainIsDifferent() throws Exception  {
+    void assertUserHasAccessToShareDomainsShouldThrowWhenOneDomainIsDifferent() throws Exception  {
         MailboxACL mailboxACL = new MailboxACL(new MailboxACL.Entry("a@domain.org", Right.Write), 
                 new MailboxACL.Entry("b@otherdomain.org", Right.Write), 
                 new MailboxACL.Entry("c@domain.org", Right.Write));
         
-        assertThatThrownBy(() -> storeRightManager.assertSharesBelongsToUserDomain(Username.of("user@domain.org"), mailboxACL.getEntries()))
+        assertThatThrownBy(() -> storeRightManager.assertUserHasAccessToShareDomains(Username.of("user@domain.org"), mailboxACL.getEntries()))
             .isInstanceOf(DifferentDomainException.class);
     }
 
     @Test
-    void assertSharesBelongsToUserDomainShouldNotThrowWhenDomainsAreIdentical() throws Exception  {
+    void assertUserHasAccessToShareDomainsShouldNotThrowWhenDomainsAreIdentical() throws Exception  {
         MailboxACL mailboxACL = new MailboxACL(new MailboxACL.Entry("a@domain.org", Right.Write), 
                 new MailboxACL.Entry("b@domain.org", Right.Write), 
                 new MailboxACL.Entry("c@domain.org", Right.Write));
         
-        storeRightManager.assertSharesBelongsToUserDomain(Username.of("user@domain.org"), mailboxACL.getEntries());
+        storeRightManager.assertUserHasAccessToShareDomains(Username.of("user@domain.org"), mailboxACL.getEntries());
+    }
+
+    @Test
+    void assertUserHasAccessToShareDomainsShouldNotThrowOnDifferentDomainsWhenCrossDomainAccessEnabled() throws Exception  {
+        try {
+            System.setProperty("james.rights.users.crossdomain", "true");
+
+            MailboxACL mailboxACL = new MailboxACL(new MailboxACL.Entry("a@domain.org", Right.Write),
+                    new MailboxACL.Entry("b@otherdomain.org", Right.Write),
+                    new MailboxACL.Entry("c@domain.org", Right.Write));
+
+            storeRightManager.assertUserHasAccessToShareDomains(Username.of("user@domain.org"), mailboxACL.getEntries());
+        }
+        finally {
+            System.clearProperty("james.rights.users.crossdomain");
+        }
     }
 
     @Test
@@ -287,5 +309,31 @@ class StoreRightManagerTest {
        
         assertThatThrownBy(() -> storeRightManager.applyRightsCommand(mailboxPath, aclCommand, aliceSession))
             .isInstanceOf(DifferentDomainException.class);
+    }
+
+    @Test
+    void applyRightsCommandShouldNotThrowOnDifferentDomainsWhenCrossDomainEnabled() throws MailboxException {
+        try {
+            System.setProperty("james.rights.users.crossdomain", "true");
+
+            MailboxPath mailboxPath = MailboxPath.forUser(Username.of("user@domain.org"), "mailbox");
+            Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY, MAILBOX_ID);
+            mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.Administer)));
+            ACLCommand aclCommand = MailboxACL.command()
+                    .forUser(Username.of("otherUser@otherdomain.org"))
+                    .rights(Right.Read)
+                    .asAddition();
+
+            when(mockedMailboxMapper.findMailboxByPath(mailboxPath)).thenReturn(Mono.just(mailbox));
+            when(mockedMailboxMapper.updateACL(mailbox, aclCommand)).thenReturn(Mono.just(ACLDiff.computeDiff(MailboxACL.EMPTY, new MailboxACL(
+                    new MailboxACL.Entry("user@domain.org", Right.Read)
+            ))));
+            when(eventBus.dispatch(any(Event.class), any(MailboxIdRegistrationKey.class))).thenReturn(Mono.empty());
+
+            assertThatCode(() -> storeRightManager.applyRightsCommand(mailboxPath, aclCommand, aliceSession))
+                    .doesNotThrowAnyException();
+        } finally {
+            System.clearProperty("james.rights.users.crossdomain");
+        }
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
@@ -265,37 +265,36 @@ class StoreRightManagerTest {
     }
 
     @Test
-    void assertUserHasAccessToShareDomainsShouldThrowWhenOneDomainIsDifferent() throws Exception  {
+    void assertUserHasAccessToShareeDomainsShouldThrowWhenOneDomainIsDifferent() throws Exception  {
         MailboxACL mailboxACL = new MailboxACL(new MailboxACL.Entry("a@domain.org", Right.Write), 
                 new MailboxACL.Entry("b@otherdomain.org", Right.Write), 
                 new MailboxACL.Entry("c@domain.org", Right.Write));
         
-        assertThatThrownBy(() -> storeRightManager.assertUserHasAccessToShareDomains(Username.of("user@domain.org"), mailboxACL.getEntries()))
+        assertThatThrownBy(() -> storeRightManager.assertUserHasAccessToShareeDomains(Username.of("user@domain.org"), mailboxACL.getEntries()))
             .isInstanceOf(DifferentDomainException.class);
     }
 
     @Test
-    void assertUserHasAccessToShareDomainsShouldNotThrowWhenDomainsAreIdentical() throws Exception  {
+    void assertUserHasAccessToShareeDomainsShouldNotThrowWhenDomainsAreIdentical() throws Exception  {
         MailboxACL mailboxACL = new MailboxACL(new MailboxACL.Entry("a@domain.org", Right.Write), 
                 new MailboxACL.Entry("b@domain.org", Right.Write), 
                 new MailboxACL.Entry("c@domain.org", Right.Write));
         
-        storeRightManager.assertUserHasAccessToShareDomains(Username.of("user@domain.org"), mailboxACL.getEntries());
+        storeRightManager.assertUserHasAccessToShareeDomains(Username.of("user@domain.org"), mailboxACL.getEntries());
     }
 
     @Test
     void assertUserHasAccessToShareDomainsShouldNotThrowOnDifferentDomainsWhenCrossDomainAccessEnabled() throws Exception  {
         try {
-            System.setProperty("james.rights.users.crossdomain", "true");
+            StoreRightManager.IS_CROSS_DOMAIN_ACCESS_ALLOWED = true;
 
             MailboxACL mailboxACL = new MailboxACL(new MailboxACL.Entry("a@domain.org", Right.Write),
                     new MailboxACL.Entry("b@otherdomain.org", Right.Write),
                     new MailboxACL.Entry("c@domain.org", Right.Write));
 
-            storeRightManager.assertUserHasAccessToShareDomains(Username.of("user@domain.org"), mailboxACL.getEntries());
-        }
-        finally {
-            System.clearProperty("james.rights.users.crossdomain");
+            storeRightManager.assertUserHasAccessToShareeDomains(Username.of("user@domain.org"), mailboxACL.getEntries());
+        } finally {
+            StoreRightManager.IS_CROSS_DOMAIN_ACCESS_ALLOWED = false;
         }
     }
 
@@ -314,7 +313,7 @@ class StoreRightManagerTest {
     @Test
     void applyRightsCommandShouldNotThrowOnDifferentDomainsWhenCrossDomainEnabled() throws MailboxException {
         try {
-            System.setProperty("james.rights.users.crossdomain", "true");
+            StoreRightManager.IS_CROSS_DOMAIN_ACCESS_ALLOWED = true;
 
             MailboxPath mailboxPath = MailboxPath.forUser(Username.of("user@domain.org"), "mailbox");
             Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY, MAILBOX_ID);
@@ -333,7 +332,7 @@ class StoreRightManagerTest {
             assertThatCode(() -> storeRightManager.applyRightsCommand(mailboxPath, aclCommand, aliceSession))
                     .doesNotThrowAnyException();
         } finally {
-            System.clearProperty("james.rights.users.crossdomain");
+            StoreRightManager.IS_CROSS_DOMAIN_ACCESS_ALLOWED = false;
         }
     }
 }

--- a/server/apps/cassandra-app/docker-configuration/jvm.properties
+++ b/server/apps/cassandra-app/docker-configuration/jvm.properties
@@ -52,4 +52,4 @@ sun.rmi.dgc.client.gcInterval=3600000000
 #james.relaxed.mailbox.name.validation=true
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/cassandra-app/docker-configuration/jvm.properties
+++ b/server/apps/cassandra-app/docker-configuration/jvm.properties
@@ -50,3 +50,6 @@ sun.rmi.dgc.client.gcInterval=3600000000
 # Relax validating `*` and `%` characters in the mailbox name. Defaults to false.
 # Be careful turning on this as `%` and `*` are ambiguous for the LIST / LSUB commands that interpret those as wildcard thus returning all mailboxes matching the pattern.
 #james.relaxed.mailbox.name.validation=true
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false

--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -73,3 +73,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # Relax validating `*` and `%` characters in the mailbox name. Defaults to false.
 # Be careful turning on this as `%` and `*` are ambiguous for the LIST / LSUB commands that interpret those as wildcard thus returning all mailboxes matching the pattern.
 #james.relaxed.mailbox.name.validation=true
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false

--- a/server/apps/cassandra-app/sample-configuration/jvm.properties
+++ b/server/apps/cassandra-app/sample-configuration/jvm.properties
@@ -75,4 +75,4 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 #james.relaxed.mailbox.name.validation=true
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/distributed-app/docker-configuration/jvm.properties
+++ b/server/apps/distributed-app/docker-configuration/jvm.properties
@@ -52,4 +52,4 @@ sun.rmi.dgc.client.gcInterval=3600000000
 #james.relaxed.mailbox.name.validation=true
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/distributed-app/docker-configuration/jvm.properties
+++ b/server/apps/distributed-app/docker-configuration/jvm.properties
@@ -50,3 +50,6 @@ sun.rmi.dgc.client.gcInterval=3600000000
 # Relax validating `*` and `%` characters in the mailbox name. Defaults to false.
 # Be careful turning on this as `%` and `*` are ambiguous for the LIST / LSUB commands that interpret those as wildcard thus returning all mailboxes matching the pattern.
 #james.relaxed.mailbox.name.validation=true
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -97,3 +97,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # From which point should range operation be used? Defaults to 3.
 # james.jmap.email.set.range.threshold=3
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -99,4 +99,4 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # james.jmap.email.set.range.threshold=3
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/distributed-pop3-app/docker-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/docker-configuration/jvm.properties
@@ -52,4 +52,4 @@ sun.rmi.dgc.client.gcInterval=3600000000
 #james.relaxed.mailbox.name.validation=true
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/distributed-pop3-app/docker-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/docker-configuration/jvm.properties
@@ -50,3 +50,6 @@ sun.rmi.dgc.client.gcInterval=3600000000
 # Relax validating `*` and `%` characters in the mailbox name. Defaults to false.
 # Be careful turning on this as `%` and `*` are ambiguous for the LIST / LSUB commands that interpret those as wildcard thus returning all mailboxes matching the pattern.
 #james.relaxed.mailbox.name.validation=true
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -65,4 +65,4 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 #james.relaxed.mailbox.name.validation=true
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/jvm.properties
@@ -63,3 +63,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # Relax validating `*` and `%` characters in the mailbox name. Defaults to false.
 # Be careful turning on this as `%` and `*` are ambiguous for the LIST / LSUB commands that interpret those as wildcard thus returning all mailboxes matching the pattern.
 #james.relaxed.mailbox.name.validation=true
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -61,3 +61,6 @@ openjpa.Multithreaded=true
 # Relax validating `*` and `%` characters in the mailbox name. Defaults to false.
 # Be careful turning on this as `%` and `*` are ambiguous for the LIST / LSUB commands that interpret those as wildcard thus returning all mailboxes matching the pattern.
 #james.relaxed.mailbox.name.validation=true
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false

--- a/server/apps/jpa-app/sample-configuration/jvm.properties
+++ b/server/apps/jpa-app/sample-configuration/jvm.properties
@@ -63,4 +63,4 @@ openjpa.Multithreaded=true
 #james.relaxed.mailbox.name.validation=true
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -65,4 +65,4 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 #james.relaxed.mailbox.name.validation=true
 
 # Allow users to have rights for shares of different domain. Defaults to false.
-#james.rights.users.crossdomain=false
+#james.rights.crossdomain.allow=false

--- a/server/apps/memory-app/sample-configuration/jvm.properties
+++ b/server/apps/memory-app/sample-configuration/jvm.properties
@@ -63,3 +63,6 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 # Relax validating `*` and `%` characters in the mailbox name. Defaults to false.
 # Be careful turning on this as `%` and `*` are ambiguous for the LIST / LSUB commands that interpret those as wildcard thus returning all mailboxes matching the pattern.
 #james.relaxed.mailbox.name.validation=true
+
+# Allow users to have rights for shares of different domain. Defaults to false.
+#james.rights.users.crossdomain=false


### PR DESCRIPTION
[James-4097](https://issues.apache.org/jira/browse/JAMES-4097)

Add a configuration switch lifting the same-domain requirement when assigning rights.

This feature is opt-in - the default configuration will still forbid cross-domain access.