### PR TITLE
[FIX] Email/set destroy should fire one event per impacted mailbox

### DIFF
--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
@@ -181,12 +181,13 @@ public abstract class AbstractMessageIdManagerSideEffectTest {
         AbstractListAssert<?, List<? extends Expunged>, Expunged, ObjectAssert<Expunged>> events =
             assertThat(eventCollector.getEvents())
                 .filteredOn(event -> event instanceof Expunged)
-                .hasSize(2)
-                .extracting(event -> (Expunged) event);
+                .hasSize(1)
+                .extracting(event -> (Expunged) event)
+                .allMatch(event -> event.getExpunged().size() == 2);
         events.extracting(MailboxEvent::getMailboxId).containsOnly(mailbox1.getMailboxId(), mailbox1.getMailboxId());
         events.extracting(Expunged::getExpunged)
-            .containsOnly(ImmutableSortedMap.of(simpleMessageMetaData1.getUid(), simpleMessageMetaData1),
-                ImmutableSortedMap.of(simpleMessageMetaData2.getUid(), simpleMessageMetaData2));
+            .containsOnly(ImmutableSortedMap.of(simpleMessageMetaData1.getUid(), simpleMessageMetaData1,
+                simpleMessageMetaData2.getUid(), simpleMessageMetaData2));
     }
 
     @Test


### PR DESCRIPTION
This limits downstream chatter:
 - RabbitMQ / Redis dispatch overhead
 - Websocket resynchs