### PR TITLE
[ENHANCEMENT] Do not retry storing mails when OverQuotaException

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
@@ -83,6 +83,7 @@ public class LocalDelivery extends GenericMailet {
             .onMailetException(getInitParameter("onMailetException", Mail.ERROR))
             .retries(MailetUtil.getInitParameterAsInteger(getInitParameter("retries"), Optional.of(MailDispatcher.RETRIES)))
             .mailetContext(getMailetContext())
+            .usersRepository(usersRepository)
             .build();
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailDispatcher.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailDispatcher.java
@@ -29,9 +29,12 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.Username;
 import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.mailbox.exception.OverQuotaException;
 import org.apache.james.server.core.MailImpl;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.util.AuditTrail;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailetContext;
@@ -65,6 +68,7 @@ public class MailDispatcher {
         static final boolean DEFAULT_CONSUME = true;
         static final String DEFAULT_ERROR_PROCESSOR = Mail.ERROR;
         private MailStore mailStore;
+        private UsersRepository usersRepository;
         private Boolean consume;
         private MailetContext mailetContext;
         private String onMailetException;
@@ -85,6 +89,11 @@ public class MailDispatcher {
             return this;
         }
 
+        public Builder usersRepository(UsersRepository usersRepository) {
+            this.usersRepository = usersRepository;
+            return this;
+        }
+
         public Builder onMailetException(String onMailetException) {
             this.onMailetException = onMailetException;
             return this;
@@ -100,9 +109,11 @@ public class MailDispatcher {
         public MailDispatcher build() {
             Preconditions.checkNotNull(mailStore);
             Preconditions.checkNotNull(mailetContext);
+            Preconditions.checkNotNull(usersRepository);
+
             return new MailDispatcher(mailStore, mailetContext,
                 Optional.ofNullable(consume).orElse(DEFAULT_CONSUME),
-                retries, Optional.ofNullable(onMailetException).orElse(DEFAULT_ERROR_PROCESSOR));
+                retries, Optional.ofNullable(onMailetException).orElse(DEFAULT_ERROR_PROCESSOR), usersRepository);
         }
     }
 
@@ -113,8 +124,9 @@ public class MailDispatcher {
     private final boolean propagate;
     private final Optional<Integer> retries;
     private final String errorProcessor;
+    private final UsersRepository usersRepository;
 
-    private MailDispatcher(MailStore mailStore, MailetContext mailetContext, boolean consume, Optional<Integer> retries, String onMailetException) {
+    private MailDispatcher(MailStore mailStore, MailetContext mailetContext, boolean consume, Optional<Integer> retries, String onMailetException, UsersRepository usersRepository) {
         this.mailStore = mailStore;
         this.consume = consume;
         this.mailetContext = mailetContext;
@@ -122,6 +134,7 @@ public class MailDispatcher {
         this.errorProcessor = onMailetException;
         this.ignoreError = onMailetException.equalsIgnoreCase("ignore");
         this.propagate = onMailetException.equalsIgnoreCase("propagate");
+        this.usersRepository = usersRepository;
     }
 
     public void dispatch(Mail mail) throws MessagingException {
@@ -196,10 +209,11 @@ public class MailDispatcher {
     }
 
     private Mono<Void> storeMailWithRetry(Mail mail, MailAddress recipient) {
+        Username username = computeUsername(recipient);
         AtomicInteger remainRetries = new AtomicInteger(retries.orElse(0));
 
         Mono<Void> operation = Mono.from(mailStore.storeMail(recipient, mail))
-            .doOnError(OverQuotaException.class, e -> LOGGER.info("Could not store mail due to quota error", e))
+            .doOnError(OverQuotaException.class, e -> LOGGER.info("Could not store mail due to quota error for user {}", username.asString()))
             .doOnError(e -> !(e instanceof OverQuotaException), error -> LOGGER.warn("Error While storing mail. This error will be retried for {} more times.", remainRetries.getAndDecrement(), error));
 
         return retries.map(count ->
@@ -210,6 +224,15 @@ public class MailDispatcher {
                     .scheduler(Schedulers.parallel()))
                 .then())
             .orElse(operation);
+    }
+
+    private Username computeUsername(MailAddress recipient) {
+        try {
+            return usersRepository.getUsername(recipient);
+        } catch (UsersRepositoryException e) {
+            LOGGER.warn("Unable to retrieve username for {}", recipient.asPrettyString(), e);
+            return Username.of(recipient.asString());
+        }
     }
 
     private Map<String, List<String>> saveHeaders(Mail mail, MailAddress recipient) throws MessagingException {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailboxAppenderImpl.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailboxAppenderImpl.java
@@ -124,8 +124,7 @@ public class MailboxAppenderImpl implements MailboxAppender {
             },
             session -> appendMessageToMailbox(mail, session, mailboxPath, flags),
             this::closeProcessing)
-            .onErrorMap(OverQuotaException.class, e -> new MessagingException("Could not append due to quota error", e))
-            .onErrorMap(MailboxException.class, e -> new MessagingException("Unable to access mailbox.", e));
+            .onErrorMap(e -> e instanceof MailboxException && !(e instanceof OverQuotaException), e -> new MessagingException("Unable to access mailbox.", (MailboxException) e));
     }
 
     protected Mono<AppendResult> appendMessageToMailbox(MimeMessage mail, MailboxSession session, MailboxPath path, Optional<Flags> flags) {

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailDispatcherTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailDispatcherTest.java
@@ -38,6 +38,8 @@ import jakarta.mail.MessagingException;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.memory.MemoryUsersRepository;
 import org.apache.james.util.MimeMessageUtil;
 import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders.Header;
@@ -64,12 +66,14 @@ class MailDispatcherTest {
 
     private FakeMailContext fakeMailContext;
     private MailStore mailStore;
+    private UsersRepository usersRepository;
 
     @BeforeEach
     public void setUp() throws Exception {
         fakeMailContext = FakeMailContext.defaultContext();
         mailStore = mock(MailStore.class);
         when(mailStore.storeMail(any(), any())).thenReturn(Mono.empty());
+        usersRepository = MemoryUsersRepository.withVirtualHosting(null);
     }
 
     @Test
@@ -78,6 +82,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .consume(true)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -101,6 +106,7 @@ class MailDispatcherTest {
             .retries(3)
             .mailStore(mailStore)
             .consume(true)
+            .usersRepository(usersRepository)
             .build();
 
         AtomicInteger counter = new AtomicInteger(0);
@@ -132,6 +138,7 @@ class MailDispatcherTest {
             .retries(0)
             .mailStore(mailStore)
             .consume(true)
+            .usersRepository(usersRepository)
             .build();
 
         AtomicInteger counter = new AtomicInteger(0);
@@ -162,6 +169,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .consume(true)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -181,6 +189,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         String state = "state";
@@ -201,6 +210,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .consume(true)
+            .usersRepository(usersRepository)
             .build();
         doReturn(Mono.error(new MessagingException()))
             .when(mailStore)
@@ -237,6 +247,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -262,6 +273,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(accumulatorTestHeaderMailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -285,6 +297,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(accumulatorTestHeaderMailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -308,6 +321,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(accumulatorTestHeaderMailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -333,6 +347,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(accumulatorTestHeaderMailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -359,6 +374,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(accumulatorTestHeaderMailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         FakeMail mail = FakeMail.builder()
@@ -382,6 +398,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(accumulatorTestHeaderMailStore)
             .consume(false)
+            .usersRepository(usersRepository)
             .build();
 
         String headerValue = "arbitraryValue";
@@ -406,6 +423,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .onMailetException("ignore")
+            .usersRepository(usersRepository)
             .build();
 
         doReturn(Mono.error(new MessagingException()))
@@ -434,6 +452,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .onMailetException("errorProcessor1")
+            .usersRepository(usersRepository)
             .build();
 
         doReturn(Mono.error(new MessagingException()))
@@ -463,6 +482,7 @@ class MailDispatcherTest {
             .mailetContext(fakeMailContext)
             .mailStore(mailStore)
             .onMailetException("propagate")
+            .usersRepository(usersRepository)
             .build();
 
         doReturn(Mono.error(new MessagingException()))


### PR DESCRIPTION
And log level INFO.

Was:
```
Caused by: jakarta.mail.MessagingException: Could not append due to quota error
	at org.apache.james.transport.mailets.delivery.MailboxAppenderImpl.lambda$append$7(MailboxAppenderImpl.java:127)
	at reactor.core.publisher.Mono.lambda$onErrorMap$27(Mono.java:3840)
	at reactor.core.publisher.Mono.lambda$onErrorResume$29(Mono.java:3930)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:94)
	... 62 common frames omitted
Caused by: org.apache.james.mailbox.exception.OverQuotaException: You use too much space in #private&akishtoo@govmu.org
	at org.apache.james.mailbox.store.quota.QuotaChecker.trySizeAddition(QuotaChecker.java:68)
	at org.apache.james.mailbox.store.quota.QuotaChecker.tryAddition(QuotaChecker.java:59)
	at org.apache.james.mailbox.store.StoreMessageManager.lambda$createAndDispatchMessage$5(StoreMessageManager.java:537)
	at com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)
	at reactor.core.publisher.FluxPeek$PeekSubscriber.onNext(FluxPeek.java:185)
	... 54 common frames omitted
```