### PR TITLE
Jib build - update extraClasspath jdbc driver for jpa-app, jpa-smtp-app

### DIFF
--- a/server/apps/jpa-app/README.adoc
+++ b/server/apps/jpa-app/README.adoc
@@ -124,7 +124,7 @@ With `jdbc-driver.jar` being the JAR file of your driver, placed in the current 
 In `james-database.properties`, one can specify any JDBC driver on the class path.
 
 With docker, such drivers can be added to the classpath by placing the driver JAR in a volume
-and mounting it within `/root/libs` directory.
+and mounting it at `/root/libs/james-jdbc-driver.jar`.
 
 We do ship a [docker-compose](https://github.com/apache/james-project/blob/master/server/apps/jpa-smtp-app/docker-compose.yml)
 file demonstrating James JPA app usage with MariaDB. In order to run it:

--- a/server/apps/jpa-app/docker-compose.yml
+++ b/server/apps/jpa-app/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     container_name: james
     hostname: james.local
     volumes:
-      - $PWD/mariadb-java-client-2.7.2.jar:/root/libs/mariadb-java-client-2.7.2.jar
+      - $PWD/mariadb-java-client-2.7.2.jar:/root/libs/james-jdbc-driver.jar
       - $PWD/sample-configuration/james-database-mariadb.properties:/root/conf/james-database.properties
       - $PWD/keystore:/root/conf/keystore
 

--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -312,7 +312,7 @@
                             <!-- Data for derby database -->
                             <volume>/var/store</volume>
                         </volumes>
-                        <extraClasspath>/root/libs/mariadb-java-client-2.7.2.jar</extraClasspath>
+                        <extraClasspath>/root/libs/james-jdbc-driver.jar</extraClasspath>
                     </container>
                     <extraDirectories>
                         <paths>

--- a/server/apps/jpa-app/pom.xml
+++ b/server/apps/jpa-app/pom.xml
@@ -312,6 +312,7 @@
                             <!-- Data for derby database -->
                             <volume>/var/store</volume>
                         </volumes>
+                        <extraClasspath>/root/libs/mariadb-java-client-2.7.2.jar</extraClasspath>
                     </container>
                     <extraDirectories>
                         <paths>

--- a/server/apps/jpa-smtp-app/README.adoc
+++ b/server/apps/jpa-smtp-app/README.adoc
@@ -126,7 +126,7 @@ With `jdbc-driver.jar` being the JAR file of your driver, placed in the current 
 In `james-database.properties`, one can specify any JDBC driver on the class path.
 
 With docker, such drivers can be added to the classpath by placing the driver JAR in a volume
-and mounting it within `/root/libs` directory.
+and mounting it at `/root/libs/james-jdbc-driver.jar`.
 
 We do ship a [docker-compose](https://github.com/apache/james-project/blob/master/server/apps/jpa-smtp-app/docker-compose.yml)
 file demonstrating James JPA app usage with MariaDB. In order to run it:

--- a/server/apps/jpa-smtp-app/docker-compose.yml
+++ b/server/apps/jpa-smtp-app/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     container_name: james
     hostname: james.local
     volumes:
-      - $PWD/mariadb-java-client-2.7.2.jar:/root/libs/mariadb-java-client-2.7.2.jar
+      - $PWD/mariadb-java-client-2.7.2.jar:/root/libs/james-jdbc-driver.jar
       - $PWD/sample-configuration/james-database-mariadb.properties:/root/conf/james-database.properties
       - $PWD/keystore:/root/conf/keystore
 

--- a/server/apps/jpa-smtp-app/pom.xml
+++ b/server/apps/jpa-smtp-app/pom.xml
@@ -291,6 +291,7 @@
                             <volume>/root/glowroot/data</volume>
                             <volume>/root/extensions-jars</volume>
                         </volumes>
+                        <extraClasspath>/root/libs/mariadb-java-client-2.7.2.jar</extraClasspath>
                     </container>
                     <extraDirectories>
                         <paths>

--- a/server/apps/jpa-smtp-app/pom.xml
+++ b/server/apps/jpa-smtp-app/pom.xml
@@ -291,7 +291,7 @@
                             <volume>/root/glowroot/data</volume>
                             <volume>/root/extensions-jars</volume>
                         </volumes>
-                        <extraClasspath>/root/libs/mariadb-java-client-2.7.2.jar</extraClasspath>
+                        <extraClasspath>/root/libs/james-jdbc-driver.jar</extraClasspath>
                     </container>
                     <extraDirectories>
                         <paths>


### PR DESCRIPTION
Validate from jib 3.1.0 https://github.com/GoogleContainerTools/jib/blob/master/jib-gradle-plugin/CHANGELOG.md#310