### PR TITLE
JAMES-4102 Fix build migrating Zenko cloudserv S3 test image from reg…

### DIFF
--- a/docs/modules/servers/pages/distributed/operate/logging/docker-compose-block.adoc
+++ b/docs/modules/servers/pages/distributed/operate/logging/docker-compose-block.adoc
@@ -46,7 +46,7 @@ services:
       - "15672:15672"
 
   s3:
-    image: registry.scality.com/cloudserver/cloudserver:8.7.25
+    image: ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a
     container_name: s3.docker.test
     environment:
       - SCALITY_ACCESS_KEY_ID=accessKey1

--- a/docs/modules/servers/pages/distributed/run/run-docker.adoc
+++ b/docs/modules/servers/pages/distributed/run/run-docker.adoc
@@ -61,7 +61,7 @@ You need a running *rabbitmq* in docker which connects to *james* network. To ac
 
 You need a running *Zenko Cloudserver* objectstorage in docker which connects to *james* network. To achieve this run:
 
-    $ docker run -d --network james --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 registry.scality.com/cloudserver/cloudserver:8.7.25
+    $ docker run -d --network james --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a
 
 You need a running *OpenSearch* in docker which connects to *james* network. To achieve this run:
 

--- a/docs/modules/servers/pages/distributed/run/run-java.adoc
+++ b/docs/modules/servers/pages/distributed/run/run-java.adoc
@@ -53,7 +53,7 @@ running. You can either install the servers or launch them via docker:
 $ docker run -d -p 9042:9042 --name=cassandra cassandra:4.1.5
 $ docker run -d --network james -p 9200:9200 --name=opensearch --env 'discovery.type=single-node' opensearchproject/opensearch:2.14.0
 $ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.13.3-management
-$ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 registry.scality.com/cloudserver/cloudserver:8.7.25
+$ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a
 ----
 
 Once everything is set up, you just have to run the jar with:

--- a/server/apps/distributed-app/README.adoc
+++ b/server/apps/distributed-app/README.adoc
@@ -20,7 +20,7 @@ Third party compulsory dependencies:
 $ docker run -d --network james -p 9042:9042 --name=cassandra cassandra:4.1.5
 $ docker run -d --network james -p 9200:9200 --name=opensearch --env 'discovery.type=single-node' --env 'DISABLE_SECURITY_PLUGIN=true' --env 'DISABLE_INSTALL_DEMO_CONFIG=true' opensearchproject/opensearch:2.14.0
 $ docker run -d --network james -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.13.3-management
-$ docker run -d --network james -p 8000:8000 --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 registry.scality.com/cloudserver/cloudserver:8.7.25
+$ docker run -d --network james -p 8000:8000 --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a
 ----
 
 == Docker distribution

--- a/server/apps/distributed-app/docker-compose-with-pulsar.yml
+++ b/server/apps/distributed-app/docker-compose-with-pulsar.yml
@@ -71,7 +71,7 @@ services:
       - james
 
   s3:
-    image: registry.scality.com/cloudserver/cloudserver:8.7.25
+    image: ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a #v8.80.41
     container_name: s3.docker.test
     environment:
       - SCALITY_ACCESS_KEY_ID=accessKey1

--- a/server/apps/distributed-app/docker-compose.yml
+++ b/server/apps/distributed-app/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - james
 
   s3:
-    image: registry.scality.com/cloudserver/cloudserver:8.7.25
+    image: ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a #v8.80.41
     container_name: s3.docker.test
     environment:
       - SCALITY_ACCESS_KEY_ID=accessKey1

--- a/server/apps/distributed-pop3-app/README.adoc
+++ b/server/apps/distributed-pop3-app/README.adoc
@@ -21,7 +21,7 @@ Third party compulsory dependencies:
 ----
 $ docker run -d --network james -p 9042:9042 --name=cassandra cassandra:4.1.5
 $ docker run -d --network james -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.13.3-management
-$ docker run -d --network james --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 registry.scality.com/cloudserver/cloudserver:8.7.25
+$ docker run -d --network james --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a
 ----
 
 == Docker distribution

--- a/server/apps/distributed-pop3-app/docker-compose.yml
+++ b/server/apps/distributed-pop3-app/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - james
 
   s3:
-    image: registry.scality.com/cloudserver/cloudserver:8.7.25
+    image: ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a #v8.80.41
     container_name: s3.docker.test
     environment:
       - SCALITY_ACCESS_KEY_ID=accessKey1

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/DockerAwsS3Container.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/DockerAwsS3Container.java
@@ -28,7 +28,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class DockerAwsS3Container {
 
-    private static final String AWS_S3_DOCKER_IMAGE = "registry.scality.com/cloudserver/cloudserver:8.7.25";
+    private static final String AWS_S3_DOCKER_IMAGE = "ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a"; //v8.80.41
     private static final int AWS_S3_PORT = 8000;
     private static final int ONE_TIME = 1;
 

--- a/src/site/markdown/server/install/guice-cassandra-rabbitmq-s3.md
+++ b/src/site/markdown/server/install/guice-cassandra-rabbitmq-s3.md
@@ -50,7 +50,7 @@ You need to have a Cassandra, OpenSearch, S3 and RabbitMQ instance running. You 
 $ docker run -d -p 9042:9042 --name=cassandra cassandra:4.1.5
 $ docker run -d --network james -p 9200:9200 --name=opensearch --env 'discovery.type=single-node' opensearchproject/opensearch:2.14.0
 $ docker run -d -p 5672:5672 -p 15672:15672 --name=rabbitmq rabbitmq:3.13.3-management
-$ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 registry.scality.com/cloudserver/cloudserver:8.7.25
+$ docker run -d --env 'REMOTE_MANAGEMENT_DISABLE=1' --env 'SCALITY_ACCESS_KEY_ID=accessKey1' --env 'SCALITY_SECRET_ACCESS_KEY=secretKey1' --name=s3 ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a
 ```
 
 Once everything is set up, you just have to run the jar with:

--- a/third-party/clamav/docker-compose.yml
+++ b/third-party/clamav/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - james
 
   s3:
-    image: registry.scality.com/cloudserver/cloudserver:8.7.25
+    image: ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a #v8.80.41
     container_name: s3.docker.test
     environment:
       - SCALITY_ACCESS_KEY_ID=accessKey1

--- a/third-party/rspamd/docker-compose-distributed.yml
+++ b/third-party/rspamd/docker-compose-distributed.yml
@@ -80,7 +80,7 @@ services:
       - james
 
   s3:
-    image: registry.scality.com/cloudserver/cloudserver:8.7.25
+    image: ghcr.io/scality/cloudserver:8cbe2c066b3505b26d339dc67315d1041b8c7f3a #v8.80.41
     container_name: s3.docker.test
     environment:
       - SCALITY_ACCESS_KEY_ID=accessKey1


### PR DESCRIPTION
…istry.scality.com to ghcr.io

Upgrading as well from 8.7.25 to latest 8.80.41

Tested locally with S3BlobStoreDAOTest quickly, tests seem to pass. Let's see on the all build overall.