### PR TITLE
[devscout] adds missing binding for S3RequestOption

### DIFF
--- a/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
+++ b/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/Main.java
@@ -23,6 +23,7 @@ import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreDAO;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.objectstorage.aws.S3BlobStoreDAO;
+import org.apache.james.blob.objectstorage.aws.S3RequestOption;
 import org.apache.james.mailrepository.api.MailRepositoryUrlStore;
 import org.apache.james.mailrepository.jpa.JPAMailRepositoryUrlStore;
 import org.apache.james.modules.RunArgumentsModule;
@@ -71,6 +72,7 @@ public class Main implements JamesServerMain {
         new S3BlobStoreModule(),
         new S3BucketModule(),
         binder -> {
+            binder.bind(S3RequestOption.class).toInstance(S3RequestOption.DEFAULT);
             binder.bind(BlobStoreDAO.class).to(S3BlobStoreDAO.class)
                 .in(Scopes.SINGLETON);
             binder.bind(BlobStore.class)


### PR DESCRIPTION
Without this fix the scaling pulsar smtp assembly doesn't start This is not detected by tests because the  AwsS3BlobStoreExtension injects the awsS3TestRule's module which does inject the default option in scope so it only affects the production code.

cc @vttranlina @quantranhong1999 