### PR TITLE
Improve documentation for activating debug mode for tests

### DIFF
--- a/docs/modules/development/pages/logging.adoc
+++ b/docs/modules/development/pages/logging.adoc
@@ -49,11 +49,11 @@ When investigating failing tests, increasing the log level can provide valuable 
 === Log Configuration
 
 All modules in James inherit their default test log configurations from the `testing-base` module.
-The log settings are defined in `resources/logback-test.xml`.
+The log settings are defined in link:https://github.com/apache/james-project/blob/master/testing/base/src/main/resources/logback-test.xml[resources/logback-test.xml].
 
 === Activating Debug Logs
 
-To enable debug logs, refer to the instructions in the header of `logback-test.xml`.
+To enable debug logs, refer to the instructions in the header of `link:https://github.com/apache/james-project/blob/master/testing/base/src/main/resources/logback-test.xml[resources/logback-test.xml]`.
 Carefully follow the steps mentioned to adjust the log level appropriately.
 
 

--- a/docs/modules/development/pages/logging.adoc
+++ b/docs/modules/development/pages/logging.adoc
@@ -41,3 +41,19 @@ The most useful loggers should to be documented below.
 Please maintain this list of loggers.
 
 org.apache.james.CONFIGURATION:: It is used to log events related to configuration loading and updating.
+
+== Logging when debugging tests
+
+When investigating failing tests, increasing the log level can provide valuable insights.
+
+=== Log Configuration
+
+All modules in James inherit their default test log configurations from the `testing-base` module.
+The log settings are defined in `resources/logback-test.xml`.
+
+=== Activating Debug Logs
+
+To enable debug logs, refer to the instructions in the header of `logback-test.xml`.
+Carefully follow the steps mentioned to adjust the log level appropriately.
+
+

--- a/testing/base/src/main/resources/logback-test.xml
+++ b/testing/base/src/main/resources/logback-test.xml
@@ -1,4 +1,6 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- NOTE: To activate debug mode, follow Steps 1 & 2 -->
 <configuration>
         <appender name="FILE" class="ch.qos.logback.core.FileAppender">
                 <file>target/test-run.log</file>
@@ -18,12 +20,13 @@
                         <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
                 </encoder>
                 <immediateFlush>false</immediateFlush>
-                <!-- Disable below block for debug logs mode-->
+                <!-- Step 1: Disable below block for debug logs mode-->
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                         <level>ERROR</level>
                 </filter>
         </appender>
 
+        <!-- Step 2: Set log level to DEBUG-->
         <root level="WARN">
                 <appender-ref ref="CONSOLE" />
                 <appender-ref ref="FILE" />

--- a/testing/base/src/main/resources/logback-test.xml
+++ b/testing/base/src/main/resources/logback-test.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- NOTE: To activate debug mode, follow Steps 1 & 2 -->
 <configuration>


### PR DESCRIPTION
This sample config can be used when debugging tests by setting the log level to DEBUG.