### PR TITLE
JAMES-4108: James stuck in authentication loop after successful XOAUTH2 authentication

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
@@ -190,7 +190,7 @@ public class AuthCmdHandler
                     return doPlainAuth(session, l);
                 }
             });
-            return AUTH_READY_USERNAME_LOGIN;
+            return AUTH_READY_PLAIN;
         });
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
@@ -106,6 +106,7 @@ public class UsersRepositoryAuthHook implements AuthHook {
             users.assertValid(username);
             session.setUsername(username);
             session.setRelayingAllowed(true);
+            //session.popLineHandler();
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.ok())
                 .smtpDescription("Authentication successful.")

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPSaslTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPSaslTest.java
@@ -118,6 +118,9 @@ class SMTPSaslTest {
         client.sendCommand("AUTH OAUTHBEARER " + VALID_TOKEN);
 
         assertThat(client.getReplyString()).contains("235 Authentication successful.");
+
+        client.sendCommand("NOOP");
+        assertThat(client.getReplyString()).contains("250 2.0.0 OK");
     }
 
     @Test
@@ -129,6 +132,9 @@ class SMTPSaslTest {
         client.sendCommand(VALID_TOKEN);
 
         assertThat(client.getReplyString()).contains("235 Authentication successful.");
+
+        client.sendCommand("NOOP");
+        assertThat(client.getReplyString()).contains("250 2.0.0 OK");
     }
 
     @Test
@@ -140,6 +146,9 @@ class SMTPSaslTest {
         client.sendCommand(VALID_TOKEN);
 
         assertThat(client.getReplyString()).contains("235 Authentication successful.");
+
+        client.sendCommand("NOOP");
+        assertThat(client.getReplyString()).contains("250 2.0.0 OK");
     }
 
     @Test


### PR DESCRIPTION
I only added some test cases here to show that there is a problem. The commented line would fix those tests but I am not 100% sure that it does not have other side effects.

This also includes a very small fix (rename) for plain authentication which currently asks for a username although the correct message is present in the same file. I can also put this in another MR if you want.