### PR TITLE
[ENHANCEMENT] Allow plug custom indexers into OpenSearchListeningMessageSearchIndex

### DIFF
--- a/docs/modules/servers/pages/distributed/configure/jvm.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jvm.adoc
@@ -3,3 +3,16 @@
 
 :sample-configuration-prefix-url: https://github.com/apache/james-project/blob/master/server/apps/distributed-app/sample-configuration
 include::partial$configure/jvm.adoc[]
+
+== Disable OpenSearchListeningMessageSearchIndex fetch full message content
+
+Whether to fetch full message content when indexing messages in OpenSearch. This is useful when you want to avoid fetch full message content while indexing only headers for example.
+
+Be careful whether the custom `OpenSearchListeningMessageSearchIndex.Indexer` (s) need full message content or not.
+
+Ex in `jvm.properties`:
+----
+opensearch.index.listener.fetch.full.content=false
+----
+
+Optional. Boolean. Defaults to true.

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndex.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndex.java
@@ -238,6 +238,7 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
 
     }
 
+    private static final boolean FETCH_FULL_MESSAGE_CONTENT = Boolean.valueOf(System.getProperty("opensearch.index.listener.fetch.full.content", "true"));
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchListeningMessageSearchIndex.class);
     private static final String ID_SEPARATOR = ":";
     private static final Group GROUP = new OpenSearchListeningMessageSearchIndexGroup();
@@ -342,6 +343,9 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
     }
 
     private FetchType chooseFetchType() {
+        if (FETCH_FULL_MESSAGE_CONTENT) {
+            return FetchType.FULL;
+        }
         if (indexBody == IndexBody.YES) {
             return FetchType.FULL;
         }

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndex.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndex.java
@@ -107,6 +107,17 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
         Mono<Void> handleAddedEvent(MailboxSession session, MailboxEvents.Added addedEvent, MailboxId mailboxId);
     }
 
+    public interface Indexer {
+        Mono<Void> added(MailboxSession session, MailboxEvents.Added addedEvent, Mailbox mailbox, MailboxMessage message);
+
+        static Indexer merge(Indexer defaultIndexer, Set<Indexer> overrides) {
+            return (session, addedEvent, mailbox, message) -> defaultIndexer.added(session, addedEvent, mailbox, message)
+                .then(Flux.fromIterable(overrides)
+                    .concatMap(indexer -> indexer.added(session, addedEvent, mailbox, message))
+                    .then());
+        }
+    }
+
     class NaiveIndexingStrategy implements IndexingStrategy {
 
         @Override
@@ -117,6 +128,20 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
         @Override
         public Mono<Void> handleAddedEvent(MailboxSession session, MailboxEvents.Added addedEvent, MailboxId mailboxId) {
             return processAddedEvent(session, addedEvent, mailboxId);
+        }
+    }
+
+    class DefaultIndexer implements Indexer {
+        @Override
+        public Mono<Void> added(MailboxSession session, MailboxEvents.Added addedEvent, Mailbox mailbox, MailboxMessage message) {
+            LOGGER.info("Indexing mailbox {}-{} of user {} on message {}",
+                mailbox.getName(),
+                mailbox.getMailboxId().serialize(),
+                session.getUser().asString(),
+                message.getUid().asLong());
+
+            return generateIndexedJson(mailbox, message, session)
+                .flatMap(jsonContent -> add(mailbox.getMailboxId(), message.getUid(), jsonContent));
         }
     }
 
@@ -231,6 +256,7 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
     private final Metric reIndexNotFoundMetric;
     private final IndexingStrategy indexingStrategy;
     private final IndexBody indexBody;
+    private final Set<Indexer> indexerOverrides;
 
     @Inject
     public OpenSearchListeningMessageSearchIndex(MailboxSessionMapperFactory factory,
@@ -238,7 +264,7 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
                                                  @Named(MailboxOpenSearchConstants.InjectionNames.MAILBOX) OpenSearchIndexer indexer,
                                                  OpenSearchSearcher searcher, MessageToOpenSearchJson messageToOpenSearchJson,
                                                  SessionProvider sessionProvider, RoutingKey.Factory<MailboxId> routingKeyFactory, MessageId.Factory messageIdFactory,
-                                                 OpenSearchMailboxConfiguration configuration, MetricFactory metricFactory) {
+                                                 OpenSearchMailboxConfiguration configuration, MetricFactory metricFactory, Set<Indexer> indexersOverride) {
         super(factory, searchOverrides, sessionProvider);
         this.sessionProvider = sessionProvider;
         this.factory = factory;
@@ -247,6 +273,7 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
         this.searcher = searcher;
         this.routingKeyFactory = routingKeyFactory;
         this.messageIdFactory = messageIdFactory;
+        this.indexerOverrides = indexersOverride;
         if (configuration.isOptimiseMoves()) {
             this.indexingStrategy = new OptimizedIndexingStrategy();
         } else {
@@ -346,14 +373,13 @@ public class OpenSearchListeningMessageSearchIndex extends ListeningMessageSearc
 
     @Override
     public Mono<Void> add(MailboxSession session, Mailbox mailbox, MailboxMessage message) {
-        LOGGER.info("Indexing mailbox {}-{} of user {} on message {}",
-            mailbox.getName(),
-            mailbox.getMailboxId().serialize(),
-            session.getUser().asString(),
-            message.getUid().asLong());
+        return add(session, mailbox, message, null);
+    }
 
-        return generateIndexedJson(mailbox, message, session)
-            .flatMap(jsonContent -> add(mailbox.getMailboxId(), message.getUid(), jsonContent));
+    @Override
+    public Mono<Void> add(MailboxSession session, Mailbox mailbox, MailboxMessage message, MailboxEvents.Added added) {
+        return Indexer.merge(new DefaultIndexer(), indexerOverrides)
+            .added(session, added, mailbox, message);
     }
 
     private Mono<Void> add(MailboxId mailboxId, MessageUid messageUid, String jsonContent) {

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchIntegrationTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchIntegrationTest.java
@@ -162,7 +162,8 @@ class OpenSearchIntegrationTest extends AbstractMessageSearchIndexTest {
                     readAliasName, routingKeyFactory),
                 new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory,
-                openSearchMailboxConfiguration(), new RecordingMetricFactory()))
+                openSearchMailboxConfiguration(), new RecordingMetricFactory(),
+                ImmutableSet.of()))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchNoIndexBodyIntegrationTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchNoIndexBodyIntegrationTest.java
@@ -126,7 +126,8 @@ public class OpenSearchNoIndexBodyIntegrationTest {
                 new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE, readAliasName, routingKeyFactory),
                 new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES, IndexBody.NO),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory,
-                OpenSearchMailboxConfiguration.builder().indexBody(IndexBody.NO).build(), new RecordingMetricFactory()))
+                OpenSearchMailboxConfiguration.builder().indexBody(IndexBody.NO).build(), new RecordingMetricFactory(),
+                ImmutableSet.of()))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/events/OpenSearchListeningMessageSearchIndexTest.java
@@ -220,7 +220,8 @@ class OpenSearchListeningMessageSearchIndexTest {
         testee = new OpenSearchListeningMessageSearchIndex(mapperFactory,
             ImmutableSet.of(), openSearchIndexer, openSearchSearcher,
             messageToOpenSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory(), messageIdFactory,
-            OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory());
+            OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory(),
+            ImmutableSet.of());
         session = sessionProvider.createSystemSession(USERNAME);
 
         mailbox = mapperFactory.getMailboxMapper(session).create(MailboxPath.forUser(USERNAME, DefaultMailboxes.INBOX), UidValidity.generate()).block();
@@ -287,7 +288,8 @@ class OpenSearchListeningMessageSearchIndexTest {
         testee = new OpenSearchListeningMessageSearchIndex(mapperFactory,
             ImmutableSet.of(), openSearchIndexer, openSearchSearcher,
             messageToOpenSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory(), new InMemoryMessageId.Factory(),
-            OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory());
+            OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory(),
+            ImmutableSet.of());
 
         testee.add(session, mailbox, MESSAGE_WITH_ATTACHMENT).block();
         awaitForOpenSearch(QueryBuilders.matchAll().build().toQuery(), 1L);

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearchHighlighterTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearchHighlighterTest.java
@@ -142,7 +142,8 @@ public class OpenSearchSearchHighlighterTest implements SearchHighLighterContrac
                 openSearchSearcher,
                 new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory,
-                openSearchMailboxConfiguration, new RecordingMetricFactory()))
+                openSearchMailboxConfiguration, new RecordingMetricFactory(),
+                ImmutableSet.of()))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcherTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcherTest.java
@@ -132,7 +132,8 @@ class OpenSearchSearcherTest {
                 new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE, readAliasName, routingKeyFactory),
                 new MessageToOpenSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory,
-                OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory()))
+                OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory(),
+                ImmutableSet.of()))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
@@ -141,7 +141,7 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
         return Flux.fromIterable(MessageRange.toRanges(added.getUids()))
             .concatMap(range -> retrieveMailboxMessages(session, mailbox, range, fetchType))
             .publishOn(Schedulers.parallel())
-            .concatMap(mailboxMessage -> add(session, mailbox, mailboxMessage))
+            .concatMap(mailboxMessage -> add(session, mailbox, mailboxMessage, added))
             .then();
     }
 
@@ -160,6 +160,10 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
      * @param message The added message
      */
     public abstract Mono<Void> add(MailboxSession session, Mailbox mailbox, MailboxMessage message);
+
+    public Mono<Void> add(MailboxSession session, Mailbox mailbox, MailboxMessage message, Added added) {
+        return add(session, mailbox, message);
+    }
 
     /**
      * Delete the concerned UIDs for the given {@link Mailbox} from the index

--- a/mpt/impl/imap-mailbox/opensearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/OpenSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/opensearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/OpenSearchHostSystem.java
@@ -108,7 +108,8 @@ public class OpenSearchHostSystem extends JamesImapHostSystem {
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
                 new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
                 preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory,
-                OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory()))
+                OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory(),
+                ImmutableSet.of()))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/server/container/guice/opensearch/src/main/java/org/apache/james/modules/mailbox/OpenSearchMailboxModule.java
+++ b/server/container/guice/opensearch/src/main/java/org/apache/james/modules/mailbox/OpenSearchMailboxModule.java
@@ -104,6 +104,8 @@ public class OpenSearchMailboxModule extends AbstractModule {
         Multibinder.newSetBinder(binder(), StartUpCheck.class)
             .addBinding()
             .to(OpenSearchStartUpCheck.class);
+
+        Multibinder.newSetBinder(binder(), OpenSearchListeningMessageSearchIndex.Indexer.class);
     }
 
     @Provides

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -705,6 +705,7 @@ class MailboxesRoutesTest {
 
                 verify(searchIndex).deleteAll(any(MailboxSession.class), mailboxIdCaptor.capture());
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+                verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture(), any());
                 verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 
@@ -1129,6 +1130,7 @@ class MailboxesRoutesTest {
 
                 verify(searchIndex).deleteAll(any(MailboxSession.class), mailboxIdCaptor.capture());
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+                verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture(), any());
                 verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 
@@ -1295,6 +1297,7 @@ class MailboxesRoutesTest {
                 ArgumentCaptor<Mailbox> mailboxCaptor = ArgumentCaptor.forClass(Mailbox.class);
 
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor.capture(), messageCaptor.capture());
+                verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor.capture(), messageCaptor.capture(), any());
                 verifyNoMoreInteractions(searchIndex);
 
                 assertThat(mailboxCaptor.getValue()).matches(mailbox -> mailbox.getMailboxId().equals(mailboxId));
@@ -1626,6 +1629,7 @@ class MailboxesRoutesTest {
                 ArgumentCaptor<MailboxMessage> messageCaptor = ArgumentCaptor.forClass(MailboxMessage.class);
                 ArgumentCaptor<Mailbox> mailboxCaptor = ArgumentCaptor.forClass(Mailbox.class);
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor.capture(), messageCaptor.capture());
+                verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor.capture(), messageCaptor.capture(), any());
                 verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -165,7 +165,8 @@ class MailboxesRoutesTest {
                 new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,
                     MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
                 new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
-                preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory, OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory()))
+                preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory, OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory(),
+                ImmutableSet.of()))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -2072,6 +2072,7 @@ class UserMailboxesRoutesTest {
 
                 verify(searchIndex).deleteAll(any(MailboxSession.class), mailboxIdCaptor.capture());
                 verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture());
+                verify(searchIndex).add(any(MailboxSession.class), mailboxCaptor2.capture(), messageCaptor.capture(), any());
                 verify(searchIndex).postReindexing();
                 verifyNoMoreInteractions(searchIndex);
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -1521,7 +1521,8 @@ class UserMailboxesRoutesTest {
                     new OpenSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,
                         MailboxOpenSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
                     new MessageToOpenSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES, IndexHeaders.YES),
-                    preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory, OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory()))
+                    preInstanciationStage.getSessionProvider(), routingKeyFactory, messageIdFactory, OpenSearchMailboxConfiguration.builder().build(), new RecordingMetricFactory(),
+                    ImmutableSet.of()))
                 .noPreDeletionHooks()
                 .storeQuotaManager()
                 .build();


### PR DESCRIPTION
During the listener process, we need to re-download the all message in order to...

- Index it in search engine
- Pre-compute the JMAP preview

That would cause x2 network traffic and x2 S3 bill.

We can download the message just once doing both the job to optimize the performance and cost.