### PR TITLE
JAMES-3788 Allow configuring if Proxy or SSL frames should be handled…

### DIFF
--- a/docs/modules/servers/partials/configure/imap.adoc
+++ b/docs/modules/servers/partials/configure/imap.adoc
@@ -119,7 +119,7 @@ with other proxies (e.g. traefik). If enabled, it is *required* to initiate the 
 using HAProxy's proxy protocol.
 
 | proxyFirst
-| Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+| Whether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
 (so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
 (more suited for some cloud vendors). Defaults to true (TCP transparent).
 

--- a/docs/modules/servers/partials/configure/imap.adoc
+++ b/docs/modules/servers/partials/configure/imap.adoc
@@ -118,6 +118,11 @@ Integer, defaults to 4096, must be positive, 0 means no queue.
 with other proxies (e.g. traefik). If enabled, it is *required* to initiate the connection
 using HAProxy's proxy protocol.
 
+| proxyFirst
+| Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+(so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
+(more suited for some cloud vendors). Defaults to true (TCP transparent).
+
 | bossWorkerCount
 | Set the maximum count of boss threads. Boss threads are responsible for accepting incoming IMAP connections
 and initializing associated resources. Optional integer, by default, boss threads are not used and this responsibility is being dealt with

--- a/docs/modules/servers/partials/configure/smtp.adoc
+++ b/docs/modules/servers/partials/configure/smtp.adoc
@@ -57,6 +57,11 @@ this case, if nobody is present, the value "localhost" will be used.
 with other proxies (e.g. traefik). If enabled, it is *required* to initiate the connection
 using HAProxy's proxy protocol.
 
+| proxyFirst
+| Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+(so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
+(more suited for some cloud vendors). Defaults to true (TCP transparent).
+
 | authRequired
 | (deprecated) use auth.announce instead.
 

--- a/docs/modules/servers/partials/configure/smtp.adoc
+++ b/docs/modules/servers/partials/configure/smtp.adoc
@@ -58,7 +58,7 @@ with other proxies (e.g. traefik). If enabled, it is *required* to initiate the 
 using HAProxy's proxy protocol.
 
 | proxyFirst
-| Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+| Whether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
 (so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
 (more suited for some cloud vendors). Defaults to true (TCP transparent).
 

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/AbstractSSLAwareChannelPipelineFactory.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/AbstractSSLAwareChannelPipelineFactory.java
@@ -32,21 +32,23 @@ import io.netty.util.concurrent.EventExecutorGroup;
 @ChannelHandler.Sharable
 public abstract class AbstractSSLAwareChannelPipelineFactory<C extends SocketChannel> extends AbstractChannelPipelineFactory<C> {
     private final boolean proxyRequired;
+    private final boolean proxyFirst;
     private Supplier<Encryption> secure;
 
     public AbstractSSLAwareChannelPipelineFactory(int timeout,
                                                   int maxConnections, int maxConnectsPerIp,
-                                                  boolean proxyRequired,
+                                                  boolean proxyRequired, boolean proxyFirst,
                                                   ChannelHandlerFactory frameHandlerFactory,
                                                   EventExecutorGroup eventExecutorGroup) {
         super(timeout, maxConnections, maxConnectsPerIp, proxyRequired, frameHandlerFactory, eventExecutorGroup);
         this.proxyRequired = proxyRequired;
+        this.proxyFirst = proxyFirst;
     }
 
     public AbstractSSLAwareChannelPipelineFactory(int timeout,
-            int maxConnections, int maxConnectsPerIp, boolean proxyRequired, Supplier<Encryption> secure,
-            ChannelHandlerFactory frameHandlerFactory, EventExecutorGroup eventExecutorGroup) {
-        this(timeout, maxConnections, maxConnectsPerIp, proxyRequired, frameHandlerFactory, eventExecutorGroup);
+                                                  int maxConnections, int maxConnectsPerIp, boolean proxyRequired, boolean proxyFirst, Supplier<Encryption> secure,
+                                                  ChannelHandlerFactory frameHandlerFactory, EventExecutorGroup eventExecutorGroup) {
+        this(timeout, maxConnections, maxConnectsPerIp, proxyRequired, proxyFirst, frameHandlerFactory, eventExecutorGroup);
 
         this.secure = secure;
     }
@@ -56,7 +58,7 @@ public abstract class AbstractSSLAwareChannelPipelineFactory<C extends SocketCha
         super.initChannel(channel);
 
         if (isSSLSocket()) {
-            if (proxyRequired) {
+            if (proxyRequired && proxyFirst) {
                 channel.pipeline().addAfter(HandlerConstants.PROXY_HANDLER, HandlerConstants.SSL_HANDLER, secure.get().sslHandler());
             } else {
                 channel.pipeline().addFirst(HandlerConstants.SSL_HANDLER, secure.get().sslHandler());

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyServer.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyServer.java
@@ -123,11 +123,13 @@ public class NettyServer extends AbstractAsyncServer {
     @Override
     protected AbstractChannelPipelineFactory createPipelineFactory() {
 
+        boolean proxyFirst = true;
         return new AbstractSSLAwareChannelPipelineFactory(
             getTimeout(),
             maxCurConnections,
             maxCurConnectionsPerIP,
             proxyRequired,
+            proxyFirst,
             () -> secure,
             getFrameHandlerFactory(),
             new DefaultEventLoopGroup(16)) {

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServer.java
@@ -321,7 +321,7 @@ public class IMAPServer extends AbstractConfigurableAsyncServer implements ImapC
                
                 Encryption secure = getEncryption();
                 if (secure != null && !secure.isStartTLS()) {
-                    if (proxyRequired) {
+                    if (proxyRequired && proxyFirst) {
                         channel.pipeline().addAfter("proxyInformationHandler", SSL_HANDLER, secure.sslHandler());
                     } else {
                         channel.pipeline().addFirst(SSL_HANDLER, secure.sslHandler());

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
@@ -90,6 +90,7 @@ public abstract class AbstractConfigurableAsyncServer
 
     /** The name of the parameter defining the service hello name. */
     public static final String PROXY_REQUIRED = "proxyRequired";
+    public static final String PROXY_FIRST = "proxyFirst";
 
     public static final int DEFAULT_MAX_EXECUTOR_COUNT = 16;
 
@@ -98,6 +99,7 @@ public abstract class AbstractConfigurableAsyncServer
     private boolean enabled;
 
     protected boolean proxyRequired;
+    protected boolean proxyFirst;
 
     protected int connPerIP;
 
@@ -251,6 +253,7 @@ public abstract class AbstractConfigurableAsyncServer
         Optional.ofNullable(config.getBoolean("useEpoll", null)).ifPresent(this::setUseEpoll);
 
         proxyRequired = config.getBoolean(PROXY_REQUIRED, false);
+        proxyFirst = config.getBoolean(PROXY_FIRST, false);
 
         doConfigure(config);
 
@@ -488,7 +491,7 @@ public abstract class AbstractConfigurableAsyncServer
     @Override
     protected AbstractChannelPipelineFactory createPipelineFactory() {
         return new AbstractSSLAwareChannelPipelineFactory<>(getTimeout(), connectionLimit, connPerIP,
-            proxyRequired,
+            proxyRequired, proxyFirst,
             this::getEncryption, getFrameHandlerFactory(), getExecutorGroup()) {
 
             @Override

--- a/src/site/xdoc/server/config-imap4.xml
+++ b/src/site/xdoc/server/config-imap4.xml
@@ -86,12 +86,17 @@
         <dt><strong>maxQueueSize</strong></dt>
         <dd>Upper bound to the IMAP throttler queue. Upon burst, requests that cannot be queued are rejected and not executed.
             Integer, defaults to 4096, must be positive, 0 means no queue.</dd>
-        <dt><strong>handler.proxyRequired</strong></dt>
+        <dt><strong>proxyRequired</strong></dt>
         <dd>
           Enables proxy support for this service for incoming connections. HAProxy's protocol
           (https://www.haproxy.org/download/2.7/doc/proxy-protocol.txt) is used and might be compatible
           with other proxies (e.g. traefik). If enabled, it is *required* to initiate the connection
           using HAProxy's proxy protocol.
+        </dd>
+        <dt><strong>proxyFirst</strong></dt>
+        <dd>Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+            (so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
+            (more suited for some cloud vendors). Defaults to true (TCP transparent).
         </dd>
         <dt><strong>handler.handlerchain</strong></dt>
         <dd>This loads the core CommandHandlers. Only remove this if you really 

--- a/src/site/xdoc/server/config-imap4.xml
+++ b/src/site/xdoc/server/config-imap4.xml
@@ -94,7 +94,7 @@
           using HAProxy's proxy protocol.
         </dd>
         <dt><strong>proxyFirst</strong></dt>
-        <dd>Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+        <dd>Whether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
             (so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
             (more suited for some cloud vendors). Defaults to true (TCP transparent).
         </dd>

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -82,7 +82,7 @@
         using HAProxy's proxy protocol.
       </dd>
         <dt><strong>proxyFirst</strong></dt>
-        <dd>Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+        <dd>Whether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
             (so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
             (more suited for some cloud vendors). Defaults to true (TCP transparent).
         </dd>

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -81,6 +81,11 @@
         with other proxies (e.g. traefik). If enabled, it is *required* to initiate the connection
         using HAProxy's proxy protocol.
       </dd>
+        <dt><strong>proxyFirst</strong></dt>
+        <dd>Wether proxy frames should be handled before SSL handshakes. This allows setting either the loadbalancer in TCP mode
+            (so transparent for SSL then Proxy frames needs to be handled first) or set up SSL termination between proxy and server
+            (more suited for some cloud vendors). Defaults to true (TCP transparent).
+        </dd>
         <dt><strong>authRequired</strong></dt>
         <dd>(deprecated) use auth.announce instead.
             This is an optional tag with a boolean body.  If true, then the server will


### PR DESCRIPTION
… first

 - SSL aware load balancer with an SSL backend would generally establish SSL termination first then handover proxy information, for example secure setup in a third party data center.
 - Simpler setup in just TCP transparent and (eg HAProxy in TCP mode) and would only append the proxy frames prior to the SSL handshake.

 We need a mode to distinguish both setups.