### PR TITLE
[UPGRADE] Netty 4.1.110 => 4.1.118

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -644,7 +644,7 @@
         <junit.platform.version>1.10.2</junit.platform.version>
         <junit.vintage.version>5.10.2</junit.vintage.version>
         <concurrent.version>1.3.4</concurrent.version>
-        <netty.version>4.1.110.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <cucumber.version>7.15.0</cucumber.version>
 
         <jackson.version>2.17.1</jackson.version>

--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Blob :: S3</name>
 
     <properties>
-        <s3-sdk.version>2.26.5</s3-sdk.version>
+        <s3-sdk.version>2.30.16</s3-sdk.version>
     </properties>
 
     <dependencies>

--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Blob :: S3</name>
 
     <properties>
-        <s3-sdk.version>2.30.16</s3-sdk.version>
+        <s3-sdk.version>2.29.52</s3-sdk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Addresses CVE-2025-24970: Input validation for native SSL