### PR TITLE
JAMES-3171 - JMAP - Mailbox/get - Fix missing MailboxDelete right in response for shared mailbox

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -6525,7 +6525,7 @@ trait MailboxSetMethodContract {
          |                "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
          |                "update": {
          |                    "${mailboxId.serialize}": {
-         |                      "sharedWith/${ANDRE.asString()}": ["x"]
+         |                      "sharedWith/${ANDRE.asString()}": ["y"]
          |                    }
          |                }
          |           },
@@ -6561,7 +6561,7 @@ trait MailboxSetMethodContract {
          |                "notUpdated": {
          |                    "${mailboxId.serialize}": {
          |                        "type": "invalidArguments",
-         |                        "description": "Specified value do not match the expected JSON format: List(((0),List(JsonValidationError(List(Unknown right 'x'),List()))))",
+         |                        "description": "Specified value do not match the expected JSON format: List(((0),List(JsonValidationError(List(Unknown right 'y'),List()))))",
          |                        "properties": [
          |                            "sharedWith/andre@domain.tld"
          |                        ]

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxFactory.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxFactory.scala
@@ -112,7 +112,7 @@ class MailboxFactory @Inject() (mailboxManager: MailboxManager,
         maySetKeywords = MaySetKeywords(rights.contains(Right.Write)),
         mayCreateChild = MayCreateChild(false),
         mayRename = MayRename(false),
-        mayDelete = MayDelete(false),
+        mayDelete = MayDelete(rights.contains(Right.DeleteMailbox)),
         maySubmit = MaySubmit(false))
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Rights.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Rights.scala
@@ -67,8 +67,9 @@ object Right {
   val DeleteMessages = Right(JavaRight.DeleteMessages)
   val Write = Right(JavaRight.Write)
   val Post = Right(JavaRight.Post)
+  val DeleteMailbox = Right(JavaRight.DeleteMailbox)
 
-  private val allRights = Seq(Administer, Expunge, Insert, Lookup, Read, Seen, DeleteMessages, Write, Post)
+  private val allRights = Seq(Administer, Expunge, Insert, Lookup, Read, Seen, DeleteMessages, Write, Post, DeleteMailbox)
 
   def forRight(right: JavaRight): Option[Right] = allRights.find(_.right.equals(right))
 

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/mail/RightsTest.scala
@@ -19,7 +19,7 @@
 
 package org.apache.james.jmap.mail
 
-import org.apache.james.core.Username
+import org.apache.james.jmap.mail.Right.DeleteMailbox
 import org.apache.james.mailbox.model.MailboxACL.{EntryKey, Rfc4314Rights => JavaRfc4314Rights, Right => JavaRight}
 import org.apache.james.mailbox.model.{MailboxACL => JavaMailboxACL}
 import org.scalatest.matchers.must.Matchers
@@ -85,7 +85,7 @@ class RightsTest extends AnyWordSpec with Matchers {
       val acl = new JavaMailboxACL(Map(
         USER_ENTRYKEY -> JavaRfc4314Rights.fromSerializedRfc4314Rights("aetxk")).asJava)
 
-      Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USER_ENTRYKEY, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages)))
+      Rights.fromACL(MailboxACL.fromJava(acl)) must be(Rights.of(USER_ENTRYKEY, Seq(Right.Administer, Right.Expunge, Right.DeleteMessages, Right.DeleteMailbox)))
     }
   }
   "To ACL" should  {


### PR DESCRIPTION
Currently, `mayDelete` always returns `false`, even when another user has the `DeleteMailbox` right, 

and the `right` property is missing the `x` right in the response.