### PR TITLE
Update postgres attachment to use string as id instead of UUID

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -52,6 +52,7 @@ import org.apache.james.mailbox.cassandra.user.CassandraSubscriptionMapper;
 import org.apache.james.mailbox.store.BatchSizes;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.AnnotationMapper;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.mailbox.store.mail.AttachmentMapperFactory;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
@@ -104,7 +105,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
                                                 CassandraUserMailboxRightsDAO userMailboxRightsDAO,
                                                 RecomputeMailboxCountersService recomputeMailboxCountersService,
                                                 CassandraConfiguration cassandraConfiguration,
-                                                BatchSizes batchSizes, CassandraAttachmentMapper.AttachmentIdAssignationStrategy attachmentIdAssignationStrategy,
+                                                BatchSizes batchSizes, AttachmentIdAssignationStrategy attachmentIdAssignationStrategy,
                                                 Clock clock) {
         this.uidProvider = uidProvider;
         this.modSeqProvider = modSeqProvider;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -31,7 +31,6 @@ import java.util.List;
 import jakarta.inject.Inject;
 
 import org.apache.james.blob.api.BlobStore;
-import org.apache.james.mailbox.AttachmentIdFactory;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2.DAOAttachment;
 import org.apache.james.mailbox.exception.AttachmentNotFoundException;
 import org.apache.james.mailbox.model.AttachmentId;
@@ -39,6 +38,7 @@ import org.apache.james.mailbox.model.AttachmentMetadata;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.ParsedAttachment;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
@@ -53,24 +53,6 @@ import reactor.core.publisher.Mono;
 
 public class CassandraAttachmentMapper implements AttachmentMapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraAttachmentMapper.class);
-
-    public interface AttachmentIdAssignationStrategy {
-        AttachmentId assign(ParsedAttachment parsedAttachment, MessageId messageId);
-
-        class Default implements AttachmentIdAssignationStrategy {
-            private final AttachmentIdFactory attachmentIdFactory;
-
-            @Inject
-            public Default(AttachmentIdFactory attachmentIdFactory) {
-                this.attachmentIdFactory = attachmentIdFactory;
-            }
-
-            @Override
-            public AttachmentId assign(ParsedAttachment parsedAttachment, MessageId messageId) {
-                return attachmentIdFactory.random();
-            }
-        }
-    }
 
     private final CassandraAttachmentDAOV2 attachmentDAOV2;
     private final BlobStore blobStore;

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
@@ -38,7 +38,6 @@ import org.apache.james.mailbox.SubscriptionManagerContract;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
-import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
@@ -60,6 +59,7 @@ import org.apache.james.mailbox.cassandra.modules.CassandraSubscriptionModule;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.BatchSizes;
 import org.apache.james.mailbox.store.StoreSubscriptionManager;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.user.model.Subscription;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,7 +110,7 @@ class CassandraSubscriptionManagerTest implements SubscriptionManagerContract {
         CassandraUidProvider uidProvider = null;
         CassandraModSeqProvider modSeqProvider = null;
         RecomputeMailboxCountersService recomputeMailboxCountersService = null;
-        CassandraAttachmentMapper.AttachmentIdAssignationStrategy attachmentIdAssignationStrategy = null;
+        AttachmentIdAssignationStrategy attachmentIdAssignationStrategy = null;
 
         mailboxSessionMapperFactory =  new CassandraMailboxSessionMapperFactory(
             uidProvider,

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/GuiceUtils.java
@@ -42,12 +42,12 @@ import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.mail.ACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
-import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider;
 import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
 import org.apache.james.mailbox.cassandra.mail.eventsourcing.acl.ACLModule;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.BatchSizes;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.ModSeqProvider;
 import org.apache.james.mailbox.store.mail.UidProvider;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
@@ -86,7 +86,7 @@ public class GuiceUtils {
             binder -> binder.bind(MessageId.Factory.class).toInstance(messageIdFactory),
             binder -> binder.bind(BatchSizes.class).toInstance(BatchSizes.defaultValues()),
             binder -> binder.bind(UidProvider.class).to(CassandraUidProvider.class),
-            binder -> binder.bind(CassandraAttachmentMapper.AttachmentIdAssignationStrategy.class).to(CassandraAttachmentMapper.AttachmentIdAssignationStrategy.Default.class),
+            binder -> binder.bind(AttachmentIdAssignationStrategy.class).to(AttachmentIdAssignationStrategy.Default.class),
             binder -> binder.bind(ModSeqProvider.class).to(CassandraModSeqProvider.class),
             binder -> binder.bind(ACLMapper.class).to(CassandraACLMapper.class),
             binder -> binder.bind(BlobId.Factory.class).toInstance(new PlainBlobId.Factory()),

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/PostgresMailboxSessionMapperFactory.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/PostgresMailboxSessionMapperFactory.java
@@ -47,6 +47,7 @@ import org.apache.james.mailbox.postgres.user.PostgresSubscriptionDAO;
 import org.apache.james.mailbox.postgres.user.PostgresSubscriptionMapper;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.AnnotationMapper;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.AttachmentMapperFactory;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.MessageIdMapper;
@@ -62,18 +63,21 @@ public class PostgresMailboxSessionMapperFactory extends MailboxSessionMapperFac
     private final BlobId.Factory blobIdFactory;
     private final Clock clock;
     private final RowLevelSecurity rowLevelSecurity;
+    private final AttachmentIdAssignationStrategy attachmentIdAssignationStrategy;
 
     @Inject
     public PostgresMailboxSessionMapperFactory(PostgresExecutor.Factory executorFactory,
                                                Clock clock,
                                                BlobStore blobStore,
                                                BlobId.Factory blobIdFactory,
-                                               PostgresConfiguration postgresConfiguration) {
+                                               PostgresConfiguration postgresConfiguration,
+                                               AttachmentIdAssignationStrategy attachmentIdAssignationStrategy) {
         this.executorFactory = executorFactory;
         this.blobStore = blobStore;
         this.blobIdFactory = blobIdFactory;
         this.clock = clock;
         this.rowLevelSecurity = postgresConfiguration.getRowLevelSecurity();
+        this.attachmentIdAssignationStrategy = attachmentIdAssignationStrategy;
     }
 
     @Override
@@ -94,7 +98,8 @@ public class PostgresMailboxSessionMapperFactory extends MailboxSessionMapperFac
             getUidProvider(session),
             blobStore,
             clock,
-            blobIdFactory);
+            blobIdFactory,
+            attachmentIdAssignationStrategy);
     }
 
     @Override
@@ -132,7 +137,7 @@ public class PostgresMailboxSessionMapperFactory extends MailboxSessionMapperFac
     @Override
     public PostgresAttachmentMapper createAttachmentMapper(MailboxSession session) {
         PostgresAttachmentDAO postgresAttachmentDAO = new PostgresAttachmentDAO(executorFactory.create(session.getUser().getDomainPart()), blobIdFactory);
-        return new PostgresAttachmentMapper(postgresAttachmentDAO, blobStore);
+        return new PostgresAttachmentMapper(postgresAttachmentDAO, blobStore, attachmentIdAssignationStrategy);
     }
 
     @Override

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentMapper.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentMapper.java
@@ -33,7 +33,7 @@ import org.apache.james.mailbox.model.AttachmentMetadata;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.ParsedAttachment;
-import org.apache.james.mailbox.model.UuidBackedAttachmentId;
+import org.apache.james.mailbox.model.StringBackedAttachmentId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresAttachmentDAO;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
 
@@ -112,7 +112,7 @@ public class PostgresAttachmentMapper implements AttachmentMapper {
         return Mono.fromCallable(parsedAttachment::getContent)
             .flatMap(content -> Mono.from(blobStore.save(blobStore.getDefaultBucketName(), parsedAttachment.getContent(), BlobStore.StoragePolicy.LOW_COST))
                 .flatMap(blobId -> {
-                    AttachmentId attachmentId = UuidBackedAttachmentId.random();
+                    AttachmentId attachmentId = StringBackedAttachmentId.random();
                     return postgresAttachmentDAO.storeAttachment(AttachmentMetadata.builder()
                             .attachmentId(attachmentId)
                             .type(parsedAttachment.getContentType())

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentModule.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentModule.java
@@ -35,7 +35,7 @@ public interface PostgresAttachmentModule {
     interface PostgresAttachmentTable {
 
         Table<Record> TABLE_NAME = DSL.table("attachment");
-        Field<UUID> ID = DSL.field("id", SQLDataType.UUID.notNull());
+        Field<String> ID = DSL.field("id", SQLDataType.VARCHAR.notNull());
         Field<String> BLOB_ID = DSL.field("blob_id", SQLDataType.VARCHAR);
         Field<String> TYPE = DSL.field("type", SQLDataType.VARCHAR);
         Field<UUID> MESSAGE_ID = DSL.field("message_id", SQLDataType.UUID);

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapper.java
@@ -58,6 +58,7 @@ import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxMessageDAO;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMessageDAO;
 import org.apache.james.mailbox.store.FlagsUpdateCalculator;
 import org.apache.james.mailbox.store.MailboxReactorUtils;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
@@ -102,7 +103,8 @@ public class PostgresMessageMapper implements MessageMapper {
                                  PostgresUidProvider uidProvider,
                                  BlobStore blobStore,
                                  Clock clock,
-                                 BlobId.Factory blobIdFactory) {
+                                 BlobId.Factory blobIdFactory,
+                                 AttachmentIdAssignationStrategy attachmentIdAssignationStrategy) {
         this.messageDAO = new PostgresMessageDAO(postgresExecutor, blobIdFactory);
         this.mailboxMessageDAO = new PostgresMailboxMessageDAO(postgresExecutor);
         this.mailboxDAO = new PostgresMailboxDAO(postgresExecutor);
@@ -110,7 +112,7 @@ public class PostgresMessageMapper implements MessageMapper {
         this.uidProvider = uidProvider;
         this.blobStore = blobStore;
         this.clock = clock;
-        PostgresAttachmentMapper attachmentMapper = new PostgresAttachmentMapper(new PostgresAttachmentDAO(postgresExecutor, blobIdFactory), blobStore);
+        PostgresAttachmentMapper attachmentMapper = new PostgresAttachmentMapper(new PostgresAttachmentDAO(postgresExecutor, blobIdFactory), blobStore, attachmentIdAssignationStrategy);
         this.messageRetriever = new PostgresMessageRetriever(blobStore, blobIdFactory, attachmentMapper);
     }
 

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresAttachmentDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresAttachmentDAO.java
@@ -31,7 +31,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.core.Domain;
 import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.AttachmentMetadata;
-import org.apache.james.mailbox.model.UuidBackedAttachmentId;
+import org.apache.james.mailbox.model.StringBackedAttachmentId;
 import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.PostgresAttachmentModule.PostgresAttachmentTable;
 
@@ -73,7 +73,7 @@ public class PostgresAttachmentDAO {
                     PostgresAttachmentTable.MESSAGE_ID,
                     PostgresAttachmentTable.SIZE)
                 .from(PostgresAttachmentTable.TABLE_NAME)
-                .where(PostgresAttachmentTable.ID.eq(attachmentId.asUUID()))))
+                .where(PostgresAttachmentTable.ID.eq(attachmentId.getId()))))
             .map(row -> Pair.of(
                 AttachmentMetadata.builder()
                     .attachmentId(attachmentId)
@@ -91,7 +91,7 @@ public class PostgresAttachmentDAO {
         return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.selectFrom(PostgresAttachmentTable.TABLE_NAME)
                 .where(PostgresAttachmentTable.ID.in(attachmentIds.stream().map(AttachmentId::getId).collect(ImmutableList.toImmutableList())))))
             .map(row -> AttachmentMetadata.builder()
-                .attachmentId(UuidBackedAttachmentId.from(row.get(PostgresAttachmentTable.ID)))
+                .attachmentId(StringBackedAttachmentId.from(row.get(PostgresAttachmentTable.ID)))
                 .type(row.get(PostgresAttachmentTable.TYPE))
                 .messageId(PostgresMessageId.Factory.of(row.get(PostgresAttachmentTable.MESSAGE_ID)))
                 .size(row.get(PostgresAttachmentTable.SIZE))
@@ -100,7 +100,7 @@ public class PostgresAttachmentDAO {
 
     public Mono<Void> storeAttachment(AttachmentMetadata attachment, BlobId blobId) {
         return postgresExecutor.executeVoid(dslContext -> Mono.from(dslContext.insertInto(PostgresAttachmentTable.TABLE_NAME)
-            .set(PostgresAttachmentTable.ID, attachment.getAttachmentId().asUUID())
+            .set(PostgresAttachmentTable.ID, attachment.getAttachmentId().getId())
             .set(PostgresAttachmentTable.BLOB_ID, blobId.asString())
             .set(PostgresAttachmentTable.TYPE, attachment.getType().asString())
             .set(PostgresAttachmentTable.MESSAGE_ID, ((PostgresMessageId) attachment.getMessageId()).asUuid())

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dto/AttachmentsDTO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dto/AttachmentsDTO.java
@@ -32,7 +32,7 @@ import java.util.stream.StreamSupport;
 import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.Cid;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
-import org.apache.james.mailbox.model.UuidBackedAttachmentId;
+import org.apache.james.mailbox.model.StringBackedAttachmentId;
 import org.apache.james.mailbox.postgres.mail.MessageRepresentation;
 import org.jooq.BindingGetResultSetContext;
 import org.jooq.BindingSetStatementContext;
@@ -95,7 +95,7 @@ public class AttachmentsDTO extends ArrayList<MessageRepresentation.AttachmentRe
         }
 
         private MessageRepresentation.AttachmentRepresentation fromJsonNode(JsonNode jsonNode) {
-            AttachmentId attachmentId = UuidBackedAttachmentId.from(jsonNode.get(ATTACHMENT_ID_PROPERTY).asText());
+            AttachmentId attachmentId = StringBackedAttachmentId.from(jsonNode.get(ATTACHMENT_ID_PROPERTY).asText());
             Optional<String> name = Optional.ofNullable(jsonNode.get(NAME_PROPERTY)).map(JsonNode::asText);
             Optional<Cid> cid = Optional.ofNullable(jsonNode.get(CID_PROPERTY)).map(JsonNode::asText).map(Cid::from);
             boolean isInline = jsonNode.get(IN_LINE_PROPERTY).asBoolean();

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/DeleteMessageListenerTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/DeleteMessageListenerTest.java
@@ -33,6 +33,7 @@ import org.apache.james.events.EventBusTestFixture;
 import org.apache.james.events.InVMEventBus;
 import org.apache.james.events.MemoryEventDeadLetters;
 import org.apache.james.events.delivery.InVmEventDelivery;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresAttachmentDAO;
@@ -44,6 +45,7 @@ import org.apache.james.mailbox.store.SessionProviderImpl;
 import org.apache.james.mailbox.store.StoreMailboxAnnotationManager;
 import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParserImpl;
 import org.apache.james.mailbox.store.quota.QuotaComponents;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
@@ -70,7 +72,8 @@ public class DeleteMessageListenerTest extends DeleteMessageListenerContract {
             Clock.systemUTC(),
             blobStore,
             BLOB_ID_FACTORY,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
 
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         MessageParserImpl messageParser = new MessageParserImpl();

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/DeleteMessageListenerWithRLSTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/DeleteMessageListenerWithRLSTest.java
@@ -37,6 +37,7 @@ import org.apache.james.events.EventBusTestFixture;
 import org.apache.james.events.InVMEventBus;
 import org.apache.james.events.MemoryEventDeadLetters;
 import org.apache.james.events.delivery.InVmEventDelivery;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresAttachmentDAO;
@@ -48,6 +49,7 @@ import org.apache.james.mailbox.store.SessionProviderImpl;
 import org.apache.james.mailbox.store.StoreMailboxAnnotationManager;
 import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParserImpl;
 import org.apache.james.mailbox.store.quota.QuotaComponents;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
@@ -76,7 +78,8 @@ public class DeleteMessageListenerWithRLSTest extends DeleteMessageListenerContr
             Clock.systemUTC(),
             blobStore,
             blobIdFactory,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
 
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         MessageParserImpl messageParser = new MessageParserImpl();

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresMailboxManagerAttachmentTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresMailboxManagerAttachmentTest.java
@@ -39,6 +39,7 @@ import org.apache.james.events.MemoryEventDeadLetters;
 import org.apache.james.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresAttachmentDAO;
@@ -55,6 +56,7 @@ import org.apache.james.mailbox.store.StoreMailboxAnnotationManager;
 import org.apache.james.mailbox.store.StoreMessageIdManager;
 import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.AttachmentMapperFactory;
 import org.apache.james.mailbox.store.mail.NaiveThreadIdGuessingAlgorithm;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
@@ -84,7 +86,8 @@ public class PostgresMailboxManagerAttachmentTest extends AbstractMailboxManager
         BlobId.Factory blobIdFactory = new PlainBlobId.Factory();
         DeDuplicationBlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, blobIdFactory);
         mapperFactory = new PostgresMailboxSessionMapperFactory(postgresExtension.getExecutorFactory(), Clock.systemUTC(), blobStore, blobIdFactory,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
 
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         MessageParserImpl messageParser = new MessageParserImpl();

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresMailboxManagerProvider.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresMailboxManagerProvider.java
@@ -34,6 +34,7 @@ import org.apache.james.events.MemoryEventDeadLetters;
 import org.apache.james.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.Authenticator;
 import org.apache.james.mailbox.Authorizator;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.store.PreDeletionHooks;
@@ -41,6 +42,7 @@ import org.apache.james.mailbox.store.SessionProviderImpl;
 import org.apache.james.mailbox.store.StoreMailboxAnnotationManager;
 import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.NaiveThreadIdGuessingAlgorithm;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParserImpl;
 import org.apache.james.mailbox.store.quota.QuotaComponents;
@@ -99,7 +101,8 @@ public class PostgresMailboxManagerProvider {
             Clock.systemUTC(),
             blobStore,
             blobIdFactory,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
     }
 
 }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresTestSystemFixture.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresTestSystemFixture.java
@@ -40,6 +40,7 @@ import org.apache.james.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.AttachmentContentLoader;
 import org.apache.james.mailbox.Authenticator;
 import org.apache.james.mailbox.Authorizator;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.postgres.quota.PostgresCurrentQuotaManager;
 import org.apache.james.mailbox.postgres.quota.PostgresPerUserMaxQuotaManager;
@@ -54,6 +55,7 @@ import org.apache.james.mailbox.store.StoreMessageIdManager;
 import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.event.MailboxAnnotationListener;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.NaiveThreadIdGuessingAlgorithm;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParserImpl;
 import org.apache.james.mailbox.store.quota.DefaultUserQuotaRootResolver;
@@ -70,7 +72,8 @@ public class PostgresTestSystemFixture {
         DeDuplicationBlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, blobIdFactory);
 
         return new PostgresMailboxSessionMapperFactory(postgresExtension.getExecutorFactory(), Clock.systemUTC(), blobStore, blobIdFactory,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
     }
 
     public static PostgresMailboxManager createMailboxManager(PostgresMailboxSessionMapperFactory mapperFactory) {

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresAnnotationMapperRowLevelSecurityTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresAnnotationMapperRowLevelSecurityTest.java
@@ -33,6 +33,7 @@ import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.model.MailboxAnnotation;
 import org.apache.james.mailbox.model.MailboxAnnotationKey;
 import org.apache.james.mailbox.model.MailboxId;
@@ -41,6 +42,7 @@ import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
 import org.apache.james.mailbox.postgres.PostgresMailboxSessionMapperFactory;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxDAO;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.server.blob.deduplication.DeDuplicationBlobStore;
 import org.apache.james.utils.UpdatableTickingClock;
@@ -77,7 +79,8 @@ public class PostgresAnnotationMapperRowLevelSecurityTest {
             new UpdatableTickingClock(Instant.now()),
             new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, blobIdFactory),
             blobIdFactory,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
 
         mailboxId = generateMailboxId();
     }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentBlobReferenceSourceTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentBlobReferenceSourceTest.java
@@ -26,7 +26,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.AttachmentMetadata;
-import org.apache.james.mailbox.model.UuidBackedAttachmentId;
+import org.apache.james.mailbox.model.StringBackedAttachmentId;
 import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
 import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresAttachmentDAO;
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class PostgresAttachmentBlobReferenceSourceTest {
 
-    private static final AttachmentId ATTACHMENT_ID = UuidBackedAttachmentId.random();
-    private static final AttachmentId ATTACHMENT_ID_2 = UuidBackedAttachmentId.random();
+    private static final AttachmentId ATTACHMENT_ID = StringBackedAttachmentId.random();
+    private static final AttachmentId ATTACHMENT_ID_2 = StringBackedAttachmentId.random();
     private static final BlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
 
     @RegisterExtension

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentMapperTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresAttachmentMapperTest.java
@@ -25,9 +25,11 @@ import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresAttachmentDAO;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.mailbox.store.mail.model.AttachmentMapperTest;
 import org.apache.james.server.blob.deduplication.DeDuplicationBlobStore;
@@ -44,7 +46,7 @@ class PostgresAttachmentMapperTest extends AttachmentMapperTest {
     protected AttachmentMapper createAttachmentMapper() {
         PostgresAttachmentDAO postgresAttachmentDAO = new PostgresAttachmentDAO(postgresExtension.getDefaultPostgresExecutor(), BLOB_ID_FACTORY);
         BlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, BLOB_ID_FACTORY);
-        return new PostgresAttachmentMapper(postgresAttachmentDAO, blobStore);
+        return new PostgresAttachmentMapper(postgresAttachmentDAO, blobStore, new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
     }
 
     @Override

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapperRowLevelSecurityTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMessageMapperRowLevelSecurityTest.java
@@ -35,6 +35,7 @@ import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.model.ByteContent;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -45,6 +46,7 @@ import org.apache.james.mailbox.postgres.PostgresMailboxAggregateModule;
 import org.apache.james.mailbox.postgres.PostgresMailboxSessionMapperFactory;
 import org.apache.james.mailbox.postgres.PostgresMessageId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxDAO;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -82,7 +84,8 @@ public class PostgresMessageMapperRowLevelSecurityTest {
             new UpdatableTickingClock(Instant.now()),
             new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, blobIdFactory),
             blobIdFactory,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
 
         mailbox = generateMailbox();
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentIdAssignationStrategy.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentIdAssignationStrategy.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store.mail;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.mailbox.AttachmentIdFactory;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.ParsedAttachment;
+
+public interface AttachmentIdAssignationStrategy {
+    AttachmentId assign(ParsedAttachment parsedAttachment, MessageId messageId);
+
+    class Default implements AttachmentIdAssignationStrategy {
+        private final AttachmentIdFactory attachmentIdFactory;
+
+        @Inject
+        public Default(AttachmentIdFactory attachmentIdFactory) {
+            this.attachmentIdFactory = attachmentIdFactory;
+        }
+
+        @Override
+        public AttachmentId assign(ParsedAttachment parsedAttachment, MessageId messageId) {
+            return attachmentIdFactory.random();
+        }
+    }
+}

--- a/mpt/impl/imap-mailbox/postgres/src/test/java/org/apache/james/mpt/imapmailbox/postgres/host/PostgresHostSystem.java
+++ b/mpt/impl/imap-mailbox/postgres/src/test/java/org/apache/james/mpt/imapmailbox/postgres/host/PostgresHostSystem.java
@@ -42,6 +42,7 @@ import org.apache.james.imap.main.DefaultImapDecoderFactory;
 import org.apache.james.imap.processor.main.DefaultImapProcessorFactory;
 import org.apache.james.mailbox.AttachmentContentLoader;
 import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
@@ -59,6 +60,7 @@ import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.StoreSubscriptionManager;
 import org.apache.james.mailbox.store.event.MailboxAnnotationListener;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.NaiveThreadIdGuessingAlgorithm;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParserImpl;
@@ -112,7 +114,8 @@ public class PostgresHostSystem extends JamesImapHostSystem {
         DeDuplicationBlobStore blobStore = new DeDuplicationBlobStore(new MemoryBlobStoreDAO(), BucketName.DEFAULT, blobIdFactory);
 
         PostgresMailboxSessionMapperFactory mapperFactory = new PostgresMailboxSessionMapperFactory(postgresExtension.getExecutorFactory(), Clock.systemUTC(), blobStore, blobIdFactory,
-            PostgresConfiguration.builder().username("a").password("a").build());
+            PostgresConfiguration.builder().username("a").password("a").build(),
+            new AttachmentIdAssignationStrategy.Default(new StringBackedAttachmentIdFactory()));
 
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         MessageParser messageParser = new MessageParserImpl();

--- a/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
+++ b/server/container/guice/cassandra/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
@@ -75,7 +75,6 @@ import org.apache.james.mailbox.cassandra.mail.CassandraACLDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
-import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
@@ -118,6 +117,7 @@ import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.StoreSubscriptionManager;
 import org.apache.james.mailbox.store.event.MailboxAnnotationListener;
 import org.apache.james.mailbox.store.event.MailboxSubscriptionListener;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.AttachmentMapperFactory;
 import org.apache.james.mailbox.store.mail.MailboxMapperFactory;
 import org.apache.james.mailbox.store.mail.MessageMapperFactory;
@@ -219,7 +219,7 @@ public class CassandraMailboxModule extends AbstractModule {
         bind(AttachmentContentLoader.class).to(AttachmentManager.class);
         bind(MailboxCounterCorrector.class).to(CassandraMailboxCounterCorrector.class);
         bind(MessageParser.class).toInstance(new MessageParserImpl());
-        bind(CassandraAttachmentMapper.AttachmentIdAssignationStrategy.class).to(CassandraAttachmentMapper.AttachmentIdAssignationStrategy.Default.class);
+        bind(AttachmentIdAssignationStrategy.class).to(AttachmentIdAssignationStrategy.Default.class);
 
         bind(Limit.class).annotatedWith(Names.named(CassandraEmailChangeRepository.LIMIT_NAME)).toInstance(Limit.of(256));
         bind(Limit.class).annotatedWith(Names.named(CassandraMailboxChangeRepository.LIMIT_NAME)).toInstance(Limit.of(256));

--- a/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxModule.java
+++ b/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxModule.java
@@ -46,8 +46,8 @@ import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.RightManager;
 import org.apache.james.mailbox.SessionProvider;
+import org.apache.james.mailbox.StringBackedAttachmentIdFactory;
 import org.apache.james.mailbox.SubscriptionManager;
-import org.apache.james.mailbox.UuidBackedAttachmentIdFactory;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.indexer.MessageIdReIndexer;
@@ -140,7 +140,7 @@ public class PostgresMailboxModule extends AbstractModule {
         bind(MailboxACLResolver.class).to(UnionMailboxACLResolver.class);
         bind(MessageIdManager.class).to(StoreMessageIdManager.class);
         bind(RightManager.class).to(StoreRightManager.class);
-        bind(AttachmentIdFactory.class).to(UuidBackedAttachmentIdFactory.class);
+        bind(AttachmentIdFactory.class).to(StringBackedAttachmentIdFactory.class);
         bind(AttachmentManager.class).to(StoreAttachmentManager.class);
         bind(AttachmentContentLoader.class).to(AttachmentManager.class);
         bind(AttachmentMapperFactory.class).to(PostgresMailboxSessionMapperFactory.class);

--- a/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxModule.java
+++ b/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxModule.java
@@ -76,6 +76,7 @@ import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.StoreSubscriptionManager;
 import org.apache.james.mailbox.store.event.MailboxAnnotationListener;
 import org.apache.james.mailbox.store.event.MailboxSubscriptionListener;
+import org.apache.james.mailbox.store.mail.AttachmentIdAssignationStrategy;
 import org.apache.james.mailbox.store.mail.AttachmentMapperFactory;
 import org.apache.james.mailbox.store.mail.MailboxMapperFactory;
 import org.apache.james.mailbox.store.mail.MessageMapperFactory;
@@ -146,6 +147,7 @@ public class PostgresMailboxModule extends AbstractModule {
         bind(AttachmentMapperFactory.class).to(PostgresMailboxSessionMapperFactory.class);
         bind(MailboxCounterCorrector.class).toInstance(MailboxCounterCorrector.DEFAULT);
         bind(MessageParser.class).toInstance(new MessageParserImpl());
+        bind(AttachmentIdAssignationStrategy.class).to(AttachmentIdAssignationStrategy.Default.class);
 
         bind(ReIndexer.class).to(ReIndexerImpl.class);
         bind(MessageIdReIndexer.class).to(MessageIdReIndexerImpl.class);


### PR DESCRIPTION
This PR is used for later attachment improvement apply to postgres in tmail backend