### PR TITLE
[FIX] Forward unexpected exceptions upon executing RRT

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -414,9 +414,11 @@ public class RecipientRewriteTableProcessor {
                 return new Decision(recipient, RrtExecutionResult.success(newMailAddresses));
             }
             return new Decision(recipient, RrtExecutionResult.success(recipient));
-        } catch (Exception e) {
+        } catch (RecipientRewriteTable.ErrorMappingException e) {
             LOGGER.warn("Could not rewrite recipient {}", recipient, e);
             return new Decision(recipient, RrtExecutionResult.error(recipient));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Previously, unexpected technical issues (like Cassandra driver error) were interpreted as functional errors, which is misleading and prevent retrying timely the error.