### PR TITLE
JAMES-4104 - Webadmin Spark - Fix Error `500 org. eclipse. jetty.io.EofException: Closed`

### DIFF
--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/jettyserver/JettyHandler.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/jettyserver/JettyHandler.java
@@ -51,6 +51,7 @@ public class JettyHandler extends SessionHandler {
             final HttpServletResponse httpServletResponse = servletContextRequest.getHttpServletResponse();
             final HttpServletRequest httpServletRequest = servletContextRequest.getServletApiRequest();
             final HttpRequestWrapper wrapper = new HttpRequestWrapper(httpServletRequest);
+            httpServletResponse.setHeader("Connection", "close");
 
             filter.doFilter(wrapper, httpServletResponse, null);
             callback.succeeded();

--- a/server/protocols/webadmin/webadmin-http-client/pom.xml
+++ b/server/protocols/webadmin/webadmin-http-client/pom.xml
@@ -50,11 +50,6 @@
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-okhttp</artifactId>
-            <version>${feign.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
             <artifactId>feign-slf4j</artifactId>
             <version>${feign.version}</version>
         </dependency>

--- a/server/protocols/webadmin/webadmin-http-client/src/main/java/org/apache/james/webadmin/httpclient/WebAdminHTTPClientFactory.java
+++ b/server/protocols/webadmin/webadmin-http-client/src/main/java/org/apache/james/webadmin/httpclient/WebAdminHTTPClientFactory.java
@@ -23,7 +23,6 @@ import feign.Feign;
 import feign.Logger;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
-import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 
 public class WebAdminHTTPClientFactory {
@@ -35,7 +34,6 @@ public class WebAdminHTTPClientFactory {
 
     public static Feign.Builder feignBuilder() {
         return Feign.builder()
-            .client(new OkHttpClient())
             .decoder(new JacksonDecoder())
             .encoder(new JacksonEncoder())
             .logger(new Slf4jLogger("james-webadmin-http-client"))


### PR DESCRIPTION
It will fix case `500 org. eclipse. jetty.io.EofException: Closed` when client try re-using existing connection.

I suggestion we set header `Connection: close` in the response to client for fixed it. 

Command: `curl 127.0.0.1:52389/healthcheck 127.0.0.1:52389/healthcheck -v --http1.1` 
Before:
```
*   Trying 127.0.0.1:52330...
* Connected to 127.0.0.1 (127.0.0.1) port 52330
> GET /healthcheck HTTP/1.1
> Host: 127.0.0.1:52330
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< Server: Jetty(12.0.15)
< Date: Wed, 26 Feb 2025 08:32:17 GMT
< Access-Control-Allow-Origin: *
< Access-Control-Request-Method: DELETE, GET, POST, PUT
< Access-Control-Allow-Headers: Content-Type, Authorization, Accept
< Content-Type: application/json
< Transfer-Encoding: chunked
<
* Connection #0 to host 127.0.0.1 left intact
{"status":"healthy","checks":[]}* Found bundle for host: 0x60000271c7b0 [serially]
* Re-using existing connection with host 127.0.0.1
> GET /healthcheck HTTP/1.1
> Host: 127.0.0.1:52330
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 500 Server Error
< Server: Jetty(12.0.15)
< Date: Wed, 26 Feb 2025 08:32:17 GMT
< Access-Control-Allow-Origin: *
< Access-Control-Request-Method: DELETE, GET, POST, PUT
< Access-Control-Allow-Headers: Content-Type, Authorization, Accept
< Content-Type: text/html;charset=iso-8859-1
< Cache-Control: must-revalidate,no-cache,no-store
< Content-Length: 521
<
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 org.eclipse.jetty.io.EofException: Closed</title>
</head>
<body>
<h2>HTTP ERROR 500 org.eclipse.jetty.io.EofException: Closed</h2>
<table>
<tr><th>URI:</th><td>http://127.0.0.1:52330/healthcheck</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>org.eclipse.jetty.io.EofException: Closed</td></tr>
</table>
<hr/><a href="https://jetty.org/">Powered by Jetty:// 12.0.15</a><hr/>

</body>
</html>
```

After
```
*   Trying 127.0.0.1:52389...
* Connected to 127.0.0.1 (127.0.0.1) port 52389
> GET /healthcheck HTTP/1.1
> Host: 127.0.0.1:52389
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< Server: Jetty(12.0.15)
< Date: Wed, 26 Feb 2025 08:33:48 GMT
< Access-Control-Allow-Origin: *
< Access-Control-Request-Method: DELETE, GET, POST, PUT
< Access-Control-Allow-Headers: Content-Type, Authorization, Accept
< Content-Type: application/json
< Connection: close
<
* Closing connection
{"status":"healthy","checks":[]}* Hostname 127.0.0.1 was found in DNS cache
*   Trying 127.0.0.1:52389...
* Connected to 127.0.0.1 (127.0.0.1) port 52389
> GET /healthcheck HTTP/1.1
> Host: 127.0.0.1:52389
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< Server: Jetty(12.0.15)
< Date: Wed, 26 Feb 2025 08:33:48 GMT
< Access-Control-Allow-Origin: *
< Access-Control-Request-Method: DELETE, GET, POST, PUT
< Access-Control-Allow-Headers: Content-Type, Authorization, Accept
< Content-Type: application/json
< Connection: close
<
* Closing connection
{"status":"healthy","checks":[]}%
```


