### PR TITLE
[ENHANCEMENT] CommandInjectionDetectedException: cary over the exception

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/AllButStartTlsLineBasedChannelHandler.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/AllButStartTlsLineBasedChannelHandler.java
@@ -64,7 +64,7 @@ public class AllButStartTlsLineBasedChannelHandler extends LineBasedFrameDecoder
                 .map(Boolean.class::cast)
                 .orElse(false);
             if (hasCommandInjection(trimedLowerCasedInput) || startTlsInFlight) {
-                throw new CommandInjectionDetectedException();
+                throw new CommandInjectionDetectedException(trimedLowerCasedInput);
             }
             // Prevents further reads on this channel to avoid race conditions
             // Framer can accept IMAP requests sent concurrently while the channel is

--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/CommandInjectionDetectedException.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/CommandInjectionDetectedException.java
@@ -19,5 +19,7 @@
 package org.apache.james.protocols.netty;
 
 public class CommandInjectionDetectedException extends RuntimeException {
-
+    public CommandInjectionDetectedException(String input) {
+        super("Client input: " + input);
+    }
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -23,6 +23,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -74,7 +75,7 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
                 || line[line.length - 2] != '\r'
                 || line[line.length - 1] != '\n') {
 
-                throw new CommandInjectionDetectedException();
+                throw new CommandInjectionDetectedException(new String(line, StandardCharsets.UTF_8));
             }
         }
     }


### PR DESCRIPTION
**WHY** We have this exception arising on a prod environment (low occurence) and we are blind...

Is it a faulty client?

Is it an attack by injection attempt?

Are we too strict?

The analysis of the actual line causing the failure could be very helpful to answer those questions...

**Debug info we can't get**: starttls is the very begining of a connection so BEFORE auth and BEFORE mua details. Those are thus not available to the diagnostic...