### PR TITLE
[ENHANCEMENT] MDC should be lenient when duplicate keys

### DIFF
--- a/server/container/util/src/main/java/org/apache/james/util/MDCBuilder.java
+++ b/server/container/util/src/main/java/org/apache/james/util/MDCBuilder.java
@@ -147,7 +147,7 @@ public class MDCBuilder {
 
     @VisibleForTesting
     Map<String, String> buildContextMap() {
-        return contextMap.build();
+        return contextMap.buildKeepingLast();
     }
 
     public <T> T execute(Supplier<T> supplier) {

--- a/server/container/util/src/test/java/org/apache/james/util/MDCBuilderTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/MDCBuilderTest.java
@@ -65,6 +65,20 @@ class MDCBuilderTest {
     }
 
     @Test
+    void buildContextMapShouldNotFailWhenDuplicateKeys() {
+        // keep the last value when duplicate keys
+        assertThat(
+            MDCBuilder.create()
+                .addToContext(KEY_1, VALUE_1)
+                .addToContext(KEY_1, VALUE_2)
+                .addToContext(KEY_2, VALUE_2)
+                .buildContextMap())
+            .containsOnlyKeys(KEY_1, KEY_2)
+            .containsEntry(KEY_1, VALUE_2)
+            .containsEntry(KEY_2, VALUE_2);
+    }
+
+    @Test
     void addContextShouldFilterOutNullValues() {
         assertThat(
             MDCBuilder.create()


### PR DESCRIPTION
Keeping the last value is OK IMO.
This would avoid similar MDC issues as the IMAP ID command issue where `mailUserAgent` was added multiple times to MDC.
