### PR TITLE
[ENHANCEMENT] Allow setting a preview for TTL

### DIFF
--- a/docs/modules/servers/partials/configure/jmap.adoc
+++ b/docs/modules/servers/partials/configure/jmap.adoc
@@ -109,6 +109,14 @@ This allows to prevent users from using some specific JMAP extensions.
 
 |===
 
+In cassandra we can set an expiry for preview in an attempt to mitigate disk space usage. In `jvm.properties`:
+
+....
+# Previews takes roughly 10% DB space though can easily be recomputed. Storing preview for historical preview is
+# also needless. This property allows setting an expiry for previews.
+# james.jmap.preview.ttl=30d
+....
+
 == Wire tapping
 
 Enabling *TRACE* on `org.apache.james.jmap.wire` enables reactor-netty wiretap, logging of

--- a/server/apps/distributed-app/sample-configuration/jvm.properties
+++ b/server/apps/distributed-app/sample-configuration/jvm.properties
@@ -106,3 +106,7 @@ jmx.remote.x.mlet.allow.getMBeansFromURL=false
 
 # Allow users to have rights for shares of different domain. Defaults to false.
 #james.rights.crossdomain.allow=false
+
+# Previews takes roughly 10% DB space though can easily be recomputed. Storing preview for historical preview is
+# also needless. This property allows setting an expiry for previews.
+# james.jmap.preview.ttl=30d


### PR DESCRIPTION
## Why ?

It does take rougthly 10% of the DB space

```
		Table: message_fast_view_projection
		SSTable count: 11
		Space used (live): 11602029036
```

We are also to fallback leniently if unused.

## How?

So setting an optional TTL, contolled by an system property, defaulting to none, could be great to improve tiering of this table.

A value of 30 days would also seem relevant...