### PR TITLE
[JAMES-4119] Core data JPA to PG migration tool

### DIFF
--- a/mpt/impl/smtp/jpa-pulsar/pom.xml
+++ b/mpt/impl/smtp/jpa-pulsar/pom.xml
@@ -33,6 +33,12 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-backends-postgres</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-backends-pulsar</artifactId>
         </dependency>
         <dependency>
@@ -41,6 +47,7 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mpt-smtp-core</artifactId>

--- a/mpt/impl/smtp/jpa-pulsar/src/test/java/org/apache/james/mpt/smtp/JpaPulsarForwardSmtpTest.java
+++ b/mpt/impl/smtp/jpa-pulsar/src/test/java/org/apache/james/mpt/smtp/JpaPulsarForwardSmtpTest.java
@@ -23,7 +23,7 @@ import static org.apache.james.modules.protocols.SmtpGuiceProbe.SmtpServerConnec
 
 import org.apache.james.JamesServerExtension;
 import org.apache.james.Main;
-import org.apache.james.PostgresExtension;
+import org.apache.james.PostgresJPAExtension;
 import org.apache.james.PulsarExtension;
 import org.apache.james.TestingSmtpRelayJamesServerBuilder;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
@@ -35,7 +35,7 @@ public class JpaPulsarForwardSmtpTest implements ForwardSmtpTest {
     @Order(1)
     @RegisterExtension
     static JamesServerExtension testExtension = TestingSmtpRelayJamesServerBuilder.forConfiguration(c -> c)
-            .extension(new PostgresExtension())
+            .extension(new PostgresJPAExtension())
             .extension(new PulsarExtension())
             .extension(new AwsS3BlobStoreExtension())
             .extension(new InMemoryDnsExtension())

--- a/mpt/impl/smtp/jpa-pulsar/src/test/java/org/apache/james/mpt/smtp/JpaPulsarSmtpStarttlsCommandTest.java
+++ b/mpt/impl/smtp/jpa-pulsar/src/test/java/org/apache/james/mpt/smtp/JpaPulsarSmtpStarttlsCommandTest.java
@@ -23,7 +23,7 @@ import static org.apache.james.modules.protocols.SmtpGuiceProbe.SmtpServerConnec
 
 import org.apache.james.JamesServerExtension;
 import org.apache.james.Main;
-import org.apache.james.PostgresExtension;
+import org.apache.james.PostgresJPAExtension;
 import org.apache.james.PulsarExtension;
 import org.apache.james.TestingSmtpRelayJamesServerBuilder;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
@@ -35,7 +35,7 @@ public class JpaPulsarSmtpStarttlsCommandTest extends SmtpStarttlsCommandTest {
     @Order(1)
     @RegisterExtension
     static JamesServerExtension testExtension = TestingSmtpRelayJamesServerBuilder.forConfiguration(c -> c)
-            .extension(new PostgresExtension())
+            .extension(new PostgresJPAExtension())
             .extension(new PulsarExtension())
             .extension(new AwsS3BlobStoreExtension())
             .extension(new InMemoryDnsExtension())

--- a/pom.xml
+++ b/pom.xml
@@ -3014,6 +3014,11 @@
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
+                <artifactId>mariadb</artifactId>
+                <version>${testcontainers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${testcontainers.version}</version>
             </dependency>

--- a/server/apps/migration/core-data-jpa-to-pg/README.adoc
+++ b/server/apps/migration/core-data-jpa-to-pg/README.adoc
@@ -1,0 +1,59 @@
+= James Core Data migration tool
+
+== Introduction ==
+
+Starting with James 3.9, a new SQL database backend was introduced. The new backend only targets PostgresSQL a modern, fully opensource, production ready database suitable for small to rather large deployments.
+
+The database schema for the new backend has been rebuilt from scratch and does not match the schema used by the legacy JPA stack.
+
+To facilitate migrating from any database backed by the JPA backend to PostgreSQL on the new backend, this migration tool will convert all the data from the JPA schema to the Jooq/PostgreSQL schema.
+
+The recommended migration process is to :
+
+- stop your server,
+- backup your database (and make sure you can restore your backup),
+- run the migration tool,
+- start your server with the new version.
+
+This tool is non-destructive (it only reads the JPA data), it is also designed to be idempotent.
+Running the migration several times will not crash because data already exists.
+
+Therefore, if an error occur you can quickly restart your service using the old version of your app.
+You can then analyse the problem and solve it before attempting the migration again.
+
+Once the migration is successful, you will have to delete the old tables using your usual DBA tools.
+
+
+== Building the application
+
+In order to build the packages, run:
+----
+mvn clean install -DskipTests
+----
+
+== ZIP distribution
+
+Available in `target` directory, the ZIP include detailed instructions.
+
+== Docker distribution
+
+To import the image locally:
+
+----
+docker image load -i target/jib-image.tar
+
+----
+
+Then run it:
+
+----
+docker run apache/james:migration-core-data-jpa-to-pg-latest
+
+----
+
+Use the https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#jvm-flags[JAVA_TOOL_OPTIONS environment option]
+to pass extra JVM flags. For instance:
+
+----
+docker run -e "JAVA_TOOL_OPTIONS=-Xmx500m -Xms500m" apache/james:scaling-pulsar-smtp-latest
+----

--- a/server/apps/migration/core-data-jpa-to-pg/pom.xml
+++ b/server/apps/migration/core-data-jpa-to-pg/pom.xml
@@ -213,7 +213,7 @@
                     <to>
                         <image>apache/james</image>
                         <tags>
-                            <tag>migration/core-data-jpa-to-pg</tag>
+                            <tag>migration-core-data-jpa-to-pg-latest</tag>
                         </tags>
                     </to>
                     <container>
@@ -257,6 +257,24 @@
                     <execution>
                         <goals>
                             <goal>buildTar</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorSourceDirectory>src/assemble/</descriptorSourceDirectory>
+                    <tarLongFileMode>gnu</tarLongFileMode>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <finalName>james-server-memory-app</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <goals>
+                            <goal>single</goal>
                         </goals>
                         <phase>package</phase>
                     </execution>

--- a/server/apps/migration/core-data-jpa-to-pg/pom.xml
+++ b/server/apps/migration/core-data-jpa-to-pg/pom.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>james-server</artifactId>
+        <version>3.9.0-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>migration-core-data-jpa-to-pg</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Apache James :: Server :: Binaries :: core data migration tool from JPA to PG</name>
+    <description>
+        A tool to help migrating servers from the JPA implementation
+        (regardless of backing database) to the new recommended Postgres
+        implementation. This tool only migrates Core DATA supported by JPA:
+        - Domains
+        - Users
+        - RRT
+        - Mail Repository urls
+        - DropLists
+        - Sieve (quota and scripts)
+    </description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
+                <artifactId>james-server-guice</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-backends-postgres</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-sieve-postgres</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-jpa-common-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-postgres-common-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>mailrepository-blob</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>james-server-guice-memory</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>2.7.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mariadb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <includeScope>compile</includeScope>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/${project.artifactId}.lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${project.artifactId}</finalName>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <classpathPrefix>${project.artifactId}.lib/</classpathPrefix>
+                                    <mainClass>org.apache.james.JpaToPgCoreDataMigration</mainClass>
+                                    <useUniqueVersions>false</useUniqueVersions>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <from>
+                        <image>eclipse-temurin:21-jre-jammy</image>
+                    </from>
+                    <to>
+                        <image>apache/james</image>
+                        <tags>
+                            <tag>migration/core-data-jpa-to-pg</tag>
+                        </tags>
+                    </to>
+                    <container>
+                        <mainClass>org.apache.james.JpaToPgCoreDataMigration</mainClass>
+                        <extraClasspath>/root/extensions-jars/*</extraClasspath>
+                        <appRoot>/root</appRoot>
+                        <jvmFlags>
+                            <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
+                            <jvmFlag>-Dworking.directory=/root/</jvmFlag>
+                            <!-- Prevents Logjam (CVE-2015-4000) -->
+                            <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
+                            <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
+                        </jvmFlags>
+                        <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+                        <volumes>
+                            <volume>/logs</volume>
+                            <volume>/root/conf</volume>
+                        </volumes>
+                    </container>
+                    <extraDirectories>
+                        <paths>
+                            <path>
+                                <from>sample-configuration</from>
+                                <into>/root/conf</into>
+                            </path>
+                            <path>
+                                <from>src/main/scripts</from>
+                                <into>/usr/bin</into>
+                            </path>
+                        </paths>
+                        <permissions>
+                            <permission>
+                                <file>/usr/bin/james-migration</file>
+                                <mode>755</mode>
+                                <!-- Read/write/execute for owner, read/execute for group/other -->
+                            </permission>
+                        </permissions>
+                    </extraDirectories>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>buildTar</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/server/apps/migration/core-data-jpa-to-pg/sample-configuration/blob.properties
+++ b/server/apps/migration/core-data-jpa-to-pg/sample-configuration/blob.properties
@@ -1,0 +1,66 @@
+# ============================================= BlobStore Implementation ==================================
+# Read https://james.apache.org/server/config-blobstore.html for further details
+
+# Choose your BlobStore implementation
+# Mandatory, allowed values are: file, s3, postgres.
+implementation=postgres
+
+# ========================================= Deduplication ========================================
+# If you choose to enable deduplication, the mails with the same content will be stored only once.
+# Warning: Once this feature is enabled, there is no turning back as turning it off will lead to the deletion of all
+# the mails sharing the same content once one is deleted.
+# Mandatory, Allowed values are: true, false
+deduplication.enable=true
+
+# deduplication.family needs to be incremented every time the deduplication.generation.duration is changed
+# Positive integer, defaults to 1
+# deduplication.gc.generation.family=1
+
+# Duration of generation.
+# Deduplication only takes place within a singe generation.
+# Only items two generation old can be garbage collected. (This prevent concurrent insertions issues and
+# accounts for a clock skew).
+# deduplication.family needs to be incremented everytime this parameter is changed.
+# Duration. Default unit: days. Defaults to 30 days.
+# deduplication.gc.generation.duration=30days
+
+# ========================================= Encryption ========================================
+# If you choose to enable encryption, the blob content will be encrypted before storing them in the BlobStore.
+# Warning: Once this feature is enabled, there is no turning back as turning it off will lead to all content being
+# encrypted. This comes at a performance impact but presents you from leaking data if, for instance the third party
+# offering you a S3 service is compromised.
+# Optional, Allowed values are: true, false, defaults to false
+encryption.aes.enable=false
+
+# Mandatory (if AES encryption is enabled) salt and password. Salt needs to be an hexadecimal encoded string
+#encryption.aes.password=xxx
+#encryption.aes.salt=73616c7479
+# Optional, defaults to PBKDF2WithHmacSHA512
+#encryption.aes.private.key.algorithm=PBKDF2WithHmacSHA512
+
+# ============================================ Blobs Exporting ==============================================
+# Read https://james.apache.org/server/config-blob-export.html for further details
+
+# Choosing blob exporting mechanism, allowed mechanism are: localFile, linshare
+# LinShare is a file sharing service, will be explained in the below section
+# Optional, default is localFile
+blob.export.implementation=localFile
+
+# ======================================= Local File Blobs Exporting ========================================
+# Optional, directory to store exported blob, directory path follows James file system format
+# default is file://var/blobExporting
+blob.export.localFile.directory=file://var/blobExporting
+
+# ======================================= LinShare File Blobs Exporting ========================================
+# LinShare is a sharing service where you can use james, connects to an existing LinShare server and shares files to
+# other mail addresses as long as those addresses available in LinShare. For example you can deploy James and LinShare
+# sharing the same LDAP repository
+# Mandatory if you choose LinShare, url to connect to LinShare service
+# blob.export.linshare.url=http://linshare:8080
+
+# ======================================= LinShare Configuration BasicAuthentication ===================================
+# Authentication is mandatory if you choose LinShare, TechnicalAccount is need to connect to LinShare specific service.
+# For Example: It will be formalized to 'Authorization: Basic {Credential of UUID/password}'
+
+# blob.export.linshare.technical.account.uuid=Technical_Account_UUID
+# blob.export.linshare.technical.account.password=password

--- a/server/apps/migration/core-data-jpa-to-pg/sample-configuration/james-database.properties
+++ b/server/apps/migration/core-data-jpa-to-pg/sample-configuration/james-database.properties
@@ -1,0 +1,45 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+#  This template file can be used as example for James Server configuration
+#  DO NOT USE IT AS SUCH AND ADAPT IT TO YOUR NEEDS
+
+# Read https://james.apache.org/server/config-system.html#james-database.properties for further details
+
+# Use derby as default
+database.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
+database.url=jdbc:derby:../var/store/derby;create=true
+#database.url=${env:DATABASE_URL}
+database.username=app
+#database.username=${env:DATABASE_USERNAME}
+database.password=app
+#database.password=${env:DATABASE_PASSWORD}
+
+# Use streaming for Blobs
+# This is only supported on a limited set of databases atm. You should check if its supported by your DB before enable
+# it. 
+# 
+# See:
+# http://openjpa.apache.org/builds/latest/docs/manual/ref_guide_mapping_jpa.html  #7.11.  LOB Streaming 
+# 
+#openjpa.streaming=false
+
+# Validate the data source before using it
+# datasource.testOnBorrow=true
+# datasource.validationQueryTimeoutSec=2
+# This is different per database. See https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases#10684260
+# datasource.validationQuery=select 1

--- a/server/apps/migration/core-data-jpa-to-pg/sample-configuration/logback.xml
+++ b/server/apps/migration/core-data-jpa-to-pg/sample-configuration/logback.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+        <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+                <resetJUL>true</resetJUL>
+        </contextListener>
+
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                        <pattern>%d{HH:mm:ss.SSS} %highlight([%-5level]) %logger{15} - %msg%n%rEx</pattern>
+                        <immediateFlush>false</immediateFlush>
+                </encoder>
+        </appender>
+
+        <appender name="LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>/logs/james.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+                    <fileNamePattern>/logs/james.%i.log.tar.gz</fileNamePattern>
+                    <minIndex>1</minIndex>
+                    <maxIndex>3</maxIndex>
+                </rollingPolicy>
+
+                <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+                    <maxFileSize>100MB</maxFileSize>
+                </triggeringPolicy>
+
+                <encoder>
+                        <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+                        <immediateFlush>false</immediateFlush>
+                </encoder>
+        </appender>
+        <root level="WARN">
+                <appender-ref ref="CONSOLE" />
+                <appender-ref ref="LOG_FILE" />
+        </root>
+
+        <logger name="org.apache.james" level="INFO" />
+
+</configuration>

--- a/server/apps/migration/core-data-jpa-to-pg/sample-configuration/postgres.properties
+++ b/server/apps/migration/core-data-jpa-to-pg/sample-configuration/postgres.properties
@@ -1,0 +1,51 @@
+# String. Optional, default to 'postgres'. Database name.
+database.name=james
+#database.name=${env:POSTGRESQL_DATABASE_NAME}
+
+# String. Optional, default to 'public'. Database schema.
+database.schema=public
+#database.schema=${env:POSTGRESQL_DATABASE_SCHEMA}
+
+# String. Optional, default to 'localhost'. Database host.
+database.host=postgres
+#database.host=${env:POSTGRESQL_HOST}
+
+# Integer. Optional, default to 5432. Database port.
+database.port=5432
+#database.port=${env:POSTGRESQL_PORT}
+
+# String. Required. Database username.
+database.username=james
+#database.username=${env:POSTGRESQL_USERNAME}
+
+# String. Required. Database password of the user.
+database.password=secret1
+#database.password=${env:POSTGRESQL_PASSWORD}
+
+# Boolean. Optional, default to false. Whether to enable row level security.
+row.level.security.enabled=false
+
+# String. It is required when row.level.security.enabled is true. Database username with the permission of bypassing RLS.
+#database.by-pass-rls.username=bypassrlsjames
+
+# String. It is required when row.level.security.enabled is true. Database password of by-pass-rls user.
+#database.by-pass-rls.password=secret1
+
+# Integer. Optional, default to 10. Database connection pool initial size.
+pool.initial.size=10
+
+# Integer. Optional, default to 15. Database connection pool max size.
+pool.max.size=15
+
+# Integer. Optional, default to 5. rls-bypass database connection pool initial size.
+by-pass-rls.pool.initial.size=5
+
+# Integer. Optional, default to 10. rls-bypass database connection pool max size.
+by-pass-rls.pool.max.size=10
+
+# String. Optional, defaults to allow. SSLMode required to connect to the Postgresql db server.
+# Check https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION for a list of supported SSLModes.
+ssl.mode=allow
+
+## Duration. Optional, defaults to 10 second. jOOQ reactive timeout when executing Postgres query. This setting prevent jooq reactive bug from causing hanging issue.
+#jooq.reactive.timeout=10second

--- a/server/apps/migration/core-data-jpa-to-pg/src/assemble/README.adoc
+++ b/server/apps/migration/core-data-jpa-to-pg/src/assemble/README.adoc
@@ -1,0 +1,20 @@
+= Guice-Memory Module How-to
+
+== Requirements
+
+ * Java SDK, the minimum version can be found in the https://github.com/apache/james-project/blob/master/pom.xml#L612[build descriptor]
+
+== Running
+
+To run james, you have to create a directory containing required configuration files.
+
+James requires the configuration to be in a subfolder of working directory that is called
+**conf**. A https://github.com/apache/james-project/tree/master/server/apps/migration/migration-core-data-jpa-to-pg/sample-configuration[sample directory]
+is provided with some default values you may need to replace. You will need to update its content to match your needs.
+
+Once everything is set up, you just have to run the jar with:
+
+[source]
+----
+$ java -Dworking.directory=. -Dlogback.configurationFile=conf/logback.xml -Djdk.tls.ephemeralDHKeySize=2048 -jar migration-core-data-jpa-to-pg.jar
+----

--- a/server/apps/migration/core-data-jpa-to-pg/src/assemble/app.xml
+++ b/server/apps/migration/core-data-jpa-to-pg/src/assemble/app.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed  under the  License is distributed on an "AS IS" BASIS,
+WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
+implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>app</id>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <fileSets>
+        <!-- include README -->
+        <fileSet>
+            <directory>src/assemble</directory>
+            <directoryMode>0755</directoryMode>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>README*</include>
+            </includes>
+        </fileSet>
+        <!-- include configs -->
+        <fileSet>
+            <directory>sample-configuration</directory>
+            <directoryMode>0755</directoryMode>
+            <outputDirectory>conf</outputDirectory>
+            <!-- set some sane security defaults for config files -->
+            <fileMode>0600</fileMode>
+        </fileSet>
+        <!-- include stuff from jar plugin -->
+        <fileSet>
+            <directory>target/migration-core-data-jpa-to-pg.lib</directory>
+            <outputDirectory>/migration-core-data-jpa-to-pg.lib</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0600</fileMode>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>src/assemble/license-for-binary.txt</source>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0644</fileMode>
+            <destName>LICENSE</destName>
+            <lineEnding>crlf</lineEnding>
+        </file>
+        <file>
+            <source>src/assemble/README.adoc</source>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0644</fileMode>
+            <lineEnding>crlf</lineEnding>
+        </file>
+        <file>
+            <source>src/assemble/extensions-jars.txt</source>
+            <outputDirectory>/extensions-jars</outputDirectory>
+            <fileMode>0644</fileMode>
+            <lineEnding>crlf</lineEnding>
+            <destName>README.md</destName>
+        </file>
+        <file>
+            <source>target/migration-core-data-jpa-to-pg.jar</source>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0755</fileMode>
+            <destName>migration-core-data-jpa-to-pg.jar</destName>
+        </file>
+    </files>
+</assembly>

--- a/server/apps/migration/core-data-jpa-to-pg/src/assemble/extensions-jars.txt
+++ b/server/apps/migration/core-data-jpa-to-pg/src/assemble/extensions-jars.txt
@@ -1,0 +1,5 @@
+# Adding Jars to JAMES
+
+The jar in this folder will be added to JAMES classpath when mounted under /root/extensions-jars inside the running container.
+
+You can use it to add you customs Mailets/Matchers.

--- a/server/apps/migration/core-data-jpa-to-pg/src/assemble/license-for-binary.txt
+++ b/server/apps/migration/core-data-jpa-to-pg/src/assemble/license-for-binary.txt
@@ -1,0 +1,1105 @@
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+This distribution contains third party resources.
+Within the bin directory
+    licensed under the Tanuki Software License (as follows)
+ 
+            
+              Copyright (c) 1999, 2006 Tanuki Software, Inc.
+            
+              Permission is hereby granted, free of charge, to any person
+              obtaining a copy of the Java Service Wrapper and associated
+              documentation files (the "Software"), to deal in the Software
+              without  restriction, including without limitation the rights
+              to use, copy, modify, merge, publish, distribute, sub-license,
+              and/or sell copies of the Software, and to permit persons to
+              whom the Software is furnished to do so, subject to the
+              following conditions:
+            
+              The above copyright notice and this permission notice shall be
+              included in all copies or substantial portions of the Software.
+            
+              THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+              EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+              OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+              NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+              HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+              WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+              FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+              OTHER DEALINGS IN THE SOFTWARE.
+            
+            
+              Portions of the Software have been derived from source code
+              developed by Silver Egg Technology under the following license:
+                
+                Copyright (c) 2001 Silver Egg Technology
+                
+                Permission is hereby granted, free of charge, to any person
+                obtaining a copy of this software and associated documentation
+                files (the "Software"), to deal in the Software without 
+                restriction, including without limitation the rights to use, 
+                copy, modify, merge, publish, distribute, sub-license, and/or 
+                sell copies of the Software, and to permit persons to whom the
+                Software is furnished to do so, subject to the following 
+                conditions:
+                
+                The above copyright notice and this permission notice shall be
+                included in all copies or substantial portions of the Software.
+                
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+                EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+                OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+                NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+                HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+                WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+                FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+                OTHER DEALINGS IN THE SOFTWARE.
+                        
+        from Tanuki Software  http://www.tanukisoftware.com/ 
+            james
+            james.bat
+            wrapper
+            wrapper-linux-ppc-64
+            wrapper-linux-x86-32
+            wrapper-linux-x86-64
+            wrapper-macosx-ppc-32
+            wrapper-macosx-universal-32
+            wrapper-solaris-sparc-32
+            wrapper-solaris-sparc-64
+            wrapper-solaris-x86-32
+            wrapper-windows-x86-32.exe
+
+Within the conf directory
+    licensed under the Tanuki Software License (as follows)
+ 
+            
+              Copyright (c) 1999, 2006 Tanuki Software, Inc.
+            
+              Permission is hereby granted, free of charge, to any person
+              obtaining a copy of the Java Service Wrapper and associated
+              documentation files (the "Software"), to deal in the Software
+              without  restriction, including without limitation the rights
+              to use, copy, modify, merge, publish, distribute, sub-license,
+              and/or sell copies of the Software, and to permit persons to
+              whom the Software is furnished to do so, subject to the
+              following conditions:
+            
+              The above copyright notice and this permission notice shall be
+              included in all copies or substantial portions of the Software.
+            
+              THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+              EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+              OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+              NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+              HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+              WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+              FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+              OTHER DEALINGS IN THE SOFTWARE.
+            
+            
+              Portions of the Software have been derived from source code
+              developed by Silver Egg Technology under the following license:
+                
+                Copyright (c) 2001 Silver Egg Technology
+                
+                Permission is hereby granted, free of charge, to any person
+                obtaining a copy of this software and associated documentation
+                files (the "Software"), to deal in the Software without 
+                restriction, including without limitation the rights to use, 
+                copy, modify, merge, publish, distribute, sub-license, and/or 
+                sell copies of the Software, and to permit persons to whom the
+                Software is furnished to do so, subject to the following 
+                conditions:
+                
+                The above copyright notice and this permission notice shall be
+                included in all copies or substantial portions of the Software.
+                
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+                EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+                OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+                NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+                HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+                WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+                FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+                OTHER DEALINGS IN THE SOFTWARE.
+                        
+        from Tanuki Software  http://www.tanukisoftware.com/ 
+            wrapper.conf
+
+Within the lib directory
+    placed in the public domain
+        by Doug Lea 
+            concurrent-1.3.4.jar
+        by Drew Noakes 
+            metadata-extractor-2.4.0-beta-1.jar
+        by The AOP Alliance  http://aopalliance.sourceforge.net/ 
+            aopalliance-1.0.jar
+
+    licensed under the Apache License, Version 2 http://www.apache.org/licenses/LICENSE-2.0.txt  (as above)
+        from Boilerpipe  http://code.google.com/p/boilerpipe/ 
+            boilerpipe-1.1.0.jar
+        from FuseSource  http://www.fusesource.org 
+            commons-management-1.0.jar
+        from JBoss, a division of Red Hat, Inc.  http://www.jboss.org 
+            netty-3.2.4.Final.jar
+        from John Cowan  http://home.ccil.org/~cowan/XML/tagsoup/ 
+            tagsoup-1.2.jar
+        from Oracle  http://www.oracle.com 
+            rome-0.9.jar
+        from The JASYPT team  http://www.jasypt.org 
+            jasypt-1.6.jar
+        from The Spring Framework Project  http://www.springframework.org 
+            spring-aop-3.1.RELEASE.jar
+            spring-asm-3.1.RELEASE.jar
+            spring-beans-3.1.RELEASE.jar
+            spring-context-3.1.RELEASE.jar
+            spring-core-3.1.RELEASE.jar
+            spring-expression-3.1.RELEASE.jar
+            spring-jdbc-3.1.RELEASE.jar
+            spring-jms-3.1.RELEASE.jar
+            spring-orm-3.1.RELEASE.jar
+            spring-tx-3.1.RELEASE.jar
+            spring-web-3.1.RELEASE.jar
+
+    licensed under the BSD (3-clause) http://www.opensource.org/licenses/BSD-3-Clause  (as follows)
+
+            ASM: a very small and fast Java bytecode manipulation framework
+            Copyright (c) 2000-2007 INRIA, France Telecom
+            All rights reserved. 
+            
+              Redistribution and use in source and binary forms, with or without
+              modification, are permitted provided that the following conditions
+              are met:
+              1. Redistributions of source code must retain the above copyright
+                 notice, this list of conditions and the following disclaimer.
+              2. Redistributions in binary form must reproduce the above copyright
+                 notice, this list of conditions and the following disclaimer in the
+                 documentation and/or other materials provided with the distribution.
+              3. Neither the name of the copyright holders nor the names of its
+                 contributors may be used to endorse or promote products derived from
+                 this software without specific prior written permission.
+             
+              THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+              AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+              IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+              ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+              LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+              CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+              SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+              INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+              CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+              ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+              THE POSSIBILITY OF SUCH DAMAGE.
+                            
+        from OW2  http://www.ow2.org/ 
+            asm-3.1.jar
+
+    licensed under the BSD (2-clause) http://www.opensource.org/licenses/BSD-2-Clause  (as follows)
+
+            dnsjava is placed under the BSD license.  Several files are also under
+            additional licenses; see the individual files for details.
+            
+            Copyright (c) 1998-2011, Brian Wellington.
+            All rights reserved.
+
+            Redistribution and use in source and binary forms, with or without
+            modification, are permitted provided that the following conditions are met:
+
+              * Redistributions of source code must retain the above copyright notice,
+                this list of conditions and the following disclaimer.
+
+              * Redistributions in binary form must reproduce the above copyright notice,
+                this list of conditions and the following disclaimer in the documentation
+                and/or other materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+            AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+            IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+            ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+            LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+            CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+            SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+            INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+            CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+            ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+                            
+        from Brian Wellington 
+            dnsjava-2.1.8.jar
+
+    licensed under the BSD (3-clause) http://www.opensource.org/licenses/BSD-3-Clause  (as follows)
+
+            Copyright (c) 2002-2007, A. Abram White
+            All rights reserved. 
+            
+            Redistribution and use in source and binary forms, with or without
+            modification, are permitted provided that the following conditions are met:
+            
+               * Redistributions of source code must retain the above copyright notice,
+                 this list of conditions and the following disclaimer.
+               * Redistributions in binary form must reproduce the above copyright notice,
+                 this list of conditions and the following disclaimer in the documentation
+                 and/or other materials provided with the distribution.
+               * Neither the name of 'serp' nor the names of its contributors
+                 may be used to endorse or promote products derived from this software
+                 without specific prior written permission.
+            
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+            ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                            
+        from The Serp Project  http://serp.sourceforge.net/ 
+            serp-1.13.1.jar
+
+    licensed under the Bouncy Castle Licence http://www.bouncycastle.org/licence.html  (as follows)
+
+            Copyright (c) 2000 - 2011 The Legion Of The Bouncy Castle (http://www.bouncycastle.org) 
+            
+            Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+            and associated documentation files (the "Software"), to deal in the Software without restriction, 
+            including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+            and/or sell copies of the Software, and to permit persons to whom the Software is furnished to 
+            do so, subject to the following conditions:
+            
+            The above copyright notice and this permission notice shall be included in all copies or substantial 
+            portions of the Software.
+            
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+            FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS 
+            OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+            IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+            WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+                            
+        from The Legion of the Bouncy Castle  http://www.bouncycastle.org/ 
+            bcjmail-jdk18on-1.77.jar
+            bcprov-jdk18on-1.77.jar
+
+    licensed under the COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 http://www.opensource.org/licenses/CDDL-1.0  (as follows)
+ 
+            
+            COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+            
+            1. Definitions.
+            
+            1.1. "Contributor" means each individual or entity that
+            creates or contributes to the creation of Modifications.
+            
+            1.2. "Contributor Version" means the combination of the
+            Original Software, prior Modifications used by a
+            Contributor (if any), and the Modifications made by that
+            particular Contributor.
+            
+            1.3. "Covered Software" means (a) the Original Software, or
+            (b) Modifications, or (c) the combination of files
+            containing Original Software with files containing
+            Modifications, in each case including portions thereof.
+            
+            1.4. "Executable" means the Covered Software in any form
+            other than Source Code.
+            
+            1.5. "Initial Developer" means the individual or entity
+            that first makes Original Software available under this
+            License.
+            
+            1.6. "Larger Work" means a work which combines Covered
+            Software or portions thereof with code not governed by the
+            terms of this License.
+            
+            1.7. "License" means this document.
+            
+            1.8. "Licensable" means having the right to grant, to the
+            maximum extent possible, whether at the time of the initial
+            grant or subsequently acquired, any and all of the rights
+            conveyed herein.
+            
+            1.9. "Modifications" means the Source Code and Executable
+            form of any of the following:
+            
+            A. Any file that results from an addition to,
+            deletion from or modification of the contents of a
+            file containing Original Software or previous
+            Modifications;
+            
+            B. Any new file that contains any part of the
+            Original Software or previous Modification; or
+            
+            C. Any new file that is contributed or otherwise made
+            available under the terms of this License.
+            
+            1.10. "Original Software" means the Source Code and
+            Executable form of computer software code that is
+            originally released under this License.
+            
+            1.11. "Patent Claims" means any patent claim(s), now owned
+            or hereafter acquired, including without limitation,
+            method, process, and apparatus claims, in any patent
+            Licensable by grantor.
+            
+            1.12. "Source Code" means (a) the common form of computer
+            software code in which modifications are made and (b)
+            associated documentation included in or with such code.
+            
+            1.13. "You" (or "Your") means an individual or a legal
+            entity exercising rights under, and complying with all of
+            the terms of, this License. For legal entities, "You"
+            includes any entity which controls, is controlled by, or is
+            under common control with You. For purposes of this
+            definition, "control" means (a) the power, direct or
+            indirect, to cause the direction or management of such
+            entity, whether by contract or otherwise, or (b) ownership
+            of more than fifty percent (50%) of the outstanding shares
+            or beneficial ownership of such entity.
+            
+            2. License Grants.
+            
+            2.1. The Initial Developer Grant.
+            
+            Conditioned upon Your compliance with Section 3.1 below and
+            subject to third party intellectual property claims, the
+            Initial Developer hereby grants You a world-wide,
+            royalty-free, non-exclusive license:
+            
+            (a) under intellectual property rights (other than
+            patent or trademark) Licensable by Initial Developer,
+            to use, reproduce, modify, display, perform,
+            sublicense and distribute the Original Software (or
+            portions thereof), with or without Modifications,
+            and/or as part of a Larger Work; and
+            
+            (b) under Patent Claims infringed by the making,
+            using or selling of Original Software, to make, have
+            made, use, practice, sell, and offer for sale, and/or
+            otherwise dispose of the Original Software (or
+            portions thereof).
+            
+            (c) The licenses granted in Sections 2.1(a) and (b)
+            are effective on the date Initial Developer first
+            distributes or otherwise makes the Original Software
+            available to a third party under the terms of this
+            License.
+            
+            (d) Notwithstanding Section 2.1(b) above, no patent
+            license is granted: (1) for code that You delete from
+            the Original Software, or (2) for infringements
+            caused by: (i) the modification of the Original
+            Software, or (ii) the combination of the Original
+            Software with other software or devices.
+            
+            2.2. Contributor Grant.
+            
+            Conditioned upon Your compliance with Section 3.1 below and
+            subject to third party intellectual property claims, each
+            Contributor hereby grants You a world-wide, royalty-free,
+            non-exclusive license:
+            
+            (a) under intellectual property rights (other than
+            patent or trademark) Licensable by Contributor to
+            use, reproduce, modify, display, perform, sublicense
+            and distribute the Modifications created by such
+            Contributor (or portions thereof), either on an
+            unmodified basis, with other Modifications, as
+            Covered Software and/or as part of a Larger Work; and
+            
+            (b) under Patent Claims infringed by the making,
+            using, or selling of Modifications made by that
+            Contributor either alone and/or in combination with
+            its Contributor Version (or portions of such
+            combination), to make, use, sell, offer for sale,
+            have made, and/or otherwise dispose of: (1)
+            Modifications made by that Contributor (or portions
+            thereof); and (2) the combination of Modifications
+            made by that Contributor with its Contributor Version
+            (or portions of such combination).
+            
+            (c) The licenses granted in Sections 2.2(a) and
+            2.2(b) are effective on the date Contributor first
+            distributes or otherwise makes the Modifications
+            available to a third party.
+            
+            (d) Notwithstanding Section 2.2(b) above, no patent
+            license is granted: (1) for any code that Contributor
+            has deleted from the Contributor Version; (2) for
+            infringements caused by: (i) third party
+            modifications of Contributor Version, or (ii) the
+            combination of Modifications made by that Contributor
+            with other software (except as part of the
+            Contributor Version) or other devices; or (3) under
+            Patent Claims infringed by Covered Software in the
+            absence of Modifications made by that Contributor.
+            
+            3. Distribution Obligations.
+            
+            3.1. Availability of Source Code.
+            
+            Any Covered Software that You distribute or otherwise make
+            available in Executable form must also be made available in
+            Source Code form and that Source Code form must be
+            distributed only under the terms of this License. You must
+            include a copy of this License with every copy of the
+            Source Code form of the Covered Software You distribute or
+            otherwise make available. You must inform recipients of any
+            such Covered Software in Executable form as to how they can
+            obtain such Covered Software in Source Code form in a
+            reasonable manner on or through a medium customarily used
+            for software exchange.
+            
+            3.2. Modifications.
+            
+            The Modifications that You create or to which You
+            contribute are governed by the terms of this License. You
+            represent that You believe Your Modifications are Your
+            original creation(s) and/or You have sufficient rights to
+            grant the rights conveyed by this License.
+            
+            3.3. Required Notices.
+            
+            You must include a notice in each of Your Modifications
+            that identifies You as the Contributor of the Modification.
+            You may not remove or alter any copyright, patent or
+            trademark notices contained within the Covered Software, or
+            any notices of licensing or any descriptive text giving
+            attribution to any Contributor or the Initial Developer.
+            
+            3.4. Application of Additional Terms.
+            
+            You may not offer or impose any terms on any Covered
+            Software in Source Code form that alters or restricts the
+            applicable version of this License or the recipients'
+            rights hereunder. You may choose to offer, and to charge a
+            fee for, warranty, support, indemnity or liability
+            obligations to one or more recipients of Covered Software.
+            However, you may do so only on Your own behalf, and not on
+            behalf of the Initial Developer or any Contributor. You
+            must make it absolutely clear that any such warranty,
+            support, indemnity or liability obligation is offered by
+            You alone, and You hereby agree to indemnify the Initial
+            Developer and every Contributor for any liability incurred
+            by the Initial Developer or such Contributor as a result of
+            warranty, support, indemnity or liability terms You offer.
+            
+            3.5. Distribution of Executable Versions.
+            
+            You may distribute the Executable form of the Covered
+            Software under the terms of this License or under the terms
+            of a license of Your choice, which may contain terms
+            different from this License, provided that You are in
+            compliance with the terms of this License and that the
+            license for the Executable form does not attempt to limit
+            or alter the recipient's rights in the Source Code form
+            from the rights set forth in this License. If You
+            distribute the Covered Software in Executable form under a
+            different license, You must make it absolutely clear that
+            any terms which differ from this License are offered by You
+            alone, not by the Initial Developer or Contributor. You
+            hereby agree to indemnify the Initial Developer and every
+            Contributor for any liability incurred by the Initial
+            Developer or such Contributor as a result of any such terms
+            You offer.
+            
+            3.6. Larger Works.
+            
+            You may create a Larger Work by combining Covered Software
+            with other code not governed by the terms of this License
+            and distribute the Larger Work as a single product. In such
+            a case, You must make sure the requirements of this License
+            are fulfilled for the Covered Software.
+            
+            4. Versions of the License.
+            
+            4.1. New Versions.
+            
+            Sun Microsystems, Inc. is the initial license steward and
+            may publish revised and/or new versions of this License
+            from time to time. Each version will be given a
+            distinguishing version number. Except as provided in
+            Section 4.3, no one other than the license steward has the
+            right to modify this License.
+            
+            4.2. Effect of New Versions.
+            
+            You may always continue to use, distribute or otherwise
+            make the Covered Software available under the terms of the
+            version of the License under which You originally received
+            the Covered Software. If the Initial Developer includes a
+            notice in the Original Software prohibiting it from being
+            distributed or otherwise made available under any
+            subsequent version of the License, You must distribute and
+            make the Covered Software available under the terms of the
+            version of the License under which You originally received
+            the Covered Software. Otherwise, You may also choose to
+            use, distribute or otherwise make the Covered Software
+            available under the terms of any subsequent version of the
+            License published by the license steward.
+            
+            4.3. Modified Versions.
+            
+            When You are an Initial Developer and You want to create a
+            new license for Your Original Software, You may create and
+            use a modified version of this License if You: (a) rename
+            the license and remove any references to the name of the
+            license steward (except to note that the license differs
+            from this License); and (b) otherwise make it clear that
+            the license contains terms which differ from this License.
+            
+            5. DISCLAIMER OF WARRANTY.
+            
+            COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS"
+            BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+            INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED
+            SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR
+            PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND
+            PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY
+            COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+            INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF
+            ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF
+            WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF
+            ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS
+            DISCLAIMER.
+            
+            6. TERMINATION.
+            
+            6.1. This License and the rights granted hereunder will
+            terminate automatically if You fail to comply with terms
+            herein and fail to cure such breach within 30 days of
+            becoming aware of the breach. Provisions which, by their
+            nature, must remain in effect beyond the termination of
+            this License shall survive.
+            
+            6.2. If You assert a patent infringement claim (excluding
+            declaratory judgment actions) against Initial Developer or
+            a Contributor (the Initial Developer or Contributor against
+            whom You assert such claim is referred to as "Participant")
+            alleging that the Participant Software (meaning the
+            Contributor Version where the Participant is a Contributor
+            or the Original Software where the Participant is the
+            Initial Developer) directly or indirectly infringes any
+            patent, then any and all rights granted directly or
+            indirectly to You by such Participant, the Initial
+            Developer (if the Initial Developer is not the Participant)
+            and all Contributors under Sections 2.1 and/or 2.2 of this
+            License shall, upon 60 days notice from Participant
+            terminate prospectively and automatically at the expiration
+            of such 60 day notice period, unless if within such 60 day
+            period You withdraw Your claim with respect to the
+            Participant Software against such Participant either
+            unilaterally or pursuant to a written agreement with
+            Participant.
+            
+            6.3. In the event of termination under Sections 6.1 or 6.2
+            above, all end user licenses that have been validly granted
+            by You or any distributor hereunder prior to termination
+            (excluding licenses granted to You by any distributor)
+            shall survive termination.
+            
+            7. LIMITATION OF LIABILITY.
+            
+            UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+            (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+            INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF
+            COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE
+            LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR
+            CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+            LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+            STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+            COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+            INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+            LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
+            INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT
+            APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO
+            NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR
+            CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT
+            APPLY TO YOU.
+            
+            8. U.S. GOVERNMENT END USERS.
+            
+            The Covered Software is a "commercial item," as that term is
+            defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial
+            computer software" (as that term is defined at 48 C.F.R. ?
+            252.227-7014(a)(1)) and "commercial computer software
+            documentation" as such terms are used in 48 C.F.R. 12.212 (Sept.
+            1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1
+            through 227.7202-4 (June 1995), all U.S. Government End Users
+            acquire Covered Software with only those rights set forth herein.
+            This U.S. Government Rights clause is in lieu of, and supersedes,
+            any other FAR, DFAR, or other clause or provision that addresses
+            Government rights in computer software under this License.
+            
+            9. MISCELLANEOUS.
+            
+            This License represents the complete agreement concerning subject
+            matter hereof. If any provision of this License is held to be
+            unenforceable, such provision shall be reformed only to the
+            extent necessary to make it enforceable. This License shall be
+            governed by the law of the jurisdiction specified in a notice
+            contained within the Original Software (except to the extent
+            applicable law, if any, provides otherwise), excluding such
+            jurisdiction's conflict-of-law provisions. Any litigation
+            relating to this License shall be subject to the jurisdiction of
+            the courts located in the jurisdiction and venue specified in a
+            notice contained within the Original Software, with the losing
+            party responsible for costs, including, without limitation, court
+            costs and reasonable attorneys' fees and expenses. The
+            application of the United Nations Convention on Contracts for the
+            International Sale of Goods is expressly excluded. Any law or
+            regulation which provides that the language of a contract shall
+            be construed against the drafter shall not apply to this License.
+            You agree that You alone are responsible for compliance with the
+            United States export administration regulations (and the export
+            control laws and regulation of any other countries) when You use,
+            distribute or otherwise make available any Covered Software.
+            
+            10. RESPONSIBILITY FOR CLAIMS.
+            
+            As between Initial Developer and the Contributors, each party is
+            responsible for claims and damages arising, directly or
+            indirectly, out of its utilization of rights under this License
+            and You agree to work with Initial Developer and Contributors to
+            distribute such responsibility on an equitable basis. Nothing
+            herein is intended or shall be deemed to constitute any admission
+            of liability.
+                        
+        from Oracle  http://www.oracle.com 
+            mail-1.4.4.jar
+
+    licensed under the Day Specification License with Addendum http://www.day.com/content/dam/day/downloads/jsr283/LICENSE.txt  (as follows)
+ 
+            
+            Day Management AG ("Licensor") is willing to license this specification to you ONLY UPON 
+            THE CONDITION THAT YOU ACCEPT ALL OF THE TERMS CONTAINED IN THIS LICENSE AGREEMENT 
+            ("Agreement"). Please read the terms and conditions of this Agreement carefully.
+            
+            Content Repository for JavaTM Technology API Specification ("Specification")
+            Version: 2.0
+            Status: FCS
+            Release: 10 August 2009
+            
+            Copyright 2009 Day Management AG
+            Barf?sserplatz 6, 4001 Basel, Switzerland.
+            All rights reserved.
+            
+            NOTICE; LIMITED LICENSE GRANTS
+            
+            1. License for Purposes of Evaluation and Developing Applications. Licensor hereby grants 
+               you a fully-paid, non-exclusive, non-transferable, worldwide, limited license (without the 
+               right to sublicense), under Licensor's applicable intellectual property rights to view, 
+               download, use and reproduce the Specification only for the purpose of internal evaluation. 
+               This includes developing applications intended to run on an implementation of the 
+               Specification provided that such applications do not themselves implement any portion(s) 
+               of the Specification.
+            
+            2. License for the Distribution of Compliant Implementations. Licensor also grants you a 
+               perpetual, non-exclusive, non-transferable, worldwide, fully paid-up, royalty free, limited 
+               license (without the right to sublicense) under any applicable copyrights or, subject to 
+               the provisions of subsection 4 below, patent rights it may have covering the Specification 
+               to create and/or distribute an Independent Implementation of the Specification that:
+                
+                  (a) fully implements the Specification including all its required interfaces and 
+                      functionality; 
+                  (b) does not modify, subset, superset or otherwise extend the Licensor Name Space, 
+                      or include any public or protected packages, classes, Java interfaces, fields 
+                      or methods within the Licensor Name Space other than those required/authorized 
+                      by the Specification or Specifications being implemented; and 
+                  (c) passes the Technology Compatibility Kit (including satisfying the requirements 
+                      of the applicable TCK Users Guide) for such Specification ("Compliant Implementation"). 
+                      In addition, the foregoing license is expressly conditioned on your not acting 
+                      outside its scope. No license is granted hereunder for any other purpose (including, 
+                      for example, modifying the Specification, other than to the extent of your fair use 
+                      rights, or distributing the Specification to third parties).
+            
+            3. Pass-through Conditions. You need not include limitations (a)-(c) from the previous paragraph
+               or any other particular "pass through" requirements in any license You grant concerning the 
+               use of your Independent Implementation or products derived from it. However, except with 
+               respect to Independent Implementations (and products derived from them) that satisfy 
+               limitations (a)-(c) from the previous paragraph, You may neither: 
+               
+                   (a) grant or otherwise pass through to your licensees any licenses under Licensor's 
+                       applicable intellectual property rights; nor 
+                   (b) authorize your licensees to make any claims concerning their implementation's 
+                       compliance with the Specification.
+            
+            4. Reciprocity Concerning Patent Licenses. With respect to any patent claims covered by the 
+               license granted under subparagraph 2 above that would be infringed by all technically 
+               feasible implementations of the Specification, such license is conditioned upon your 
+               offering on fair, reasonable and non-discriminatory terms, to any party seeking it from 
+               You, a perpetual, non-exclusive, non-transferable, worldwide license under Your patent 
+               rights that are or would be infringed by all technically feasible implementations of the 
+               Specification to develop, distribute and use a Compliant Implementation.
+            
+            5. Definitions. For the purposes of this Agreement: "Independent Implementation" shall mean an 
+               implementation of the Specification that neither derives from any of Licensor's source code 
+               or binary code materials nor, except with an appropriate and separate license from Licensor, 
+               includes any of Licensor's source code or binary code materials; "Licensor Name Space" shall 
+               mean the public class or interface declarations whose names begin with "java", "javax", 
+               "javax.jcr" or their equivalents in any subsequent naming convention adopted by Licensor 
+               through the Java Community Process, or any recognized successors or replacements thereof; 
+               and "Technology Compatibility Kit" or "TCK" shall mean the test suite and accompanying TCK 
+               User's Guide provided by Licensor which corresponds to the particular version of the 
+               Specification being tested.
+            
+            6. Termination. This Agreement will terminate immediately without notice from Licensor if 
+               you fail to comply with any material provision of or act outside the scope of the licenses 
+               granted above.
+            
+            7. Trademarks. No right, title, or interest in or to any trademarks, service marks, or trade 
+               names of Licensor is granted hereunder. Java is a registered trademark of Sun Microsystems, 
+               Inc. in the United States and other countries.
+            
+            8. Disclaimer of Warranties. The Specification is provided "AS IS". LICENSOR MAKES NO 
+               REPRESENTATIONS OR WARRANTIES, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, 
+               WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT 
+               (INCLUDING AS A CONSEQUENCE OF ANY PRACTICE OR IMPLEMENTATION OF THE SPECIFICATION), 
+               OR THAT THE CONTENTS OF THE SPECIFICATION ARE SUITABLE FOR ANY PURPOSE. This document 
+               does not represent any commitment to release or implement any portion of the Specification 
+               in any product.
+            
+               The Specification could include technical inaccuracies or typographical errors. Changes are 
+               periodically added to the information therein; these changes will be incorporated into new 
+               versions of the Specification, if any. Licensor may make improvements and/or changes to the 
+               product(s) and/or the program(s) described in the Specification at any time. Any use of such 
+               changes in the Specification will be governed by the then-current license for the applicable 
+               version of the Specification.
+            
+            9. Limitation of Liability. TO THE EXTENT NOT PROHIBITED BY LAW, IN NO EVENT WILL LICENSOR 
+               BE LIABLE FOR ANY DAMAGES, INCLUDING WITHOUT LIMITATION, LOST REVENUE, PROFITS OR DATA, OR 
+               FOR SPECIAL, INDIRECT, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND 
+               REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF OR RELATED TO ANY FURNISHING, 
+               PRACTICING, MODIFYING OR ANY USE OF THE SPECIFICATION, EVEN IF LICENSOR HAS BEEN ADVISED 
+               OF THE POSSIBILITY OF SUCH DAMAGES.
+            
+            10. Report. If you provide Licensor with any comments or suggestions in connection with your 
+                use of the Specification ("Feedback"), you hereby: (i) agree that such Feedback is provided 
+                on a non-proprietary and non-confidential basis, and (ii) grant Licensor a perpetual, 
+                non-exclusive, worldwide, fully paid-up, irrevocable license, with the right to sublicense 
+                through multiple levels of sublicensees, to incorporate, disclose, and use without 
+                limitation the Feedback for any purpose related to the Specification and future versions, 
+                implementations, and test suites thereof.
+            
+            Day Specification License Addendum
+            
+            In addition to the permissions granted under the Specification
+            License, Day Management AG hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            license to reproduce, publicly display, publicly perform,
+            sublicense, and distribute unmodified copies of the Content
+            Repository for Java Technology API (JCR 2.0) Java Archive (JAR)
+            file ("jcr-2.0.jar") and to make, have made, use, offer to sell,
+            sell, import, and otherwise transfer said file on its own or
+            as part of a larger work that makes use of the JCR API.
+            
+            With respect to any patent claims covered by this license
+            that would be infringed by all technically feasible implementations
+            of the Specification, such license is conditioned upon your
+            offering on fair, reasonable and non-discriminatory terms,
+            to any party seeking it from You, a perpetual, non-exclusive,
+            non-transferable, worldwide license under Your patent rights
+            that are or would be infringed by all technically feasible
+            implementations of the Specification to develop, distribute
+            and use a Compliant Implementation.
+            
+                            
+        from Day Software  http://www.day.com 
+            jcr-2.0.jar
+
+    licensed under the MIT License http://www.opensource.org/licenses/mit-license.php  (as follows)
+
+            Copyright (c) 2004-2008 QOS.ch
+            All rights reserved. 
+            
+            Permission is hereby granted, free  of charge, to any person obtaining
+            a  copy  of this  software  and  associated  documentation files  (the
+            "Software"), to  deal in  the Software without  restriction, including
+            without limitation  the rights to  use, copy, modify,  merge, publish,
+            distribute,  sublicense, and/or sell  copies of  the Software,  and to
+            permit persons to whom the Software  is furnished to do so, subject to
+            the following conditions:
+            
+            The  above  copyright  notice  and  this permission  notice  shall  be
+            included in all copies or substantial portions of the Software.
+            
+            THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+            EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+            MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+            NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+            LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+            OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+            WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+                            
+        from QOS.ch  http://www.qos.ch 
+            jcl-over-slf4j-1.6.1.jar
+            slf4j-api-1.6.1.jar
+            slf4j-log4j12-1.6.1.jar
+
+    licensed under the Tanuki Software License (as follows)
+ 
+            
+              Copyright (c) 1999, 2006 Tanuki Software, Inc.
+            
+              Permission is hereby granted, free of charge, to any person
+              obtaining a copy of the Java Service Wrapper and associated
+              documentation files (the "Software"), to deal in the Software
+              without  restriction, including without limitation the rights
+              to use, copy, modify, merge, publish, distribute, sub-license,
+              and/or sell copies of the Software, and to permit persons to
+              whom the Software is furnished to do so, subject to the
+              following conditions:
+            
+              The above copyright notice and this permission notice shall be
+              included in all copies or substantial portions of the Software.
+            
+              THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+              EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+              OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+              NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+              HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+              WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+              FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+              OTHER DEALINGS IN THE SOFTWARE.
+            
+            
+              Portions of the Software have been derived from source code
+              developed by Silver Egg Technology under the following license:
+                
+                Copyright (c) 2001 Silver Egg Technology
+                
+                Permission is hereby granted, free of charge, to any person
+                obtaining a copy of this software and associated documentation
+                files (the "Software"), to deal in the Software without 
+                restriction, including without limitation the rights to use, 
+                copy, modify, merge, publish, distribute, sub-license, and/or 
+                sell copies of the Software, and to permit persons to whom the
+                Software is furnished to do so, subject to the following 
+                conditions:
+                
+                The above copyright notice and this permission notice shall be
+                included in all copies or substantial portions of the Software.
+                
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+                EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+                OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+                NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+                HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+                WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+                FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+                OTHER DEALINGS IN THE SOFTWARE.
+                        
+        from Tanuki Software  http://www.tanukisoftware.com/ 
+            libwrapper-linux-ppc-64.so
+            libwrapper-linux-x86-32.so
+            libwrapper-linux-x86-64.so
+            libwrapper-macosx-ppc-32.jnilib
+            libwrapper-macosx-universal-32.jnilib
+            libwrapper-solaris-sparc-32.so
+            libwrapper-solaris-sparc-64.so
+            libwrapper-solaris-x86-32.so
+            wrapper-windows-x86-32.dll
+            wrapper.jar
+
+
+    licensed under the Day Specification License http://www.day.com/content/dam/day/downloads/jsr283/LICENSE.txt  (as follows)
+
+            In addition to the permissions granted under the Specification
+            License, Day Management AG hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            license to reproduce, publicly display, publicly perform,
+            sublicense, and distribute unmodified copies of the Content
+            Repository for Java Technology API (JCR 2.0) Java Archive (JAR)
+            file ("jcr-2.0.jar") and to make, have made, use, offer to sell,
+            sell, import, and otherwise transfer said file on its own or
+            as part of a larger work that makes use of the JCR API.
+            
+            With respect to any patent claims covered by this license
+            that would be infringed by all technically feasible implementations
+            of the Specification, such license is conditioned upon your
+            offering on fair, reasonable and non-discriminatory terms,
+            to any party seeking it from You, a perpetual, non-exclusive,
+            non-transferable, worldwide license under Your patent rights
+            that are or would be infringed by all technically feasible
+            implementations of the Specification to develop, distribute
+            and use a Compliant Implementation.
+            

--- a/server/apps/migration/core-data-jpa-to-pg/src/main/java/org/apache/james/JpaToPgCoreDataMigration.java
+++ b/server/apps/migration/core-data-jpa-to-pg/src/main/java/org/apache/james/JpaToPgCoreDataMigration.java
@@ -1,0 +1,504 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.apache.james.modules.blobstore.BlobStoreModulesChooser.chooseBlobStoreDAOModule;
+import static org.apache.james.modules.blobstore.BlobStoreModulesChooser.chooseEncryptionModule;
+import static org.apache.james.modules.blobstore.BlobStoreModulesChooser.chooseStoragePolicyModule;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.apache.james.backends.postgres.PostgresModule;
+import org.apache.james.core.Username;
+import org.apache.james.domainlist.api.DomainListException;
+import org.apache.james.domainlist.jpa.JPADomainList;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.postgres.PostgresDomainList;
+import org.apache.james.droplists.jpa.JPADropList;
+import org.apache.james.droplists.postgres.PostgresDropList;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.mailrepository.api.MailKey;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.mailrepository.api.MailRepositoryUrlStore;
+import org.apache.james.mailrepository.jpa.JPAMailRepositoryFactory;
+import org.apache.james.mailrepository.jpa.JPAMailRepositoryUrlStore;
+import org.apache.james.mailrepository.postgres.PostgresMailRepositoryContentDAO;
+import org.apache.james.mailrepository.postgres.PostgresMailRepositoryUrlStore;
+import org.apache.james.modules.ClockModule;
+import org.apache.james.modules.blobstore.BlobStoreCacheModulesChooser;
+import org.apache.james.modules.blobstore.BlobStoreConfiguration;
+import org.apache.james.modules.data.JPAEntityManagerModule;
+import org.apache.james.modules.data.PostgresCommonModule;
+import org.apache.james.modules.data.PostgresDomainListModule;
+import org.apache.james.modules.data.PostgresDropListsModule;
+import org.apache.james.modules.data.PostgresQuotaGuiceModule;
+import org.apache.james.modules.data.PostgresRecipientRewriteTableModule;
+import org.apache.james.modules.data.PostgresUsersRepositoryModule;
+import org.apache.james.modules.data.SievePostgresRepositoryModules;
+import org.apache.james.modules.server.DNSServiceModule;
+import org.apache.james.modules.server.DropWizardMetricsModule;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.apache.james.rrt.jpa.JPARecipientRewriteTable;
+import org.apache.james.rrt.postgres.PostgresRecipientRewriteTable;
+import org.apache.james.server.core.configuration.Configuration;
+import org.apache.james.server.core.configuration.ConfigurationProvider;
+import org.apache.james.server.core.configuration.FileConfigurationProvider;
+import org.apache.james.server.core.filesystem.FileSystemImpl;
+import org.apache.james.sieve.jpa.JPASieveRepository;
+import org.apache.james.sieve.jpa.model.JPASieveScript;
+import org.apache.james.sieve.postgres.PostgresSieveRepository;
+import org.apache.james.sieverepository.api.ScriptContent;
+import org.apache.james.sieverepository.api.ScriptName;
+import org.apache.james.user.api.AlreadyExistInUsersRepositoryException;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.user.jpa.JPAUsersDAO;
+import org.apache.james.user.jpa.model.JPAUser;
+import org.apache.james.user.lib.model.Algorithm;
+import org.apache.james.user.lib.model.DefaultUser;
+import org.apache.james.user.postgres.PostgresUsersDAO;
+import org.apache.james.user.postgres.PostgresUsersRepositoryConfiguration;
+import org.apache.james.util.LoggingLevel;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitializationOperations;
+import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.utils.PropertiesProvider;
+import org.apache.mailet.Mail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.google.inject.util.Modules;
+
+public class JpaToPgCoreDataMigration {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JpaToPgCoreDataMigration.class);
+
+    private static final Module JPA_MODULES = Modules.combine(
+            new JPAEntityManagerModule(),
+            new UnboundJPAMigrationModule()
+    );
+    private static final Module POSTGRESQL_MODULES = Modules.combine(
+            new PostgresCommonModule(),
+            new PostgresDomainListModule(),
+            new PostgresRecipientRewriteTableModule(),
+            new PostgresUsersRepositoryModule(),
+            new org.apache.james.modules.data.PostgresMailRepositoryModule(),
+            new PostgresDropListsModule(),
+            new PostgresQuotaGuiceModule(),
+            new SievePostgresRepositoryModules()
+    );
+
+    static final Module MIGRATION_MODULES = Modules.combine(
+            new DNSServiceModule(),
+            new DropWizardMetricsModule(),
+            new ClockModule(),
+            new CoreEntityValidatorsModule(),
+            PostgresUsersRepositoryModule.USER_CONFIGURATION_MODULE,
+            JPA_MODULES,
+            POSTGRESQL_MODULES
+    );
+
+    private final Injector injector;
+
+    public static void main(String[] args) {
+        MigrationConfiguration configuration = MigrationConfiguration.builder()
+                .useWorkingDirectoryEnvProperty()
+                .build();
+        LOGGER.info("Loading configuration {}", configuration.toString());
+        var blobstoreModule  = Modules.combine(chooseBlobStoreModules(configuration));
+        var module = Modules.combine(
+                new MigrationModule(configuration),
+                MIGRATION_MODULES,
+                blobstoreModule
+        );
+
+
+        JpaToPgCoreDataMigration migration = new JpaToPgCoreDataMigration(module);
+        migration.start();
+    }
+
+    static List<Module> chooseBlobStoreModules(MigrationConfiguration configuration) {
+        ImmutableList.Builder<Module> builder = ImmutableList.<Module>builder()
+                .addAll(chooseModules(configuration.blobStoreConfiguration()))
+                .add(new BlobStoreCacheModulesChooser.CacheDisabledModule());
+
+
+        return builder.build();
+    }
+
+    public static List<Module> chooseModules(BlobStoreConfiguration choosingConfiguration) {
+        return ImmutableList.<Module>builder()
+                .add(chooseEncryptionModule(choosingConfiguration.getCryptoConfig()))
+                .add(chooseBlobStoreDAOModule(choosingConfiguration.getImplementation()))
+                .addAll(chooseStoragePolicyModule(choosingConfiguration.storageStrategy()))
+                .add(binder -> binder.bind(BlobStoreConfiguration.class).toInstance(choosingConfiguration))
+                .build();
+    }
+
+    static class DomainMigration {
+        private static final Logger LOGGER = LoggerFactory.getLogger(DomainMigration.class);
+
+        private final JPADomainList jpaDomainList;
+        private final PostgresDomainList pgDomainList;
+
+        @Inject
+        DomainMigration(
+                JPADomainList jpaDomainList,
+                PostgresDomainList pgDomainList
+        ) {
+            this.jpaDomainList = jpaDomainList;
+            this.pgDomainList = pgDomainList;
+        }
+
+        void doMigration() {
+            LOGGER.info("Start domains migration");
+            try {
+                jpaDomainList.getDomains().forEach(domain -> {
+                            try {
+                                pgDomainList.addDomain(domain);
+                            } catch (DomainListException e) {
+                                if (!e.getMessage().contains("already exists.")) {
+                                    LOGGER.warn("Failed to migrate domain {}", domain, e);
+                                }
+                            }
+                        }
+                );
+
+            } catch (DomainListException e) {
+                throw new RuntimeException("Unable to migrate domains, aborting processing", e);
+            }
+            LOGGER.info("Domains migration completed");
+        }
+    }
+
+    static class UsersMigration {
+        private static final Logger LOGGER = LoggerFactory.getLogger(UsersMigration.class);
+        private final Algorithm algorithm;
+        private final JPAUsersDAO jpaUsersDAO;
+        private final PostgresUsersDAO postgresUsersDAO;
+
+
+        @Inject
+        UsersMigration(
+                JPAUsersDAO jpaUsersDAO,
+                PostgresUsersDAO postgresUsersDAO,
+                PostgresUsersRepositoryConfiguration postgresUsersRepositoryConfiguration
+        ) {
+            this.algorithm = postgresUsersRepositoryConfiguration.getPreferredAlgorithm();
+            this.jpaUsersDAO = jpaUsersDAO;
+            this.postgresUsersDAO = postgresUsersDAO;
+        }
+
+        void doMigration() {
+            LOGGER.info("Start users migration");
+            try {
+                jpaUsersDAO.list().forEachRemaining(username -> {
+                            try {
+                                jpaUsersDAO.getUserByName(username).ifPresent(user -> {
+                                    var jpaUser = (JPAUser) user;
+                                    var pgUser = new DefaultUser(
+                                            username,
+                                            jpaUser.getPasswordHash(),
+                                            jpaUser.getAlgorithm(),
+                                            algorithm
+                                    );
+                                    try {
+                                        postgresUsersDAO.addUser(username, UUID.randomUUID().toString());
+                                    } catch (RuntimeException e) {
+                                        if (!(e.getCause() instanceof AlreadyExistInUsersRepositoryException)) {
+                                            throw e;
+                                        }
+                                        // Idempotent behavior, if the user already exists, we
+                                        // only update it.
+                                    }
+                                    Throwing.runnable(() ->
+                                            postgresUsersDAO.updateUser(pgUser)
+                                    ).sneakyThrow().run();
+
+                                });
+                            } catch (UsersRepositoryException e) {
+                                LOGGER.warn("Failed to migrate user {}", username, e);
+                            }
+                        }
+                );
+            } catch (UsersRepositoryException e) {
+                throw new RuntimeException("Failed to retrieve users for migration", e);
+            }
+            LOGGER.info("Users migration complete");
+        }
+    }
+
+    static class RRTMigration {
+        private static final Logger LOGGER = LoggerFactory.getLogger(RRTMigration.class);
+
+        private final JPARecipientRewriteTable jpaRRTRepository;
+        private final PostgresRecipientRewriteTable pgRRTRepository;
+
+        @Inject
+        RRTMigration(
+                JPARecipientRewriteTable jpaRRTRepository,
+                PostgresRecipientRewriteTable pgRRTRepository
+        ) {
+            this.jpaRRTRepository = jpaRRTRepository;
+            this.pgRRTRepository = pgRRTRepository;
+        }
+
+        void doMigration() {
+            LOGGER.info("Start RRT migration");
+            try {
+                jpaRRTRepository.getAllMappings().forEach((mappingSource, mappings) ->
+                        mappings.forEach(mapping ->
+                                pgRRTRepository.addMapping(mappingSource, mapping)
+                        )
+                );
+            } catch (RecipientRewriteTableException e) {
+                throw new RuntimeException(e);
+            }
+            LOGGER.info("RRT migration complete");
+        }
+    }
+
+    static class MailRepositoryMigration {
+        private static final Logger LOGGER = LoggerFactory.getLogger(MailRepositoryMigration.class);
+
+        private final JPAMailRepositoryUrlStore jpaMailRepositoryUrlStore;
+        private final JPAMailRepositoryFactory jpaMailRepositoryFactory;
+        private final PostgresMailRepositoryUrlStore pgMailRepositoryUrlStore;
+        private final PostgresMailRepositoryContentDAO postgresMailRepositoryContentDAO;
+
+        @Inject
+        MailRepositoryMigration(
+                JPAMailRepositoryUrlStore jpaMailRepositoryUrlStore,
+                JPAMailRepositoryFactory jpaMailRepositoryFactory,
+                PostgresMailRepositoryUrlStore pgMailRepositoryUrlStore,
+                PostgresMailRepositoryContentDAO postgresMailRepositoryContentDAO
+        ) {
+            this.jpaMailRepositoryUrlStore = jpaMailRepositoryUrlStore;
+            this.jpaMailRepositoryFactory = jpaMailRepositoryFactory;
+            this.pgMailRepositoryUrlStore = pgMailRepositoryUrlStore;
+            this.postgresMailRepositoryContentDAO = postgresMailRepositoryContentDAO;
+        }
+
+        void doMigration() {
+            LOGGER.info("Start mail repository urls migration");
+            jpaMailRepositoryUrlStore.listDistinct().forEach(
+                    Throwing.consumer((MailRepositoryUrl url) -> {
+                        pgMailRepositoryUrlStore.add(url);
+                        MailRepository mailRepository = jpaMailRepositoryFactory.create(url);
+                        mailRepository.list().forEachRemaining(
+                                Throwing.consumer((MailKey mailKey) -> {
+                                    Mail jpaMail = mailRepository.retrieve(mailKey);
+                                    postgresMailRepositoryContentDAO.store(jpaMail, url);
+                                })
+                        );
+                    }).sneakyThrow()
+            );
+            LOGGER.info("Mail repository urls migration complete");
+        }
+    }
+
+    static class DropListMigration {
+        private static final Logger LOGGER =
+                LoggerFactory.getLogger(MailRepositoryMigration.class);
+
+        private final JPADropList jpaDropList;
+        private final PostgresDropList pgDropList;
+
+        @Inject
+        DropListMigration(
+                JPADropList jpaDropList,
+                PostgresDropList pgDropList
+        ) {
+            this.jpaDropList = jpaDropList;
+            this.pgDropList = pgDropList;
+        }
+
+        void doMigration() {
+            LOGGER.info("Start drop list migration");
+            jpaDropList.listAll().flatMap(pgDropList::add).count().block();
+            LOGGER.info("Mail drop list migration complete");
+        }
+    }
+
+    static class SieveMigration {
+        private static final Logger LOGGER =
+                LoggerFactory.getLogger(MailRepositoryMigration.class);
+
+        private final JPASieveRepository jpaSieveRepository;
+        private final PostgresSieveRepository pgSieveRepository;
+
+        @Inject
+        SieveMigration(
+                JPASieveRepository jpaSieveRepository,
+                PostgresSieveRepository pgSieveRepository
+        ) {
+            this.jpaSieveRepository = jpaSieveRepository;
+            this.pgSieveRepository = pgSieveRepository;
+        }
+
+        void doMigration() {
+            LOGGER.info("Start Sieve quotas migration");
+            jpaSieveRepository.listAllSieveQuotas().forEach(quota ->
+                    pgSieveRepository.setQuota(quota.getUsername(), quota.toQuotaSize())
+            );
+            LOGGER.info("Mail Sieve quotas migration complete");
+            LOGGER.info("Start Sieve scripts migration");
+            jpaSieveRepository.listAllSieveScripts().forEach(
+                    Throwing.consumer((JPASieveScript sieveScript) -> pgSieveRepository.putScript(
+                            Username.of(sieveScript.getUsername()),
+                            new ScriptName(sieveScript.getScriptName()),
+                            new ScriptContent(sieveScript.getScriptContent())
+                    )).sneakyThrow()
+            );
+            LOGGER.info("Mail Sieve scripts migration complete");
+        }
+    }
+
+    static class MigrationModule extends AbstractModule {
+        private final Configuration configuration;
+        private final FileSystemImpl fileSystem;
+
+        @Inject
+        public MigrationModule(Configuration configuration) {
+            this.configuration = configuration;
+            this.fileSystem = new FileSystemImpl(configuration.directories());
+        }
+
+        @Override
+        protected void configure() {
+            bind(FileSystem.class).toInstance(fileSystem);
+            bind(Configuration.class).toInstance(configuration);
+
+            bind(ConfigurationProvider.class).toInstance(new FileConfigurationProvider(fileSystem, configuration));
+            bind(DomainMigration.class).in(Scopes.SINGLETON);
+            bind(UsersMigration.class).in(Scopes.SINGLETON);
+            bind(RRTMigration.class).in(Scopes.SINGLETON);
+            bind(MailRepositoryMigration.class).in(Scopes.SINGLETON);
+        }
+
+        @Provides
+        @jakarta.inject.Singleton
+        public Configuration.ConfigurationPath configurationPath() {
+            return configuration.configurationPath();
+        }
+
+        @Provides
+        @jakarta.inject.Singleton
+        public PropertiesProvider providePropertiesProvider(FileSystem fileSystem, Configuration.ConfigurationPath configurationPrefix) {
+            return new PropertiesProvider(fileSystem, configurationPrefix);
+        }
+
+        @Provides
+        @Singleton
+        DomainListConfiguration domainListConfiguration() {
+            return DomainListConfiguration.DEFAULT;
+        }
+    }
+
+    static class UnboundJPAMigrationModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(JPADomainList.class).in(Scopes.SINGLETON);
+            bind(JPARecipientRewriteTable.class).in(Scopes.SINGLETON);
+            bind(JPAMailRepositoryUrlStore.class).in(Scopes.SINGLETON);
+            bind(JPAUsersDAO.class).in(Scopes.SINGLETON);
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation configureDomainList(DomainListConfiguration configuration, JPADomainList jpaDomainList) {
+            return InitilizationOperationBuilder
+                    .forClass(JPADomainList.class)
+                    .init(() -> jpaDomainList.configure(configuration));
+        }
+
+        @ProvidesIntoSet
+        InitializationOperation configureJpaUsers(
+                EntityManagerFactory entityManagerFactory,
+                ConfigurationProvider configurationProvider,
+                JPAUsersDAO usersDAO
+        ) {
+            return InitilizationOperationBuilder
+                    .forClass(JPAUsersDAO.class)
+                    .init(() -> {
+                        usersDAO.configure(configurationProvider.getConfiguration("usersrepository", LoggingLevel.INFO));
+                        usersDAO.setEntityManagerFactory(entityManagerFactory);
+                        usersDAO.init();
+                    });
+        }
+    }
+
+    static class CoreEntityValidatorsModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            Multibinder.newSetBinder(binder(), UserEntityValidator.class).addBinding().to(DefaultUserEntityValidator.class);
+            Multibinder.newSetBinder(binder(), UserEntityValidator.class).addBinding().to(RecipientRewriteTableUserEntityValidator.class);
+        }
+
+        @Provides
+        @Singleton
+        UserEntityValidator userEntityValidator(Set<UserEntityValidator> validatorSet) {
+            return new AggregateUserEntityValidator(validatorSet);
+        }
+    }
+
+    static class PostgresMailRepositoryModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(PostgresMailRepositoryUrlStore.class).in(Scopes.SINGLETON);
+            bind(MailRepositoryUrlStore.class).to(PostgresMailRepositoryUrlStore.class);
+            Multibinder.newSetBinder(binder(), PostgresModule.class)
+                    .addBinding().toInstance(org.apache.james.mailrepository.postgres.PostgresMailRepositoryModule.MODULE);
+        }
+    }
+
+    Injector getInjector() {
+        return injector;
+    }
+
+    public JpaToPgCoreDataMigration(Module module) {
+        this.injector = Guice.createInjector(module);
+        injector.getInstance(InitializationOperations.class).initModules();
+    }
+
+    void start() {
+        injector.getInstance(DomainMigration.class).doMigration();
+        injector.getInstance(UsersMigration.class).doMigration();
+        injector.getInstance(RRTMigration.class).doMigration();
+        injector.getInstance(MailRepositoryMigration.class).doMigration();
+        injector.getInstance(DropListMigration.class).doMigration();
+        injector.getInstance(SieveMigration.class).doMigration();
+    }
+}
+

--- a/server/apps/migration/core-data-jpa-to-pg/src/main/java/org/apache/james/MigrationConfiguration.java
+++ b/server/apps/migration/core-data-jpa-to-pg/src/main/java/org/apache/james/MigrationConfiguration.java
@@ -1,0 +1,124 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.filesystem.api.JamesDirectoriesProvider;
+import org.apache.james.modules.blobstore.BlobStoreConfiguration;
+import org.apache.james.server.core.JamesServerResourceLoader;
+import org.apache.james.server.core.MissingArgumentException;
+import org.apache.james.server.core.configuration.Configuration;
+import org.apache.james.server.core.filesystem.FileSystemImpl;
+import org.apache.james.utils.PropertiesProvider;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.base.MoreObjects;
+
+public record MigrationConfiguration(
+        ConfigurationPath configurationPath,
+        JamesDirectoriesProvider directories,
+        BlobStoreConfiguration blobStoreConfiguration
+) implements Configuration {
+    private static final BlobStoreConfiguration.BlobStoreImplName DEFAULT_BLOB_STORE = BlobStoreConfiguration.BlobStoreImplName.POSTGRES;
+
+    public static class Builder {
+        private Optional<String> rootDirectory;
+        private Optional<ConfigurationPath> configurationPath;
+        private Optional<BlobStoreConfiguration> blobStoreConfiguration;
+
+        private Builder() {
+            rootDirectory = Optional.empty();
+            configurationPath = Optional.empty();
+        }
+
+        public Builder workingDirectory(String path) {
+            rootDirectory = Optional.of(path);
+            return this;
+        }
+
+        public Builder workingDirectory(File file) {
+            rootDirectory = Optional.of(file.getAbsolutePath());
+            return this;
+        }
+
+        public Builder useWorkingDirectoryEnvProperty() {
+            rootDirectory = Optional.ofNullable(System.getProperty(WORKING_DIRECTORY));
+            if (rootDirectory.isEmpty()) {
+                throw new MissingArgumentException("Server needs a working.directory env entry");
+            }
+            return this;
+        }
+
+        public Builder configurationPath(ConfigurationPath path) {
+            configurationPath = Optional.of(path);
+            return this;
+        }
+
+        public Builder configurationFromClasspath() {
+            configurationPath = Optional.of(new ConfigurationPath(FileSystem.CLASSPATH_PROTOCOL));
+            return this;
+        }
+
+
+        public MigrationConfiguration build() {
+            ConfigurationPath configurationPath = this.configurationPath.orElse(new ConfigurationPath(FileSystem.FILE_PROTOCOL_AND_CONF));
+            JamesServerResourceLoader directories = new JamesServerResourceLoader(rootDirectory
+                    .orElseThrow(() -> new MissingArgumentException("Server needs a working.directory env entry")));
+            FileSystemImpl fileSystem = new FileSystemImpl(directories);
+            PropertiesProvider propertiesProvider = new PropertiesProvider(fileSystem, configurationPath);
+            BlobStoreConfiguration blobStoreConfiguration = this.blobStoreConfiguration.orElseGet(
+                    Throwing.supplier(
+                            () -> BlobStoreConfiguration.parse(propertiesProvider, DEFAULT_BLOB_STORE)
+                    )
+            );
+            return new MigrationConfiguration(configurationPath, directories, blobStoreConfiguration);
+        }
+
+        public Builder blobStore(BlobStoreConfiguration blobStoreConfiguration) {
+            this.blobStoreConfiguration = Optional.of(blobStoreConfiguration);
+            return this;
+        }
+    }
+
+    static MigrationConfiguration.Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public ConfigurationPath configurationPath() {
+        return configurationPath;
+    }
+
+    @Override
+    public JamesDirectoriesProvider directories() {
+        return directories;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("configurationPath", configurationPath)
+                .add("directories", directories)
+                .toString();
+    }
+}

--- a/server/apps/migration/core-data-jpa-to-pg/src/main/resources/META-INF/persistence.xml
+++ b/server/apps/migration/core-data-jpa-to-pg/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+
+    <persistence-unit name="Global" transaction-type="RESOURCE_LOCAL">
+        <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAUrl</class>
+        <class>org.apache.james.mailrepository.jpa.model.JPAMail</class>
+        <class>org.apache.james.user.jpa.model.JPAUser</class>
+        <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
+        <class>org.apache.james.droplists.jpa.model.JPADropListEntry</class>
+        <class>org.apache.james.sieve.jpa.model.JPASieveScript</class>
+        <class>org.apache.james.sieve.jpa.model.JPASieveQuota</class>
+        <properties>
+            <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
+            <property name="openjpa.jdbc.MappingDefaults" value="ForeignKeyDeleteAction=cascade, JoinForeignKeyDeleteAction=cascade"/>
+            <property name="openjpa.jdbc.SchemaFactory" value="native(ForeignKeys=true)"/>
+            <property name="openjpa.jdbc.QuerySQLCache" value="false"/>
+        </properties>
+
+    </persistence-unit>
+
+</persistence>

--- a/server/apps/migration/core-data-jpa-to-pg/src/main/scripts/james-migration
+++ b/server/apps/migration/core-data-jpa-to-pg/src/main/scripts/james-migration
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+unset JAVA_TOOL_OPTIONS
+java -cp /root/resources:/root/classes:/root/libs/* \
+-Dworking.directory=/root/conf \
+-Dlogback.configurationFile=/root/conf/logback.xml \
+org.apache.james.JpaToPgCoreDataMigration "$@"

--- a/server/apps/migration/core-data-jpa-to-pg/src/test/java/org/apache/james/JpaToPgCoreDataMigrationTest.java
+++ b/server/apps/migration/core-data-jpa-to-pg/src/test/java/org/apache/james/JpaToPgCoreDataMigrationTest.java
@@ -162,7 +162,7 @@ class JpaToPgCoreDataMigrationTest {
     }
 
     @Test
-    void migrate_data() throws Exception {
+    void should_migrate_jpa_schema_to_pg_schema() throws Exception {
         // Given
         var domain = givenJpaDomain();
         var user = givenJpaUser(domain);
@@ -173,6 +173,31 @@ class JpaToPgCoreDataMigrationTest {
         var sieve = givenJpaSieveEntry(domain);
 
         // When
+        dataMigration.start();
+
+        // Then
+        verifyPgDomain(domain);
+        verifyPgUser(user);
+        verifyPgRecipientRewrite(recipientRewrite);
+        verifyPgRepositoryUrl(mailRepositoryUrl);
+        verifyPgMailInRepository(mail);
+        verifyPgDropList(dropListEntry);
+        verifyPgSieveEntry(sieve);
+    }
+
+    @Test
+    void should_be_idempotent_when_run_twice() throws Exception {
+        // Given
+        var domain = givenJpaDomain();
+        var user = givenJpaUser(domain);
+        var recipientRewrite = givenJpaRecipientRewrite(domain);
+        var mailRepositoryUrl = givenJpaMailRepositoryUrl();
+        var mail = givenJpaMailInRepository(domain, mailRepositoryUrl);
+        var dropListEntry = givenJpaDropList();
+        var sieve = givenJpaSieveEntry(domain);
+
+        // When
+        dataMigration.start();
         dataMigration.start();
 
         // Then

--- a/server/apps/migration/core-data-jpa-to-pg/src/test/java/org/apache/james/JpaToPgCoreDataMigrationTest.java
+++ b/server/apps/migration/core-data-jpa-to-pg/src/test/java/org/apache/james/JpaToPgCoreDataMigrationTest.java
@@ -1,0 +1,354 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.AddressException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.core.quota.QuotaSizeLimit;
+import org.apache.james.domainlist.api.DomainListException;
+import org.apache.james.domainlist.jpa.JPADomainList;
+import org.apache.james.domainlist.postgres.PostgresDomainList;
+import org.apache.james.droplists.api.DropListEntry;
+import org.apache.james.droplists.api.OwnerScope;
+import org.apache.james.droplists.jpa.JPADropList;
+import org.apache.james.droplists.postgres.PostgresDropList;
+import org.apache.james.mailrepository.api.MailKey;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.mailrepository.jpa.JPAMailRepositoryFactory;
+import org.apache.james.mailrepository.jpa.JPAMailRepositoryUrlStore;
+import org.apache.james.mailrepository.postgres.PostgresMailRepositoryFactory;
+import org.apache.james.mailrepository.postgres.PostgresMailRepositoryUrlStore;
+import org.apache.james.modules.blobstore.BlobStoreConfiguration;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.apache.james.rrt.jpa.JPARecipientRewriteTable;
+import org.apache.james.rrt.lib.Mapping;
+import org.apache.james.rrt.lib.MappingSource;
+import org.apache.james.rrt.postgres.PostgresRecipientRewriteTable;
+import org.apache.james.server.core.MailImpl;
+import org.apache.james.sieve.jpa.JPASieveRepository;
+import org.apache.james.sieve.postgres.PostgresSieveRepository;
+import org.apache.james.sieverepository.api.ScriptContent;
+import org.apache.james.sieverepository.api.ScriptName;
+import org.apache.james.sieverepository.api.exception.QuotaExceededException;
+import org.apache.james.sieverepository.api.exception.QuotaNotFoundException;
+import org.apache.james.sieverepository.api.exception.ScriptNotFoundException;
+import org.apache.james.sieverepository.api.exception.StorageException;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.user.jpa.JPAUsersDAO;
+import org.apache.james.user.postgres.PostgresUsersDAO;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.Mail;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.rules.TemporaryFolder;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.inject.Injector;
+import com.google.inject.util.Modules;
+
+class JpaToPgCoreDataMigrationTest {
+
+    @RegisterExtension
+    static MariaDBExtension mariaDBExtension = new MariaDBExtension();
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.empty();
+
+    @RegisterExtension
+    static TemporaryFolderRegistrableExtension folderRegistrableExtension = new TemporaryFolderRegistrableExtension();
+
+    record User(Username username, String password) {
+        static User create(Domain domain) {
+            return new User(
+                    Username.of(randomUUID() + "@" + domain.asString()),
+                    randomUUID().toString()
+            );
+        }
+    }
+
+    record RecipientRewrite(Username username, Mapping mapping) {
+        static RecipientRewrite create(Domain domain) {
+            return new RecipientRewrite(
+                    Username.of(randomUUID() + "@" + domain.asString()),
+                    Mapping.forward(randomUUID() + "@email.example")
+            );
+        }
+    }
+
+    record MailInRepository(MailRepositoryUrl url, Mail mail) {
+        static MailInRepository create(Domain domain, MailRepositoryUrl url) throws MessagingException {
+            return new MailInRepository(
+                    url,
+                    MailImpl.builder()
+                            .name(UUID.randomUUID().toString())
+                            .sender(randomUUID() + "@" + domain.asString())
+                            .addRecipient(randomUUID() + "@" + domain.asString())
+                            .addRecipient(randomUUID() + "@" + domain.asString())
+                            .addAttribute(Attribute.convertToAttribute("attr" + randomUUID(), "value" + randomUUID()))
+                            .mimeMessage(MimeMessageBuilder
+                                    .mimeMessageBuilder()
+                                    .addHeader(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+                                    .setSubject("test")
+                                    .setText("test" + UUID.randomUUID())
+                                    .build())
+                            .state(Mail.DEFAULT)
+                            .lastUpdated(new Date())
+                            .build()
+            );
+        }
+    }
+
+    record SieveEntry(Username username, QuotaSizeLimit quota, ScriptName scriptName, ScriptContent scriptContent) {
+        static SieveEntry create(Domain domain) {
+            return new SieveEntry(
+                    Username.of(randomUUID() + "@" + domain.asString()),
+                    QuotaSizeLimit.size(RandomUtils.nextLong()),
+                    new ScriptName(UUID.randomUUID().toString()),
+                    new ScriptContent(UUID.randomUUID().toString())
+            );
+        }
+    }
+
+    private static @NotNull Domain someDomain() {
+        return Domain.of(randomUUID() + ".example");
+    }
+
+    private JpaToPgCoreDataMigration dataMigration;
+    private Injector injector;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        dataMigration = createDataMigration();
+        injector = dataMigration.getInjector();
+    }
+
+    @Test
+    void migrate_data() throws Exception {
+        // Given
+        var domain = givenJpaDomain();
+        var user = givenJpaUser(domain);
+        var recipientRewrite = givenJpaRecipientRewrite(domain);
+        var mailRepositoryUrl = givenJpaMailRepositoryUrl();
+        var mail = givenJpaMailInRepository(domain, mailRepositoryUrl);
+        var dropListEntry = givenJpaDropList();
+        var sieve = givenJpaSieveEntry(domain);
+
+        // When
+        dataMigration.start();
+
+        // Then
+        verifyPgDomain(domain);
+        verifyPgUser(user);
+        verifyPgRecipientRewrite(recipientRewrite);
+        verifyPgRepositoryUrl(mailRepositoryUrl);
+        verifyPgMailInRepository(mail);
+        verifyPgDropList(dropListEntry);
+        verifyPgSieveEntry(sieve);
+    }
+
+    private Domain givenJpaDomain() throws DomainListException {
+        var domain = Domain.of(randomUUID() + ".apache.example");
+        var jpaDomainList = injector.getInstance(JPADomainList.class);
+        jpaDomainList.addDomain(domain);
+        return domain;
+    }
+
+    private void verifyPgDomain(Domain domain) throws DomainListException {
+        var domainList = injector.getInstance(PostgresDomainList.class);
+        assertThat(domainList.containsDomain(domain)).isTrue();
+    }
+
+    private User givenJpaUser(Domain domain) throws UsersRepositoryException {
+        var user = User.create(domain);
+        var usersDAO = injector.getInstance(JPAUsersDAO.class);
+        usersDAO.addUser(user.username, user.password);
+        return user;
+    }
+
+    private void verifyPgUser(User user) {
+        var usersDAO = injector.getInstance(PostgresUsersDAO.class);
+        var pgUser = usersDAO.getUserByName(user.username).orElseThrow();
+        assertThat(pgUser.verifyPassword(user.password)).isTrue();
+    }
+
+
+    private RecipientRewrite givenJpaRecipientRewrite(Domain domain)
+            throws RecipientRewriteTableException {
+        var recipientRewrite = RecipientRewrite.create(domain);
+        var recipientRewriteTable = injector.getInstance(JPARecipientRewriteTable.class);
+        recipientRewriteTable.addMapping(
+                MappingSource.fromUser(recipientRewrite.username),
+                recipientRewrite.mapping
+        );
+        return recipientRewrite;
+    }
+
+    private void verifyPgRecipientRewrite(RecipientRewrite recipientRewrite)
+            throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {
+        var rewriteTable = injector.getInstance(PostgresRecipientRewriteTable.class);
+        var resolvedMappings = rewriteTable.getResolvedMappings(
+                recipientRewrite.username.getLocalPart(),
+                recipientRewrite.username.getDomainPart().orElseThrow()
+        );
+        assertThat(resolvedMappings).contains(recipientRewrite.mapping);
+    }
+
+    private MailRepositoryUrl givenJpaMailRepositoryUrl() {
+        var url = MailRepositoryUrl.from("blob://var/mail/" + randomUUID());
+        var urlStore = injector.getInstance(JPAMailRepositoryUrlStore.class);
+        urlStore.add(url);
+        return url;
+    }
+
+    private void verifyPgRepositoryUrl(MailRepositoryUrl url) {
+        var urlStore = injector.getInstance(PostgresMailRepositoryUrlStore.class);
+        assertThat(urlStore.contains(url)).isTrue();
+    }
+
+    private MailInRepository givenJpaMailInRepository(Domain domain, MailRepositoryUrl url) throws MessagingException {
+        MailInRepository mailInRepository = MailInRepository.create(domain, url);
+        var mail = mailInRepository.mail;
+        var mailRepositoryFactory = injector.getInstance(JPAMailRepositoryFactory.class);
+        MailRepository mailRepository = mailRepositoryFactory.create(url);
+        mailRepository.store(mail);
+        return mailInRepository;
+    }
+
+    private void checkMailEquality(Mail actual, Mail expected) {
+        assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(actual.getMessage().getContent()).isEqualTo(expected.getMessage().getContent());
+            softly.assertThat(actual.getMessageSize()).isEqualTo(expected.getMessageSize());
+            softly.assertThat(actual.getName()).isEqualTo(expected.getName());
+            softly.assertThat(actual.getState()).isEqualTo(expected.getState());
+            softly.assertThat(actual.attributes()).containsAll(expected.attributes().toList());
+            softly.assertThat(actual.getErrorMessage()).isEqualTo(expected.getErrorMessage());
+            softly.assertThat(actual.getRemoteHost()).isEqualTo(expected.getRemoteHost());
+            softly.assertThat(actual.getRemoteAddr()).isEqualTo(expected.getRemoteAddr());
+            // JPA implementation trucates the date to seconds losing precision in the process
+            softly.assertThat(actual.getLastUpdated().toInstant()).isEqualTo(expected.getLastUpdated().toInstant().truncatedTo(ChronoUnit.SECONDS));
+            softly.assertThat(actual.getPerRecipientSpecificHeaders()).isEqualTo(expected.getPerRecipientSpecificHeaders());
+        }));
+    }
+
+
+    private void verifyPgMailInRepository(MailInRepository mailInRepository) throws MessagingException {
+        var mailRepositoryFactory = injector.getInstance(PostgresMailRepositoryFactory.class);
+        var mailRepository = mailRepositoryFactory.create(mailInRepository.url);
+
+        Mail retrieved = mailRepository.retrieve(MailKey.forMail(mailInRepository.mail));
+        assertThat(retrieved).satisfies(actual -> checkMailEquality(actual, mailInRepository.mail));
+    }
+
+    private DropListEntry givenJpaDropList() throws AddressException {
+        Domain aDomain = someDomain();
+        Domain anotherDomain = someDomain();
+        DropListEntry entry = DropListEntry.builder()
+                .denyDomain(aDomain)
+                .denyAddress(User.create(anotherDomain).username.asMailAddress())
+                .forAll()
+                .build();
+        var dropList = injector.getInstance(JPADropList.class);
+        dropList.add(entry).block();
+        return entry;
+    }
+
+    private void verifyPgDropList(DropListEntry entry) {
+        var dropList = injector.getInstance(PostgresDropList.class);
+        List<DropListEntry> entries =
+                dropList.list(OwnerScope.GLOBAL, "").collectList().block();
+        assertThat(entries).contains(entry);
+    }
+
+    private SieveEntry givenJpaSieveEntry(Domain domain)
+            throws StorageException, QuotaExceededException {
+        var sieveEntry = SieveEntry.create(domain);
+        var sieveRepository = injector.getInstance(JPASieveRepository.class);
+        sieveRepository.setQuota(sieveEntry.username, sieveEntry.quota);
+        sieveRepository.putScript(
+                sieveEntry.username,
+                sieveEntry.scriptName,
+                sieveEntry.scriptContent
+        );
+        return sieveEntry;
+    }
+
+    private void verifyPgSieveEntry(SieveEntry sieveEntry)
+            throws QuotaNotFoundException, ScriptNotFoundException {
+        var sieveRepository = injector.getInstance(PostgresSieveRepository.class);
+        var quota = sieveRepository.getQuota(sieveEntry.username);
+        var scripts = sieveRepository.listScripts(sieveEntry.username);
+        var script = sieveRepository.getScript(sieveEntry.username, sieveEntry.scriptName);
+
+        assertThat(quota).isEqualTo(sieveEntry.quota);
+        assertThat(scripts).hasSize(1);
+        assertThat(script).hasSameContentAs(
+                IOUtils.toInputStream(sieveEntry.scriptContent.getValue(), StandardCharsets.UTF_8)
+        );
+    }
+
+    private @NotNull JpaToPgCoreDataMigration createDataMigration() throws IOException {
+        TemporaryFolder tmpDir = folderRegistrableExtension.getTemporaryFolder();
+        MigrationConfiguration configuration = MigrationConfiguration.builder()
+                .workingDirectory(tmpDir.newFolder())
+                .configurationFromClasspath()
+                .blobStore(BlobStoreConfiguration.builder()
+                        .postgres()
+                        .disableCache()
+                        .passthrough()
+                        .noCryptoConfig())
+                .build();
+
+        var blobstoreModule = Modules.combine(JpaToPgCoreDataMigration.chooseBlobStoreModules(configuration));
+        var module = Modules.override(
+                Modules.combine(
+                        JpaToPgCoreDataMigration.MIGRATION_MODULES,
+                        blobstoreModule
+                )
+        ).with(
+                new JpaToPgCoreDataMigration.MigrationModule(configuration),
+                mariaDBExtension.getModule(),
+                postgresExtension.getModule()
+        );
+        return new JpaToPgCoreDataMigration(module);
+    }
+
+}

--- a/server/apps/migration/core-data-jpa-to-pg/src/test/java/org/apache/james/MariaDBExtension.java
+++ b/server/apps/migration/core-data-jpa-to-pg/src/test/java/org/apache/james/MariaDBExtension.java
@@ -1,0 +1,80 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.util.UUID;
+
+import org.apache.james.backends.jpa.JPAConfiguration;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.output.OutputFrame;
+
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+public class MariaDBExtension implements GuiceModuleTestExtension {
+
+    private static final Logger logger = LoggerFactory.getLogger(MariaDBExtension.class);
+
+    private static void displayDockerLog(OutputFrame outputFrame) {
+        logger.info(outputFrame.getUtf8String().trim());
+    }
+
+    private final MariaDBContainer container;
+    private JPAConfiguration jpaConfiguration;
+
+    public MariaDBExtension() {
+        container = new MariaDBContainer<>("mariadb:10.6")
+                .withLogConsumer(MariaDBExtension::displayDockerLog)
+                .withReuse(true);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        container.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        container.stop();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        var dbName = UUID.randomUUID().toString().replace('-', '_');
+        String script = String.format("create database %s; grant all on %s.* to %s", dbName, dbName, container.getUsername());
+        container.execInContainer("mariadb", "-u", "root", "--password=" + container.getPassword(), "--execute", script);
+        container.withDatabaseName(dbName);
+        jpaConfiguration = JPAConfiguration.builder()
+                .driverName(container.getDriverClassName())
+                .driverURL(container.getJdbcUrl())
+                .username(container.getUsername())
+                .password(container.getPassword())
+                .build();
+    }
+
+    @Override
+    public Module getModule() {
+        return Modules.combine(binder -> binder.bind(JPAConfiguration.class)
+                .toInstance(jpaConfiguration));
+    }
+}

--- a/server/apps/scaling-pulsar-smtp/docker-compose.yml
+++ b/server/apps/scaling-pulsar-smtp/docker-compose.yml
@@ -57,7 +57,9 @@ services:
       - REMOTE_MANAGEMENT_DISABLE=1
 
   postgres:
-    image: postgres:14
+    image: postgres:16.3
+    ports:
+      - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=password
 

--- a/server/apps/scaling-pulsar-smtp/pom.xml
+++ b/server/apps/scaling-pulsar-smtp/pom.xml
@@ -54,6 +54,12 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-backends-postgres</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-backends-pulsar</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -189,7 +195,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/SMTPRelayConfiguration.java
+++ b/server/apps/scaling-pulsar-smtp/src/main/java/org/apache/james/SMTPRelayConfiguration.java
@@ -28,6 +28,8 @@ import org.apache.james.server.core.JamesServerResourceLoader;
 import org.apache.james.server.core.MissingArgumentException;
 import org.apache.james.server.core.configuration.Configuration;
 
+import com.google.common.base.MoreObjects;
+
 public class SMTPRelayConfiguration implements Configuration {
     public static class Builder {
         private Optional<String> rootDirectory;
@@ -98,4 +100,11 @@ public class SMTPRelayConfiguration implements Configuration {
         return directories;
     }
 
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("configurationPath", configurationPath)
+                .add("directories", directories)
+                .toString();
+    }
 }

--- a/server/apps/scaling-pulsar-smtp/src/test/java/org/apache/james/SMTPJamesServerTest.java
+++ b/server/apps/scaling-pulsar-smtp/src/test/java/org/apache/james/SMTPJamesServerTest.java
@@ -37,7 +37,7 @@ class SMTPJamesServerTest {
 
     @RegisterExtension
     static JamesServerExtension testExtension = TestingSmtpRelayJamesServerBuilder.forConfiguration(c -> c)
-        .extension(new PostgresExtension())
+        .extension(new PostgresJPAExtension())
         .extension(new PulsarExtension())
         .extension(new AwsS3BlobStoreExtension())
         .server(Main::createServer)

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/blobstore/BlobStoreModulesChooser.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/blobstore/BlobStoreModulesChooser.java
@@ -180,7 +180,7 @@ public class BlobStoreModulesChooser {
         return encryptionModule.orElse(new NoEncryptionModule());
     }
 
-    private static List<Module> chooseStoragePolicyModule(StorageStrategy storageStrategy) {
+    public static List<Module> chooseStoragePolicyModule(StorageStrategy storageStrategy) {
         switch (storageStrategy) {
             case DEDUPLICATION:
                 Module deduplicationBlobModule = binder -> binder.bind(BlobStore.class)

--- a/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxModule.java
+++ b/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxModule.java
@@ -85,6 +85,7 @@ import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParserImpl;
 import org.apache.james.mailbox.store.user.SubscriptionMapperFactory;
 import org.apache.james.modules.data.PostgresCommonModule;
+import org.apache.james.modules.data.PostgresQuotaGuiceModule;
 import org.apache.james.user.api.DeleteUserDataTaskStep;
 import org.apache.james.user.api.UsernameChangeTaskStep;
 import org.apache.james.utils.MailboxManagerDefinition;
@@ -107,7 +108,8 @@ public class PostgresMailboxModule extends AbstractModule {
         Multibinder<PostgresModule> postgresDataDefinitions = Multibinder.newSetBinder(binder(), PostgresModule.class);
         postgresDataDefinitions.addBinding().toInstance(PostgresMailboxAggregateModule.MODULE);
 
-        install(new PostgresQuotaModule());
+        install(new PostgresQuotaGuiceModule());
+        install(new PostgresMailboxQuotaModule());
 
         bind(PostgresMailboxSessionMapperFactory.class).in(Scopes.SINGLETON);
         bind(PostgresMailboxManager.class).in(Scopes.SINGLETON);

--- a/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxQuotaModule.java
+++ b/server/container/guice/mailbox-postgres/src/main/java/org/apache/james/modules/mailbox/PostgresMailboxQuotaModule.java
@@ -20,8 +20,6 @@
 package org.apache.james.modules.mailbox;
 
 import org.apache.james.adapter.mailbox.UsersRepositoryUsernameSupplier;
-import org.apache.james.backends.postgres.PostgresModule;
-import org.apache.james.backends.postgres.quota.PostgresQuotaCurrentValueDAO;
 import org.apache.james.events.EventListener;
 import org.apache.james.mailbox.postgres.quota.PostgresCurrentQuotaManager;
 import org.apache.james.mailbox.postgres.quota.PostgresPerUserMaxQuotaManager;
@@ -42,17 +40,13 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 
-public class PostgresQuotaModule extends AbstractModule {
+public class PostgresMailboxQuotaModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        Multibinder<PostgresModule> postgresDataDefinitions = Multibinder.newSetBinder(binder(), PostgresModule.class);
-        postgresDataDefinitions.addBinding().toInstance(org.apache.james.backends.postgres.quota.PostgresQuotaModule.MODULE);
-
         bind(DefaultUserQuotaRootResolver.class).in(Scopes.SINGLETON);
         bind(PostgresPerUserMaxQuotaManager.class).in(Scopes.SINGLETON);
         bind(StoreQuotaManager.class).in(Scopes.SINGLETON);
-        bind(PostgresQuotaCurrentValueDAO.class).in(Scopes.SINGLETON);
         bind(PostgresCurrentQuotaManager.class).in(Scopes.SINGLETON);
 
         bind(UserQuotaRootResolver.class).to(DefaultUserQuotaRootResolver.class);

--- a/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresDropListsModule.java
+++ b/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresDropListsModule.java
@@ -19,15 +19,21 @@
 
 package org.apache.james.modules.data;
 
+import org.apache.james.backends.postgres.PostgresModule;
 import org.apache.james.droplists.api.DropList;
 import org.apache.james.droplists.postgres.PostgresDropList;
+import org.apache.james.droplists.postgres.PostgresDropListModule;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 
 public class PostgresDropListsModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(DropList.class).to(PostgresDropList.class).in(Scopes.SINGLETON);
+
+        Multibinder<PostgresModule> postgresDataDefinitions = Multibinder.newSetBinder(binder(), PostgresModule.class);
+        postgresDataDefinitions.addBinding().toInstance(PostgresDropListModule.MODULE);
     }
 }

--- a/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresQuotaGuiceModule.java
+++ b/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresQuotaGuiceModule.java
@@ -36,7 +36,7 @@ public class PostgresQuotaGuiceModule extends AbstractModule {
     @Override
     public void configure() {
         bind(PostgresQuotaCurrentValueDAO.class).in(Scopes.SINGLETON);
-//        bind(PostgresQuotaLimitDAO.class).in(Scopes.SINGLETON);
+        bind(PostgresQuotaLimitDAO.class).in(Scopes.SINGLETON);
 
         Multibinder<PostgresModule> postgresDataDefinitions = Multibinder.newSetBinder(binder(), PostgresModule.class);
         postgresDataDefinitions.addBinding().toInstance(org.apache.james.backends.postgres.quota.PostgresQuotaModule.MODULE);

--- a/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresQuotaGuiceModule.java
+++ b/server/container/guice/postgres-common/src/main/java/org/apache/james/modules/data/PostgresQuotaGuiceModule.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.data;
+
+import org.apache.james.backends.postgres.PostgresModule;
+import org.apache.james.backends.postgres.quota.PostgresQuotaCurrentValueDAO;
+import org.apache.james.backends.postgres.quota.PostgresQuotaLimitDAO;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.postgres.PostgresDomainList;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.ProvidesIntoSet;
+
+public class PostgresQuotaGuiceModule extends AbstractModule {
+    @Override
+    public void configure() {
+        bind(PostgresQuotaCurrentValueDAO.class).in(Scopes.SINGLETON);
+//        bind(PostgresQuotaLimitDAO.class).in(Scopes.SINGLETON);
+
+        Multibinder<PostgresModule> postgresDataDefinitions = Multibinder.newSetBinder(binder(), PostgresModule.class);
+        postgresDataDefinitions.addBinding().toInstance(org.apache.james.backends.postgres.quota.PostgresQuotaModule.MODULE);
+    }
+
+    @ProvidesIntoSet
+    InitializationOperation configureDomainList(DomainListConfiguration configuration, PostgresDomainList postgresDomainList) {
+        return InitilizationOperationBuilder
+            .forClass(PostgresDomainList.class)
+            .init(() -> postgresDomainList.configure(configuration));
+    }
+}

--- a/server/data/data-jpa/src/main/java/org/apache/james/droplists/jpa/model/JPADropListEntry.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/droplists/jpa/model/JPADropListEntry.java
@@ -45,6 +45,8 @@ import com.google.common.base.MoreObjects;
 @Table(name = "JAMES_DROP_LIST")
 @NamedQuery(name = "listDropListEntries",
     query = "SELECT j FROM JamesDropList j WHERE j.ownerScope = :ownerScope AND j.owner = :owner")
+@NamedQuery(name = "listAllDropListEntries",
+        query = "SELECT j FROM JamesDropList j")
 @NamedQuery(name = "queryDropListEntry",
     query = "SELECT j FROM JamesDropList j WHERE j.ownerScope = :ownerScope AND j.owner = :owner AND j.deniedEntity IN :deniedEntity")
 @NamedQuery(name = "removeDropListEntry",

--- a/server/data/data-jpa/src/main/java/org/apache/james/sieve/jpa/model/JPASieveQuota.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/sieve/jpa/model/JPASieveQuota.java
@@ -27,12 +27,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
+import org.apache.james.core.Username;
 import org.apache.james.core.quota.QuotaSizeLimit;
 
 import com.google.common.base.MoreObjects;
 
 @Entity(name = "JamesSieveQuota")
 @Table(name = "JAMES_SIEVE_QUOTA")
+@NamedQuery(name = "listAllSieveQuotas", query = "SELECT sieveQuota FROM JamesSieveQuota sieveQuota")
 @NamedQuery(name = "findByUsername", query = "SELECT sieveQuota FROM JamesSieveQuota sieveQuota WHERE sieveQuota.username=:username")
 public class JPASieveQuota {
 
@@ -90,5 +92,9 @@ public class JPASieveQuota {
                 .add("username", username)
                 .add("size", size)
                 .toString();
+    }
+
+    public Username getUsername() {
+        return Username.of(username);
     }
 }

--- a/server/data/data-jpa/src/main/java/org/apache/james/sieve/jpa/model/JPASieveScript.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/sieve/jpa/model/JPASieveScript.java
@@ -39,6 +39,7 @@ import com.google.common.base.Preconditions;
 
 @Entity(name = "JamesSieveScript")
 @Table(name = "JAMES_SIEVE_SCRIPT")
+@NamedQuery(name = "listAllSieveScripts", query = "SELECT sieveScript FROM JamesSieveScript sieveScript")
 @NamedQuery(name = "findAllByUsername", query = "SELECT sieveScript FROM JamesSieveScript sieveScript WHERE sieveScript.username=:username")
 @NamedQuery(name = "findActiveByUsername", query = "SELECT sieveScript FROM JamesSieveScript sieveScript WHERE sieveScript.username=:username AND sieveScript.isActive=true")
 @NamedQuery(name = "findSieveScript", query = "SELECT sieveScript FROM JamesSieveScript sieveScript WHERE sieveScript.username=:username AND sieveScript.scriptName=:scriptName")

--- a/server/data/data-jpa/src/main/java/org/apache/james/user/jpa/model/JPAUser.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/user/jpa/model/JPAUser.java
@@ -57,7 +57,7 @@ public class JPAUser implements User {
      */
     @VisibleForTesting
     static String hashPassword(String password, String nullableSalt, String nullableAlgorithm) {
-        Algorithm algorithm = Algorithm.of(Optional.ofNullable(nullableAlgorithm).orElse("SHA-512"));
+        Algorithm algorithm = buildAlgorithm(nullableAlgorithm);
         if (algorithm.isPBKDF2()) {
             return algorithm.digest(password, nullableSalt);
         }
@@ -67,6 +67,19 @@ public class JPAUser implements User {
         }
         return chooseHashFunction(algorithm.getName()).apply(credentials);
     }
+
+    private static Algorithm buildAlgorithm(String nullableAlgorithm) {
+        return Algorithm.of(Optional.ofNullable(nullableAlgorithm).orElse("SHA-512"));
+    }
+
+    public String getPasswordHash() {
+        return password;
+    }
+
+    public Algorithm getAlgorithm() {
+        return buildAlgorithm(alg);
+    }
+
 
     interface PasswordHashFunction extends Function<String, String> {}
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -46,6 +46,7 @@
         <module>apps/jpa-app</module>
         <module>apps/jpa-smtp-app</module>
         <module>apps/memory-app</module>
+        <module>apps/migration/core-data-jpa-to-pg</module>
         <module>apps/postgres-app</module>
         <module>apps/scaling-pulsar-smtp</module>
         <module>apps/spring-app</module>


### PR DESCRIPTION
Hello Everyone, 

I propose to add this migration application which copies all the core data supported by JPA into the corresponding Postgres store. 

I built it because I intend to migrate `scaling-pulsar-smtp` from JPA to Postgres and wanted to offer a reasonably easy migration path if there are any users other than me.

The migration tool has a single integration test that : stores some data in JPA, executes the migration then demonstrates it can be read back from the PG stack. 

Doing so I encountered a few issues/misses from the PG implementation which I fixed in preliminary devscout commits.
