### PR TITLE
[ENHANCEMENT] Improve smtp debug logs

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/HeloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/HeloCmdHandler.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 
 import jakarta.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.api.ProtocolSession.State;
@@ -82,6 +83,8 @@ public class HeloCmdHandler extends AbstractHookableCmdHandler<HeloHook> {
         response.append(session.getConfiguration().getHelloName()).append(
                 " Hello ").append(parameters).append(" [").append(
                 session.getRemoteAddress().getAddress().getHostAddress()).append("])");
+
+        LOGGER.debug("HELO {} {}", StringUtils.abbreviate(command, 80), StringUtils.abbreviate(parameters, 80));
         return new SMTPResponse(SMTPRetCode.MAIL_OK, response);
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
@@ -29,6 +29,7 @@ import java.util.StringTokenizer;
 import jakarta.inject.Inject;
 import jakarta.mail.internet.AddressException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.metrics.api.MetricFactory;
@@ -110,6 +111,8 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
             responseBuffer.append(sender.asString());
         }
         responseBuffer.append("> OK");
+
+        LOGGER.debug("MAIL FROM {}", StringUtils.abbreviate(sender.asString(), 80));
         return new SMTPResponse(SMTPRetCode.MAIL_OK, responseBuffer);
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/QuitCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/QuitCmdHandler.java
@@ -31,6 +31,8 @@ import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.QuitHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -38,6 +40,7 @@ import com.google.common.collect.ImmutableSet;
  * Handles QUIT command
  */
 public class QuitCmdHandler extends AbstractHookableCmdHandler<QuitHook> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuitCmdHandler.class);
 
     /**
      * The name of the command handled by the command handler
@@ -45,7 +48,7 @@ public class QuitCmdHandler extends AbstractHookableCmdHandler<QuitHook> {
     private static final Collection<String> COMMANDS = ImmutableSet.of("QUIT");
 
     private static final Response SYNTAX_ERROR;
-    
+
     static {
         SMTPResponse response = new SMTPResponse(
                 SMTPRetCode.SYNTAX_ERROR_COMMAND_UNRECOGNIZED, DSNStatus
@@ -80,6 +83,8 @@ public class QuitCmdHandler extends AbstractHookableCmdHandler<QuitHook> {
                     " Service closing transmission channel");
             SMTPResponse ret = new SMTPResponse(SMTPRetCode.SYSTEM_QUIT, response);
             ret.setEndSession(true);
+
+            LOGGER.debug("QUIT");
             return ret;
         } else {
             return SYNTAX_ERROR;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
@@ -28,6 +28,7 @@ import java.util.StringTokenizer;
 
 import jakarta.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
@@ -85,12 +86,14 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
         MailAddress recipientAddress = session.getAttachment(CURRENT_RECIPIENT, State.Transaction).orElse(MailAddress.nullSender());
         rcptColl.add(recipientAddress);
         session.setAttachment(SMTPSession.RCPT_LIST, rcptColl, State.Transaction);
+
         StringBuilder response = new StringBuilder();
-        response
-                .append(
-                        DSNStatus.getStatus(DSNStatus.SUCCESS,
-                                DSNStatus.ADDRESS_VALID))
+        String status = DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.ADDRESS_VALID);
+        response.append(status)
                 .append(" Recipient <").append(recipientAddress).append("> OK");
+
+        LOGGER.debug("RCPT TO {}", StringUtils.abbreviate(recipientAddress.asString(), 80));
+
         return new SMTPResponse(SMTPRetCode.MAIL_OK, response);
 
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/EhloCmdHandler.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 
 import jakarta.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Response;
@@ -95,6 +96,8 @@ public class EhloCmdHandler extends AbstractHookableCmdHandler<HeloHook> impleme
                 COMMAND_NAME, State.Connection);
 
         processExtensions(session, resp);
+
+        LOGGER.debug("EHLO {}", StringUtils.abbreviate(argument, 80));
  
         return resp;
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/log/HookResultLogger.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/log/HookResultLogger.java
@@ -48,7 +48,7 @@ public class HookResultLogger implements HookResultHook {
                 hResult.getSmtpRetCode(),
                 hResult.getSmtpDescription());
         } else {
-            LOGGER.debug("{}: result= ({} {})", hook.getClass().getName(),
+            LOGGER.trace("{}: result= ({} {})", hook.getClass().getName(),
                 result.getAction(),
                 result.getConnectionStatus());
         }


### PR DESCRIPTION
I had a rought debugging session with a customer and getting detailed actions from any SMTP transaction included turning on debug logs and being flooded with irrelevant logs. My feeling was that we could easily do better.

This changeset proposes to keep:
 - Email rejection at INFO level (so that it gets logged on system production)
 - Mail SMTP commands at level DEBUG 
 - And the noise at level TRACE (detailed hooks & their results)

Care is taken to truncate input to 80 chars...