### PR TITLE
JAMES-4077 Relax HTML escaping for highlight result

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/searchhighligt/SearchHighLighterContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/searchhighligt/SearchHighLighterContract.java
@@ -97,6 +97,132 @@ public interface SearchHighLighterContract {
     }
 
     @Test
+    default void shouldHtmlEscapeTheAmpersandCharacter() throws Exception {
+        MailboxSession session = session(USERNAME1);
+
+        // & (ampersand), < (less-than sign), and > (greater-than sign) characters must be HTML escaped
+        // following JMAP specs https://jmap.io/spec-mail.html#search-snippets
+        ComposedMessageId m1 = appendMessage(MessageManager.AppendCommand.from(
+                Message.Builder.of()
+                    .setTo("to@james.local")
+                    .setSubject("Hallo, this & character should be escaped.")
+                    .setBody("append contentA to inbox", StandardCharsets.UTF_8)),
+            session).getId();
+
+        verifyMessageWasIndexed(1);
+
+        // When searching for the word `character` in the subject
+        MultimailboxesSearchQuery multiMailboxSearch = MultimailboxesSearchQuery.from(SearchQuery.of(SearchQuery.subject("character")))
+            .inMailboxes(List.of(m1.getMailboxId()))
+            .build();
+
+        List<SearchSnippet> searchSnippets = Flux.from(testee().highlightSearch(List.of(m1.getMessageId()), multiMailboxSearch, session))
+            .collectList()
+            .block();
+
+        // Then highlightSearch should return the SearchSnippet with the highlightedSubject that has ampersand character escaped.
+        assertThat(searchSnippets).hasSize(1);
+        assertSoftly(softly -> {
+            softly.assertThat(searchSnippets.getFirst().messageId()).isEqualTo(m1.getMessageId());
+            softly.assertThat(searchSnippets.getFirst().highlightedSubject()).contains("Hallo, this &amp; <mark>character</mark> should be escaped.");
+        });
+    }
+
+    @Test
+    default void shouldHtmlEscapeTheLessThanCharacter() throws Exception {
+        MailboxSession session = session(USERNAME1);
+
+        // & (ampersand), < (less-than sign), and > (greater-than sign) characters must be HTML escaped
+        // following JMAP specs https://jmap.io/spec-mail.html#search-snippets
+        ComposedMessageId m1 = appendMessage(MessageManager.AppendCommand.from(
+                Message.Builder.of()
+                    .setTo("to@james.local")
+                    .setSubject("Hallo, this < character should be escaped.")
+                    .setBody("append contentA to inbox", StandardCharsets.UTF_8)),
+            session).getId();
+
+        verifyMessageWasIndexed(1);
+
+        // When searching for the word `character` in the subject
+        MultimailboxesSearchQuery multiMailboxSearch = MultimailboxesSearchQuery.from(SearchQuery.of(SearchQuery.subject("character")))
+            .inMailboxes(List.of(m1.getMailboxId()))
+            .build();
+
+        List<SearchSnippet> searchSnippets = Flux.from(testee().highlightSearch(List.of(m1.getMessageId()), multiMailboxSearch, session))
+            .collectList()
+            .block();
+
+        // Then highlightSearch should return the SearchSnippet with the highlightedSubject that has ampersand character escaped.
+        assertThat(searchSnippets).hasSize(1);
+        assertSoftly(softly -> {
+            softly.assertThat(searchSnippets.getFirst().messageId()).isEqualTo(m1.getMessageId());
+            softly.assertThat(searchSnippets.getFirst().highlightedSubject()).contains("Hallo, this &lt; <mark>character</mark> should be escaped.");
+        });
+    }
+
+    @Test
+    default void shouldHtmlEscapeTheGreaterThanCharacter() throws Exception {
+        MailboxSession session = session(USERNAME1);
+
+        // & (ampersand), < (less-than sign), and > (greater-than sign) characters must be HTML escaped
+        // following JMAP specs https://jmap.io/spec-mail.html#search-snippets
+        ComposedMessageId m1 = appendMessage(MessageManager.AppendCommand.from(
+                Message.Builder.of()
+                    .setTo("to@james.local")
+                    .setSubject("Hallo, this > character should be escaped.")
+                    .setBody("append contentA to inbox", StandardCharsets.UTF_8)),
+            session).getId();
+
+        verifyMessageWasIndexed(1);
+
+        // When searching for the word `character` in the subject
+        MultimailboxesSearchQuery multiMailboxSearch = MultimailboxesSearchQuery.from(SearchQuery.of(SearchQuery.subject("character")))
+            .inMailboxes(List.of(m1.getMailboxId()))
+            .build();
+
+        List<SearchSnippet> searchSnippets = Flux.from(testee().highlightSearch(List.of(m1.getMessageId()), multiMailboxSearch, session))
+            .collectList()
+            .block();
+
+        // Then highlightSearch should return the SearchSnippet with the highlightedSubject that has ampersand character escaped.
+        assertThat(searchSnippets).hasSize(1);
+        assertSoftly(softly -> {
+            softly.assertThat(searchSnippets.getFirst().messageId()).isEqualTo(m1.getMessageId());
+            softly.assertThat(searchSnippets.getFirst().highlightedSubject()).contains("Hallo, this &gt; <mark>character</mark> should be escaped.");
+        });
+    }
+
+    @Test
+    default void shouldNotHtmlEscapeTheSlashCharacter() throws Exception {
+        MailboxSession session = session(USERNAME1);
+
+        ComposedMessageId m1 = appendMessage(MessageManager.AppendCommand.from(
+                Message.Builder.of()
+                    .setTo("to@james.local")
+                    .setSubject("Hallo, this / character should not be escaped.")
+                    .setBody("append contentA to inbox", StandardCharsets.UTF_8)),
+            session).getId();
+
+        verifyMessageWasIndexed(1);
+
+        // When searching for the word `character` in the subject
+        MultimailboxesSearchQuery multiMailboxSearch = MultimailboxesSearchQuery.from(SearchQuery.of(SearchQuery.subject("character")))
+            .inMailboxes(List.of(m1.getMailboxId()))
+            .build();
+
+        List<SearchSnippet> searchSnippets = Flux.from(testee().highlightSearch(List.of(m1.getMessageId()), multiMailboxSearch, session))
+            .collectList()
+            .block();
+
+        // Then highlightSearch should return the SearchSnippet with the highlightedSubject that has ampersand character escaped.
+        assertThat(searchSnippets).hasSize(1);
+        assertSoftly(softly -> {
+            softly.assertThat(searchSnippets.getFirst().messageId()).isEqualTo(m1.getMessageId());
+            softly.assertThat(searchSnippets.getFirst().highlightedSubject()).contains("Hallo, this / <mark>character</mark> should not be escaped.");
+        });
+    }
+
+    @Test
     default void highlightSearchShouldReturnHighlightedBodyWhenMatched() throws Exception {
         MailboxSession session = session(USERNAME1);
 

--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneSearchHighlighter.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneSearchHighlighter.java
@@ -57,7 +57,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.highlight.Formatter;
 import org.apache.lucene.search.highlight.Highlighter;
 import org.apache.lucene.search.highlight.QueryScorer;
-import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
 import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
 import org.apache.lucene.search.highlight.SimpleSpanFragmenter;
 
@@ -127,7 +126,7 @@ public class LuceneSearchHighlighter implements SearchHighlighter {
         Query query = buildQueryFromSearchQuery(searchQuery);
         QueryScorer scorer = new QueryScorer(query);
         Highlighter highlighter = new Highlighter(formatter, scorer);
-        highlighter.setEncoder(new SimpleHTMLEncoder());
+        highlighter.setEncoder(new RelaxedHTMLEncoder());
         highlighter.setTextFragmenter(new SimpleSpanFragmenter(scorer, configuration.fragmentSize()));
         return highlighter;
     }

--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/RelaxedHTMLEncoder.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/RelaxedHTMLEncoder.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.lucene.search;
+
+import org.apache.lucene.search.highlight.Encoder;
+
+/** Relaxed version of {@link org.apache.lucene.search.highlight.SimpleHTMLEncoder} that only
+ * encodes & (ampersand), < (less-than sign), and > (greater-than sign) characters. */
+public class RelaxedHTMLEncoder implements Encoder {
+  public RelaxedHTMLEncoder() {
+
+  }
+
+  @Override
+  public String encodeText(String originalText) {
+    return htmlEncode(originalText);
+  }
+
+  /** Encode string into HTML */
+  public static String htmlEncode(String plainText) {
+    if (plainText == null || plainText.isEmpty()) {
+      return "";
+    }
+
+    StringBuilder result = new StringBuilder(plainText.length());
+
+    for (int index = 0; index < plainText.length(); index++) {
+      char ch = plainText.charAt(index);
+
+      switch (ch) {
+        case '&':
+          result.append("&amp;");
+          break;
+        case '<':
+          result.append("&lt;");
+          break;
+        case '>':
+          result.append("&gt;");
+          break;
+        default:
+          result.append(ch);
+      }
+    }
+
+    return result.toString();
+  }
+}

--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcher.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearcher.java
@@ -85,7 +85,7 @@ public class OpenSearchSearcher {
             .build();
 
         this.highlightQuery = new Highlight.Builder()
-            .encoder(HighlighterEncoder.Html)
+            .encoder(HighlighterEncoder.Default)
             .fields(JsonMessageConstants.SUBJECT, highlightField)
             .fields(JsonMessageConstants.TEXT_BODY, highlightField)
             .fields(JsonMessageConstants.HTML_BODY, highlightField)

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearchHighlighterTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/search/OpenSearchSearchHighlighterTest.java
@@ -55,6 +55,7 @@ import org.apache.james.mailbox.opensearch.query.CriterionConverter;
 import org.apache.james.mailbox.opensearch.query.QueryConverter;
 import org.apache.james.mailbox.searchhighligt.SearchHighLighterContract;
 import org.apache.james.mailbox.searchhighligt.SearchHighlighter;
+import org.apache.james.mailbox.searchhighligt.SearchHighlighterConfiguration;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.mailbox.store.StoreMessageManager;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
@@ -155,7 +156,7 @@ public class OpenSearchSearchHighlighterTest implements SearchHighLighterContrac
         storeMailboxManager.createMailbox(inboxPath, session);
         inboxMessageManager = (StoreMessageManager) storeMailboxManager.getMailbox(inboxPath, session);
 
-        testee = new OpenSearchSearchHighlighter(openSearchSearcher, storeMailboxManager, messageIdFactory);
+        testee = new OpenSearchSearchHighlighter(openSearchSearcher, storeMailboxManager, messageIdFactory, SearchHighlighterConfiguration.DEFAULT);
     }
 
     @Override

--- a/server/container/guice/opensearch/src/main/java/org/apache/james/modules/mailbox/OpenSearchMailboxModule.java
+++ b/server/container/guice/opensearch/src/main/java/org/apache/james/modules/mailbox/OpenSearchMailboxModule.java
@@ -42,6 +42,7 @@ import org.apache.james.mailbox.opensearch.OpenSearchMailboxConfiguration;
 import org.apache.james.mailbox.opensearch.events.OpenSearchListeningMessageSearchIndex;
 import org.apache.james.mailbox.opensearch.query.QueryConverter;
 import org.apache.james.mailbox.opensearch.search.OpenSearchSearcher;
+import org.apache.james.mailbox.searchhighligt.SearchHighlighterConfiguration;
 import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.utils.InitializationOperation;
@@ -113,12 +114,14 @@ public class OpenSearchMailboxModule extends AbstractModule {
     private OpenSearchSearcher createMailboxOpenSearchSearcher(ReactorOpenSearchClient client,
                                                                QueryConverter queryConverter,
                                                                OpenSearchMailboxConfiguration configuration,
-                                                               RoutingKey.Factory<MailboxId> routingKeyFactory) {
+                                                               RoutingKey.Factory<MailboxId> routingKeyFactory,
+                                                               SearchHighlighterConfiguration searchHighlighterConfiguration) {
         return new OpenSearchSearcher(
             client,
             queryConverter,
             DEFAULT_SEARCH_SIZE,
-            configuration.getReadAliasMailboxName(), routingKeyFactory);
+            configuration.getReadAliasMailboxName(), routingKeyFactory,
+            searchHighlighterConfiguration);
     }
 
     @Provides
@@ -148,5 +151,11 @@ public class OpenSearchMailboxModule extends AbstractModule {
         return InitilizationOperationBuilder
             .forClass(MailboxIndexCreator.class)
             .init(instance::createIndex);
+    }
+
+    @Provides
+    @Singleton
+    SearchHighlighterConfiguration provideSearchHighlighterConfiguration() {
+        return SearchHighlighterConfiguration.DEFAULT;
     }
 }


### PR DESCRIPTION
Previously, we did HTML escaping for almost all possible characters. cf https://github.com/apache/james-project/pull/2593
The highlight rendering could be ugly. e.g. the slash `/` character was escaped. `subject": "<mark>Work</mark> from home request (Monday 31&#x2F;03)"`.

Following JMAP SearchSnippet specs (https://jmap.io/spec-mail.html#search-snippets): `&` (ampersand), `<` (less-than sign), and `>` (greater-than sign) characters **MUST** be escaped, while the remaining characters **MAY** depend on server choice.

Let's balance between security and visibility IMO: escape the 3 **MUST** `&` `<` `>` characters, and relax escaping for the rest.