### PR TITLE
JAMES-4072 Enable timeout option in RedisClientFactory

### DIFF
--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisClientFactory.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisClientFactory.scala
@@ -20,10 +20,9 @@
 package org.apache.james.backends.redis
 
 import java.time.Duration
-
 import io.lettuce.core.cluster.{ClusterClientOptions, RedisClusterClient}
 import io.lettuce.core.resource.ClientResources
-import io.lettuce.core.{AbstractRedisClient, ClientOptions, RedisClient, SslOptions}
+import io.lettuce.core.{AbstractRedisClient, ClientOptions, RedisClient, SslOptions, TimeoutOptions}
 import jakarta.annotation.PreDestroy
 import jakarta.inject.{Inject, Singleton}
 import org.apache.james.filesystem.api.FileSystem
@@ -80,6 +79,7 @@ class RedisClientFactory @Singleton() @Inject()
 
   private def createClientOptions(useSSL: Boolean, mayBeSSLConfiguration: Option[SSLConfiguration]): ClientOptions = {
     val clientOptionsBuilder = ClientOptions.builder
+    clientOptionsBuilder.timeoutOptions(TimeoutOptions.enabled)
     if (useSSL) {
       mayBeSSLConfiguration.foreach(sslConfig => {
         if (!sslConfig.ignoreCertificateCheck) {

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
@@ -176,6 +176,7 @@ public class RedisClusterExtension implements GuiceModuleTestExtension {
             .setScheme("redis")
             .setHost(redisContainer.getHost())
             .setPort(redisContainer.getMappedPort(DEFAULT_PORT))
+            .setParameter("timeout", "3s")
             .build()).get();
     }
 }

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisMasterReplicaExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisMasterReplicaExtension.java
@@ -92,7 +92,8 @@ public class RedisMasterReplicaExtension implements GuiceModuleTestExtension {
             return redisContainer -> "redis://123@" +
                 redisContainer.getHost() +
                 ":" +
-                redisContainer.getMappedPort(DEFAULT_PORT);
+                redisContainer.getMappedPort(DEFAULT_PORT)
+                + "?timeout=3s";
         }
     }
 

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisSentinelExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisSentinelExtension.java
@@ -109,7 +109,7 @@ public class RedisSentinelExtension implements GuiceModuleTestExtension {
             sb.append("redis-sentinel://123@");
             sb.append(this.stream().map(container -> container.getHost() + ":" + container.getMappedPort(SENTINEL_PORT))
                 .collect(Collectors.joining(",")));
-            sb.append("?sentinelMasterId=mymaster");
+            sb.append("?sentinelMasterId=mymaster&timeout=3s");
             return sb.toString();
         }
     }

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisTLSExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisTLSExtension.java
@@ -61,6 +61,7 @@ public class RedisTLSExtension implements GuiceModuleTestExtension {
                 .append(":")
                 .append(container.getMappedPort(DEFAULT_PORT))
                 .append("?verifyPeer=NONE")
+                .append("&timeout=3s")
                 .toString();
         }
     }


### PR DESCRIPTION
Currently, in the `RedisHealthcheck`, we are using Reactor's timeout handling, not the timeout provided by Redis Lettuce.
With this configuration, the timeout will be correctly handled by the Lettuce library

Reference: https://github.com/redis/lettuce/discussions/2614