### PR TITLE
[FIX] Limit MinIO folder depth to 2

### DIFF
--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3WithMinIOGenerationAwareBlobIdTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3WithMinIOGenerationAwareBlobIdTest.java
@@ -126,7 +126,7 @@ public class S3WithMinIOGenerationAwareBlobIdTest implements BlobStoreContract {
         String blobIdString = blobId.asString();
 
         // Then: BlobId string and parsed BlobId should match expectations
-        assertThat(blobIdString).isEqualTo("1/628/M/f/e/m/XjFVhqwZi9eYtmKc5JA9CJlHbVdBqfMuLlIbamY=");
+        assertThat(blobIdString).isEqualTo("1/628/M/f/emXjFVhqwZi9eYtmKc5JA9CJlHbVdBqfMuLlIbamY=");
         assertThat(blobId).isEqualTo(blobIdFactory().parse(blobIdString));
     }
 

--- a/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobId.java
+++ b/server/blob/blob-storage-strategy/src/main/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobId.java
@@ -74,13 +74,11 @@ public class MinIOGenerationAwareBlobId implements BlobId, GenerationAware {
         }
 
         private static String injectFoldersInBlobId(String blobIdPart) {
-            int folderDepthToCreate = 4;
+            int folderDepthToCreate = 2;
             if (blobIdPart.length() > folderDepthToCreate) {
                 return blobIdPart.charAt(0) + "/" +
                     blobIdPart.charAt(1) + "/" +
-                    blobIdPart.charAt(2) + "/" +
-                    blobIdPart.charAt(3) + "/" +
-                    blobIdPart.substring(4);
+                    blobIdPart.substring(2);
             }
             return blobIdPart;
         }

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobIdTest.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobIdTest.java
@@ -62,7 +62,7 @@ class MinIOGenerationAwareBlobIdTest {
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(actual.getFamily()).isEqualTo(GenerationAwareBlobId.Configuration.DEFAULT.getFamily());
                 soft.assertThat(actual.getGeneration()).isEqualTo(628L);
-                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.of("4/c/c/b/692e-3efb-40e9-8876-4ecfd51ffd4d"));
+                soft.assertThat(actual.getDelegate()).isEqualTo(delegate.of("4/c/cb692e-3efb-40e9-8876-4ecfd51ffd4d"));
             });
         }
     }

--- a/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobIdTest.java
+++ b/server/blob/blob-storage-strategy/src/test/java/org/apache/james/server/blob/deduplication/MinIOGenerationAwareBlobIdTest.java
@@ -95,6 +95,22 @@ class MinIOGenerationAwareBlobIdTest {
         }
 
         @Test
+        void previousFourFolderDepthBlobIdsShouldBeParsedAsMinIOGenerationAwareBlobId() {
+            String fourDepthBlobIdString = delegate.of("1/628/3/6/8/2/5033-d835-4490-9f5a-eef120b1e85c").asString();
+
+            BlobId actual = testee.parse(fourDepthBlobIdString);
+            assertThat(actual)
+                .isInstanceOfSatisfying(MinIOGenerationAwareBlobId.class, actualBlobId -> {
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(actualBlobId.getFamily()).isEqualTo(1);
+                        soft.assertThat(actualBlobId.getGeneration()).isEqualTo(628L);
+                        soft.assertThat(actualBlobId.getDelegate().asString()).isEqualTo("3/6/8/2/5033-d835-4490-9f5a-eef120b1e85c");
+                        soft.assertThat(actualBlobId.asString()).isEqualTo("1/628/3/6/8/2/5033-d835-4490-9f5a-eef120b1e85c");
+                    });
+                });
+        }
+
+        @Test
         void noFamilyShouldBeParsable() {
             String originalBlobId = "abcdef";
             String blobIdString = "0/0/" + delegate.of(originalBlobId).asString();
@@ -206,7 +222,7 @@ class MinIOGenerationAwareBlobIdTest {
         void asStringShouldIntegrateFamilyAndGeneration() {
             BlobId blobId = testee.of("36825033-d835-4490-9f5a-eef120b1e85c");
 
-            assertThat(blobId.asString()).isEqualTo("1/628/3/6/8/2/5033-d835-4490-9f5a-eef120b1e85c");
+            assertThat(blobId.asString()).isEqualTo("1/628/3/6/825033-d835-4490-9f5a-eef120b1e85c");
         }
 
         @Test
@@ -220,7 +236,8 @@ class MinIOGenerationAwareBlobIdTest {
         @ValueSource(strings = {
             "1/2/a/b/c/d/efgh",
             "abc",
-            "1/2/abc"
+            "1/2/abc",
+            "1/628/3/6/8/2/5033-d835-4490-9f5a-eef120b1e85c"
         })
         void asStringShouldRevertFromString(String blobIdString) {
             BlobId blobId = testee.parse(blobIdString);


### PR DESCRIPTION
Avoids creating tons of intermediate folders thus reduces inode pressure while still on disk splitting objects in 4.000 slots

So the MinIO retex gains complexity.

Actually we are encountering more complex than it seems issues with it.

After the OOM as everyting was stored in single GB big folder ( !!! ) that is impossible to ls, thus breaking MinIO inner work (...) which needs spreading accross several folders, we did run into a inode shortage issue (isize 512, inpode space percentage 5%, XFS). Our study found that each object stored resulted in ~5 inodes being used (including versionning, meta info part info, object entry, but also `/`` into the part. 

Email being small blob intensive, we are running out of into before running out of disk space.

One generation with 4 `/` and storing ~2 million objects consummes 2,250 M additional inodes with the folders prefix. Density of level 4 is terrible: 1 folder for one object. Density for level 3 is also not good: one level for ~8 underlying levels.

We thus believe that 2 levels (whish already splits objects in slots of 4096 items thus can scale to hundreds of millions items per generation)  is thus a much more default.

Please also find hereby recommended XFS settings / MinIO settings for a 4 node cluster:
 - isize = 256 (which is XFS default and not 512)
 - imaxpct = 10 
 - Errasure coding settings: 8 stripes with 2 or 3 parity block which allows for a 75-63% density while tollerating one server failure (and potentially one additional disk failure). Note choosing a strip of 16 is important as it spreads workload better