### PR TITLE
JAMES-2182 StoreMailboxManager should avoid throwing exception in `.filterWhen`

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -1874,6 +1874,23 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        void renameMailboxToAnExistingMailboxShouldThrowMailboxExistsException() throws MailboxException {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath existingPath = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath toBeRenamed = MailboxPath.forUser(USER_1, "mbx2");
+
+            mailboxManager.createMailbox(existingPath, session);
+            subscriptionManager.subscribe(session, existingPath);
+
+            mailboxManager.createMailbox(toBeRenamed, session);
+            subscriptionManager.subscribe(session, toBeRenamed);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(toBeRenamed, existingPath, RENAME_SUBSCRIPTIONS, session))
+                .isInstanceOf(MailboxExistsException.class);
+        }
+
+        @Test
         void renameMailboxShouldRenameSubscriptionWhenCalledWithRenameSubscriptionOption() throws MailboxException {
             MailboxSession session = mailboxManager.createSystemSession(USER_1);
 

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/RenameSharedMailbox.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/RenameSharedMailbox.test
@@ -46,14 +46,14 @@ C: a2 MYRIGHTS #user.boby.sharedMailbox.child2-eiklprstw
 S: \* MYRIGHTS \"#user.boby.sharedMailbox.child2-eiklprstw\" \"eiklprstw\"
 S: a2 OK MYRIGHTS completed.
 C: a3 RENAME #user.boby.sharedMailbox.child2-eiklprstw #user.boby.sharedMailbox.newChild2
-S: a3 NO RENAME processing failed.
+S: a3 NO RENAME failed. Insufficient rights.
 
 # Cannot rename a shared mailbox if the parent of the target mailbox lacks the "create mailbox" right
 C: a4 MYRIGHTS #user.boby.sharedMailbox-eilprstwx
 S: \* MYRIGHTS \"#user.boby.sharedMailbox-eilprstwx\" \"eilprstwx\"
 S: a4 OK MYRIGHTS completed.
 C: a5 RENAME #user.boby.sharedMailbox.child1-eiklprstwx #user.boby.sharedMailbox-eilprstwx.newChild1
-S: a5 NO RENAME processing failed.
+S: a5 NO RENAME failed. Insufficient rights.
 
 # Cannot rename a mailbox to an existing mailbox name
 C: a52 RENAME #user.boby.sharedMailbox.child1-eiklprstwx #user.boby.sharedMailbox.child2-eiklprstw

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
@@ -182,6 +182,8 @@ public class HumanReadableText {
     public static final String UNSUFFICIENT_RIGHTS_DEFAULT_VALUE = "You need the {0} right to perform command {1} on mailbox {2}.";
     public static final String UNSUFFICIENT_RIGHTS_KEY = "org.apache.james.imap.UNSUFFICIENT_RIGHTS";
 
+    public static final HumanReadableText UNSUFFICIENT_RIGHTS = new HumanReadableText(UNSUFFICIENT_RIGHTS_KEY, "failed. Insufficient rights.");
+
     public static final String UNSUPPORTED_RIGHT_KEY = "org.apache.james.imap.UNSUPPORTED_RIGHT";
     public static final String UNSUPPORTED_RIGHT_DEFAULT_VALUE = "The {0} right is not supported.";
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -57,6 +57,7 @@ import org.apache.james.mailbox.MessageManager.MailboxMetaData;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.NullableMessageSequenceNumber;
+import org.apache.james.mailbox.exception.InsufficientRightsException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MessageRangeException;
 import org.apache.james.mailbox.exception.OverQuotaException;
@@ -99,6 +100,10 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
                         .onErrorResume(DeniedAccessOnSharedMailboxException.class, e -> {
                             no(acceptableMessage, responder, HumanReadableText.DENIED_SHARED_MAILBOX);
                             return Mono.empty();
+                        })
+                        .onErrorResume(InsufficientRightsException.class, e -> {
+                            no(acceptableMessage, responder, HumanReadableText.UNSUFFICIENT_RIGHTS);
+                            return ReactorUtils.logAsMono(() -> LOGGER.info("Processing failed due to insufficient rights", e));
                         })
                         .onErrorResume(OverQuotaException.class, e -> {
                             no(acceptableMessage, responder, HumanReadableText.FAILURE_OVERQUOTA, StatusResponse.ResponseCode.overQuota());

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -103,7 +103,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
                         })
                         .onErrorResume(InsufficientRightsException.class, e -> {
                             no(acceptableMessage, responder, HumanReadableText.UNSUFFICIENT_RIGHTS);
-                            return ReactorUtils.logAsMono(() -> LOGGER.info("Processing failed due to insufficient rights", e));
+                            return ReactorUtils.logAsMono(() -> LOGGER.warn("Processing failed due to insufficient rights", e));
                         })
                         .onErrorResume(OverQuotaException.class, e -> {
                             no(acceptableMessage, responder, HumanReadableText.FAILURE_OVERQUOTA, StatusResponse.ResponseCode.overQuota());

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -3573,7 +3573,7 @@ class IMAPServerTest {
             String response = testIMAPClient.sendCommand("RENAME #user.bobo.sharedMailbox.child1 #user.bobo.sharedMailbox.newChild");
 
             // Assert that the operation fails due to insufficient rights
-            assertThat(response).contains("NO RENAME processing failed.");
+            assertThat(response).contains("NO RENAME failed. Insufficient rights.");
         }
     }
 


### PR DESCRIPTION
We observed a few `MailboxExistsException` error logs since the change https://github.com/apache/james-project/commit/91f50b031ce2fd1040aa345272ae3f3a76e13b99#diff-51e67dcd44af864286be49fbe7d5474bff07b8fe6cd0536121b4f2898dbbda9e.

Actually, the errors are still caught by the main reactor stream, therefore no impact to users. However, it seems errors emitted by asynchronous operators like `.filterWhen` can be propagated through their own internal asynchronous paths and result in unhandled exceptions being logged (e.g., `onErrorDropped`).