### PR TITLE
JAMES-3539 WebPushClient should accept more flexible 20x codes from Push server

### DIFF
--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/pushsubscription/WebPushClient.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/pushsubscription/WebPushClient.scala
@@ -128,7 +128,7 @@ class DefaultWebPushClient @Inject()(configuration: PushClientConfiguration) ext
   private def afterHTTPResponseHandler(httpResponse: HttpClientResponse, dataBuf: ByteBufMono): Mono[Void] =
     Mono.just(httpResponse.status())
       .flatMap {
-        case HttpResponseStatus.CREATED => Mono.empty()
+        case HttpResponseStatus.OK | HttpResponseStatus.CREATED | HttpResponseStatus.ACCEPTED => Mono.empty()
         case HttpResponseStatus.BAD_REQUEST => preProcessingData(dataBuf)
           .flatMap(string => Mono.error(WebPushInvalidRequestException(string)))
         case _ => preProcessingData(dataBuf)


### PR DESCRIPTION
It seems that some push gateways, like MSGraph, are using return codes 200 and 202 as well.