### PR TITLE
JAMES-3539 Types field in push subscription should accept null value

### DIFF
--- a/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/pushsubscription/CassandraPushSubscriptionRepositoryTest.java
+++ b/server/data/data-jmap-cassandra/src/test/java/org/apache/james/jmap/cassandra/pushsubscription/CassandraPushSubscriptionRepositoryTest.java
@@ -47,7 +47,8 @@ public class CassandraPushSubscriptionRepositoryTest implements PushSubscription
         pushSubscriptionRepository = new CassandraPushSubscriptionRepository(
             new CassandraPushSubscriptionDAO(cassandra.getConf(),
                 new TypeStateFactory(CollectionConverters.asJava(PushSubscriptionRepositoryContract.TYPE_NAME_SET()))),
-            clock);
+            clock,
+            new TypeStateFactory(CollectionConverters.asJava(PushSubscriptionRepositoryContract.TYPE_NAME_SET())));
     }
 
     @Override

--- a/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/pushsubscription/PostgresPushSubscriptionRepository.java
+++ b/server/data/data-jmap-postgres/src/main/java/org/apache/james/jmap/postgres/pushsubscription/PostgresPushSubscriptionRepository.java
@@ -68,7 +68,8 @@ public class PostgresPushSubscriptionRepository implements PushSubscriptionRepos
         return validateCreationRequest(request)
             .then(Mono.defer(() -> {
                 PushSubscription pushSubscription = PushSubscription.from(request,
-                    evaluateExpiresTime(OptionConverters.toJava(request.expires().map(PushSubscriptionExpiredTime::value)), clock));
+                    evaluateExpiresTime(OptionConverters.toJava(request.expires().map(PushSubscriptionExpiredTime::value)), clock),
+                    typeStateFactory);
 
                 return pushSubscriptionDAO.save(username, pushSubscription)
                     .thenReturn(pushSubscription);

--- a/server/data/data-jmap/src/main/scala/org/apache/james/jmap/api/change/TypeStateFactory.scala
+++ b/server/data/data-jmap/src/main/scala/org/apache/james/jmap/api/change/TypeStateFactory.scala
@@ -27,7 +27,7 @@ import scala.jdk.CollectionConverters._
 
 case class TypeStateFactory @Inject()(setTypeName: java.util.Set[TypeName]) {
   val logger: Logger = LoggerFactory.getLogger(classOf[TypeStateFactory])
-  val all: scala.collection.mutable.Set[TypeName] = setTypeName.asScala
+  val all: Set[TypeName] = setTypeName.asScala.toSet
 
   def strictParse(string: String): Either[IllegalArgumentException, TypeName] =
     all.flatMap(_.parse(string))

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/pushsubscription/MemoryPushSubscriptionRepositoryTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/pushsubscription/MemoryPushSubscriptionRepositoryTest.java
@@ -19,10 +19,13 @@
 
 package org.apache.james.jmap.memory.pushsubscription;
 
+import org.apache.james.jmap.api.change.TypeStateFactory;
 import org.apache.james.jmap.api.pushsubscription.PushSubscriptionRepository;
 import org.apache.james.jmap.api.pushsubscription.PushSubscriptionRepositoryContract;
 import org.apache.james.utils.UpdatableTickingClock;
 import org.junit.jupiter.api.BeforeEach;
+
+import scala.jdk.javaapi.CollectionConverters;
 
 public class MemoryPushSubscriptionRepositoryTest implements PushSubscriptionRepositoryContract {
     UpdatableTickingClock clock;
@@ -31,7 +34,8 @@ public class MemoryPushSubscriptionRepositoryTest implements PushSubscriptionRep
     @BeforeEach
     void setup() {
         clock = new UpdatableTickingClock(PushSubscriptionRepositoryContract.NOW());
-        pushSubscriptionRepository = new MemoryPushSubscriptionRepository(clock);
+        pushSubscriptionRepository = new MemoryPushSubscriptionRepository(clock,
+            new TypeStateFactory(CollectionConverters.asJava(PushSubscriptionRepositoryContract.TYPE_NAME_SET())));
     }
 
     @Override

--- a/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/pushsubscription/PushSubscriptionRepositoryContract.scala
+++ b/server/data/data-jmap/src/test/scala/org/apache/james/jmap/api/pushsubscription/PushSubscriptionRepositoryContract.scala
@@ -80,7 +80,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     val singleRecordSaved = SFlux.fromPublisher(testee.get(ALICE, Set(pushSubscriptionId).asJava)).count().block()
 
@@ -92,7 +92,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     val newSavedSubscription = SFlux.fromPublisher(testee.get(ALICE, Set(pushSubscriptionId).asJava)).blockFirst().get
 
@@ -105,7 +105,7 @@ trait PushSubscriptionRepositoryContract {
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
       expires = Some(PushSubscriptionExpiredTime(VALID_EXPIRE.plusDays(8))),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, request)).block().id
     val newSavedSubscription = SFlux.fromPublisher(testee.get(ALICE, Set(pushSubscriptionId).asJava)).blockFirst().get
 
@@ -118,7 +118,7 @@ trait PushSubscriptionRepositoryContract {
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
       expires = Some(PushSubscriptionExpiredTime(INVALID_EXPIRE)),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
 
     assertThatThrownBy(() => SMono.fromPublisher(testee.save(ALICE, invalidRequest)).block())
       .isInstanceOf(classOf[ExpireTimeInvalidException])
@@ -129,13 +129,13 @@ trait PushSubscriptionRepositoryContract {
     val firstRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     SMono.fromPublisher(testee.save(ALICE, firstRequest)).block()
 
     val secondRequestWithDuplicatedDeviceClientId = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
 
     assertThatThrownBy(() => SMono.fromPublisher(testee.save(ALICE, secondRequestWithDuplicatedDeviceClientId)).block())
       .isInstanceOf(classOf[DeviceClientIdInvalidException])
@@ -146,7 +146,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
 
     assertThatThrownBy(() => SMono.fromPublisher(testee.updateExpireTime(ALICE, pushSubscriptionId, INVALID_EXPIRE)).block())
@@ -158,7 +158,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     SMono.fromPublisher(testee.updateExpireTime(ALICE, pushSubscriptionId, MAX_EXPIRE.plusDays(1))).block()
 
@@ -179,7 +179,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     SMono.fromPublisher(testee.updateExpireTime(ALICE, pushSubscriptionId, VALID_EXPIRE)).block()
 
@@ -192,7 +192,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     val fixedExpires = SMono.fromPublisher(testee.updateExpireTime(ALICE, pushSubscriptionId, MAX_EXPIRE.plusDays(1))).block()
 
@@ -204,7 +204,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
 
     val newTypes: Set[TypeName] = Set(CustomTypeName1, CustomTypeName2)
@@ -236,7 +236,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     val singleRecordSaved = SFlux.fromPublisher(testee.get(ALICE, Set(pushSubscriptionId).asJava)).count().block()
     assertThat(singleRecordSaved).isEqualTo(1)
@@ -252,7 +252,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     val singleRecordSaved = SFlux.fromPublisher(testee.get(ALICE, Set(pushSubscriptionId).asJava)).count().block()
     assertThat(singleRecordSaved).isEqualTo(1)
@@ -285,12 +285,12 @@ trait PushSubscriptionRepositoryContract {
       deviceClientId = deviceClientId1,
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
       expires = Option(PushSubscriptionExpiredTime(VALID_EXPIRE)),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val validRequest2 = PushSubscriptionCreationRequest(
       deviceClientId = deviceClientId2,
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
       expires = Option(PushSubscriptionExpiredTime(VALID_EXPIRE)),
-      types = Seq(CustomTypeName2))
+      types = Some(Seq(CustomTypeName2)))
     val pushSubscriptionId1 = SMono.fromPublisher(testee.save(ALICE, validRequest1)).block().id
     val pushSubscriptionId2 = SMono.fromPublisher(testee.save(ALICE, validRequest2)).block().id
 
@@ -306,7 +306,7 @@ trait PushSubscriptionRepositoryContract {
       deviceClientId = deviceClientId1,
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
       expires = Option(PushSubscriptionExpiredTime(VALID_EXPIRE)),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId1 = SMono.fromPublisher(testee.save(ALICE, validRequest1)).block().id
     val pushSubscriptionId2 = PushSubscriptionId.generate()
 
@@ -321,7 +321,7 @@ trait PushSubscriptionRepositoryContract {
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
       expires = Option(PushSubscriptionExpiredTime(VALID_EXPIRE.plusDays(1))),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest1)).block().id
 
     clock.setInstant(VALID_EXPIRE.plusDays(2).toInstant)
@@ -338,11 +338,11 @@ trait PushSubscriptionRepositoryContract {
     val validRequest1 = PushSubscriptionCreationRequest(
       deviceClientId = deviceClientId1,
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val validRequest2 = PushSubscriptionCreationRequest(
       deviceClientId = deviceClientId2,
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName2))
+      types = Some(Seq(CustomTypeName2)))
     val pushSubscriptionId1: PushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest1)).block().id
     val pushSubscriptionId2: PushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest2)).block().id
 
@@ -360,7 +360,7 @@ trait PushSubscriptionRepositoryContract {
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
       expires = Option(PushSubscriptionExpiredTime(VALID_EXPIRE.plusDays(1))),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest1)).block().id
 
     clock.setInstant(VALID_EXPIRE.plusDays(2).toInstant)
@@ -375,7 +375,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
     SMono.fromPublisher(testee.validateVerificationCode(ALICE, pushSubscriptionId)).block()
 
@@ -397,7 +397,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1),
+      types = Some(Seq(CustomTypeName1)),
       keys = fullKeyPair)
 
     val pushSubscriptionId1 = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
@@ -413,7 +413,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1),
+      types = Some(Seq(CustomTypeName1)),
       keys = emptyKeyPair)
     val pushSubscriptionId1 = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
 
@@ -429,7 +429,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL()),
-      types = Seq(CustomTypeName1),
+      types = Some(Seq(CustomTypeName1)),
       keys = emptyP256hKey)
 
     assertThatThrownBy(() => SMono.fromPublisher(testee.save(ALICE, validRequest)).block())
@@ -443,7 +443,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URI("https://example.com/push").toURL),
-      types = Seq(CustomTypeName1),
+      types = Some(Seq(CustomTypeName1)),
       keys = emptyAuthKey)
 
     assertThatThrownBy(() => SMono.fromPublisher(testee.save(ALICE, validRequest)).block())
@@ -455,7 +455,7 @@ trait PushSubscriptionRepositoryContract {
     val validRequest = PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("1"),
       url = PushSubscriptionServerURL(new URL("https://example.com/push")),
-      types = Seq(CustomTypeName1))
+      types = Some(Seq(CustomTypeName1)))
 
     val pushSubscriptionId = SMono.fromPublisher(testee.save(ALICE, validRequest)).block().id
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/distributed/DistributedPushSubscriptionSetMethodTest.java
+++ b/server/protocols/jmap-rfc-8621-integration-tests/distributed-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/distributed/DistributedPushSubscriptionSetMethodTest.java
@@ -30,6 +30,7 @@ import org.apache.james.jmap.pushsubscription.PushClientConfiguration;
 import org.apache.james.jmap.rfc8621.contract.PushServerExtension;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionProbeModule;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionSetMethodContract;
+import org.apache.james.jmap.rfc8621.contract.probe.TypeStateModule;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
 import org.apache.james.modules.RabbitMQExtension;
 import org.apache.james.modules.TestJMAPServerModule;
@@ -54,7 +55,7 @@ public class DistributedPushSubscriptionSetMethodTest implements PushSubscriptio
         .extension(new AwsS3BlobStoreExtension())
         .extension(new ClockExtension())
         .server(configuration -> CassandraRabbitMQJamesServerMain.createServer(configuration)
-            .overrideWith(new TestJMAPServerModule(), new PushSubscriptionProbeModule())
+            .overrideWith(new TestJMAPServerModule(), new PushSubscriptionProbeModule(), new TypeStateModule())
             .overrideWith(binder -> binder.bind(PushClientConfiguration.class).toInstance(PushClientConfiguration.UNSAFE_DEFAULT())))
         .build();
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/probe/TypeStateProbe.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/probe/TypeStateProbe.scala
@@ -1,0 +1,39 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.rfc8621.contract.probe
+
+import com.google.inject.AbstractModule
+import com.google.inject.multibindings.Multibinder
+import jakarta.inject.Inject
+import org.apache.james.jmap.api.change.TypeStateFactory
+import org.apache.james.jmap.api.model.TypeName
+import org.apache.james.utils.GuiceProbe
+
+class TypeStateModule extends AbstractModule {
+  override def configure(): Unit =
+    Multibinder.newSetBinder(binder(), classOf[GuiceProbe])
+      .addBinding()
+      .to(classOf[TypeStateProbe])
+}
+
+class TypeStateProbe @Inject()(typeStateFactory: TypeStateFactory) extends GuiceProbe {
+  def typesNames(): java.util.Set[TypeName] =
+    typeStateFactory.setTypeName
+}

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryPushSubscriptionSetMethodTest.java
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryPushSubscriptionSetMethodTest.java
@@ -30,6 +30,7 @@ import org.apache.james.jmap.pushsubscription.PushClientConfiguration;
 import org.apache.james.jmap.rfc8621.contract.PushServerExtension;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionProbeModule;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionSetMethodContract;
+import org.apache.james.jmap.rfc8621.contract.probe.TypeStateModule;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -43,7 +44,7 @@ public class MemoryPushSubscriptionSetMethodTest implements PushSubscriptionSetM
             .build())
         .extension(new ClockExtension())
         .server(configuration -> MemoryJamesServerMain.createServer(configuration)
-            .overrideWith(new TestJMAPServerModule(), new PushSubscriptionProbeModule())
+            .overrideWith(new TestJMAPServerModule(), new PushSubscriptionProbeModule(), new TypeStateModule())
             .overrideWith(binder -> binder.bind(PushClientConfiguration.class).toInstance(PushClientConfiguration.UNSAFE_DEFAULT())))
         .build();
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/postgres-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/postgres/PostgresPushSubscriptionSetMethodTest.java
+++ b/server/protocols/jmap-rfc-8621-integration-tests/postgres-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/postgres/PostgresPushSubscriptionSetMethodTest.java
@@ -32,6 +32,7 @@ import org.apache.james.jmap.pushsubscription.PushClientConfiguration;
 import org.apache.james.jmap.rfc8621.contract.PushServerExtension;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionProbeModule;
 import org.apache.james.jmap.rfc8621.contract.PushSubscriptionSetMethodContract;
+import org.apache.james.jmap.rfc8621.contract.probe.TypeStateModule;
 import org.apache.james.modules.RabbitMQExtension;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
@@ -58,6 +59,7 @@ public class PostgresPushSubscriptionSetMethodTest implements PushSubscriptionSe
         .server(configuration -> PostgresJamesServerMain.createServer(configuration)
             .overrideWith(new TestJMAPServerModule())
             .overrideWith(new PushSubscriptionProbeModule())
+            .overrideWith(new TypeStateModule())
             .overrideWith(binder -> binder.bind(PushClientConfiguration.class).toInstance(PushClientConfiguration.UNSAFE_DEFAULT())))
         .build();
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/PushSubscriptionSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/PushSubscriptionSet.scala
@@ -35,7 +35,7 @@ import org.apache.james.jmap.core.Properties.toProperties
 import org.apache.james.jmap.core.SetError.SetErrorDescription
 import org.apache.james.jmap.mail.{InvalidPropertyException, InvalidUpdateException, PatchUpdateValidationException, UnsupportedPropertyUpdatedException}
 import org.apache.james.jmap.method.{SetRequest, WithoutAccountId}
-import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
+import play.api.libs.json.{JsArray, JsNull, JsObject, JsString, JsValue}
 
 import scala.util.{Failure, Success, Try}
 
@@ -133,7 +133,8 @@ object TypesUpdate {
       .map(js => parseType(js, typeStateFactory))
       .sequence
       .map(_.toSet)
-      .map(TypesUpdate(_))
+      .map(types => TypesUpdate(Some(types)))
+    case JsNull => Right(TypesUpdate(None))
     case _ => Left(InvalidUpdateException("types", "Expecting an array of JSON strings as an argument"))
   }
   def parseType(jsValue: JsValue, typeStateFactory: TypeStateFactory): Either[PatchUpdateValidationException, TypeName] = jsValue match {
@@ -156,7 +157,7 @@ object ExpiresUpdate {
 
 sealed trait Update
 case class VerificationCodeUpdate(newVerificationCode: VerificationCode) extends Update
-case class TypesUpdate(types: Set[TypeName]) extends Update
+case class TypesUpdate(types: Option[Set[TypeName]]) extends Update
 case class ExpiresUpdate(newExpires: UTCDate) extends Update
 
 object ValidatedPushSubscriptionPatchObject {
@@ -166,7 +167,7 @@ object ValidatedPushSubscriptionPatchObject {
 }
 
 case class ValidatedPushSubscriptionPatchObject(verificationCodeUpdate: Option[VerificationCode],
-                                                typesUpdate: Option[Set[TypeName]],
+                                                typesUpdate: Option[Option[Set[TypeName]]],
                                                 expiresUpdate: Option[PushSubscriptionExpiredTime]) {
   val shouldUpdate: Boolean = verificationCodeUpdate.isDefined || typesUpdate.isDefined || expiresUpdate.isDefined
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionUpdatePerformer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionUpdatePerformer.scala
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.method
 
 import com.google.common.collect.ImmutableSet
+import eu.timepit.refined.auto._
 import jakarta.inject.Inject
 import org.apache.james.jmap.api.change.TypeStateFactory
 import org.apache.james.jmap.api.model.{ExpireTimeInvalidException, PushSubscription, PushSubscriptionExpiredTime, PushSubscriptionId, PushSubscriptionNotFoundException, TypeName, VerificationCode}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/pushsubscription/PushListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/pushsubscription/PushListenerTest.scala
@@ -66,7 +66,8 @@ class PushListenerTest {
   def setUp(): Unit = {
     val pushSerializer = PushSerializer(TypeStateFactory(ImmutableSet.of[TypeName](MailboxTypeName, EmailTypeName, EmailDeliveryTypeName)))
 
-    pushSubscriptionRepository = new MemoryPushSubscriptionRepository(Clock.systemUTC())
+    pushSubscriptionRepository = new MemoryPushSubscriptionRepository(Clock.systemUTC(),
+      TypeStateFactory(ImmutableSet.of[TypeName](MailboxTypeName, EmailTypeName, EmailDeliveryTypeName)))
     webPushClient = mock(classOf[WebPushClient])
     delegationStore = new MemoryDelegationStore()
     testee = new PushListener(pushSubscriptionRepository, webPushClient, pushSerializer, delegationStore, Clock.systemUTC())
@@ -87,7 +88,7 @@ class PushListenerTest {
     SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit"),
       url = url,
-      types = Seq(MailboxTypeName, EmailTypeName)))).block()
+      types = Some(Seq(MailboxTypeName, EmailTypeName))))).block()
 
     SMono(testee.reactiveEvent(StateChangeEvent(EventId.random(), bob,
       Map(EmailTypeName -> UuidState(UUID.randomUUID()))))).block()
@@ -100,7 +101,7 @@ class PushListenerTest {
     val id = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit"),
       url = url,
-      types = Seq(EmailDeliveryTypeName)))).block().id
+      types = Some(Seq(EmailDeliveryTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, id)).block()
 
     SMono(testee.reactiveEvent(StateChangeEvent(EventId.random(), bob,
@@ -114,7 +115,7 @@ class PushListenerTest {
     val id = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit"),
       url = url,
-      types = Seq(EmailTypeName, MailboxTypeName)))).block().id
+      types = Some(Seq(EmailTypeName, MailboxTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, id)).block()
 
     val state1 = UuidState(UUID.randomUUID())
@@ -136,7 +137,7 @@ class PushListenerTest {
     val bobSubscriptionId = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit1"),
       url = url,
-      types = Seq(EmailTypeName, MailboxTypeName)))).block().id
+      types = Some(Seq(EmailTypeName, MailboxTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, bobSubscriptionId)).block()
 
     val state1 = UuidState(UUID.randomUUID())
@@ -152,12 +153,12 @@ class PushListenerTest {
     val bobSubscriptionId = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit1"),
       url = url,
-      types = Seq(EmailTypeName, MailboxTypeName)))).block().id
+      types = Some(Seq(EmailTypeName, MailboxTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, bobSubscriptionId)).block()
     val aliceSubscriptionId = SMono(pushSubscriptionRepository.save(alice, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit2"),
       url = url,
-      types = Seq(EmailTypeName, MailboxTypeName)))).block().id
+      types = Some(Seq(EmailTypeName, MailboxTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(alice, aliceSubscriptionId)).block()
 
     val state1 = UuidState(UUID.randomUUID())
@@ -180,7 +181,7 @@ class PushListenerTest {
     val bobSubscriptionId = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit1"),
       url = url,
-      types = Seq(EmailTypeName, MailboxTypeName)))).block().id
+      types = Some(Seq(EmailTypeName, MailboxTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, bobSubscriptionId)).block()
 
     val stateChangeBob = UuidState(UUID.randomUUID())
@@ -203,7 +204,7 @@ class PushListenerTest {
     val id = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit"),
       url = url,
-      types = Seq(EmailTypeName, MailboxTypeName)))).block().id
+      types = Some(Seq(EmailTypeName, MailboxTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, id)).block()
 
     val state1 = UuidState(UUID.randomUUID())
@@ -227,7 +228,7 @@ class PushListenerTest {
     val id = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit"),
       url = url,
-      types = Seq(EmailDeliveryTypeName, EmailTypeName)))).block().id
+      types = Some(Seq(EmailDeliveryTypeName, EmailTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, id)).block()
 
     val state1 = UuidState(UUID.randomUUID())
@@ -246,7 +247,7 @@ class PushListenerTest {
     val id = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit"),
       url = url,
-      types = Seq(EmailDeliveryTypeName, EmailTypeName)))).block().id
+      types = Some(Seq(EmailDeliveryTypeName, EmailTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, id)).block()
 
     val state1 = UuidState(UUID.randomUUID())
@@ -264,7 +265,7 @@ class PushListenerTest {
     val id = SMono(pushSubscriptionRepository.save(bob, PushSubscriptionCreationRequest(
       deviceClientId = DeviceClientId("junit"),
       url = url,
-      types = Seq(EmailDeliveryTypeName, EmailTypeName)))).block().id
+      types = Some(Seq(EmailDeliveryTypeName, EmailTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, id)).block()
 
     val state1 = UuidState(UUID.randomUUID())
@@ -296,7 +297,7 @@ class PushListenerTest {
       keys = Some(PushSubscriptionKeys(p256dh = Base64.getUrlEncoder.encodeToString(uaPublicKey.getEncoded),
         auth = Base64.getUrlEncoder.encodeToString(authSecret))),
       url = url,
-      types = Seq(EmailTypeName, MailboxTypeName)))).block().id
+      types = Some(Seq(EmailTypeName, MailboxTypeName))))).block().id
     SMono(pushSubscriptionRepository.validateVerificationCode(bob, id)).block()
 
     val state1 = UuidState(UUID.randomUUID())

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/memory/MemoryUserDeletionIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/memory/MemoryUserDeletionIntegrationTest.java
@@ -291,7 +291,7 @@ class MemoryUserDeletionIntegrationTest {
                 new PushSubscriptionServerURL(new URI("http://whatever/toto").toURL()),
                 Option.empty(),
                 Option.empty(),
-                PushSubscriptionCreationRequest.noTypes()));
+                Option.apply(PushSubscriptionCreationRequest.noTypes())));
 
         String taskId = webAdminApi
             .queryParam("action", "deleteData")


### PR DESCRIPTION
According to the rfc https://datatracker.ietf.org/doc/html/rfc8620#section-7.2 PushSubscription/set should accept a null value for types, and in this case register the push ith all the types available on the server.

We need to fix this to be RFC compliant.