### PR TITLE
JAMES-4133 POC RFC-6532 Support for i8n emails

### DIFF
--- a/core/src/test/java/org/apache/james/core/DomainTest.java
+++ b/core/src/test/java/org/apache/james/core/DomainTest.java
@@ -1,0 +1,81 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+
+class DomainTest {
+    @Test
+    void testPlainDomain() {
+        Domain d1 = Domain.of("example.com");
+        assertThat(d1.name().equals(d1.asString()));
+        Domain d2 = Domain.of("Example.com");
+        assertThat(d2.name()).isNotEqualTo(d2.asString());
+        assertThat(d1.asString()).isEqualTo(d2.asString());
+    }
+
+    @Test
+    void testIPv4Domain() {
+        Domain d1 = Domain.of("192.0.4.1");
+        assertThat(d1.asString()).isEqualTo("192.0.4.1");
+    }
+
+    @Test
+    void testPunycodeIDN() {
+        Domain d1 = Domain.of("xn--gr-zia.example");
+        assertThat(d1.asString()).isEqualTo("grå.example");
+    }
+
+    @Test
+    void testDevanagariDomain() {
+        Domain d1 = Domain.of("डाटामेल.भारत");
+        assertThat(d1.asString()).isEqualTo(d1.name());
+    }
+
+    private static Stream<Arguments> malformedDomains() {
+        return Stream.of(
+                         "😊☺️.example", // emoji not permitted by IDNA
+                         "#.example", // really and truly not permitted
+                         "\uFEFF.example", // U+FEFF is the byte order mark
+                         "\u200C.example", // U+200C is a zero-width non-joiner
+                         "\u200Eibm.example" // U+200E is left-to-right
+                         )
+            .map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("malformedDomains")
+    void testMalformedDomains(String malformed) {
+        assertThatThrownBy(() -> Domain.of(malformed))
+            .as("rejecting malformed domain " + malformed)
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}
+
+

--- a/mailbox/opensearch/src/test/resources/eml/cve-2024-23184.eml
+++ b/mailbox/opensearch/src/test/resources/eml/cve-2024-23184.eml
@@ -1,0 +1,45 @@
+MIME-Version: 1.0
+Subject: Test
+From: Benoit TELLIER <btellier@linagora.com>
+To: Benoit TELLIER <btellier@linagora.com>
+Date: Tue, 13 Feb 2024 23:01:18 +0000
+Message-ID: <Mime4j.17d.c7b7d059b303c215.18da4b4076b@linagora.com>
+Content-Type: multipart/mixed;
+ boundary="-=Part.17f.732e3d28e1c76db4.18da4b40791.62ef5e3fa995057d=-"
+
+---=Part.17f.732e3d28e1c76db4.18da4b40791.62ef5e3fa995057d=-
+Content-Type: multipart/alternative;
+ boundary="-=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=-"
+
+---=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=-
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+Test
+
+---=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=-
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>Test<br><br></div>
+
+---=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=---
+
+---=Part.17f.732e3d28e1c76db4.18da4b40791.62ef5e3fa995057d=-
+Content-Type: application/json; name="=?US-ASCII?Q?id=5Frsa.txt?="
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+
+c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFDQVFDa0dXMkp5c2lKR2hQZXdBOXRr
+bVFFQm5EVjRaQ0llLy92ZFoyV0RybnZiNlZLQzdpWldjODFpU1ZkTFcxUkRBTll4c3ExN0dQanpV
+OFlWdk9sRkFJSk1WTm9ESWhuQWtYOU9VUUJpd1hpOHlHZ3FLNGR0RmIxczJBRzNrQmxNUFFJOE5K
+MkpLT2Z5MW51VnJubEtoVDlCVnpYMm5iSjNOak9PZlkxQlJEaDZZcVl1a2RuejBUT2k1Rkp1YUJT
+NDZQemx3eWdIa0dzeXBLVHM2Y2FUNjBRdjl3eWFadm4yenN1RmNML3o2Mmd3aGZyZGFsakF1UGRX
+cERlNG1IRVFmMXA2SXNRMDdPb0lwTmRHQ0tLZHRZQlVTcktzTXRpMllLUGZpSzB2WGU1L3owRWJE
+VlRja1BrY3NwQ2cwYVZuZTB2eFVsRGt2U2pwV2tiQkZ0YTk5ekJjOVlJL0ROK28vRmtONlFTdXV5
+U29tNDZkamZpUjdqSzNMRmJKUkhaem9BblNvaTZvRlR0MW1LWjNzam44bnZWUG1PV3pJWHY0Tm1O
+R1ExZHFrV1hXcUtyQjlIZUZiQnRPWVAzaEkxQ0kvaVhNbVR1SkdvcHVTUmlTNW1QZXlSQWV6VGtk
+UG8vZ2NSVWNzbklhVW1EallUWHBFNzU3Yk5LWVNHbFJsS3FrbEhKc2JveEdTK0NaVzBJS2dZeTdG
+cmZRZ1FGMTdvaUpWM1JJQ1VHcU9rM1I2VnZOYlhlL2VmZS9IT24xd0lZUS9qVGRzY0hCamRIM2FF
+MmY4Y3dVS1IzNUtWNlJ1SE4vYVpiekxiVkJxUEMvUTcwd3NMQlloV29Da1dRMElUUmxGV2N3bnN3
+VTE5NnlGWkVHSmthOUNEaHZQdUVBV0NLWnFRT3gyMnRoYWVSQlE9PSBiZW53YUBob3Jpem9uCg==

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
         <activemq.version>6.1.6</activemq.version>
-        <apache-mime4j.version>0.8.12</apache-mime4j.version>
+        <apache-mime4j.version>0.8.13-SNAPSHOT</apache-mime4j.version>
         <apache.openjpa.version>4.0.0</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>
         <log4j2.version>2.23.1</log4j2.version>

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
@@ -19,10 +19,9 @@
 
 package org.apache.james.protocols.api;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
-
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -216,7 +215,7 @@ public class ProtocolSessionImpl implements ProtocolSession {
      */
     @Override
     public Charset getCharset() {
-        return US_ASCII;
+        return StandardCharsets.UTF_8;
     }
 
     /**

--- a/server/container/core/src/main/java/org/apache/james/server/core/InternetHeadersInputStream.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/InternetHeadersInputStream.java
@@ -69,7 +69,7 @@ public class InternetHeadersInputStream extends InputStream {
             if (!headerLines.hasMoreElements()) {
                 line += LINE_SEPERATOR;
             }
-            currLine = line.getBytes(StandardCharsets.US_ASCII);
+            currLine = line.getBytes(StandardCharsets.UTF_8);
             return true;
         } else {
             return false;

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailHeaders.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailHeaders.java
@@ -39,8 +39,8 @@ import org.apache.mailet.base.RFC2822Headers;
  * </pre>
  */
 public class MailHeaders extends InternetHeaders implements Serializable, Cloneable {
-
     private static final long serialVersionUID = 238748126601L;
+    private static final boolean ALLOWUTF_8 = true;
     private boolean modified = false;
     private long size = -1;
 
@@ -67,7 +67,7 @@ public class MailHeaders extends InternetHeaders implements Serializable, Clonea
      */
     public MailHeaders(InputStream in) throws MessagingException {
         super();
-        load(in);
+        load(in, ALLOWUTF_8);
     }
 
     /**

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/AddDeliveredToHeaderTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/AddDeliveredToHeaderTest.java
@@ -29,10 +29,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 
+import org.apache.james.jmap.mailet.filter.JMAPFiltering;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.probe.DataProbe;
 import org.apache.james.transport.mailets.AddDeliveredToHeader;
+import org.apache.james.transport.mailets.LocalDelivery;
+import org.apache.james.transport.mailets.RecipientRewriteTable;
+import org.apache.james.transport.mailets.RemoteDelivery;
+import org.apache.james.transport.mailets.ToProcessor;
+import org.apache.james.transport.mailets.VacationMailet;
+import org.apache.james.transport.matchers.All;
+import org.apache.james.transport.matchers.RecipientIsLocal;
+import org.apache.james.transport.matchers.SMTPAuthSuccessful;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.SMTPMessageSender;
 import org.apache.james.utils.TestIMAPClient;
@@ -43,7 +54,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 class AddDeliveredToHeaderTest {
-    public static final String RECIPIENT2 = "rené@" + DEFAULT_DOMAIN;
+    private static final String POSTMASTER = "postmaster@" + DEFAULT_DOMAIN;
+    public static final String RECIPIENT2_UTF8 = "rené@" + DEFAULT_DOMAIN;
+    public static final String RECIPIENT2 = "rene@" + DEFAULT_DOMAIN;
     @RegisterExtension
     public TestIMAPClient testIMAPClient = new TestIMAPClient();
     @RegisterExtension
@@ -53,7 +66,11 @@ class AddDeliveredToHeaderTest {
 
     @BeforeEach
     void setup(@TempDir File temporaryFolder) throws Exception {
-        jamesServer = TemporaryJamesServer.builder().build(temporaryFolder);
+        jamesServer = TemporaryJamesServer.builder()
+            .withMailetContainer(TemporaryJamesServer.defaultMailetContainerConfiguration()
+                .postmaster(POSTMASTER)
+                .putProcessor(transport()))
+            .build(temporaryFolder);
         jamesServer.start();
 
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
@@ -84,24 +101,59 @@ class AddDeliveredToHeaderTest {
 
     @Test
     void receivedMessagesShouldContainDeliveredToHeadersI8N() throws Exception {
-        String message = "FROM: " + RECIPIENT2 + "\r\n" +
+        jamesServer.getProbe(DataProbeImpl.class).addUserAliasMapping("rené", "james.org", RECIPIENT2);
+        String message = "FROM: " + RECIPIENT2_UTF8 + "\r\n" +
             "subject: testé\r\n" +
             "Content-Type: text/plain; charset=UTF-8\r\n" +
             "Content-Encoding: 8bit\r\n" +
             "\r\n" +
-            "contenté\r\n" +
-            ".\r\n";
+            "contenté\r\n";
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .authenticate(FROM, PASSWORD)
-            .sendMessageWithHeaders(FROM, RECIPIENT2, message);
+            .sendMessageWithHeaders(FROM, RECIPIENT2_UTF8, message);
+
+        Thread.sleep(1000);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
             .login(RECIPIENT2, PASSWORD)
             .select(TestIMAPClient.INBOX)
             .awaitMessage(awaitAtMostOneMinute);
-        assertThat(testIMAPClient.readFirstMessageHeaders())
-            .contains("René")
+
+        assertThat(testIMAPClient.readFirstMessage())
+            .contains(RECIPIENT2_UTF8)
             .contains("testé")
             .contains("contenté");
+    }
+
+    private ProcessorConfiguration.Builder transport() {
+        return ProcessorConfiguration.transport()
+            .enableJmx(false)
+            .addMailet(MailetConfiguration.builder()
+                .matcher(All.class)
+                .mailet(RecipientRewriteTable.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(RecipientIsLocal.class)
+                .mailet(VacationMailet.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(RecipientIsLocal.class)
+                .mailet(JMAPFiltering.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(RecipientIsLocal.class)
+                .mailet(LocalDelivery.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(SMTPAuthSuccessful.class)
+                .mailet(RemoteDelivery.class)
+                .addProperty("outgoingQueue", "outgoing")
+                .addProperty("delayTime", "5000, 100000, 500000")
+                .addProperty("maxRetries", "3")
+                .addProperty("maxDnsProblemRetries", "0")
+                .addProperty("deliveryThreads", "10")
+                .addProperty("sendpartial", "true")
+                .addProperty("bounceProcessor", "bounces"))
+            .addMailet(MailetConfiguration.BCC_STRIPPER)
+            .addMailet(MailetConfiguration.builder()
+                .matcher(All.class)
+                .mailet(ToProcessor.class)
+                .addProperty("processor", "error"));
     }
 }


### PR DESCRIPTION
CF https://issues.apache.org/jira/browse/JAMES-4133

Fails lamentably:

```
jakarta.mail.internet.AddressException: Invalid character in local-part (user account) at position 4 in 'ren��@james.org'
	at org.apache.james.core.MailAddress.parseUnquotedLocalPart(MailAddress.java:561)
	at org.apache.james.core.MailAddress.parseUnquotedLocalPartOrThrowException(MailAddress.java:272)
	at org.apache.james.core.MailAddress.<init>(MailAddress.java:193)
	at org.apache.james.protocols.smtp.core.RcptCmdHandler.doFilterChecks(RcptCmdHandler.java:157)
	at org.apache.james.protocols.smtp.core.AbstractHookableCmdHandler.onCommand(AbstractHookableCmdHandler.java:72)
	at org.apache.james.protocols.smtp.core.AbstractHookableCmdHandler.onCommand(AbstractHookableCmdHandler.java:50)
	at org.apache.james.protocols.api.handler.CommandDispatcher.dispatchCommandHandlers(CommandDispatcher.java:165)
	at org.apache.james.protocols.api.handler.CommandDispatcher.onLine(CommandDispatcher.java:142)
	at org.apache.james.protocols.netty.BasicChannelInboundHandler.channelRead(BasicChannelInboundHandler.java:196)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.access$600(AbstractChannelHandlerContext.java:61)
	at io.netty.channel.AbstractChannelHandlerContext$7.run(AbstractChannelHandlerContext.java:425)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.DefaultEventExecutor.run(DefaultEventExecutor.java:66)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```