### PR TITLE
[FIX] Attachment filename should be indexed when missing in the `Content-Disposition` header but exists in the `Content-Type` header

### DIFF
--- a/mailbox/opensearch/src/test/resources/eml/alternative.json
+++ b/mailbox/opensearch/src/test/resources/eml/alternative.json
@@ -3,8 +3,8 @@
     {
       "mediaType":"application",
       "subtype":"json",
-      "fileName":null,
-      "fileExtension":null,
+      "fileName":"id_rsa.txt",
+      "fileExtension":"txt",
       "contentDisposition":"attachment",
       "textContent":null
     }

--- a/mailbox/opensearch/src/test/resources/eml/attachments-filename-in-content-type.eml
+++ b/mailbox/opensearch/src/test/resources/eml/attachments-filename-in-content-type.eml
@@ -1,0 +1,48 @@
+MIME-Version: 1.0
+Subject: Hello xyz
+From: Bob <bob@linagora.com>
+To: alice@linagora.com
+Message-ID: <Mime4j.14.31ce45ac61ec422b.196e75ccf9b@linagora.com>
+User-Agent: Twake-Mail/0.15.3 Mozilla/5.0 (Macintosh; Intel Mac OS X
+ 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0
+ Safari/537.36
+Content-Type: multipart/mixed;
+ boundary="-=Part.16.2ce5c5497f23d613.196e75cd044.32ca13e0fd5dd663=-"
+
+---=Part.16.2ce5c5497f23d613.196e75cd044.32ca13e0fd5dd663=-
+Content-Type: multipart/alternative;
+ boundary="-=Part.15.4e5239b38c309d78.196e75cd043.9d6830842151817f=-"
+
+---=Part.15.4e5239b38c309d78.196e75cd043.9d6830842151817f=-
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT, de-DE
+Content-Language: vi-VN
+
+body
+
+
+---=Part.15.4e5239b38c309d78.196e75cd043.9d6830842151817f=-
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT, de-DE
+Content-Language: vi-VN
+
+<div>body<br><br></div>
+---=Part.15.4e5239b38c309d78.196e75cd043.9d6830842151817f=---
+
+---=Part.16.2ce5c5497f23d613.196e75cd044.32ca13e0fd5dd663=-
+Content-Type: text/plain; name="=?US-ASCII?Q?1.txt?="; charset=windows-1252
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+
+d2hhdGV2ZXIK
+
+---=Part.16.2ce5c5497f23d613.196e75cd044.32ca13e0fd5dd663=-
+Content-Type: text/plain; name="=?US-ASCII?Q?2.txt?="; charset=windows-1252
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+
+d2hhdGV2ZXIyCg==
+
+---=Part.16.2ce5c5497f23d613.196e75cd044.32ca13e0fd5dd663=---

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/mime/MimePartParser.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/mime/MimePartParser.java
@@ -129,8 +129,12 @@ public class MimePartParser {
             Optional.ofNullable(descriptor.getSubType())
                 .map(SubType::of)
                 .ifPresent(currentlyBuildMimePart::addSubType);
-            currentlyBuildMimePart.addContentDisposition(descriptor.getContentDispositionType())
-                .addFileName(descriptor.getContentDispositionFilename());
+            currentlyBuildMimePart.addContentDisposition(descriptor.getContentDispositionType());
+
+            Optional.ofNullable(descriptor.getContentDispositionFilename())
+                .or(() -> Optional.ofNullable(descriptor.getContentTypeParameters().get("name")))
+                .ifPresent(currentlyBuildMimePart::addFileName);
+
             extractCharset(descriptor);
         } catch (Exception e) {
             LOGGER.warn("Failed to extract mime body part description", e);

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/resources/eml/attachment-filename-in-content-type.eml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/resources/eml/attachment-filename-in-content-type.eml
@@ -1,0 +1,43 @@
+MIME-Version: 1.0
+Subject: test send mail with attachment filename search
+From: Bob <bob@linagora.com>
+To: "alice@gmail.com" <alice@gmail.com>
+Reply-To: bob@linagora.com
+Message-ID: <Mime4j.7.2182050b7626964a.196e6b48459@linagora.com>
+User-Agent: Twake-Mail/0.15.3 Mozilla/5.0 (Macintosh; Intel Mac OS X
+ 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0
+ Safari/537.36
+Content-Type: multipart/mixed;
+ boundary="-=Part.9.facdaad4d7d1e26d.196e6b48470.15f465553d6bace6=-"
+
+---=Part.9.facdaad4d7d1e26d.196e6b48470.15f465553d6bace6=-
+Content-Type: multipart/alternative;
+ boundary="-=Part.8.8fd856f88f8fdedd.196e6b48470.d48dd74354571387=-"
+
+---=Part.8.8fd856f88f8fdedd.196e6b48470.d48dd74354571387=-
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT, de-DE
+Content-Language: vi-VN
+
+body
+
+
+---=Part.8.8fd856f88f8fdedd.196e6b48470.d48dd74354571387=-
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT, de-DE
+Content-Language: vi-VN
+
+<div>body<br><br></div>
+---=Part.8.8fd856f88f8fdedd.196e6b48470.d48dd74354571387=---
+
+---=Part.9.facdaad4d7d1e26d.196e6b48470.15f465553d6bace6=-
+Content-Type: text/plain; name="=?US-ASCII?Q?filename.txt?=";
+ charset=windows-1252
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+
+d2hhdGV2ZXIgY29udGVudCA1OTUzNjI0NzY0Cg==
+
+---=Part.9.facdaad4d7d1e26d.196e6b48470.15f465553d6bace6=---

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
@@ -6706,6 +6706,50 @@ trait EmailQueryMethodContract {
   }
 
   @Test
+  def attachmentFilenameShouldBeSearchableWhenMissingInContentDispositionAndExistsInContentType(server: GuiceJamesServer): Unit = {
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(inbox(BOB))
+    val messageId = server.getProbe(classOf[MailboxProbeImpl])
+      .appendMessage(BOB.asString, MailboxPath.inbox(BOB), AppendCommand.from(
+        ClassLoaderUtils.getSystemResourceAsSharedStream("eml/attachment-filename-in-content-type.eml")))
+      .getMessageId
+
+    val request =
+      s"""{
+         |  "using": [
+         |    "urn:ietf:params:jmap:core",
+         |    "urn:ietf:params:jmap:mail"],
+         |  "methodCalls": [[
+         |    "Email/query",
+         |    {
+         |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |      "filter": {
+         |        "text": "filename"
+         |      }
+         |    },
+         |    "c1"]]
+         |}""".stripMargin
+
+    awaitAtMostTenSeconds.untilAsserted { () =>
+      val response = `given`
+        .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+        .body(request)
+      .when
+        .post
+      .`then`
+        .statusCode(SC_OK)
+        .contentType(JSON)
+        .extract
+        .body
+        .asString
+
+      assertThatJson(response)
+        .inPath("$.methodResponses[0][1].ids")
+        .isEqualTo(
+          s"""["${messageId.serialize()}"]""".stripMargin)
+    }
+  }
+
+  @Test
   def emailQueryShouldSupportAndOperator(server: GuiceJamesServer): Unit = {
     val message: Message = buildTestMessage
     server.getProbe(classOf[MailboxProbeImpl]).createMailbox(MailboxPath.inbox(BOB))


### PR DESCRIPTION
Make the attachment filename search more resilient.