### PR TITLE
JAMES-4133 Add support for unicode adddresses as defined in RFC6532.

### DIFF
--- a/core/src/main/java/org/apache/james/core/Domain.java
+++ b/core/src/main/java/org/apache/james/core/Domain.java
@@ -55,7 +55,17 @@ public class Domain implements Serializable {
         Preconditions.checkArgument(domain.length() <= MAXIMUM_DOMAIN_LENGTH,
             "Domain name length should not exceed %s characters", MAXIMUM_DOMAIN_LENGTH);
 
-        String domainWithoutBrackets = IDN.toASCII(removeBrackets(domain), IDN.ALLOW_UNASSIGNED);
+        String domainWithoutBrackets;
+        try {
+            domainWithoutBrackets = IDN.toASCII(removeBrackets(domain), IDN.ALLOW_UNASSIGNED);
+        } catch (IllegalArgumentException e) {
+            // IDN.toASCII's own message can be cryptic ("Empty label is not
+            // a legal name", "A prohibited code point was found in the
+            // input..."). Let's save wear and tear on the poor developer's
+            // brain.
+            throw new IllegalArgumentException(
+                "Domain '" + domain + "' is invalid according to IDNA: " + e.getMessage(), e);
+        }
         Preconditions.checkArgument(PART_CHAR_MATCHER.matchesAllOf(domainWithoutBrackets),
                                     "Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in %s", domain);
 
@@ -63,7 +73,8 @@ public class Domain implements Serializable {
             domainWithoutBrackets.contains(".xn--")) {
             domainWithoutBrackets = IDN.toUnicode(domainWithoutBrackets);
             Preconditions.checkArgument(!domainWithoutBrackets.startsWith("xn--") &&
-                                        !domainWithoutBrackets.contains(".xn--"));
+                                        !domainWithoutBrackets.contains(".xn--"),
+                                        "A-label could not be decoded to Unicode in %s", domain);
         }
 
         int pos = 0;

--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -521,6 +521,24 @@ public class MailAddress implements java.io.Serializable {
                             "characters exception <CR>, <LF>, quote (\"), or backslash (\\) at position " +
                             (pos + 1) + " in '" + address + "'");
                 }
+                // Same surrogate-pair check as in parseUnquotedLocalPart:
+                // unpaired or mis-ordered surrogates would produce
+                // ill-formed UTF-8 on output.
+                if (Character.isLowSurrogate(q)) {
+                    throw new AddressException("Unpaired UTF-16 low surrogate in quoted local-part at position " +
+                            (pos + 1) + " in '" + address + "'");
+                }
+                if (Character.isHighSurrogate(q)) {
+                    if (pos + 1 >= address.length()
+                            || !Character.isLowSurrogate(address.charAt(pos + 1))) {
+                        throw new AddressException("Unpaired UTF-16 high surrogate in quoted local-part at position " +
+                                (pos + 1) + " in '" + address + "'");
+                    }
+                    lpSB.append(q);
+                    lpSB.append(address.charAt(pos + 1));
+                    pos += 2;
+                    continue;
+                }
                 lpSB.append(q);
                 pos++;
             }
@@ -561,13 +579,35 @@ public class MailAddress implements java.io.Serializable {
                 //    unicode codepoint, but not <special> or <SP>
                 //<special> ::= "<" | ">" | "(" | ")" | "[" | "]" | "\" | "."
                 //    | "," | ";" | ":" | "@"  """ | the control
-                //    characters (ASCII codes 0 through 31 inclusive and
-                //    127)
+                //    characters (ASCII codes 0 through 31 inclusive,
+                //    127, and the C1 controls 128 through 159)
                 //<SP> ::= the space character (ASCII code 32)
                 char c = address.charAt(pos);
-                if (c <= 31 || c == 127 || c == ' ') {
+                if (c <= 31 || c == 127 || c == ' ' || (c >= 0x80 && c <= 0x9F)) {
                     throw new AddressException("Invalid character in local-part (user account) at position " +
                             (pos + 1) + " in '" + address + "'", address, pos + 1);
+                }
+                // Java strings are UTF-16, so a supplementary-plane
+                // codepoint (emoji, CJK extension, etc.) appears here as a
+                // high-surrogate followed by a low-surrogate. We must keep
+                // them paired so the address can serialise as well-formed
+                // UTF-8 (RFC 6532 §3.1) — a lone or mis-ordered surrogate
+                // would produce ill-formed UTF-8 octets on output.
+                if (Character.isLowSurrogate(c)) {
+                    throw new AddressException("Unpaired UTF-16 low surrogate in local-part at position " +
+                            (pos + 1) + " in '" + address + "'", address, pos + 1);
+                }
+                if (Character.isHighSurrogate(c)) {
+                    if (pos + 1 >= address.length()
+                            || !Character.isLowSurrogate(address.charAt(pos + 1))) {
+                        throw new AddressException("Unpaired UTF-16 high surrogate in local-part at position " +
+                                (pos + 1) + " in '" + address + "'", address, pos + 1);
+                    }
+                    lpSB.append(c);
+                    lpSB.append(address.charAt(pos + 1));
+                    pos += 2;
+                    lastCharDot = false;
+                    continue;
                 }
                 int i = 0;
                 while (i < SPECIAL.length) {

--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -20,6 +20,7 @@
 package org.apache.james.core;
 
 import java.net.IDN;
+import java.text.Normalizer;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -173,7 +174,13 @@ public class MailAddress implements java.io.Serializable {
      * @throws AddressException if the parse failed
      */
     public MailAddress(String address) throws AddressException {
-        address = address.trim();
+        // RFC 6532 §3.1 recommends NFC normalisation. Canonically-equivalent
+        // Unicode strings (for example U+00E9 vs U+0065 U+0301 — both render
+        // as "é") then produce equal MailAddress objects with equal hashCode
+        // values, which dedup, alias resolution and routing-table lookups
+        // rely on. NFC is a no-op for pure ASCII, so ASCII addresses are
+        // unaffected.
+        address = Normalizer.normalize(address.trim(), Normalizer.Form.NFC);
         int pos = 0;
 
         // Test if mail address has source routing information (RFC-821) and get rid of it!!

--- a/core/src/test/java/org/apache/james/core/DomainTest.java
+++ b/core/src/test/java/org/apache/james/core/DomainTest.java
@@ -1,0 +1,81 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+
+class DomainTest {
+    @Test
+    void testPlainDomain() {
+        Domain d1 = Domain.of("example.com");
+        assertThat(d1.name().equals(d1.asString()));
+        Domain d2 = Domain.of("Example.com");
+        assertThat(d2.name()).isNotEqualTo(d2.asString());
+        assertThat(d1.asString()).isEqualTo(d2.asString());
+    }
+
+    @Test
+    void testIPv4Domain() {
+        Domain d1 = Domain.of("192.0.4.1");
+        assertThat(d1.asString()).isEqualTo("192.0.4.1");
+    }
+
+    @Test
+    void testPunycodeIDN() {
+        Domain d1 = Domain.of("xn--gr-zia.example");
+        assertThat(d1.asString()).isEqualTo("grå.example");
+    }
+
+    @Test
+    void testDevanagariDomain() {
+        Domain d1 = Domain.of("डाटामेल.भारत");
+        assertThat(d1.asString()).isEqualTo(d1.name());
+    }
+
+    private static Stream<Arguments> malformedDomains() {
+        return Stream.of(
+                         "😊☺️.example", // emoji not permitted by IDNA
+                         "#.example", // really and truly not permitted
+                         "\uFEFF.example", // U+FEFF is the byte order mark
+                         "\u200C.example", // U+200C is a zero-width non-joiner
+                         "\u200Eibm.example" // U+200E is left-to-right
+                         )
+            .map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("malformedDomains")
+    void testMalformedDomains(String malformed) {
+        assertThatThrownBy(() -> Domain.of(malformed))
+            .as("rejecting malformed domain " + malformed)
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}
+
+

--- a/core/src/test/java/org/apache/james/core/DomainTest.java
+++ b/core/src/test/java/org/apache/james/core/DomainTest.java
@@ -76,6 +76,16 @@ class DomainTest {
             .as("rejecting malformed domain " + malformed)
             .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @ParameterizedTest
+    @MethodSource("malformedDomains")
+    void exceptionForMalformedDomainShouldNameTheOffendingInput(String malformed) {
+        // Without the offending input in the message, "Domain invalid
+        // according to IDNA" leaves a future debugger guessing what
+        // string actually triggered it.
+        assertThatThrownBy(() -> Domain.of(malformed))
+            .hasMessageContaining(malformed);
+    }
 }
 
 

--- a/core/src/test/java/org/apache/james/core/MailAddressTest.java
+++ b/core/src/test/java/org/apache/james/core/MailAddressTest.java
@@ -22,6 +22,7 @@ package org.apache.james.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.text.Normalizer;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -327,6 +328,60 @@ class MailAddressTest {
     void stripDetailsShouldBePreciseWithMultipleCharacterDelimiter() throws AddressException {
         MailAddress mailAddress = new MailAddress("localpart---details@example.com");
         assertThat(mailAddress.stripDetails("--")).isEqualTo("localpart@example.com");
+    }
+
+    // RFC 6532 §3.1 — NFC normalisation
+
+    @Test
+    void nfcAndNfdFormsOfSameAddressShouldCompareEqual() throws AddressException {
+        // "pelé" as NFC: p, e, l, U+00E9
+        MailAddress nfc = new MailAddress("pelé@example.com");
+        // "pelé" as NFD: p, e, l, U+0065, U+0301 (combining acute)
+        MailAddress nfd = new MailAddress("pelé@example.com");
+
+        assertThat(nfc).isEqualTo(nfd);
+        assertThat(nfc.hashCode()).isEqualTo(nfd.hashCode());
+        assertThat(nfc.asString()).isEqualTo(nfd.asString());
+    }
+
+    @Test
+    void nfdInputShouldBeStoredAsNfc() throws AddressException {
+        // Build the input string explicitly in NFD form: the local
+        // part is p, e, l, e, U+0301 (combining acute) — five codepoints.
+        String input = "pele\u0301@example.com";
+        int atIndex = input.indexOf('@');
+        int lIndex = input.indexOf('l');
+
+        // Sanity-check that the input is actually NFD: there should be
+        // two codepoints between 'l' and '@' (the 'e' and the
+        // combining acute).
+        assertThat(input.codePointCount(lIndex + 1, atIndex)).isEqualTo(2);
+
+        MailAddress address = new MailAddress(input);
+
+        // The local part comes back in NFC form (single U+00E9), not
+        // the two codepoints that went in.
+        assertThat(address.getLocalPart()).isEqualTo("pelé");
+        assertThat(address.getLocalPart().codePointAt(3)).isEqualTo(0x00E9);
+    }
+
+    @Test
+    void nfcNormalisationShouldBeNoopForAsciiAddresses() throws AddressException {
+        MailAddress address = new MailAddress("arnt@example.com");
+
+        assertThat(address.asString()).isEqualTo("arnt@example.com");
+    }
+
+    @Test
+    void nfcNormalisationShouldApplyToDomainsToo() throws AddressException {
+        // Unicode combining sequence in the domain's Unicode form. After
+        // construction, asString() should round-trip through NFC (whether the
+        // domain is ultimately stored as A-label or U-label is the Domain
+        // class's concern — here we only check that the two spellings collapse).
+        MailAddress nfc = new MailAddress("info@grå.org");
+        MailAddress nfd = new MailAddress("info@gra\u030A.org");
+
+        assertThat(nfc).isEqualTo(nfd);
     }
 
 }

--- a/core/src/test/java/org/apache/james/core/MailAddressTest.java
+++ b/core/src/test/java/org/apache/james/core/MailAddressTest.java
@@ -60,6 +60,9 @@ class MailAddressTest {
                 "Abc@10.42.0.1",
                 "Abc.123@example.com",
                 "Loïc.Accentué@voilà.fr8",
+                // Supplementary-plane codepoint as a properly-paired
+                // UTF-16 surrogate pair (U+1F600).
+                "abc\uD83D\uDE00@example.com",
                 "pelé@exemple.com",
                 "δοκιμή@παράδειγμα.δοκιμή",
                 "我買@屋企.香港",
@@ -112,6 +115,21 @@ class MailAddressTest {
                 "server-dev\\.@james.apache.org", // jakarta.mail is unable to handle this so we better reject it
                 "a..b@domain.com",
                 "sales@\u200Eibm.example", // U+200E is left-to-right
+                // Unpaired and mis-ordered UTF-16 surrogates would
+                // produce ill-formed UTF-8 on output, so we reject
+                // them: lone high surrogate at end, lone low
+                // surrogate, and a high surrogate not followed by
+                // a low one.
+                "abc\uD83D@example.com",
+                "abc\uDE00def@example.com",
+                "abc\uD83Ddef@example.com",
+                // C1 controls in the local part: rejected on the
+                // same grounds as C0. Tested with U+0080 (start),
+                // U+0085 (NEL — common in EBCDIC interop bugs),
+                // and U+009F (end of the C1 range).
+                "abc\u0080def@example.com",
+                "abc\u0085def@example.com",
+                "abc\u009Fdef@example.com",
                 // According to wikipedia this address is valid but as jakarta.mail is unable
                 // to work with it we shall rather reject them (note that this is not breaking retro-compatibility)
                 "mail.allow\\,d@james.apache.org")

--- a/mailbox/opensearch/src/test/resources/eml/cve-2024-23184.eml
+++ b/mailbox/opensearch/src/test/resources/eml/cve-2024-23184.eml
@@ -1,0 +1,45 @@
+MIME-Version: 1.0
+Subject: Test
+From: Benoit TELLIER <btellier@linagora.com>
+To: Benoit TELLIER <btellier@linagora.com>
+Date: Tue, 13 Feb 2024 23:01:18 +0000
+Message-ID: <Mime4j.17d.c7b7d059b303c215.18da4b4076b@linagora.com>
+Content-Type: multipart/mixed;
+ boundary="-=Part.17f.732e3d28e1c76db4.18da4b40791.62ef5e3fa995057d=-"
+
+---=Part.17f.732e3d28e1c76db4.18da4b40791.62ef5e3fa995057d=-
+Content-Type: multipart/alternative;
+ boundary="-=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=-"
+
+---=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=-
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+Test
+
+---=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=-
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>Test<br><br></div>
+
+---=Part.17e.48ac92d73c356567.18da4b40791.360a293e2f389efe=---
+
+---=Part.17f.732e3d28e1c76db4.18da4b40791.62ef5e3fa995057d=-
+Content-Type: application/json; name="=?US-ASCII?Q?id=5Frsa.txt?="
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+
+c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFDQVFDa0dXMkp5c2lKR2hQZXdBOXRr
+bVFFQm5EVjRaQ0llLy92ZFoyV0RybnZiNlZLQzdpWldjODFpU1ZkTFcxUkRBTll4c3ExN0dQanpV
+OFlWdk9sRkFJSk1WTm9ESWhuQWtYOU9VUUJpd1hpOHlHZ3FLNGR0RmIxczJBRzNrQmxNUFFJOE5K
+MkpLT2Z5MW51VnJubEtoVDlCVnpYMm5iSjNOak9PZlkxQlJEaDZZcVl1a2RuejBUT2k1Rkp1YUJT
+NDZQemx3eWdIa0dzeXBLVHM2Y2FUNjBRdjl3eWFadm4yenN1RmNML3o2Mmd3aGZyZGFsakF1UGRX
+cERlNG1IRVFmMXA2SXNRMDdPb0lwTmRHQ0tLZHRZQlVTcktzTXRpMllLUGZpSzB2WGU1L3owRWJE
+VlRja1BrY3NwQ2cwYVZuZTB2eFVsRGt2U2pwV2tiQkZ0YTk5ekJjOVlJL0ROK28vRmtONlFTdXV5
+U29tNDZkamZpUjdqSzNMRmJKUkhaem9BblNvaTZvRlR0MW1LWjNzam44bnZWUG1PV3pJWHY0Tm1O
+R1ExZHFrV1hXcUtyQjlIZUZiQnRPWVAzaEkxQ0kvaVhNbVR1SkdvcHVTUmlTNW1QZXlSQWV6VGtk
+UG8vZ2NSVWNzbklhVW1EallUWHBFNzU3Yk5LWVNHbFJsS3FrbEhKc2JveEdTK0NaVzBJS2dZeTdG
+cmZRZ1FGMTdvaUpWM1JJQ1VHcU9rM1I2VnZOYlhlL2VmZS9IT24xd0lZUS9qVGRzY0hCamRIM2FF
+MmY4Y3dVS1IzNUtWNlJ1SE4vYVpiekxiVkJxUEMvUTcwd3NMQlloV29Da1dRMElUUmxGV2N3bnN3
+VTE5NnlGWkVHSmthOUNEaHZQdUVBV0NLWnFRT3gyMnRoYWVSQlE9PSBiZW53YUBob3Jpem9uCg==

--- a/mdn/src/main/java/org/apache/james/mdn/MDN.java
+++ b/mdn/src/main/java/org/apache/james/mdn/MDN.java
@@ -38,6 +38,7 @@ import jakarta.mail.util.ByteArrayDataSource;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.javax.MimeMultipartReport;
+import org.apache.james.mdn.fields.AddressType;
 import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.dom.Entity;
 import org.apache.james.mime4j.dom.Message;
@@ -59,8 +60,14 @@ public class MDN {
     private static final NameValuePair UTF_8_CHARSET = new NameValuePair("charset", Charsets.UTF_8.name());
 
     public static final String DISPOSITION_CONTENT_TYPE = "message/disposition-notification";
+    public static final String GLOBAL_DISPOSITION_CONTENT_TYPE = "message/global-disposition-notification";
     public static final String REPORT_SUB_TYPE = "report";
     public static final String DISPOSITION_NOTIFICATION_REPORT_TYPE = "disposition-notification";
+
+    private static boolean isDispositionNotificationType(String mimeType) {
+        return mimeType.equals(DISPOSITION_CONTENT_TYPE)
+            || mimeType.equals(GLOBAL_DISPOSITION_CONTENT_TYPE);
+    }
 
     public static class Builder {
         private String humanReadableText;
@@ -170,7 +177,7 @@ public class MDN {
 
     public static Optional<MDNReport> extractMDNReport(List<Entity> entities) {
         return entities.stream()
-            .filter(entity -> entity.getMimeType().startsWith(DISPOSITION_CONTENT_TYPE))
+            .filter(entity -> isDispositionNotificationType(entity.getMimeType()))
             .findAny()
             .flatMap(entity -> {
                 try (InputStream inputStream = ((SingleBody) entity.getBody()).getInputStream()) {
@@ -187,7 +194,7 @@ public class MDN {
     }
 
     public boolean isReport(Entity entity) {
-        return entity.getMimeType().startsWith(DISPOSITION_CONTENT_TYPE);
+        return isDispositionNotificationType(entity.getMimeType());
     }
 
     private final String humanReadableText;
@@ -245,8 +252,24 @@ public class MDN {
 
     public BodyPart computeReportPart() throws MessagingException {
         MimeBodyPart mdnPart = new MimeBodyPart();
-        mdnPart.setContent(report.formattedValue(), DISPOSITION_CONTENT_TYPE);
+        mdnPart.setContent(report.formattedValue(), dispositionContentType());
         return mdnPart;
+    }
+
+    /**
+     * Per RFC 6533, emits {@code message/global-disposition-notification} when
+     * any recipient in the report uses the {@code utf-8} addr-type, otherwise
+     * the RFC 3798 form {@code message/disposition-notification}.
+     */
+    private String dispositionContentType() {
+        boolean finalIsUtf8 = report.getFinalRecipientField().getAddressType()
+            .equals(AddressType.UTF_8);
+        boolean originalIsUtf8 = report.getOriginalRecipientField()
+            .map(r -> r.getAddressType().equals(AddressType.UTF_8))
+            .orElse(false);
+        return finalIsUtf8 || originalIsUtf8
+            ? GLOBAL_DISPOSITION_CONTENT_TYPE
+            : DISPOSITION_CONTENT_TYPE;
     }
 
     public BodyPart computeOriginalMessagePart(Message message) throws MessagingException {
@@ -276,7 +299,7 @@ public class MDN {
         builder.addBodyPart(BodyPartBuilder.create()
             .use(new BasicBodyFactory())
             .setBody(report.formattedValue(), Charsets.UTF_8)
-            .setContentType(DISPOSITION_CONTENT_TYPE, UTF_8_CHARSET));
+            .setContentType(dispositionContentType(), UTF_8_CHARSET));
 
         return builder.build();
     }

--- a/mdn/src/main/java/org/apache/james/mdn/fields/AddressType.java
+++ b/mdn/src/main/java/org/apache/james/mdn/fields/AddressType.java
@@ -26,7 +26,22 @@ import com.google.common.base.Preconditions;
 public class AddressType {
     public static final AddressType DNS = new AddressType("dns");
     public static final AddressType RFC_822 = new AddressType("rfc822");
+    public static final AddressType UTF_8 = new AddressType("utf-8");
     public static final AddressType UNKNOWN = new AddressType("unknown");
+
+    /**
+     * Picks the appropriate addr-type per RFC 6533: {@link #UTF_8} when the
+     * address contains non-ASCII octets, otherwise {@link #RFC_822}.
+     */
+    public static AddressType pickFor(Text text) {
+        String value = text.formatted();
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 0x7F) {
+                return UTF_8;
+            }
+        }
+        return RFC_822;
+    }
 
     private final String type;
 

--- a/mdn/src/main/java/org/apache/james/mdn/fields/FinalRecipient.java
+++ b/mdn/src/main/java/org/apache/james/mdn/fields/FinalRecipient.java
@@ -57,7 +57,7 @@ public class FinalRecipient implements Field {
         public FinalRecipient build() {
             Preconditions.checkNotNull(finalRecipient);
 
-            return new FinalRecipient(addressType.orElse(AddressType.RFC_822), finalRecipient);
+            return new FinalRecipient(addressType.orElseGet(() -> AddressType.pickFor(finalRecipient)), finalRecipient);
         }
     }
 

--- a/mdn/src/main/java/org/apache/james/mdn/fields/OriginalRecipient.java
+++ b/mdn/src/main/java/org/apache/james/mdn/fields/OriginalRecipient.java
@@ -61,7 +61,7 @@ public class OriginalRecipient implements Field {
         public OriginalRecipient build() {
             Preconditions.checkNotNull(originalRecipient);
 
-            return new OriginalRecipient(addressType.orElse(AddressType.RFC_822), originalRecipient);
+            return new OriginalRecipient(addressType.orElseGet(() -> AddressType.pickFor(originalRecipient)), originalRecipient);
         }
     }
 

--- a/mdn/src/test/java/org/apache/james/mdn/MDNTest.java
+++ b/mdn/src/test/java/org/apache/james/mdn/MDNTest.java
@@ -521,4 +521,86 @@ class MDNTest {
     private String asString(Message message) throws Exception {
         return new String(DefaultMessageWriter.asBytes(message), StandardCharsets.UTF_8);
     }
+
+    // RFC 6533 section
+
+    @Test
+    void asMime4JMessageShouldUseLegacyContentTypeWhenRecipientsAreAscii() throws Exception {
+        MDN mdn = MDN.builder()
+            .humanReadableText("human")
+            .report(MINIMAL_REPORT)
+            .build();
+
+        assertThat(asString(mdn.asMime4JMessageBuilder().build()))
+            .contains("Content-Type: message/disposition-notification")
+            .doesNotContain("message/global-disposition-notification");
+    }
+
+    @Test
+    void asMime4JMessageShouldUseGlobalContentTypeWhenFinalRecipientIsUtf8() throws Exception {
+        MDNReport report = MDNReport.builder()
+            .finalRecipientField(FinalRecipient.builder()
+                .finalRecipient(Text.fromRawText("user@grå.org"))
+                .build())
+            .dispositionField(Disposition.builder()
+                .actionMode(DispositionActionMode.Automatic)
+                .sendingMode(DispositionSendingMode.Automatic)
+                .type(DispositionType.Deleted)
+                .build())
+            .build();
+        MDN mdn = MDN.builder()
+            .humanReadableText("human")
+            .report(report)
+            .build();
+
+        assertThat(asString(mdn.asMime4JMessageBuilder().build()))
+            .contains("Content-Type: message/global-disposition-notification");
+    }
+
+    @Test
+    void parseShouldAcceptGlobalDispositionNotificationContentType() throws Exception {
+        MDNReport parsed = parseReportWithContentType(
+            "Final-Recipient: utf-8; user@grå.org\r\n" +
+                "Disposition: automatic-action/MDN-sent-automatically;processed/error,failed\r\n",
+            "message/global-disposition-notification");
+
+        assertThat(parsed.getFinalRecipientField().getFinalRecipient())
+            .isEqualTo(Text.fromRawText("user@grå.org"));
+        assertThat(parsed.getFinalRecipientField().getAddressType())
+            .isEqualTo(AddressType.UTF_8);
+    }
+
+    @Test
+    void parsedReportShouldBeIndistinguishableAcrossFormatsForAsciiAddress() throws Exception {
+        // Same recipient, both addr-types — parsed reports should be equal on the
+        // fields callers actually care about (recipient + disposition).
+        MDNReport legacy = parseReportWithContentType(
+            "Final-Recipient: rfc822; user@example.com\r\n" +
+                "Disposition: automatic-action/MDN-sent-automatically;processed/error,failed\r\n",
+            "message/disposition-notification");
+        MDNReport global = parseReportWithContentType(
+            "Final-Recipient: rfc822; user@example.com\r\n" +
+                "Disposition: automatic-action/MDN-sent-automatically;processed/error,failed\r\n",
+            "message/global-disposition-notification");
+
+        assertThat(legacy.getFinalRecipientField().getFinalRecipient())
+            .isEqualTo(global.getFinalRecipientField().getFinalRecipient());
+        assertThat(legacy.getDispositionField())
+            .isEqualTo(global.getDispositionField());
+    }
+
+    private MDNReport parseReportWithContentType(String body, String contentType) throws Exception {
+        BodyPart mdnBodyPart = BodyPartBuilder
+            .create()
+            .setBody(SingleBodyBuilder.create().setText(body).buildText())
+            .setContentType(contentType)
+            .build();
+        Message message = Message.Builder.of()
+            .setBody(MultipartBuilder.create("report")
+                .addTextPart("first", StandardCharsets.UTF_8)
+                .addBodyPart(mdnBodyPart)
+                .build())
+            .build();
+        return MDN.parse(message).getReport();
+    }
 }

--- a/mdn/src/test/java/org/apache/james/mdn/fields/AddressTypeTest.java
+++ b/mdn/src/test/java/org/apache/james/mdn/fields/AddressTypeTest.java
@@ -86,4 +86,21 @@ class AddressTypeTest {
         assertThat(addressType.getType())
             .isEqualTo("ab");
     }
+
+    @Test
+    void utf8ConstantShouldHoldRfc6533Value() {
+        assertThat(AddressType.UTF_8.getType()).isEqualTo("utf-8");
+    }
+
+    @Test
+    void pickForShouldReturnRfc822ForAsciiAddress() {
+        assertThat(AddressType.pickFor(Text.fromRawText("user@example.com")))
+            .isEqualTo(AddressType.RFC_822);
+    }
+
+    @Test
+    void pickForShouldReturnUtf8ForNonAsciiAddress() {
+        assertThat(AddressType.pickFor(Text.fromRawText("user@grå.org")))
+            .isEqualTo(AddressType.UTF_8);
+    }
 }

--- a/mdn/src/test/java/org/apache/james/mdn/fields/FinalRecipientTest.java
+++ b/mdn/src/test/java/org/apache/james/mdn/fields/FinalRecipientTest.java
@@ -73,6 +73,27 @@ class FinalRecipientTest {
     }
 
     @Test
+    void typeShouldDefaultToUtf8WhenAddressContainsNonAscii() {
+        // RFC 6533 §3.1: use the utf-8 addr-type when the address contains UTF-8
+        Text address = Text.fromRawText("arnt@grå.org");
+
+        assertThat(FinalRecipient.builder()
+                .finalRecipient(address)
+                .build()
+                .getAddressType())
+            .isEqualTo(AddressType.UTF_8);
+    }
+
+    @Test
+    void formattedValueShouldDisplayUtf8TypeForNonAsciiAddress() {
+        assertThat(FinalRecipient.builder()
+                .finalRecipient(Text.fromRawText("arnt@grå.org"))
+                .build()
+                .formattedValue())
+            .isEqualTo("Final-Recipient: utf-8; arnt@grå.org");
+    }
+
+    @Test
     void formattedValueShouldDisplayAddress() {
         assertThat(FinalRecipient.builder()
                 .finalRecipient(Text.fromRawText("Plop"))

--- a/mdn/src/test/java/org/apache/james/mdn/fields/OriginalRecipientTest.java
+++ b/mdn/src/test/java/org/apache/james/mdn/fields/OriginalRecipientTest.java
@@ -73,6 +73,17 @@ class OriginalRecipientTest {
     }
 
     @Test
+    void addressTypeShouldDefaultToUtf8WhenAddressContainsNonAscii() {
+        Text address = Text.fromRawText("arnt@grå.org");
+
+        assertThat(OriginalRecipient.builder()
+                .originalRecipient(address)
+                .build()
+                .getAddressType())
+            .isEqualTo(AddressType.UTF_8);
+    }
+
+    @Test
     void formattedValueShouldDisplayAddress() {
         assertThat(OriginalRecipient.builder()
                 .originalRecipient(ADDRESS)

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
         <activemq.version>6.1.6</activemq.version>
-        <apache-mime4j.version>0.8.12</apache-mime4j.version>
+        <apache-mime4j.version>0.8.13-SNAPSHOT</apache-mime4j.version>
         <apache.openjpa.version>4.0.0</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>
         <log4j2.version>2.23.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
         <activemq.version>6.1.6</activemq.version>
-        <apache-mime4j.version>0.8.13-SNAPSHOT</apache-mime4j.version>
+        <apache-mime4j.version>0.8.13</apache-mime4j.version>
         <apache.openjpa.version>4.0.0</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>
         <log4j2.version>2.23.1</log4j2.version>

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/AbstractProtocolTransport.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/AbstractProtocolTransport.java
@@ -85,7 +85,12 @@ public abstract class AbstractProtocolTransport implements ProtocolTransport {
                 builder.append(CRLF);
             }
         }
-        return builder.toString().getBytes(StandardCharsets.US_ASCII);
+        // RFC 6531 §3.7.4.2: when a server echoes a UTF-8 mailbox address back
+        // to the client, those octets are UTF-8; all other reply content stays
+        // ASCII. UTF-8 is a strict superset of ASCII, so encoding the whole
+        // reply in UTF-8 preserves ASCII-only replies byte-for-byte while
+        // allowing non-ASCII addresses to survive the echo.
+        return builder.toString().getBytes(StandardCharsets.UTF_8);
     }
 
     /**

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
@@ -19,10 +19,9 @@
 
 package org.apache.james.protocols.api;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
-
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -216,7 +215,7 @@ public class ProtocolSessionImpl implements ProtocolSession {
      */
     @Override
     public Charset getCharset() {
-        return US_ASCII;
+        return StandardCharsets.UTF_8;
     }
 
     /**

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConstants.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/ImapConstants.java
@@ -104,7 +104,9 @@ public interface ImapConstants {
     Capability SUPPORTS_UIDPLUS = Capability.of("UIDPLUS");
 
     Capability SUPPORTS_ANNOTATION = Capability.of("METADATA");
-    
+
+    Capability SUPPORTS_UTF8_ACCEPT = Capability.of("UTF8=ACCEPT");
+
     String INBOX_NAME = "INBOX";
 
     String MIME_TYPE_TEXT = "TEXT";

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/ImapRequestLineReader.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/ImapRequestLineReader.java
@@ -754,7 +754,7 @@ public abstract class ImapRequestLineReader {
      */
     protected String consumeQuoted(Charset charset) throws DecodingException {
         if (charset == null) {
-            return consumeQuoted(US_ASCII);
+            return consumeQuoted(UTF_8);
         } else {
             // The 1st character must be '"'
             consumeChar('"');

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/ImapRequestLineReader.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/ImapRequestLineReader.java
@@ -20,6 +20,7 @@
 package org.apache.james.imap.decode;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -291,6 +292,7 @@ public abstract class ImapRequestLineReader {
 
     protected char nextChar; // unknown
     protected boolean nextSeen = false;
+    private boolean utf8Accept;
     private final StringBuilder stringBuilder = new StringBuilder();
 
     /**
@@ -489,7 +491,25 @@ public abstract class ImapRequestLineReader {
      * 
      */
     public String mailbox() throws DecodingException {
-       return ModifiedUtf7.decodeModifiedUTF7(mailboxUTF7());
+        if (utf8Accept) {
+            String mailbox = astring(UTF_8);
+            if (mailbox.equalsIgnoreCase(ImapConstants.INBOX_NAME)) {
+                return ImapConstants.INBOX_NAME;
+            }
+            return mailbox;
+        }
+        return ModifiedUtf7.decodeModifiedUTF7(mailboxUTF7());
+    }
+
+    /**
+     * When set, {@link #mailbox()} treats the astring as UTF-8 and does not
+     * run Modified UTF-7 decoding. Callers should set this from
+     * {@code EnableProcessor.getEnabledCapabilities(session).contains(SUPPORTS_UTF8_ACCEPT)}
+     * after the session state is known.
+     */
+    public ImapRequestLineReader setUtf8Accept(boolean utf8Accept) {
+        this.utf8Accept = utf8Accept;
+        return this;
     }
 
     /**
@@ -501,7 +521,8 @@ public abstract class ImapRequestLineReader {
      * variants of ;; INBOX (e.g. "iNbOx") MUST be interpreted as INBOX ;; not
      * as an astring.
      * 
-     * Be aware that mailbox names are encoded via a modified UTF7. For more information RFC3501
+     * Be aware that mailbox names are encoded via a modified UTF7 in unextended
+     * IMAP. For more information see RFC3501. RFC9755 changes this.
      */
     public String mailboxUTF7() throws DecodingException {
         String mailbox = astring();

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
@@ -22,6 +22,7 @@ package org.apache.james.imap.encode.base;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import jakarta.mail.Flags;
@@ -63,6 +64,8 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
     private final FastByteArrayOutputStream buffer;
 
     private boolean skipNextSpace;
+
+    private boolean utf8Accept;
 
     public ImapResponseComposerImpl(ImapResponseWriter writer, int bufferSize) {
         skipNextSpace = false;
@@ -239,8 +242,35 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
     
     @Override
     public ImapResponseComposer mailbox(String mailboxName) throws IOException {
-        quote(ModifiedUtf7.encodeModifiedUTF7(mailboxName));
+        if (utf8Accept) {
+            quoteUtf8(mailboxName);
+        } else {
+            quote(ModifiedUtf7.encodeModifiedUTF7(mailboxName));
+        }
         return this;
+    }
+
+    /**
+     * Per RFC 9755, when the client has ENABLEd UTF8=ACCEPT the server emits
+     * mailbox names and other strings as UTF-8 octets (not Modified UTF-7).
+     * Set this once per composer, from the session's enabled-capabilities set.
+     */
+    public ImapResponseComposerImpl setUtf8Accept(boolean utf8Accept) {
+        this.utf8Accept = utf8Accept;
+        return this;
+    }
+
+    private void quoteUtf8(String message) throws IOException {
+        space();
+        buffer.write(BYTE_DQUOTE);
+        byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
+        for (byte b : bytes) {
+            if (b == BYTE_BACK_SLASH || b == BYTE_DQUOTE) {
+                buffer.write(BYTE_BACK_SLASH);
+            }
+            buffer.write(b);
+        }
+        buffer.write(BYTE_DQUOTE);
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/base/ImapResponseComposerImpl.java
@@ -243,7 +243,7 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
     @Override
     public ImapResponseComposer mailbox(String mailboxName) throws IOException {
         if (utf8Accept) {
-            quoteUtf8(mailboxName);
+            quote(mailboxName);
         } else {
             quote(ModifiedUtf7.encodeModifiedUTF7(mailboxName));
         }
@@ -260,19 +260,6 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
         return this;
     }
 
-    private void quoteUtf8(String message) throws IOException {
-        space();
-        buffer.write(BYTE_DQUOTE);
-        byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
-        for (byte b : bytes) {
-            if (b == BYTE_BACK_SLASH || b == BYTE_DQUOTE) {
-                buffer.write(BYTE_BACK_SLASH);
-            }
-            buffer.write(b);
-        }
-        buffer.write(BYTE_DQUOTE);
-    }
-
     @Override
     public ImapResponseComposer commandName(ImapCommand command) throws IOException {
         return message(command.getNameAsBytes());
@@ -281,19 +268,27 @@ public class ImapResponseComposerImpl implements ImapConstants, ImapResponseComp
     @Override
     public ImapResponseComposer quote(String message) throws IOException {
         space();
-        final int length = message.length();
-       
         buffer.write(BYTE_DQUOTE);
-        for (int i = 0; i < length; i++) {
-            char character = message.charAt(i);
-            if (character == ImapConstants.BACK_SLASH || character == DQUOTE) {
-                buffer.write(BYTE_BACK_SLASH);
+        if (utf8Accept) {
+            for (byte b : message.getBytes(StandardCharsets.UTF_8)) {
+                if (b == BYTE_BACK_SLASH || b == BYTE_DQUOTE) {
+                    buffer.write(BYTE_BACK_SLASH);
+                }
+                buffer.write(b);
             }
-            // 7-bit ASCII only
-            if (character >= 128) {
-                buffer.write(BYTE_QUESTION);
-            } else {
-                buffer.write((byte) character);
+        } else {
+            final int length = message.length();
+            for (int i = 0; i < length; i++) {
+                char character = message.charAt(i);
+                if (character == ImapConstants.BACK_SLASH || character == DQUOTE) {
+                    buffer.write(BYTE_BACK_SLASH);
+                }
+                // 7-bit ASCII only
+                if (character >= 128) {
+                    buffer.write(BYTE_QUESTION);
+                } else {
+                    buffer.write((byte) character);
+                }
             }
         }
         buffer.write(BYTE_DQUOTE);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CapabilityProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CapabilityProcessor.java
@@ -26,6 +26,7 @@ import static org.apache.james.imap.api.ImapConstants.SUPPORTS_LITERAL_PLUS;
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_OBJECTID;
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_RFC3348;
 import static org.apache.james.imap.api.ImapConstants.SUPPORTS_SAVEDATE;
+import static org.apache.james.imap.api.ImapConstants.SUPPORTS_UTF8_ACCEPT;
 import static org.apache.james.mailbox.MailboxManager.MessageCapabilities.UniqueID;
 
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ import java.util.Set;
 import jakarta.inject.Inject;
 
 import org.apache.james.imap.api.ImapConfiguration;
+import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.message.Capability;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
@@ -49,7 +51,7 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Mono;
 
-public class CapabilityProcessor extends AbstractMailboxProcessor<CapabilityRequest> implements CapabilityImplementingProcessor {
+public class CapabilityProcessor extends AbstractMailboxProcessor<CapabilityRequest> implements CapabilityImplementingProcessor, PermitEnableCapabilityProcessor {
 
     private static final List<Capability> CAPS = ImmutableList.of(
         BASIC_CAPABILITIES,
@@ -58,7 +60,12 @@ public class CapabilityProcessor extends AbstractMailboxProcessor<CapabilityRequ
         SUPPORTS_I18NLEVEL_1,
         SUPPORTS_CONDSTORE,
         SUPPORTS_OBJECTID,
+        SUPPORTS_UTF8_ACCEPT,
         SUPPORTS_SAVEDATE);
+
+    // QRESYNC and CONDSTORE are also enableable, but handled by AbstractSelectionProcessor
+    // (which emits a HIGHESTMODSEQ response on enable), so they don't belong here.
+    private static final List<Capability> ENABLEABLE_CAPS = ImmutableList.of(SUPPORTS_UTF8_ACCEPT);
 
     private final List<CapabilityImplementingProcessor> capabilities = new ArrayList<>();
     private final Set<Capability> disabledCaps = new HashSet<>();
@@ -105,6 +112,16 @@ public class CapabilityProcessor extends AbstractMailboxProcessor<CapabilityRequ
     @Override
     public List<Capability> getImplementedCapabilities(ImapSession session) {
         return CAPS;
+    }
+
+    @Override
+    public List<Capability> getPermitEnableCapabilities(ImapSession session) {
+        return ENABLEABLE_CAPS;
+    }
+
+    @Override
+    public Mono<Void> enable(ImapMessage message, Responder responder, ImapSession session, Capability capability) {
+        return Mono.empty();
     }
     
     /**

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/ImapRequestLineReaderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/ImapRequestLineReaderTest.java
@@ -57,4 +57,40 @@ class ImapRequestLineReaderTest {
 
         assertThatThrownBy(() -> lineReader.nextNonSpaceChar()).isInstanceOf(DecodingException.class);
     }
+
+    @Test
+    void mailboxShouldDecodeModifiedUtf7WhenUtf8AcceptNotEnabled() throws Exception {
+        // Wire form "a&--b" is the Modified UTF-7 encoding of "a&-b".
+        inputStream = new ByteArrayInputStream("\"a&--b\" ".getBytes(StandardCharsets.US_ASCII));
+        lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
+
+        assertThat(lineReader.mailbox()).isEqualTo("a&-b");
+    }
+
+    @Test
+    void mailboxShouldDecodeUnicodeModifiedUtf7WhenUtf8AcceptNotEnabled() throws Exception {
+        // Wire form "gr&AOU-" is the Modified UTF-7 encoding of "grå".
+        inputStream = new ByteArrayInputStream("\"gr&AOU-\" ".getBytes(StandardCharsets.US_ASCII));
+        lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
+
+        assertThat(lineReader.mailbox()).isEqualTo("grå");
+    }
+
+    @Test
+    void mailboxShouldReturnRawStringWhenUtf8AcceptEnabledAndNameContainsAmpersand() throws Exception {
+        inputStream = new ByteArrayInputStream("\"a&-b\" ".getBytes(StandardCharsets.UTF_8));
+        lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
+        lineReader.setUtf8Accept(true);
+
+        assertThat(lineReader.mailbox()).isEqualTo("a&-b");
+    }
+
+    @Test
+    void mailboxShouldReturnRawUnicodeWhenUtf8AcceptEnabled() throws Exception {
+        inputStream = new ByteArrayInputStream("\"grå\" ".getBytes(StandardCharsets.UTF_8));
+        lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
+        lineReader.setUtf8Accept(true);
+
+        assertThat(lineReader.mailbox()).isEqualTo("grå");
+    }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/ImapRequestLineReaderTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/ImapRequestLineReaderTest.java
@@ -93,4 +93,15 @@ class ImapRequestLineReaderTest {
 
         assertThat(lineReader.mailbox()).isEqualTo("grå");
     }
+
+    @Test
+    void astringShouldDecodeUtf8QuotedStringByDefault() throws Exception {
+        // Many IMAP clients put UTF-8 in quoted-string arguments (e.g.
+        // SEARCH HEADER Subject "grå") without an explicit CHARSET. RFC 9051
+        // allows this, and we accept it regardless of UTF8=ACCEPT.
+        inputStream = new ByteArrayInputStream("\"grå\" ".getBytes(StandardCharsets.UTF_8));
+        lineReader = new ImapRequestStreamLineReader(inputStream, outputStream);
+
+        assertThat(lineReader.astring()).isEqualTo("grå");
+    }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/CapabilityProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/CapabilityProcessorTest.java
@@ -78,4 +78,18 @@ class CapabilityProcessorTest {
         Set<Capability> supportedCapabilities = testee.getSupportedCapabilities(null);
         assertThat(supportedCapabilities).doesNotContain(ImapConstants.SUPPORTS_CONDSTORE);
     }
+
+    @Test
+    void utf8AcceptShouldBeAdvertised() {
+        testee.configure(ImapConfiguration.builder().build());
+
+        Set<Capability> supportedCapabilities = testee.getSupportedCapabilities(null);
+        assertThat(supportedCapabilities).contains(ImapConstants.SUPPORTS_UTF8_ACCEPT);
+    }
+
+    @Test
+    void utf8AcceptShouldBeEnableable() {
+        assertThat(testee.getPermitEnableCapabilities(null))
+            .contains(ImapConstants.SUPPORTS_UTF8_ACCEPT);
+    }
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPProtocolHandlerChain.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPProtocolHandlerChain.java
@@ -48,6 +48,7 @@ import org.apache.james.protocols.smtp.core.WelcomeMessageHandler;
 import org.apache.james.protocols.smtp.core.esmtp.AuthCmdHandler;
 import org.apache.james.protocols.smtp.core.esmtp.EhloCmdHandler;
 import org.apache.james.protocols.smtp.core.esmtp.MailSizeEsmtpExtension;
+import org.apache.james.protocols.smtp.core.esmtp.SMTPUTF8Extension;
 import org.apache.james.protocols.smtp.core.esmtp.StartTlsCmdHandler;
 import org.apache.james.protocols.smtp.hook.AuthHook;
 import org.apache.james.protocols.smtp.hook.Hook;
@@ -99,6 +100,7 @@ public class SMTPProtocolHandlerChain extends ProtocolHandlerChainImpl {
         defaultHandlers.add(new VrfyCmdHandler());
         defaultHandlers.add(new DataCmdHandler(metricFactory));
         defaultHandlers.add(new MailSizeEsmtpExtension());
+        defaultHandlers.add(new SMTPUTF8Extension());
         defaultHandlers.add(new WelcomeMessageHandler());
         defaultHandlers.add(new PostmasterAbuseRcptHook());
         defaultHandlers.add(new ReceivedDataLineFilter());

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSession.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSession.java
@@ -44,6 +44,8 @@ public interface SMTPSession extends ProtocolSession {
     /** HELO or EHLO */
     AttachmentKey<String> CURRENT_HELO_MODE = AttachmentKey.of("CURRENT_HELO_MODE", String.class);
     AttachmentKey<String> CURRENT_HELO_NAME = AttachmentKey.of("CURRENT_HELO_NAME", String.class);
+    /** Set per-transaction when the client asserted the RFC 6531 SMTPUTF8 parameter on MAIL FROM. */
+    AttachmentKey<Boolean> SMTPUTF8_REQUESTED = AttachmentKey.of("SMTPUTF8_REQUESTED", Boolean.class);
 
     /**
      * Returns the service wide configuration

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSession.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSession.java
@@ -46,6 +46,10 @@ public interface SMTPSession extends ProtocolSession {
     AttachmentKey<String> CURRENT_HELO_NAME = AttachmentKey.of("CURRENT_HELO_NAME", String.class);
     /** Set per-transaction when the client asserted the RFC 6531 SMTPUTF8 parameter on MAIL FROM. */
     AttachmentKey<Boolean> SMTPUTF8_REQUESTED = AttachmentKey.of("SMTPUTF8_REQUESTED", Boolean.class);
+    /** The sender address exactly as it arrived on the wire (no bracket removal, no IDN normalisation). Used for echoing back in responses. */
+    AttachmentKey<String> RAW_SENDER_STRING = AttachmentKey.of("RAW_SENDER_STRING", String.class);
+    /** The recipient currently being processed, in wire form. See {@link #RAW_SENDER_STRING}. */
+    AttachmentKey<String> RAW_CURRENT_RECIPIENT_STRING = AttachmentKey.of("RAW_CURRENT_RECIPIENT_STRING", String.class);
 
     /**
      * Returns the service wide configuration

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AddressNormalization.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AddressNormalization.java
@@ -1,0 +1,65 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.smtp.core;
+
+import java.net.IDN;
+
+/**
+ * Address-string normalisation helpers shared by MAIL FROM and RCPT TO
+ * handling. Address validity proper lives in
+ * {@link org.apache.james.core.MailAddress}; this class is concerned only
+ * with the protocol-layer transforms.
+ */
+final class AddressNormalization {
+
+    private AddressNormalization() {
+    }
+
+    /**
+     * Convert any {@code xn--} labels (IDNA A-labels) in the domain part of
+     * {@code address} to their Unicode (U-label) form, leaving the local
+     * part untouched. Addresses without an {@code @} or without an
+     * {@code xn--} substring are returned unchanged.
+     *
+     * This runs regardless of whether the client declared SMTPUTF8, because
+     * an A-label-only address is purely ASCII on the wire and has always
+     * been valid SMTP. Storing the decoded U-label form lets upper layers
+     * reason about one canonical address.
+     *
+     * @throws IllegalArgumentException if any label still starts with
+     *         {@code xn--} after {@link IDN#toUnicode(String, int)} — which
+     *         indicates a malformed A-label that the IDN decoder could not
+     *         interpret.
+     */
+    static String aceLabelsToUnicode(String address) {
+        int at = address.lastIndexOf('@');
+        if (at < 0 || !address.substring(at + 1).contains("xn--")) {
+            return address;
+        }
+        String localPart = address.substring(0, at);
+        String domain = address.substring(at + 1);
+        String unicodeDomain = IDN.toUnicode(domain, IDN.ALLOW_UNASSIGNED);
+        if (unicodeDomain.startsWith("xn--") || unicodeDomain.contains(".xn--")) {
+            throw new IllegalArgumentException(
+                "Malformed A-label in domain: " + domain);
+        }
+        return localPart + "@" + unicodeDomain;
+    }
+}

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
@@ -72,6 +72,10 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
             DSNStatus.getStatus(DSNStatus.PERMANENT,
                     DSNStatus.ADDRESS_SYNTAX_SENDER)
                     + " Syntax error in sender address").immutable();
+    /** RFC 6531 §4.2: 553 5.6.7 when a non-ASCII sender is given without SMTPUTF8. */
+    private static final Response NON_ASCII_SENDER_WITHOUT_SMTPUTF8 = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_MAILBOX,
+            DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.CONTENT_NON_ASCII_ADDR)
+                    + " Non-ASCII addresses not permitted without SMTPUTF8").immutable();
     /**
      * A map of parameterHooks
      */
@@ -203,8 +207,14 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
                 LOGGER.info("Error parsing sender address: {}: did not start and end with < >", sender);
                 return SYNTAX_ERROR;
             }
+            String senderAddressString = removeBrackets(sender);
+            if (containsNonAscii(senderAddressString)
+                    && !session.getAttachment(SMTPSession.SMTPUTF8_REQUESTED, State.Transaction).orElse(Boolean.FALSE)) {
+                LOGGER.info("Rejected non-ASCII sender address without SMTPUTF8: {}", sender);
+                return NON_ASCII_SENDER_WITHOUT_SMTPUTF8;
+            }
             try {
-                MaybeSender senderAddress = toMaybeSender(removeBrackets(sender));
+                MaybeSender senderAddress = toMaybeSender(senderAddressString);
                 // Store the senderAddress in session map
                 session.setAttachment(SMTPSession.SENDER, senderAddress, State.Transaction);
             } catch (Exception pe) {
@@ -225,6 +235,15 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
         }
         return MaybeSender.of(new MailAddress(
             appendDefaultDomainIfNeeded(senderAsString)));
+    }
+
+    private static boolean containsNonAscii(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) > 0x7F) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String removeBrackets(String input) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
@@ -76,6 +76,9 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
     private static final Response NON_ASCII_SENDER_WITHOUT_SMTPUTF8 = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_MAILBOX,
             DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.CONTENT_NON_ASCII_ADDR)
                     + " Non-ASCII addresses not permitted without SMTPUTF8").immutable();
+    private static final Response INVALID_IDN_SENDER = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,
+            DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.ADDRESS_SYNTAX_SENDER)
+                    + " Invalid A-label (xn--) in sender domain").immutable();
     /**
      * A map of parameterHooks
      */
@@ -108,11 +111,17 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
     private Response doMAIL(SMTPSession session) {
         StringBuilder responseBuffer = new StringBuilder();
         MaybeSender sender = session.getAttachment(SMTPSession.SENDER, State.Transaction).orElse(MaybeSender.nullSender());
+        // Echo the sender back in the exact form the client sent it. RFC 6531
+        // §3.7.4.2 restricts server responses to ASCII unless SMTPUTF8 is
+        // asserted, and also lets us preserve the client's choice of
+        // A-label (xn--) vs U-label when they sent ACE form.
+        String echo = session.getAttachment(SMTPSession.RAW_SENDER_STRING, State.Transaction)
+                .orElse(sender.asString());
         responseBuffer.append(
                 DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.ADDRESS_OTHER))
                 .append(" Sender <");
         if (!sender.isNullSender()) {
-            responseBuffer.append(sender.asString());
+            responseBuffer.append(echo);
         }
         responseBuffer.append("> OK");
 
@@ -208,10 +217,17 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
                 return SYNTAX_ERROR;
             }
             String senderAddressString = removeBrackets(sender);
+            session.setAttachment(SMTPSession.RAW_SENDER_STRING, senderAddressString, State.Transaction);
             if (containsNonAscii(senderAddressString)
                     && !session.getAttachment(SMTPSession.SMTPUTF8_REQUESTED, State.Transaction).orElse(Boolean.FALSE)) {
                 LOGGER.info("Rejected non-ASCII sender address without SMTPUTF8: {}", sender);
                 return NON_ASCII_SENDER_WITHOUT_SMTPUTF8;
+            }
+            try {
+                senderAddressString = AddressNormalization.aceLabelsToUnicode(senderAddressString);
+            } catch (IllegalArgumentException e) {
+                LOGGER.info("Rejected sender address with invalid A-label: {}", sender);
+                return INVALID_IDN_SENDER;
             }
             try {
                 MaybeSender senderAddress = toMaybeSender(senderAddressString);

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
@@ -66,6 +66,9 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
     private static final Response NON_ASCII_RECIPIENT_WITHOUT_SMTPUTF8 = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_MAILBOX,
             DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.CONTENT_NON_ASCII_ADDR)
                     + " Non-ASCII addresses not permitted without SMTPUTF8").immutable();
+    private static final Response INVALID_IDN_RECIPIENT = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,
+            DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.ADDRESS_SYNTAX)
+                    + " Invalid A-label (xn--) in recipient domain").immutable();
 
     @Inject
     public RcptCmdHandler(MetricFactory metricFactory) {
@@ -91,10 +94,14 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
         rcptColl.add(recipientAddress);
         session.setAttachment(SMTPSession.RCPT_LIST, rcptColl, State.Transaction);
 
+        // Echo the recipient back in the exact form the client sent it. See
+        // the matching comment in MailCmdHandler.doMAIL — RFC 6531 §3.7.4.2.
+        String echo = session.getAttachment(SMTPSession.RAW_CURRENT_RECIPIENT_STRING, State.Transaction)
+                .orElseGet(recipientAddress::asString);
         StringBuilder response = new StringBuilder();
         String status = DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.ADDRESS_VALID);
         response.append(status)
-                .append(" Recipient <").append(recipientAddress).append("> OK");
+                .append(" Recipient <").append(echo).append("> OK");
 
         LOGGER.debug("RCPT TO {}", StringUtils.abbreviate(recipientAddress.asString(), 80));
 
@@ -157,10 +164,19 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
                     + getDefaultDomain();
         }
 
+        session.setAttachment(SMTPSession.RAW_CURRENT_RECIPIENT_STRING, recipient, State.Transaction);
+
         if (containsNonAscii(recipient)
                 && !session.getAttachment(SMTPSession.SMTPUTF8_REQUESTED, State.Transaction).orElse(Boolean.FALSE)) {
             LOGGER.info("Rejected non-ASCII recipient address without SMTPUTF8: {}", recipient);
             return NON_ASCII_RECIPIENT_WITHOUT_SMTPUTF8;
+        }
+
+        try {
+            recipient = AddressNormalization.aceLabelsToUnicode(recipient);
+        } catch (IllegalArgumentException e) {
+            LOGGER.info("Rejected recipient address with invalid A-label: {}", recipient);
+            return INVALID_IDN_RECIPIENT;
         }
 
         try {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
@@ -62,6 +62,10 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
     private static final Response SYNTAX_ERROR_ARGS = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_SYNTAX) + " Usage: RCPT TO:<recipient>").immutable();
     private static final Response SYNTAX_ERROR_DELIVERY = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_SYNTAX) + " Syntax error in parameters or arguments").immutable();
     private static final Response SYNTAX_ERROR_ADDRESS = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_MAILBOX, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.ADDRESS_SYNTAX) + " Syntax error in recipient address").immutable();
+    /** RFC 6531 §4.2: 553 5.6.7 when a non-ASCII recipient is given without SMTPUTF8. */
+    private static final Response NON_ASCII_RECIPIENT_WITHOUT_SMTPUTF8 = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_MAILBOX,
+            DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.CONTENT_NON_ASCII_ADDR)
+                    + " Non-ASCII addresses not permitted without SMTPUTF8").immutable();
 
     @Inject
     public RcptCmdHandler(MetricFactory metricFactory) {
@@ -153,6 +157,12 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
                     + getDefaultDomain();
         }
 
+        if (containsNonAscii(recipient)
+                && !session.getAttachment(SMTPSession.SMTPUTF8_REQUESTED, State.Transaction).orElse(Boolean.FALSE)) {
+            LOGGER.info("Rejected non-ASCII recipient address without SMTPUTF8: {}", recipient);
+            return NON_ASCII_RECIPIENT_WITHOUT_SMTPUTF8;
+        }
+
         try {
             recipientAddress = new MailAddress(recipient);
         } catch (Exception pe) {
@@ -193,6 +203,15 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
         session.setAttachment(CURRENT_RECIPIENT, recipientAddress, State.Transaction);
 
         return null;
+    }
+
+    private static boolean containsNonAscii(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) > 0x7F) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String getContext(SMTPSession session, MailAddress recipientAddress, String recipient) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/ReceivedHeaderGenerator.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/ReceivedHeaderGenerator.java
@@ -40,6 +40,10 @@ public class ReceivedHeaderGenerator {
     private static final String ESMTPSA = "ESMTPSA";
     private static final String ESMTP = "ESMTP";
     private static final String ESMTPS = "ESMTPS";
+    private static final String UTF8SMTP = "UTF8SMTP";
+    private static final String UTF8SMTPA = "UTF8SMTPA";
+    private static final String UTF8SMTPS = "UTF8SMTPS";
+    private static final String UTF8SMTPSA = "UTF8SMTPSA";
     private final ProtocolSession.AttachmentKey<Integer> mtPriority = ProtocolSession.AttachmentKey.of("MT-PRIORITY", Integer.class);
 
     /**
@@ -48,24 +52,32 @@ public class ReceivedHeaderGenerator {
     protected String getServiceType(SMTPSession session, String heloMode) {
         // Check if EHLO was used
         if (EHLO.equals(heloMode)) {
+            // See RFC 6531 §4.3:
+            // The new keyword "UTF8SMTP" indicates the use of ESMTP when
+            // the SMTPUTF8 extension is also used; the "A" / "S" / "SA"
+            // suffixes have the same meaning as in the E* keywords.
+            boolean smtpUtf8 = session.getAttachment(SMTPSession.SMTPUTF8_REQUESTED, ProtocolSession.State.Transaction)
+                .orElse(Boolean.FALSE);
             // Not successful auth
             if (session.getUsername() == null) {
                 if (session.isTLSStarted()) {
-                    return ESMTPS;
+                    return smtpUtf8 ? UTF8SMTPS : ESMTPS;
                 } else {
-                    return ESMTP;
+                    return smtpUtf8 ? UTF8SMTP : ESMTP;
                 }
             } else {
                 // See RFC3848:
                 // The new keyword "ESMTPA" indicates the use of ESMTP when the SMTP
                 // AUTH [3] extension is also used and authentication is successfully achieved.
                 if (session.isTLSStarted()) {
-                    return ESMTPSA;
+                    return smtpUtf8 ? UTF8SMTPSA : ESMTPSA;
                 } else {
-                    return ESMTPA;
+                    return smtpUtf8 ? UTF8SMTPA : ESMTPA;
                 }
             }
         } else {
+            // HELO was used (not EHLO), so SMTPUTF8 cannot have been
+            // negotiated — the extension requires EHLO. Plain SMTP only.
             return SMTP;
         }
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/SMTPUTF8Extension.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/SMTPUTF8Extension.java
@@ -1,0 +1,61 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.smtp.core.esmtp;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.james.protocols.api.ProtocolSession.State;
+import org.apache.james.protocols.smtp.SMTPSession;
+import org.apache.james.protocols.smtp.hook.HookResult;
+import org.apache.james.protocols.smtp.hook.MailParametersHook;
+
+/**
+ * RFC 6531 SMTPUTF8 extension.
+ *
+ * Advertises the {@code SMTPUTF8} EHLO keyword and parses the {@code SMTPUTF8}
+ * parameter on {@code MAIL FROM}. The parameter takes no value; its presence
+ * on a transaction authorises the use of UTF-8 in the envelope addresses.
+ *
+ * Gating of UTF-8 addresses themselves lives in {@code MailCmdHandler} /
+ * {@code RcptCmdHandler}, which reject non-ASCII addresses with 553 5.6.7
+ * when {@link SMTPSession#SMTPUTF8_REQUESTED} is not set.
+ */
+public class SMTPUTF8Extension implements MailParametersHook, EhloExtension {
+
+    private static final String[] MAIL_PARAMS = { "SMTPUTF8" };
+    private static final List<String> FEATURES = Collections.singletonList("SMTPUTF8");
+
+    @Override
+    public HookResult doMailParameter(SMTPSession session, String paramName, String paramValue) {
+        session.setAttachment(SMTPSession.SMTPUTF8_REQUESTED, Boolean.TRUE, State.Transaction);
+        return null;
+    }
+
+    @Override
+    public String[] getMailParamNames() {
+        return MAIL_PARAMS;
+    }
+
+    @Override
+    public List<String> getImplementedEsmtpFeatures(SMTPSession session) {
+        return FEATURES;
+    }
+}

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/dsn/DSNStatus.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/dsn/DSNStatus.java
@@ -290,6 +290,11 @@ public class DSNStatus {
      */
     public static final String CONTENT_CONVERSION_FAILED = "6.5";
 
+    /**
+     * Non-ASCII addresses not permitted for that sender/recipient (RFC 6531)
+     */
+    public static final String CONTENT_NON_ASCII_ADDR = "6.7";
+
 
     /**
      * Security or Policy Status

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPSServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPSServerTest.java
@@ -25,11 +25,13 @@ import org.apache.james.protocols.api.ProtocolServer;
 import org.apache.james.protocols.api.utils.BogusSslContextFactory;
 import org.apache.james.protocols.api.utils.BogusTrustManagerFactory;
 import org.apache.james.protocols.netty.Encryption;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 
 public abstract class AbstractSMTPSServerTest extends AbstractSMTPServerTest {
-    
-    
+
+
     @Override
     protected SMTPClient createClient() {
         SMTPSClient client = new SMTPSClient(true,BogusSslContextFactory.getClientContext());
@@ -37,11 +39,27 @@ public abstract class AbstractSMTPSServerTest extends AbstractSMTPServerTest {
         return client;
     }
 
-    
+
     @Override
     protected ProtocolServer createServer(Protocol protocol) {
         return createEncryptedServer(protocol, Encryption.createTls(BogusSslContextFactory.getServerContext()));
     }
-    
+
     protected abstract ProtocolServer createEncryptedServer(Protocol protocol, Encryption enc);
+
+    // The UTF-8 "accepted" tests use a raw TCP socket to control bytes on the
+    // wire. That does not speak TLS, so skip those cases under SMTPS — the plain
+    // variant covers the server-side logic. Rejection tests still work under
+    // SMTPS via the regular SMTPClient path.
+    @Override
+    @Test
+    @Disabled("Raw-socket UTF-8 test is not SSL-aware; covered by NettySMTPServerTest")
+    void mailFromWithNonAsciiSenderShouldBeAcceptedWhenSmtpUtf8IsAsserted() {
+    }
+
+    @Override
+    @Test
+    @Disabled("Raw-socket UTF-8 test is not SSL-aware; covered by NettySMTPServerTest")
+    void rcptToWithNonAsciiRecipientShouldBeAcceptedWhenSmtpUtf8IsAsserted() {
+    }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPSServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPSServerTest.java
@@ -62,4 +62,34 @@ public abstract class AbstractSMTPSServerTest extends AbstractSMTPServerTest {
     @Disabled("Raw-socket UTF-8 test is not SSL-aware; covered by NettySMTPServerTest")
     void rcptToWithNonAsciiRecipientShouldBeAcceptedWhenSmtpUtf8IsAsserted() {
     }
+
+    @Override
+    @Test
+    @Disabled("Raw-socket test is not SSL-aware; covered by NettySMTPServerTest")
+    void mailFromWithAceLabelDomainShouldBeAcceptedWithoutSmtpUtf8() {
+    }
+
+    @Override
+    @Test
+    @Disabled("Raw-socket test is not SSL-aware; covered by NettySMTPServerTest")
+    void rcptToWithAceLabelDomainShouldBeAcceptedWithoutSmtpUtf8() {
+    }
+
+    @Override
+    @Test
+    @Disabled("Raw-socket test is not SSL-aware; covered by NettySMTPServerTest")
+    void mailFromWithMalformedAceLabelShouldBeRejected() {
+    }
+
+    @Override
+    @Test
+    @Disabled("Raw-socket test is not SSL-aware; covered by NettySMTPServerTest")
+    void rcptToWithMalformedAceLabelShouldBeRejected() {
+    }
+
+    @Override
+    @Test
+    @Disabled("Raw-socket test is not SSL-aware; covered by NettySMTPServerTest")
+    void aceLabelDomainsShouldBeExposedToHooksAsUnicode() {
+    }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -1112,6 +1112,138 @@ public abstract class AbstractSMTPServerTest {
         }
     }
 
+    @Test
+    void aceLabelDomainsShouldBeExposedToHooksAsUnicode() throws Exception {
+        // Drive a full transaction with ACE-form addresses on the wire, then
+        // inspect the envelope that TestMessageHook captured: both sender and
+        // recipient should be in U-label form (grå.org), not the ACE form the
+        // client sent.
+        TestMessageHook hook = new TestMessageHook();
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(hook));
+            server.bind();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+
+            rawUtf8Exchange(bindedAddress,
+                "EHLO localhost\r\n",
+                "MAIL FROM:<arnt@xn--gr-zia.org>\r\n",
+                "RCPT TO:<someone@xn--gr-zia.org>\r\n",
+                "DATA\r\n",
+                MSG1 + "\r\n.\r\n",
+                "QUIT\r\n");
+
+            Iterator<MailEnvelope> queued = hook.getQueued().iterator();
+            assertThat(queued.hasNext()).isTrue();
+            MailEnvelope env = queued.next();
+            assertThat(env.getMaybeSender().asString()).isEqualTo("arnt@grå.org");
+            assertThat(env.getRecipients())
+                .extracting(MailAddress::asString)
+                .containsExactly("someone@grå.org");
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void mailFromWithAceLabelDomainShouldBeAcceptedWithoutSmtpUtf8() throws Exception {
+        // xn--gr-zia is the Punycode (A-label) form of "grå". The wire is pure
+        // ASCII, no SMTPUTF8 asserted. RFC 6531 §3.7.4.2 says the server
+        // response must stay ASCII in that case, so the echo preserves the
+        // ACE form the client sent — even though internally we store the
+        // U-label form (see aceLabelDomainsShouldBeExposedToHooksAsUnicode).
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+
+            String reply = rawUtf8Exchange(bindedAddress,
+                "EHLO localhost\r\n",
+                "MAIL FROM:<arnt@xn--gr-zia.org>\r\n",
+                "QUIT\r\n");
+
+            assertThat(reply).contains("250 2.1.0 Sender <arnt@xn--gr-zia.org> OK");
+            assertThat(reply).doesNotContain("grå");
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void rcptToWithAceLabelDomainShouldBeAcceptedWithoutSmtpUtf8() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+
+            String reply = rawUtf8Exchange(bindedAddress,
+                "EHLO localhost\r\n",
+                "MAIL FROM:<" + SENDER + ">\r\n",
+                "RCPT TO:<someone@xn--gr-zia.org>\r\n",
+                "QUIT\r\n");
+
+            assertThat(reply).contains("250 2.1.5 Recipient <someone@xn--gr-zia.org> OK");
+            assertThat(reply).doesNotContain("grå");
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void mailFromWithMalformedAceLabelShouldBeRejected() throws Exception {
+        // "xn--" on its own is not a valid A-label; IDN.toUnicode leaves it
+        // unchanged, which we detect and reject with a specific error.
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+
+            String reply = rawUtf8Exchange(bindedAddress,
+                "EHLO localhost\r\n",
+                "MAIL FROM:<arnt@xn--.example.com>\r\n",
+                "QUIT\r\n");
+
+            assertThat(reply).contains("501");
+            assertThat(reply).contains("Invalid A-label");
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void rcptToWithMalformedAceLabelShouldBeRejected() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+
+            String reply = rawUtf8Exchange(bindedAddress,
+                "EHLO localhost\r\n",
+                "MAIL FROM:<" + SENDER + ">\r\n",
+                "RCPT TO:<someone@xn--.example.com>\r\n",
+                "QUIT\r\n");
+
+            assertThat(reply).contains("501");
+            assertThat(reply).contains("Invalid A-label");
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
     /**
      * Write all {@code commands} verbatim in UTF-8 and return the concatenated
      * server response as one UTF-8 decoded string. Reads until the server

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -984,5 +984,180 @@ public abstract class AbstractSMTPServerTest {
         }
 
     }
-    
+
+    // RFC 6531 SMTPUTF8
+
+    @Test
+    void ehloShouldAdvertiseSmtpUtf8() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+
+            SMTPClient client = createClient();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+            client.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+            client.sendCommand("EHLO", "localhost");
+
+            assertThat(client.getReplyString()).contains("SMTPUTF8");
+
+            client.quit();
+            client.disconnect();
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void mailFromWithNonAsciiSenderShouldBeRejectedWhenSmtpUtf8NotAsserted() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+
+            SMTPClient client = createClient();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+            client.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+            client.sendCommand("EHLO", "localhost");
+
+            client.sendCommand("MAIL", "FROM:<arnt@grå.org>");
+
+            assertThat(client.getReplyCode()).isEqualTo(553);
+            assertThat(client.getReplyString()).contains("5.6.7");
+
+            client.quit();
+            client.disconnect();
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void mailFromWithNonAsciiSenderShouldBeAcceptedWhenSmtpUtf8IsAsserted() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+
+            String reply = rawUtf8Exchange(bindedAddress,
+                "EHLO localhost\r\n",
+                "MAIL FROM:<arnt@grå.org> SMTPUTF8\r\n",
+                "QUIT\r\n");
+
+            // RFC 6531 §3.7.4.2: the server echoes the UTF-8 sender address
+            // back unmodified.
+            assertThat(reply).contains("250 2.1.0 Sender <arnt@grå.org> OK");
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void rcptToWithNonAsciiRecipientShouldBeRejectedWhenSmtpUtf8NotAsserted() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+
+            SMTPClient client = createClient();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+            client.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+            client.sendCommand("EHLO", "localhost");
+            client.sendCommand("MAIL", "FROM:<" + SENDER + ">");
+            assertThat(SMTPReply.isPositiveCompletion(client.getReplyCode()))
+                .as("Reply=" + client.getReplyString()).isTrue();
+
+            client.sendCommand("RCPT", "TO:<arnt@grå.org>");
+
+            assertThat(client.getReplyCode()).isEqualTo(553);
+            assertThat(client.getReplyString()).contains("5.6.7");
+
+            client.quit();
+            client.disconnect();
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    @Test
+    void rcptToWithNonAsciiRecipientShouldBeAcceptedWhenSmtpUtf8IsAsserted() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+
+            String reply = rawUtf8Exchange(bindedAddress,
+                "EHLO localhost\r\n",
+                "MAIL FROM:<" + SENDER + "> SMTPUTF8\r\n",
+                "RCPT TO:<arnt@grå.org>\r\n",
+                "QUIT\r\n");
+
+            // RFC 6531 §3.7.4.2: the server echoes the UTF-8 recipient address
+            // back unmodified.
+            assertThat(reply).contains("250 2.1.5 Recipient <arnt@grå.org> OK");
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
+    /**
+     * Write all {@code commands} verbatim in UTF-8 and return the concatenated
+     * server response as one UTF-8 decoded string. Reads until the server
+     * closes the socket (which it does on QUIT).
+     */
+    private String rawUtf8Exchange(InetSocketAddress address, String... commands) throws IOException {
+        try (java.net.Socket socket = new java.net.Socket(address.getAddress().getHostAddress(), address.getPort())) {
+            socket.getOutputStream().write(String.join("", commands).getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+            java.io.ByteArrayOutputStream collected = new java.io.ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int n;
+            while ((n = socket.getInputStream().read(buf)) > 0) {
+                collected.write(buf, 0, n);
+            }
+            return collected.toString(StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    void asciiAddressesShouldStillWorkWithoutSmtpUtf8() throws Exception {
+        ProtocolServer server = null;
+        try {
+            server = createServer(createProtocol(new TestMessageHook()));
+            server.bind();
+
+            SMTPClient client = createClient();
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+            client.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+            client.sendCommand("EHLO", "localhost");
+
+            client.sendCommand("MAIL", "FROM:<arnt@example.com>");
+            assertThat(SMTPReply.isPositiveCompletion(client.getReplyCode()))
+                .as("Reply=" + client.getReplyString()).isTrue();
+
+            client.sendCommand("RCPT", "TO:<recipient@example.com>");
+            assertThat(SMTPReply.isPositiveCompletion(client.getReplyCode()))
+                .as("Reply=" + client.getReplyString()).isTrue();
+
+            client.quit();
+            client.disconnect();
+        } finally {
+            if (server != null) {
+                server.unbind();
+            }
+        }
+    }
+
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/ReceivedHeaderGeneratorTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/ReceivedHeaderGeneratorTest.java
@@ -1,0 +1,141 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.smtp.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.james.core.Username;
+import org.apache.james.protocols.api.ProtocolSession.AttachmentKey;
+import org.apache.james.protocols.api.ProtocolSession.State;
+import org.apache.james.protocols.smtp.SMTPSession;
+import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers RFC 6531 §4.3 — the UTF8SMTP / UTF8SMTPA / UTF8SMTPS / UTF8SMTPSA
+ * trace keywords used in the Received header when the transaction asserted
+ * SMTPUTF8.
+ */
+class ReceivedHeaderGeneratorTest {
+
+    private static final ReceivedHeaderGenerator generator = new ReceivedHeaderGenerator();
+
+    private static String serviceTypeFor(String heloMode, boolean tls, boolean authenticated, boolean smtpUtf8) {
+        SMTPSession session = new FakeSession(tls, authenticated, smtpUtf8);
+        // getServiceType is protected; we exercise it through a thin
+        // subclass that exposes it.
+        return new ReceivedHeaderGenerator() {
+            String invoke() {
+                return getServiceType(session, heloMode);
+            }
+        }.invoke();
+    }
+
+    // --- HELO (no extensions can have been negotiated) ---
+
+    @Test
+    void heloShouldYieldSmtp() {
+        assertThat(serviceTypeFor("HELO", false, false, false)).isEqualTo("SMTP");
+    }
+
+    @Test
+    void heloShouldYieldSmtpEvenWhenSmtpUtf8FlagIsSet() {
+        // The flag should only ever be set after EHLO + an SMTPUTF8
+        // parameter, but we double-check the HELO branch ignores it.
+        assertThat(serviceTypeFor("HELO", false, false, true)).isEqualTo("SMTP");
+    }
+
+    // --- EHLO without SMTPUTF8: existing RFC 3848 keywords ---
+
+    @Test
+    void ehloShouldYieldEsmtp() {
+        assertThat(serviceTypeFor("EHLO", false, false, false)).isEqualTo("ESMTP");
+    }
+
+    @Test
+    void ehloAuthenticatedShouldYieldEsmtpa() {
+        assertThat(serviceTypeFor("EHLO", false, true, false)).isEqualTo("ESMTPA");
+    }
+
+    @Test
+    void ehloOverTlsShouldYieldEsmtps() {
+        assertThat(serviceTypeFor("EHLO", true, false, false)).isEqualTo("ESMTPS");
+    }
+
+    @Test
+    void ehloOverTlsAuthenticatedShouldYieldEsmtpsa() {
+        assertThat(serviceTypeFor("EHLO", true, true, false)).isEqualTo("ESMTPSA");
+    }
+
+    // --- EHLO with SMTPUTF8: RFC 6531 §4.3 keywords ---
+
+    @Test
+    void ehloWithSmtpUtf8ShouldYieldUtf8Smtp() {
+        assertThat(serviceTypeFor("EHLO", false, false, true)).isEqualTo("UTF8SMTP");
+    }
+
+    @Test
+    void ehloAuthenticatedWithSmtpUtf8ShouldYieldUtf8Smtpa() {
+        assertThat(serviceTypeFor("EHLO", false, true, true)).isEqualTo("UTF8SMTPA");
+    }
+
+    @Test
+    void ehloOverTlsWithSmtpUtf8ShouldYieldUtf8Smtps() {
+        assertThat(serviceTypeFor("EHLO", true, false, true)).isEqualTo("UTF8SMTPS");
+    }
+
+    @Test
+    void ehloOverTlsAuthenticatedWithSmtpUtf8ShouldYieldUtf8Smtpsa() {
+        assertThat(serviceTypeFor("EHLO", true, true, true)).isEqualTo("UTF8SMTPSA");
+    }
+
+    private static class FakeSession extends BaseFakeSMTPSession {
+        private final boolean tls;
+        private final Username username;
+        private final boolean smtpUtf8;
+
+        FakeSession(boolean tls, boolean authenticated, boolean smtpUtf8) {
+            this.tls = tls;
+            this.username = authenticated ? Username.of("alice@example.com") : null;
+            this.smtpUtf8 = smtpUtf8;
+        }
+
+        @Override
+        public boolean isTLSStarted() {
+            return tls;
+        }
+
+        @Override
+        public Username getUsername() {
+            return username;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> Optional<T> getAttachment(AttachmentKey<T> key, State state) {
+            if (key == SMTPSession.SMTPUTF8_REQUESTED) {
+                return (Optional<T>) Optional.of(smtpUtf8);
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/server/container/core/src/main/java/org/apache/james/server/core/InternetHeadersInputStream.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/InternetHeadersInputStream.java
@@ -69,7 +69,7 @@ public class InternetHeadersInputStream extends InputStream {
             if (!headerLines.hasMoreElements()) {
                 line += LINE_SEPERATOR;
             }
-            currLine = line.getBytes(StandardCharsets.US_ASCII);
+            currLine = line.getBytes(StandardCharsets.UTF_8);
             return true;
         } else {
             return false;

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailHeaders.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailHeaders.java
@@ -39,8 +39,8 @@ import org.apache.mailet.base.RFC2822Headers;
  * </pre>
  */
 public class MailHeaders extends InternetHeaders implements Serializable, Cloneable {
-
     private static final long serialVersionUID = 238748126601L;
+    private static final boolean ALLOWUTF_8 = true;
     private boolean modified = false;
     private long size = -1;
 
@@ -67,7 +67,7 @@ public class MailHeaders extends InternetHeaders implements Serializable, Clonea
      */
     public MailHeaders(InputStream in) throws MessagingException {
         super();
-        load(in);
+        load(in, ALLOWUTF_8);
     }
 
     /**

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/AddDeliveredToHeaderTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/AddDeliveredToHeaderTest.java
@@ -29,10 +29,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 
+import org.apache.james.jmap.mailet.filter.JMAPFiltering;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.probe.DataProbe;
 import org.apache.james.transport.mailets.AddDeliveredToHeader;
+import org.apache.james.transport.mailets.LocalDelivery;
+import org.apache.james.transport.mailets.RecipientRewriteTable;
+import org.apache.james.transport.mailets.RemoteDelivery;
+import org.apache.james.transport.mailets.ToProcessor;
+import org.apache.james.transport.mailets.VacationMailet;
+import org.apache.james.transport.matchers.All;
+import org.apache.james.transport.matchers.RecipientIsLocal;
+import org.apache.james.transport.matchers.SMTPAuthSuccessful;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.SMTPMessageSender;
 import org.apache.james.utils.TestIMAPClient;
@@ -43,7 +54,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 class AddDeliveredToHeaderTest {
-    public static final String RECIPIENT2 = "rené@" + DEFAULT_DOMAIN;
+    private static final String POSTMASTER = "postmaster@" + DEFAULT_DOMAIN;
+    public static final String RECIPIENT2_UTF8 = "rené@" + DEFAULT_DOMAIN;
+    public static final String RECIPIENT2 = "rene@" + DEFAULT_DOMAIN;
     @RegisterExtension
     public TestIMAPClient testIMAPClient = new TestIMAPClient();
     @RegisterExtension
@@ -53,7 +66,11 @@ class AddDeliveredToHeaderTest {
 
     @BeforeEach
     void setup(@TempDir File temporaryFolder) throws Exception {
-        jamesServer = TemporaryJamesServer.builder().build(temporaryFolder);
+        jamesServer = TemporaryJamesServer.builder()
+            .withMailetContainer(TemporaryJamesServer.defaultMailetContainerConfiguration()
+                .postmaster(POSTMASTER)
+                .putProcessor(transport()))
+            .build(temporaryFolder);
         jamesServer.start();
 
         DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
@@ -84,24 +101,59 @@ class AddDeliveredToHeaderTest {
 
     @Test
     void receivedMessagesShouldContainDeliveredToHeadersI8N() throws Exception {
-        String message = "FROM: " + RECIPIENT2 + "\r\n" +
+        jamesServer.getProbe(DataProbeImpl.class).addUserAliasMapping("rené", "james.org", RECIPIENT2);
+        String message = "FROM: " + RECIPIENT2_UTF8 + "\r\n" +
             "subject: testé\r\n" +
             "Content-Type: text/plain; charset=UTF-8\r\n" +
             "Content-Encoding: 8bit\r\n" +
             "\r\n" +
-            "contenté\r\n" +
-            ".\r\n";
+            "contenté\r\n";
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .authenticate(FROM, PASSWORD)
-            .sendMessageWithHeaders(FROM, RECIPIENT2, message);
+            .sendMessageWithHeaders(FROM, RECIPIENT2_UTF8, message);
+
+        Thread.sleep(1000);
 
         testIMAPClient.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
             .login(RECIPIENT2, PASSWORD)
             .select(TestIMAPClient.INBOX)
             .awaitMessage(awaitAtMostOneMinute);
-        assertThat(testIMAPClient.readFirstMessageHeaders())
-            .contains("René")
+
+        assertThat(testIMAPClient.readFirstMessage())
+            .contains(RECIPIENT2_UTF8)
             .contains("testé")
             .contains("contenté");
+    }
+
+    private ProcessorConfiguration.Builder transport() {
+        return ProcessorConfiguration.transport()
+            .enableJmx(false)
+            .addMailet(MailetConfiguration.builder()
+                .matcher(All.class)
+                .mailet(RecipientRewriteTable.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(RecipientIsLocal.class)
+                .mailet(VacationMailet.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(RecipientIsLocal.class)
+                .mailet(JMAPFiltering.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(RecipientIsLocal.class)
+                .mailet(LocalDelivery.class))
+            .addMailet(MailetConfiguration.builder()
+                .matcher(SMTPAuthSuccessful.class)
+                .mailet(RemoteDelivery.class)
+                .addProperty("outgoingQueue", "outgoing")
+                .addProperty("delayTime", "5000, 100000, 500000")
+                .addProperty("maxRetries", "3")
+                .addProperty("maxDnsProblemRetries", "0")
+                .addProperty("deliveryThreads", "10")
+                .addProperty("sendpartial", "true")
+                .addProperty("bounceProcessor", "bounces"))
+            .addMailet(MailetConfiguration.BCC_STRIPPER)
+            .addMailet(MailetConfiguration.builder()
+                .matcher(All.class)
+                .mailet(ToProcessor.class)
+                .addProperty("processor", "error"));
     }
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -476,6 +476,7 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
 
     private MimeBodyPart createDSN(Mail originalMail) throws MessagingException {
         StringBuilder buffer = new StringBuilder();
+        boolean anyNonAsciiAddress = false;
 
         appendReportingMTA(buffer);
         buffer.append("Received-From-MTA: dns; " + originalMail.getRemoteHost())
@@ -496,12 +497,22 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
                 .append(LINE_BREAK));
 
         for (MailAddress rec : originalMail.getRecipients()) {
+            anyNonAsciiAddress |= containsNonAscii(rec);
             appendRecipient(buffer, rec, getDeliveryError(originalMail), originalMail.getLastUpdated());
         }
 
         MimeBodyPart bodyPart = new MimeBodyPart();
-        bodyPart.setContent(buffer.toString(), "text/plain");
-        bodyPart.setHeader("Content-Type", "message/delivery-status");
+        // RFC 6533 §3.2: when any reported address contains non-ASCII
+        // octets the DSN body part is "message/global-delivery-status";
+        // otherwise the RFC 3464 form. The outer "multipart/report;
+        // report-type=delivery-status" wrapper does not change. Setting
+        // the storage Content-Type with charset=UTF-8 first makes
+        // jakarta.mail serialise the body as UTF-8 octets; the second
+        // setHeader overrides only the type label.
+        bodyPart.setContent(buffer.toString(), "text/plain; charset=UTF-8");
+        bodyPart.setHeader("Content-Type", anyNonAsciiAddress
+            ? "message/global-delivery-status; charset=UTF-8"
+            : "message/delivery-status");
         bodyPart.setDescription("Delivery Status Notification");
         bodyPart.setFileName("status.dat");
         return bodyPart;
@@ -518,7 +529,10 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
 
     private void appendRecipient(StringBuilder buffer, MailAddress mailAddress, String deliveryError, Date lastUpdated) {
         buffer.append(LINE_BREAK);
-        buffer.append("Final-Recipient: rfc822; " + mailAddress.toString()).append(LINE_BREAK);
+        // RFC 6533 §3.2: addr-type is "utf-8" when the address contains
+        // non-ASCII octets, otherwise the legacy "rfc822".
+        buffer.append("Final-Recipient: ").append(addrType(mailAddress)).append("; ")
+            .append(mailAddress.toString()).append(LINE_BREAK);
         buffer.append("Action: ").append(action.asString().toLowerCase(Locale.US)).append(LINE_BREAK);
         buffer.append("Status: " + deliveryError).append(LINE_BREAK);
         if (action.shouldIncludeDiagnostic()) {
@@ -526,6 +540,20 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
         }
         buffer.append("Last-Attempt-Date: " + dateFormatter.format(ZonedDateTime.ofInstant(lastUpdated.toInstant(), ZoneId.systemDefault())))
             .append(LINE_BREAK);
+    }
+
+    private static String addrType(MailAddress mailAddress) {
+        return containsNonAscii(mailAddress) ? "utf-8" : "rfc822";
+    }
+
+    private static boolean containsNonAscii(MailAddress mailAddress) {
+        String s = mailAddress.toString();
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) > 0x7F) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String getDeliveryError(Mail originalMail) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
@@ -152,6 +152,21 @@ import com.google.common.collect.ImmutableMap;
  * or use the <i>mail.smtps.ssl.checkserveridentity</i> and <i>mail.smtp.ssl.checkserveridentity</i> javax properties for fine control.<br/>
  * Read <a href="https://eclipse-ee4j.github.io/angus-mail/docs/api/org.eclipse.angus.mail/org/eclipse/angus/mail/smtp/package-summary.html"><code>org.eclipse.angus.mail.smtp</code></a>
  * for full information.
+ * <br/>
+ * <b>SMTPUTF8 (RFC 6531):</b> when the first MX we reach advertises
+ * SMTPUTF8 and the envelope contains any non-ASCII character, the
+ * extension is asserted on MAIL FROM and UTF-8 addresses flow through
+ * unchanged. When the MX lacks SMTPUTF8 and only the domain parts are
+ * non-ASCII, those domains are converted to their ACE (A-label, xn--)
+ * form for the envelope commands; the message headers themselves are
+ * still allowed to carry UTF-8 (Subject, display names, etc.). This can
+ * produce a transaction where RCPT TO carries punycode but the mail
+ * headers carry UTF-8 — that mismatch is a fair compromise that
+ * optimises handling on the receiver side: a receiver that cannot speak
+ * SMTPUTF8 still accepts the envelope it understands, and a receiver
+ * that can read UTF-8 headers (most do) gets them intact. When a local
+ * part is non-ASCII and the MX lacks SMTPUTF8 the transaction fails
+ * permanently — no lossless downgrade exists.
  */
 public class RemoteDelivery extends GenericMailet {
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteDelivery.class);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
@@ -68,6 +68,7 @@ public class MailDelivrerToHost {
     public static final String BIT_MIME_8 = "8BITMIME";
     public static final String REQUIRE_TLS = "REQUIRETLS";
     public static final String STARTTLS = "STARTTLS";
+    public static final String SMTPUTF8 = "SMTPUTF8";
     public static final String MT_PRIORITY = "MT-PRIORITY";
     public static final String MAIL_PRIORITY_ATTRIBUTE_NAME = "MAIL_PRIORITY";
     private static final List<String> supportedSmtpExtensionsList = List.of(MT_PRIORITY, STARTTLS);
@@ -133,6 +134,27 @@ public class MailDelivrerToHost {
             connect(outgoingMailServer, transport);
             if (receiverDoesNotProvideNecessaryStartTls(mail, transport)) {
                 return ExecutionResult.permanentFailure(new SendFailedException("Mail delivery failed; the receiving server does not support STARTTLS"));
+            }
+            // We assume all MXes for a given destination domain advertise
+            // the same set of SMTP extensions; this decision is made once,
+            // on the first MX we reach, and we do not fall back to another
+            // MX hoping it might have different capabilities.
+            SmtpUtf8Strategy.Action utf8Action = SmtpUtf8Strategy.pick(
+                mail.getMaybeSender(), addr, transport.supportsExtension(SMTPUTF8));
+            if (utf8Action == SmtpUtf8Strategy.Action.CANNOT_DOWNGRADE) {
+                return ExecutionResult.permanentFailure(new SendFailedException(
+                    "Remote server does not advertise SMTPUTF8 but the envelope "
+                        + "contains a non-ASCII local part that cannot be downgraded"));
+            }
+            if (utf8Action == SmtpUtf8Strategy.Action.DOWNGRADE_DOMAINS) {
+                addr = toAceDomains(addr);
+                props.put(inContext(session, "mail.smtp.from"),
+                    SmtpUtf8Strategy.aceAddressString(mail.getMaybeSender().asString()));
+            } else if (utf8Action == SmtpUtf8Strategy.Action.USE_EXTENSION) {
+                // Enable Angus Mail's UTF-8 mode for this session; since the
+                // remote advertises SMTPUTF8, the transport will emit it on
+                // MAIL FROM and accept UTF-8 in the envelope.
+                session.getProperties().put("mail.mime.allowutf8", "true");
             }
             if (mail.dsnParameters().isPresent()) {
                 sendDSNAwareEmail(mail, transport, addr);
@@ -234,6 +256,14 @@ public class MailDelivrerToHost {
 
     private static boolean extensionsSupported(SMTPTransport transport) {
         return supportedSmtpExtensionsList.stream().anyMatch(transport::supportsExtension);
+    }
+
+    private static Collection<InternetAddress> toAceDomains(Collection<InternetAddress> addr) throws MessagingException {
+        Collection<InternetAddress> out = new java.util.ArrayList<>(addr.size());
+        for (InternetAddress a : addr) {
+            out.add(SmtpUtf8Strategy.toAceDomain(a));
+        }
+        return out;
     }
 
     private static boolean receiverDoesNotProvideNecessaryStartTls(Mail mail, SMTPTransport transport) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/SmtpUtf8Strategy.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/SmtpUtf8Strategy.java
@@ -1,0 +1,148 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets.remote.delivery;
+
+import java.net.IDN;
+import java.util.Collection;
+
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+
+import org.apache.james.core.MaybeSender;
+
+/**
+ * Picks a relaying strategy for the RFC 6531 SMTPUTF8 extension based on
+ * what the remote MX advertises and what's in the envelope. We assume all
+ * MXes for a single destination domain advertise the same extensions; if
+ * the first MX we try lacks SMTPUTF8 we don't retry subsequent ones hoping
+ * they'll differ.
+ */
+public final class SmtpUtf8Strategy {
+
+    public enum Action {
+        /** No envelope address has non-ASCII characters; deliver as-is. */
+        NO_UTF8_NEEDED,
+        /** Some envelope address has non-ASCII characters and the remote
+         *  advertises SMTPUTF8; deliver as-is and assert SMTPUTF8. */
+        USE_EXTENSION,
+        /** Remote lacks SMTPUTF8 but all non-ASCII lives in the domain
+         *  part, which can be downgraded to ACE (A-label, xn--) form. */
+        DOWNGRADE_DOMAINS,
+        /** Remote lacks SMTPUTF8 and at least one local part is non-ASCII,
+         *  so no lossless downgrade exists. Caller should fail the
+         *  transaction the same way it fails a SIZE overflow. */
+        CANNOT_DOWNGRADE
+    }
+
+    private SmtpUtf8Strategy() {
+    }
+
+    public static Action pick(MaybeSender sender,
+                              Collection<InternetAddress> recipients,
+                              boolean remoteSupportsSmtpUtf8) {
+        boolean nonAsciiLocalPart = hasNonAsciiLocalPart(sender, recipients);
+        boolean nonAsciiDomain = hasNonAsciiDomain(sender, recipients);
+
+        if (!nonAsciiLocalPart && !nonAsciiDomain) {
+            return Action.NO_UTF8_NEEDED;
+        }
+        if (remoteSupportsSmtpUtf8) {
+            return Action.USE_EXTENSION;
+        }
+        if (nonAsciiLocalPart) {
+            return Action.CANNOT_DOWNGRADE;
+        }
+        return Action.DOWNGRADE_DOMAINS;
+    }
+
+    /**
+     * Returns a copy of {@code address} with its domain converted to ACE
+     * (A-label) form via {@link IDN#toASCII}. Passing an already-ASCII
+     * domain through this is a no-op, so callers don't need to check.
+     *
+     * @throws AddressException if the address has no {@code @}
+     */
+    public static InternetAddress toAceDomain(InternetAddress address) throws AddressException {
+        String asString = address.getAddress();
+        int at = asString.lastIndexOf('@');
+        if (at < 0) {
+            throw new AddressException("Address has no @: " + asString);
+        }
+        String localPart = asString.substring(0, at);
+        String domain = asString.substring(at + 1);
+        // InternetAddress(String) parses strictly; bypass via setAddress so
+        // we don't reject local parts we're only passing through unchanged.
+        InternetAddress result = new InternetAddress();
+        result.setAddress(localPart + "@" + IDN.toASCII(domain, IDN.ALLOW_UNASSIGNED));
+        return result;
+    }
+
+    /** ACE form of the string address. See {@link #toAceDomain}. */
+    public static String aceAddressString(String address) {
+        int at = address.lastIndexOf('@');
+        if (at < 0) {
+            return address;
+        }
+        return address.substring(0, at + 1)
+            + IDN.toASCII(address.substring(at + 1), IDN.ALLOW_UNASSIGNED);
+    }
+
+    private static boolean hasNonAsciiLocalPart(MaybeSender sender,
+                                                Collection<InternetAddress> recipients) {
+        if (!sender.isNullSender()
+                && containsNonAscii(sender.asString().substring(0, Math.max(0, sender.asString().lastIndexOf('@'))))) {
+            return true;
+        }
+        for (InternetAddress a : recipients) {
+            int at = a.getAddress().lastIndexOf('@');
+            String localPart = at < 0 ? a.getAddress() : a.getAddress().substring(0, at);
+            if (containsNonAscii(localPart)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasNonAsciiDomain(MaybeSender sender,
+                                             Collection<InternetAddress> recipients) {
+        if (!sender.isNullSender()) {
+            int at = sender.asString().lastIndexOf('@');
+            if (at >= 0 && containsNonAscii(sender.asString().substring(at + 1))) {
+                return true;
+            }
+        }
+        for (InternetAddress a : recipients) {
+            int at = a.getAddress().lastIndexOf('@');
+            if (at >= 0 && containsNonAscii(a.getAddress().substring(at + 1))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsNonAscii(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) > 0x7F) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -1496,4 +1496,88 @@ public class DSNBounceTest {
         assertThat(MimeMessageUtil.asString(sentMessage))
             .contains("Auto-Submitted: auto-replied");
     }
+
+    @Nested
+    class Rfc6533 {
+        @Test
+        void dsnForAsciiRecipientShouldUseRfc822AddrTypeAndLegacyContentType() throws Exception {
+            FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName(MAILET_NAME)
+                .mailetContext(fakeMailContext)
+                .build();
+            dsnBounce.init(mailetConfig);
+
+            FakeMail mail = FakeMail.builder()
+                .name(MAILET_NAME)
+                .sender(new MailAddress("sender@example.com"))
+                .attribute(DELIVERY_ERROR_ATTRIBUTE)
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder().setText("body"))
+                .recipient("info@example.com")
+                .lastUpdated(Date.from(Instant.parse("2026-04-27T10:00:00.000Z")))
+                .remoteAddr("remoteHost")
+                .build();
+
+            dsnBounce.service(mail);
+
+            BodyPart dsnPart = (BodyPart) ((MimeMultipart) fakeMailContext.getSentMails()
+                .get(0).getMsg().getContent()).getBodyPart(1);
+            assertThat(dsnPart.getContentType()).startsWith("message/delivery-status");
+            String body = IOUtils.toString((SharedByteArrayInputStream) dsnPart.getContent(), StandardCharsets.UTF_8);
+            assertThat(body).contains("Final-Recipient: rfc822; info@example.com");
+        }
+
+        @Test
+        void dsnForUtf8LocalPartShouldUseUtf8AddrTypeAndGlobalContentType() throws Exception {
+            FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName(MAILET_NAME)
+                .mailetContext(fakeMailContext)
+                .build();
+            dsnBounce.init(mailetConfig);
+
+            FakeMail mail = FakeMail.builder()
+                .name(MAILET_NAME)
+                .sender(new MailAddress("sender@example.com"))
+                .attribute(DELIVERY_ERROR_ATTRIBUTE)
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder().setText("body"))
+                .recipient("grå@example.com")
+                .lastUpdated(Date.from(Instant.parse("2026-04-27T10:00:00.000Z")))
+                .remoteAddr("remoteHost")
+                .build();
+
+            dsnBounce.service(mail);
+
+            BodyPart dsnPart = (BodyPart) ((MimeMultipart) fakeMailContext.getSentMails()
+                .get(0).getMsg().getContent()).getBodyPart(1);
+            assertThat(dsnPart.getContentType()).startsWith("message/global-delivery-status");
+            String body = IOUtils.toString((SharedByteArrayInputStream) dsnPart.getContent(), StandardCharsets.UTF_8);
+            assertThat(body).contains("Final-Recipient: utf-8; grå@example.com");
+        }
+
+        @Test
+        void dsnForUtf8DomainOnlyShouldUseUtf8AddrTypeAndGlobalContentType() throws Exception {
+            FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName(MAILET_NAME)
+                .mailetContext(fakeMailContext)
+                .build();
+            dsnBounce.init(mailetConfig);
+
+            FakeMail mail = FakeMail.builder()
+                .name(MAILET_NAME)
+                .sender(new MailAddress("sender@example.com"))
+                .attribute(DELIVERY_ERROR_ATTRIBUTE)
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder().setText("body"))
+                .recipient("arnt@grå.org")
+                .lastUpdated(Date.from(Instant.parse("2026-04-27T10:00:00.000Z")))
+                .remoteAddr("remoteHost")
+                .build();
+
+            dsnBounce.service(mail);
+
+            BodyPart dsnPart = (BodyPart) ((MimeMultipart) fakeMailContext.getSentMails()
+                .get(0).getMsg().getContent()).getBodyPart(1);
+            assertThat(dsnPart.getContentType()).startsWith("message/global-delivery-status");
+            String body = IOUtils.toString((SharedByteArrayInputStream) dsnPart.getContent(), StandardCharsets.UTF_8);
+            assertThat(body).contains("Final-Recipient: utf-8; arnt@grå.org");
+        }
+    }
 }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/SmtpUtf8StrategyTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/SmtpUtf8StrategyTest.java
@@ -1,0 +1,153 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets.remote.delivery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.mail.internet.InternetAddress;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
+import org.junit.jupiter.api.Test;
+
+class SmtpUtf8StrategyTest {
+
+    private static MaybeSender sender(String addr) throws Exception {
+        return MaybeSender.of(new MailAddress(addr));
+    }
+
+    private static List<InternetAddress> rcpts(String... addrs) throws Exception {
+        List<InternetAddress> out = new java.util.ArrayList<>();
+        for (String a : addrs) {
+            InternetAddress ia = new InternetAddress();
+            ia.setAddress(a);
+            out.add(ia);
+        }
+        return out;
+    }
+
+    @Test
+    void allAsciiShouldNotNeedUtf8() throws Exception {
+        assertThat(SmtpUtf8Strategy.pick(
+                sender("arnt@example.com"),
+                rcpts("info@example.com"),
+                /* remoteSupportsSmtpUtf8 */ false))
+            .isEqualTo(SmtpUtf8Strategy.Action.NO_UTF8_NEEDED);
+    }
+
+    @Test
+    void unicodeDomainWithSmtpUtf8ShouldUseExtension() throws Exception {
+        assertThat(SmtpUtf8Strategy.pick(
+                sender("arnt@grå.org"),
+                rcpts("info@grå.org"),
+                true))
+            .isEqualTo(SmtpUtf8Strategy.Action.USE_EXTENSION);
+    }
+
+    @Test
+    void unicodeLocalPartWithSmtpUtf8ShouldUseExtension() throws Exception {
+        assertThat(SmtpUtf8Strategy.pick(
+                sender("grå@example.com"),
+                rcpts("info@example.com"),
+                true))
+            .isEqualTo(SmtpUtf8Strategy.Action.USE_EXTENSION);
+    }
+
+    @Test
+    void unicodeDomainWithoutSmtpUtf8ShouldDowngradeDomains() throws Exception {
+        // ASCII local parts everywhere — we can ACE-encode the domain(s)
+        // and send RFC 5321-clean envelope commands.
+        assertThat(SmtpUtf8Strategy.pick(
+                sender("arnt@grå.org"),
+                rcpts("info@münchen.de"),
+                false))
+            .isEqualTo(SmtpUtf8Strategy.Action.DOWNGRADE_DOMAINS);
+    }
+
+    @Test
+    void unicodeLocalPartWithoutSmtpUtf8ShouldFailTransaction() throws Exception {
+        assertThat(SmtpUtf8Strategy.pick(
+                sender("grå@example.com"),
+                rcpts("info@example.com"),
+                false))
+            .isEqualTo(SmtpUtf8Strategy.Action.CANNOT_DOWNGRADE);
+    }
+
+    @Test
+    void nonAsciiInOnlyOneRecipientShouldStillTriggerAction() throws Exception {
+        assertThat(SmtpUtf8Strategy.pick(
+                sender("arnt@example.com"),
+                rcpts("info@example.com", "गोरिल@उदाहरण.भारत"),
+                false))
+            .isEqualTo(SmtpUtf8Strategy.Action.CANNOT_DOWNGRADE);
+    }
+
+    @Test
+    void nullSenderWithAsciiRecipientShouldNotNeedUtf8() throws Exception {
+        // Bounce path: MAIL FROM:<>. Only recipients matter.
+        assertThat(SmtpUtf8Strategy.pick(
+                MaybeSender.nullSender(),
+                rcpts("info@example.com"),
+                false))
+            .isEqualTo(SmtpUtf8Strategy.Action.NO_UTF8_NEEDED);
+    }
+
+    @Test
+    void nullSenderWithUnicodeRecipientShouldFollowRecipient() throws Exception {
+        assertThat(SmtpUtf8Strategy.pick(
+                MaybeSender.nullSender(),
+                rcpts("arnt@grå.org"),
+                true))
+            .isEqualTo(SmtpUtf8Strategy.Action.USE_EXTENSION);
+    }
+
+    @Test
+    void toAceDomainShouldConvertUnicodeDomain() throws Exception {
+        InternetAddress input = new InternetAddress();
+        input.setAddress("arnt@grå.org");
+        InternetAddress converted = SmtpUtf8Strategy.toAceDomain(input);
+        assertThat(converted.getAddress()).isEqualTo("arnt@xn--gr-zia.org");
+    }
+
+    @Test
+    void toAceDomainShouldLeaveAsciiDomainUntouched() throws Exception {
+        InternetAddress input = new InternetAddress();
+        input.setAddress("arnt@example.com");
+        InternetAddress converted = SmtpUtf8Strategy.toAceDomain(input);
+        assertThat(converted.getAddress()).isEqualTo("arnt@example.com");
+    }
+
+    @Test
+    void aceAddressStringShouldConvertDomainButPreserveLocalPart() {
+        // Local part "grå" is kept verbatim — this helper is only for the
+        // downgrade path, where callers have already confirmed the local
+        // part is ASCII. Preserving whatever local part arrived is the
+        // right contract.
+        assertThat(SmtpUtf8Strategy.aceAddressString("arnt@grå.org"))
+            .isEqualTo("arnt@xn--gr-zia.org");
+    }
+
+    @Test
+    void aceAddressStringShouldPreserveNullSender() {
+        assertThat(SmtpUtf8Strategy.aceAddressString("")).isEqualTo("");
+    }
+}

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -51,6 +51,7 @@ import org.apache.james.imap.encode.base.ImapResponseComposerImpl;
 import org.apache.james.imap.main.ResponseEncoder;
 import org.apache.james.imap.message.request.AbstractImapRequest;
 import org.apache.james.imap.message.response.ImmutableStatusResponse;
+import org.apache.james.imap.processor.EnableProcessor;
 import org.apache.james.metrics.api.Metric;
 import org.apache.james.protocols.netty.Encryption;
 import org.apache.james.util.MDCBuilder;
@@ -417,7 +418,8 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
         }
 
         ChannelImapResponseWriter writer = new ChannelImapResponseWriter(ctx.channel(), session);
-        ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer);
+        ImapResponseComposerImpl response = new ImapResponseComposerImpl(writer)
+            .setUtf8Accept(EnableProcessor.getEnabledCapabilities(session).contains(ImapConstants.SUPPORTS_UTF8_ACCEPT));
         writer.setFlushCallback(response::flush);
         ImapMessage message = (ImapMessage) msg;
 

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -39,12 +39,14 @@ import java.util.function.Consumer;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.imap.api.ImapConstants;
 import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.ImapSessionState;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.decode.DecodingException;
 import org.apache.james.imap.decode.ImapDecoder;
 import org.apache.james.imap.decode.ImapRequestLineReader;
+import org.apache.james.imap.processor.EnableProcessor;
 import org.apache.james.lifecycle.api.Disposable.LeakAware;
 import org.apache.james.protocols.netty.LineHandlerAware;
 
@@ -146,6 +148,8 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         // Also check if the session was logged out if so there is not need to try to decode it. See JAMES-1341
         if (session != null && session.getState() != ImapSessionState.LOGOUT) {
             try {
+                readerAndSize.getLeft().setUtf8Accept(
+                    EnableProcessor.getEnabledCapabilities(session).contains(ImapConstants.SUPPORTS_UTF8_ACCEPT));
 
                 ImapMessage message = decoder.decode(readerAndSize.getLeft(), session);
 

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -3619,6 +3619,90 @@ class IMAPServerTest {
                 .doesNotContain("BOGUS-CAPABILITY")
                 .contains("OK ENABLE completed.");
         }
+
+        @Test
+        void listShouldEncodeMailboxNameAsModifiedUtf7WhenUtf8AcceptNotEnabled() throws Exception {
+            imapServer = createImapServer("imapServer.xml");
+            MailboxSession session = memoryIntegrationResources.getMailboxManager().createSystemSession(USER);
+            memoryIntegrationResources.getMailboxManager()
+                .createMailbox(MailboxPath.forUser(USER, "grå"), session);
+
+            try (SocketChannel c = SocketChannel.open(new InetSocketAddress(LOCALHOST_IP,
+                    imapServer.getListenAddresses().getFirst().getPort()))) {
+                readUtf8Bytes(c);
+                c.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
+                readUtf8Until(c, s -> s.contains("a0 OK"));
+                c.write(ByteBuffer.wrap("a1 LIST \"\" \"*\"\r\n".getBytes(StandardCharsets.UTF_8)));
+                List<String> replies = readUtf8Until(c, s -> s.contains("a1 OK"));
+
+                assertThat(String.join("", replies))
+                    .contains("gr&AOU-")
+                    .doesNotContain("grå");
+            }
+        }
+
+        @Test
+        void createWithUnicodeMailboxNameShouldSucceedAfterEnableUtf8Accept() throws Exception {
+            imapServer = createImapServer("imapServer.xml");
+
+            try (SocketChannel c = SocketChannel.open(new InetSocketAddress(LOCALHOST_IP,
+                    imapServer.getListenAddresses().getFirst().getPort()))) {
+                readUtf8Bytes(c);
+                c.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
+                readUtf8Until(c, s -> s.contains("a0 OK"));
+                c.write(ByteBuffer.wrap("a1 ENABLE UTF8=ACCEPT\r\n".getBytes(StandardCharsets.UTF_8)));
+                readUtf8Until(c, s -> s.contains("a1 OK"));
+                c.write(ByteBuffer.wrap("a2 CREATE \"grå\"\r\n".getBytes(StandardCharsets.UTF_8)));
+                readUtf8Until(c, s -> s.contains("a2 OK"));
+                c.write(ByteBuffer.wrap("a3 LIST \"\" \"*\"\r\n".getBytes(StandardCharsets.UTF_8)));
+                List<String> replies = readUtf8Until(c, s -> s.contains("a3 OK"));
+
+                assertThat(String.join("", replies)).contains("grå");
+            }
+        }
+
+        @Test
+        void listShouldEncodeMailboxNameAsRawUtf8WhenUtf8AcceptEnabled() throws Exception {
+            imapServer = createImapServer("imapServer.xml");
+            MailboxSession session = memoryIntegrationResources.getMailboxManager().createSystemSession(USER);
+            memoryIntegrationResources.getMailboxManager()
+                .createMailbox(MailboxPath.forUser(USER, "grå"), session);
+
+            try (SocketChannel c = SocketChannel.open(new InetSocketAddress(LOCALHOST_IP,
+                    imapServer.getListenAddresses().getFirst().getPort()))) {
+                readUtf8Bytes(c);
+                c.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
+                readUtf8Until(c, s -> s.contains("a0 OK"));
+                c.write(ByteBuffer.wrap("a1 ENABLE UTF8=ACCEPT\r\n".getBytes(StandardCharsets.UTF_8)));
+                readUtf8Until(c, s -> s.contains("a1 OK"));
+                c.write(ByteBuffer.wrap("a2 LIST \"\" \"*\"\r\n".getBytes(StandardCharsets.UTF_8)));
+                List<String> replies = readUtf8Until(c, s -> s.contains("a2 OK"));
+
+                assertThat(String.join("", replies))
+                    .contains("grå")
+                    .doesNotContain("gr&AOU-");
+            }
+        }
+
+        private byte[] readUtf8Bytes(SocketChannel channel) throws IOException {
+            ByteBuffer buf = ByteBuffer.allocate(8192);
+            channel.read(buf);
+            buf.flip();
+            byte[] out = new byte[buf.remaining()];
+            buf.get(out);
+            return out;
+        }
+
+        private List<String> readUtf8Until(SocketChannel channel, Predicate<String> condition) throws IOException {
+            ImmutableList.Builder<String> result = ImmutableList.builder();
+            while (true) {
+                String line = new String(readUtf8Bytes(channel), StandardCharsets.UTF_8);
+                result.add(line);
+                if (condition.test(line)) {
+                    return result.build();
+                }
+            }
+        }
     }
 
 }

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -3577,4 +3577,48 @@ class IMAPServerTest {
         }
     }
 
+    @Nested
+    class Utf8AcceptTest {
+        IMAPServer imapServer;
+
+        @AfterEach
+        void tearDown() {
+            if (imapServer != null) {
+                imapServer.destroy();
+            }
+        }
+
+        @Test
+        void capabilityShouldAdvertiseUtf8Accept() throws Exception {
+            imapServer = createImapServer("imapServer.xml");
+            assertThat(
+                testIMAPClient.connect("127.0.0.1", imapServer.getListenAddresses().getFirst().getPort())
+                    .sendCommand("CAPABILITY"))
+                .contains("UTF8=ACCEPT");
+        }
+
+        @Test
+        void enableUtf8AcceptShouldSucceed() throws Exception {
+            imapServer = createImapServer("imapServer.xml");
+            assertThat(
+                testIMAPClient.connect("127.0.0.1", imapServer.getListenAddresses().getFirst().getPort())
+                    .login(USER.asString(), USER_PASS)
+                    .sendCommand("ENABLE UTF8=ACCEPT"))
+                .contains("* ENABLED UTF8=ACCEPT")
+                .contains("OK ENABLE completed.");
+        }
+
+        @Test
+        void enableUtf8AcceptShouldNotEchoUnsupportedCapability() throws Exception {
+            imapServer = createImapServer("imapServer.xml");
+            assertThat(
+                testIMAPClient.connect("127.0.0.1", imapServer.getListenAddresses().getFirst().getPort())
+                    .login(USER.asString(), USER_PASS)
+                    .sendCommand("ENABLE BOGUS-CAPABILITY UTF8=ACCEPT"))
+                .contains("* ENABLED UTF8=ACCEPT")
+                .doesNotContain("BOGUS-CAPABILITY")
+                .contains("OK ENABLE completed.");
+        }
+    }
+
 }


### PR DESCRIPTION
This adds Domain tests and does enough to parse unicode email addresses.

However, I'm not quite happy. This needs documentation changes, I wouldn't mind another few Domain tests, and I do want to investigate what's up with Jakarta and `संपर्क@डाटामेल.भारत` but haven't time to do that this week.

Consider it a WIP.