### PR TITLE
JAMES-4134 Leverage MAIL FROM AUTH parameter to record the true sender of an email

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxSession.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxSession.java
@@ -144,6 +144,10 @@ public class MailboxSession {
         return loggedInUser;
     }
 
+    public boolean isDelegated() {
+        return loggedInUser.map(user -> !userName.equals(user)).orElse(false);
+    }
+
     /**
      * Gets acceptable localisation for this user in preference order.<br>
      * When localising a phrase, each <code>Locale</code> should be tried in

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -102,6 +102,7 @@ public interface Mail extends Serializable, Cloneable {
     String LOCAL_DELIVERY = "local-delivery";
 
     AttributeName SMTP_AUTH_USER = AttributeName.of("org.apache.james.SMTPAuthUser");
+    AttributeName TRUE_SENDER = AttributeName.of("org.apache.james.TrueSender");
     AttributeName SMTP_HELO = AttributeName.of("org.apache.james.HELO");
     AttributeName SSL_PROTOCOL = AttributeName.of("org.apache.james.ssl.protocol");
     AttributeName SSL_CIPHER = AttributeName.of("org.apache.james.ssl.cipher");

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/AttributeToHeader.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/AttributeToHeader.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+import com.github.fge.lambdas.Throwing;
+import jakarta.mail.MessagingException;
+
+/**
+ * Allows setting arbitrary attributes as header.
+ *
+ * Example set up in order to add true sender in the headers:
+ *
+ * <pre><code>
+ * &lt;mailet match=&quot;All&quot; class=&quot;&lt;AttributeToHeader&gt;&quot;&gt;
+ *   &lt;attributeName&gt;org.apache.james.TrueSender&lt;/attributeName&gt;
+ *   &lt;headerName&gt;X-True-Sender&lt;/headerName&gt;
+ * &lt;/mailet&gt;
+ * </code></pre>
+ */
+public class AttributeToHeader extends GenericMailet {
+    private AttributeName attributeName;
+    private String headerName;
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        mail.getAttribute(attributeName)
+            .ifPresent(Throwing.consumer(attribute -> {
+                mail.getMessage().addHeader(headerName, attribute.getValue().getValue().toString());
+                mail.getMessage().saveChanges();
+            }));
+    }
+
+    @Override
+    public void init() throws MessagingException {
+        attributeName = AttributeName.of(getInitParameter("attributeName"));
+        headerName = getInitParameter("headerName");
+    }
+
+    @Override
+    public String getMailetInfo() {
+        return "AttributeToHeader Mailet";
+    }
+}

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
@@ -34,8 +34,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.core.Username;
 import org.apache.james.protocols.api.OidcSASLConfiguration;
+import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.api.Request;
 import org.apache.james.protocols.api.Response;
 import org.apache.james.protocols.api.handler.CommandHandler;
@@ -87,6 +89,7 @@ public class AuthCmdHandler
     private static final Response AUTH_READY_PASSWORD_LOGIN = new SMTPResponse(SMTPRetCode.AUTH_READY, "UGFzc3dvcmQ6").immutable(); // base64 encoded "Password:
     private static final Response AUTH_FAILED = new SMTPResponse(SMTPRetCode.AUTH_FAILED, "Authentication Failed").immutable();
     private static final Response UNKNOWN_AUTH_TYPE = new SMTPResponse(SMTPRetCode.PARAMETER_NOT_IMPLEMENTED, "Unrecognized Authentication Type").immutable();
+    public static final ProtocolSession.AttachmentKey<MaybeSender> TRUE_SENDER_KEY = ProtocolSession.AttachmentKey.of("trueSender", MaybeSender.class);
 
     private abstract static class AbstractSMTPLineHandler implements LineHandler<SMTPSession> {
 
@@ -575,8 +578,8 @@ public class AuthCmdHandler
 
     @Override
     public HookResult doMailParameter(SMTPSession session, String paramName, String paramValue) {
-        // Ignore the AUTH command.
-        // TODO we should at least check for correct syntax and put the result in session
+        MaybeSender trueSender = MaybeSender.getMailSender(paramValue);
+        session.setAttachment(TRUE_SENDER_KEY, trueSender, ProtocolSession.State.Transaction);
         return HookResult.DECLINED;
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
@@ -70,7 +70,8 @@ public class MailDelivrerToHost {
     public static final String STARTTLS = "STARTTLS";
     public static final String MT_PRIORITY = "MT-PRIORITY";
     public static final String MAIL_PRIORITY_ATTRIBUTE_NAME = "MAIL_PRIORITY";
-    private static final List<String> supportedSmtpExtensionsList = List.of(MT_PRIORITY, STARTTLS);
+    public static final String TRUE_SENDER_ATTRIBUTE_NAME = "org.apache.james.TrueSender";
+    private static final List<String> supportedSmtpExtensionsList = List.of(MT_PRIORITY, STARTTLS, "AUTH");
     private static final List<String> supportedMailAttributesList = List.of(MAIL_PRIORITY_ATTRIBUTE_NAME, REQUIRE_TLS);
 
     private final RemoteDeliveryConfiguration configuration;
@@ -256,6 +257,8 @@ public class MailDelivrerToHost {
                     case MAIL_PRIORITY_ATTRIBUTE_NAME ->
                         smtpMessage.setMailExtension(MT_PRIORITY + "=" + attribute.getValue().value() +
                             existingMessageExtensions);
+                    case TRUE_SENDER_ATTRIBUTE_NAME ->
+                        smtpMessage.setMailExtension("AUTH=" + attribute.getValue().value());
                     case REQUIRE_TLS -> {
                         if (isRequireTlsAttribute(mail)) {
                             smtpMessage.setMailExtension(REQUIRE_TLS + existingMessageExtensions);

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailSubmissionSetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/EmailSubmissionSetMethod.scala
@@ -291,6 +291,9 @@ class EmailSubmissionSetMethod @Inject()(serializer: EmailSubmissionSetSerialize
           .addAttribute(new Attribute(MAIL_METADATA_USERNAME_ATTRIBUTE, AttributeValue.of(mailboxSession.getUser.asString())))
           .build()
         mailImpl.setMessageNoCopy(message)
+        if (mailboxSession.isDelegated) {
+           mailImpl.setAttribute(new Attribute(Mail.TRUE_SENDER, AttributeValue.of(mailboxSession.getLoggedInUser.get().asString())))
+        }
         mailImpl
       }
       _ <- enqueue(mail, delay, mailboxSession)

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -171,7 +171,8 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
             .sender(sender)
             .addRecipients(recipientCollection);
 
-        Optional<MaybeSender> trueSender = session.getAttachment(TRUE_SENDER_KEY, State.Transaction);
+        Optional<MaybeSender> trueSender = session.getAttachment(TRUE_SENDER_KEY, State.Connection)
+            .or(() -> session.getAttachment(TRUE_SENDER_KEY, State.Transaction));
         trueSender.ifPresent(s -> builder.addAttribute(new Attribute(Mail.TRUE_SENDER, AttributeValue.of(s.asString()))));
 
         return builder.build();

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -34,6 +34,7 @@ import jakarta.mail.MessagingException;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
+import org.apache.james.core.Username;
 import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Response;
@@ -171,7 +172,7 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
             .sender(sender)
             .addRecipients(recipientCollection);
 
-        Optional<MaybeSender> trueSender = session.getAttachment(TRUE_SENDER_KEY, State.Connection)
+        Optional<Username> trueSender = session.getAttachment(TRUE_SENDER_KEY, State.Connection)
             .or(() -> session.getAttachment(TRUE_SENDER_KEY, State.Transaction));
         trueSender.ifPresent(s -> builder.addAttribute(new Attribute(Mail.TRUE_SENDER, AttributeValue.of(s.asString()))));
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
@@ -108,6 +108,10 @@ public class SendMailHandler implements JamesMessageHook {
                                 .map(Throwing.function(MimeMessage::getMessageID))
                                 .orElse(""),
                             "sender", mail.getMaybeSender().asString(),
+                            "authenticatedUser", mail.getAttribute(Mail.TRUE_SENDER).map(attribute -> attribute.getValue().getValue().toString())
+                                .orElseGet(() -> Optional.ofNullable(session.getUsername())
+                                    .map(Username::asString)
+                                    .orElse("")),
                             "size", Long.toString(mail.getMessageSize()),
                             "recipients", StringUtils.join(mail.getRecipients()),
                             "holdFor", holdFor.value().toString())))
@@ -133,6 +137,10 @@ public class SendMailHandler implements JamesMessageHook {
                             "mimeMessageId", Optional.ofNullable(mail.getMessage())
                                 .map(Throwing.function(MimeMessage::getMessageID))
                                 .orElse(""),
+                            "authenticatedUser", mail.getAttribute(Mail.TRUE_SENDER).map(attribute -> attribute.getValue().getValue().toString())
+                                .orElseGet(() -> Optional.ofNullable(session.getUsername())
+                                    .map(Username::asString)
+                                    .orElse("")),
                             "sender", mail.getMaybeSender().asString(),
                             "size", Long.toString(mail.getMessageSize()),
                             "recipients", StringUtils.join(mail.getRecipients()))))

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
@@ -18,10 +18,13 @@
  ****************************************************************/
 package org.apache.james.smtpserver;
 
+import static org.apache.james.protocols.smtp.core.esmtp.AuthCmdHandler.TRUE_SENDER_KEY;
+
 import java.util.Optional;
 
 import jakarta.inject.Inject;
 
+import org.apache.james.core.MaybeSender;
 import org.apache.james.core.Username;
 import org.apache.james.jwt.OidcJwtTokenVerifier;
 import org.apache.james.jwt.introspection.IntrospectionEndpoint;
@@ -29,6 +32,7 @@ import org.apache.james.mailbox.Authorizator;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.protocols.api.OIDCSASLParser;
 import org.apache.james.protocols.api.OidcSASLConfiguration;
+import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.AuthHook;
 import org.apache.james.protocols.smtp.hook.HookResult;
@@ -93,6 +97,7 @@ public class UsersRepositoryAuthHook implements AuthHook {
     private HookResult doAuthWithDelegation(SMTPSession session, Username authenticatedUser, Username associatedUser) {
         try {
             if (Authorizator.AuthorizationState.ALLOWED.equals(authorizator.user(authenticatedUser).canLoginAs(associatedUser))) {
+                session.setAttachment(TRUE_SENDER_KEY, authenticatedUser, ProtocolSession.State.Connection);
                 return saslSuccess(session, associatedUser);
             }
         } catch (MailboxException e) {

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SmtpAuthTestTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SmtpAuthTestTest.java
@@ -1,0 +1,108 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.smtpserver;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.james.smtpserver.SMTPServerTestSystem.BOB;
+import static org.apache.james.smtpserver.SMTPServerTestSystem.PASSWORD;
+import static org.apache.mailet.DsnParameters.Notify.DELAY;
+import static org.apache.mailet.DsnParameters.Notify.FAILURE;
+import static org.apache.mailet.DsnParameters.Notify.SUCCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Base64;
+import java.util.EnumSet;
+
+import org.apache.commons.net.smtp.SMTPClient;
+import org.apache.james.core.MailAddress;
+import org.apache.james.server.core.configuration.Configuration;
+import org.apache.james.server.core.configuration.FileConfigurationProvider;
+import org.apache.mailet.DsnParameters;
+import org.apache.mailet.Mail;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SmtpAuthTestTest {
+    protected Configuration configuration;
+
+    private final SMTPServerTestSystem testSystem = new SMTPServerTestSystem();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testSystem.preSetUp();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testSystem.smtpServer.destroy();
+    }
+
+    private void authenticate(SMTPClient smtpProtocol) throws IOException {
+        smtpProtocol.sendCommand("AUTH PLAIN");
+        smtpProtocol.sendCommand(Base64.getEncoder().encodeToString(("\0" + BOB.asString() + "\0" + PASSWORD + "\0").getBytes(UTF_8)));
+        assertThat(smtpProtocol.getReplyCode())
+            .as("authenticated")
+            .isEqualTo(235);
+    }
+
+    @Test
+    void shouldSupportAuthParameterInMailFrom() throws Exception {
+        testSystem.smtpServer.configure(FileConfigurationProvider.getConfig(
+            ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
+        testSystem.smtpServer.init();
+
+        SMTPClient smtpProtocol = new SMTPClient();
+        InetSocketAddress bindedAddress = testSystem.getBindedAddress();
+        smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+        authenticate(smtpProtocol);
+
+        smtpProtocol.sendCommand("EHLO localhost");
+        smtpProtocol.sendCommand("MAIL FROM: <bob@localhost> AUTH=other@localhost");
+        smtpProtocol.sendCommand("RCPT TO:<rcpt@localhost>");
+        smtpProtocol.sendShortMessageData("From: bob@localhost\r\n\r\nSubject: test mail\r\n\r\nTest body testSimpleMailSendWithDSN\r\n.\r\n");
+
+        assertThat(testSystem.queue.getLastMail().attributesMap().get(Mail.TRUE_SENDER).getValue().getValue())
+            .isEqualTo("other@localhost");
+    }
+
+    @Test
+    void shouldSupportAuthParameterInMailFromWhenNone() throws Exception {
+        testSystem.smtpServer.configure(FileConfigurationProvider.getConfig(
+            ClassLoader.getSystemResourceAsStream("smtpserver-dsn.xml")));
+        testSystem.smtpServer.init();
+
+        SMTPClient smtpProtocol = new SMTPClient();
+        InetSocketAddress bindedAddress = testSystem.getBindedAddress();
+        smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+        authenticate(smtpProtocol);
+
+        smtpProtocol.sendCommand("EHLO localhost");
+        smtpProtocol.sendCommand("MAIL FROM: <bob@localhost> AUTH=<>");
+        smtpProtocol.sendCommand("RCPT TO:<rcpt@localhost>");
+        smtpProtocol.sendShortMessageData("From: bob@localhost\r\n\r\nSubject: test mail\r\n\r\nTest body testSimpleMailSendWithDSN\r\n.\r\n");
+
+        assertThat(testSystem.queue.getLastMail().attributesMap().get(Mail.TRUE_SENDER).getValue().getValue())
+            .isEqualTo("<>");
+    }
+
+}


### PR DESCRIPTION
Remaining work to do: 

 - [ ] validate value supplied by other domains in order to ensure this is not a spoofing attempt of one of our domains.

Note that conditionally removing the attribute, eg in a complex mail groupware can allow to either say:

 - minister did send this email
 
 or 

 - secretary did send this email in the name of minister