### PR TITLE
JAMES-3693 Polish Redis client setup code

### DIFF
--- a/backends-common/redis/pom.xml
+++ b/backends-common/redis/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>lettuce-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-scala-extensions_${scala.base}</artifactId>
             <scope>provided</scope>

--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisClientFactory.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisClientFactory.scala
@@ -83,7 +83,11 @@ class RedisClientFactory @Singleton() @Inject()
   }
 
   private def createSentinelClient(sentinelRedisConfiguration: SentinelRedisConfiguration): RedisClient = {
-    val redisClient = RedisClient.create
+    val resourceBuilder: ClientResources.Builder = ClientResources.builder()
+      .threadFactoryProvider(threadFactoryProvider)
+    sentinelRedisConfiguration.ioThreads.foreach(value => resourceBuilder.ioThreadPoolSize(value))
+    sentinelRedisConfiguration.workerThreads.foreach(value => resourceBuilder.computationThreadPoolSize(value))
+    val redisClient = RedisClient.create(resourceBuilder.build(), sentinelRedisConfiguration.redisURI)
     redisClient.setOptions(createClientOptions(sentinelRedisConfiguration.useSSL, sentinelRedisConfiguration.mayBeSSLConfiguration))
     redisClient
   }

--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisClientFactory.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisClientFactory.scala
@@ -73,7 +73,11 @@ class RedisClientFactory @Singleton() @Inject()
   }
 
   private def createMasterReplicaClient(masterReplicaRedisConfiguration: MasterReplicaRedisConfiguration): RedisClient = {
-    val redisClient = RedisClient.create
+    val resourceBuilder: ClientResources.Builder = ClientResources.builder()
+      .threadFactoryProvider(threadFactoryProvider)
+    masterReplicaRedisConfiguration.ioThreads.foreach(value => resourceBuilder.ioThreadPoolSize(value))
+    masterReplicaRedisConfiguration.workerThreads.foreach(value => resourceBuilder.computationThreadPoolSize(value))
+    val redisClient = RedisClient.create(resourceBuilder.build())
     redisClient.setOptions(createClientOptions(masterReplicaRedisConfiguration.useSSL, masterReplicaRedisConfiguration.mayBeSSLConfiguration))
     redisClient
   }

--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisConfiguration.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisConfiguration.scala
@@ -126,8 +126,9 @@ case class StandaloneRedisConfiguration(redisURI: RedisURI, useSSL: Boolean, may
   override def asString: String = MoreObjects.toStringHelper(this)
     .add("topology", STANDALONE_TOPOLOGY)
     .add("redisURI", redisURI.toString)
-    .add("redis.ioThreads", ioThreads)
-    .add("redis.workerThreads", workerThreads)
+    .add("ioThreads", ioThreads)
+    .add("workerThreads", workerThreads)
+    .add("useSSL", useSSL)
     .toString
 }
 
@@ -176,8 +177,10 @@ case class MasterReplicaRedisConfiguration(redisURI: RedisUris, useSSL: Boolean,
   override def asString: String = MoreObjects.toStringHelper(this)
     .add("topology", MASTER_REPLICA_TOPOLOGY)
     .add("redisURI", redisURI.value.map(_.toString).mkString(";"))
-    .add("redis.ioThreads", ioThreads)
-    .add("redis.workerThreads", workerThreads)
+    .add("ioThreads", ioThreads)
+    .add("workerThreads", workerThreads)
+    .add("useSSL", useSSL)
+    .add("readFrom", readFrom)
     .toString
 }
 
@@ -211,8 +214,9 @@ case class ClusterRedisConfiguration(redisURI: RedisUris, useSSL: Boolean, mayBe
   override def asString: String = MoreObjects.toStringHelper(this)
     .add("topology", CLUSTER_TOPOLOGY)
     .add("redisURI", redisURI.value.map(_.toString).mkString(";"))
-    .add("redis.ioThreads", ioThreads)
-    .add("redis.workerThreads", workerThreads)
+    .add("ioThreads", ioThreads)
+    .add("workerThreads", workerThreads)
+    .add("useSSL", useSSL)
     .add("readFrom", readFrom)
     .toString
 }
@@ -250,8 +254,10 @@ case class SentinelRedisConfiguration(redisURI: RedisURI, useSSL: Boolean, mayBe
   override def asString: String = MoreObjects.toStringHelper(this)
     .add("topology", SENTINEL_TOPOLOGY)
     .add("redisURI", redisURI.toString)
-    .add("redis.ioThreads", ioThreads)
-    .add("redis.workerThreads", workerThreads)
+    .add("ioThreads", ioThreads)
+    .add("workerThreads", workerThreads)
+    .add("useSSL", useSSL)
+    .add("readFrom", readFrom)
     .toString
 }
 

--- a/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisConfiguration.scala
+++ b/backends-common/redis/src/main/java/org/apache/james/backends/redis/RedisConfiguration.scala
@@ -97,6 +97,10 @@ trait RedisConfiguration {
 
   def workerThreads: Option[Int]
 
+  def useSSL: Boolean
+
+  def mayBeSSLConfiguration: Option[SSLConfiguration]
+
   def asString: String
 }
 

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisClusterExtension.java
@@ -52,6 +52,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 
+import io.lettuce.core.ReadFrom;
 import scala.jdk.javaapi.OptionConverters;
 
 public class RedisClusterExtension implements GuiceModuleTestExtension {
@@ -67,7 +68,8 @@ public class RedisClusterExtension implements GuiceModuleTestExtension {
                     .map(URI::toString)
                     .toArray(String[]::new),
                 OptionConverters.toScala(Optional.empty()),
-                OptionConverters.toScala(Optional.empty()));
+                OptionConverters.toScala(Optional.empty()),
+                ReadFrom.MASTER);
         }
 
         public void pauseOne() {

--- a/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
+++ b/backends-common/redis/src/test/java/org/apache/james/backends/redis/RedisConfigurationTest.scala
@@ -46,9 +46,21 @@ class RedisConfigurationTest extends AnyFlatSpec with Matchers {
     config.addProperty("redis.topology", "cluster")
     config.addProperty("redis.ioThreads", 16)
     config.addProperty("redis.workerThreads", 32)
+    config.addProperty("redis.readFrom", "any")
 
     val redisConfig = RedisConfiguration.from(config)
-    redisConfig shouldEqual ClusterRedisConfiguration(RedisUris.liftOrThrow(List(RedisURI.create("redis://localhost:6379"), RedisURI.create("redis://localhost:6380"))), useSSL = false, mayBeSSLConfiguration = None, Some(16), Some(32))
+    redisConfig shouldEqual ClusterRedisConfiguration(RedisUris.liftOrThrow(List(RedisURI.create("redis://localhost:6379"), RedisURI.create("redis://localhost:6380"))), useSSL = false, mayBeSSLConfiguration = None, Some(16), Some(32), ReadFrom.ANY)
+  }
+
+  it should "use default values for missing config values when cluster mode" in {
+    val config = new PropertiesConfiguration()
+    config.setListDelimiterHandler(new DefaultListDelimiterHandler(','))
+    config.addProperty("redisURL", "redis://localhost:6379,redis://localhost:6380")
+    config.addProperty("redis.topology", "cluster")
+
+    val redisConfig = RedisConfiguration.from(config)
+    redisConfig shouldEqual ClusterRedisConfiguration(RedisUris.liftOrThrow(List(RedisURI.create("redis://localhost:6379"), RedisURI.create("redis://localhost:6380"))), useSSL = false, mayBeSSLConfiguration = None,
+      ioThreads = None, workerThreads = None, ReadFrom.MASTER)
   }
 
   it should "use default values for missing config values" in {

--- a/docs/modules/servers/partials/configure/redis.adoc
+++ b/docs/modules/servers/partials/configure/redis.adoc
@@ -53,7 +53,7 @@ However, if your machine has only 1 CPU core or your Redis usage is not intensiv
 
 == TLS/SSL
 
-To enable ssl mode, set `redis.ssl.enalbed` to true. The keyword `rediss` must be used in redisURL. For example:
+To enable ssl mode, set `redis.ssl.enabled` to true. The keyword `rediss` must be used in redisURL. For example:
 ....
 redisURL=rediss://123@localhost:6379?verifyPeer=NONE
 ....
@@ -72,9 +72,9 @@ Once ssl mode is enabled, the following properties can be specified:
 | The password of the p12 file. Defaults to empty.
 |===
 
-Query paras in `redisURL` could be used to specify some configs for Lettuce (Redis client lib used by James)
+Query params in `redisURL` could be used to specify some configs for Lettuce (Redis client lib used by James)
 
-One of those query paras is `verifyPeer`. By default, Lettuce verifies the certificate against the validity and the common name (Name validation not supported on Java 1.6, only available on Java 1.7 and higher) of the Redis host you are connecting to. This behavior can be turned off by `verifyPeer=NONE`
+One of those query params is `verifyPeer`. By default, Lettuce verifies the certificate against the validity and the common name (Name validation not supported on Java 1.6, only available on Java 1.7 and higher) of the Redis host you are connecting to. This behavior can be turned off by `verifyPeer=NONE`
 
 For more details about query paras supported in `redisURL` as well as other Lettuce support for TLS/SSL, consult this link:
 https://github.com/redis/lettuce/wiki/SSL-Connections

--- a/server/mailet/rate-limiter-redis/src/main/java/org/apache/james/rate/limiter/redis/RedisClusterRateLimiterFactory.java
+++ b/server/mailet/rate-limiter-redis/src/main/java/org/apache/james/rate/limiter/redis/RedisClusterRateLimiterFactory.java
@@ -1,0 +1,78 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.rate.limiter.redis;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+import es.moki.ratelimitj.core.limiter.request.AbstractRequestRateLimiterFactory;
+import es.moki.ratelimitj.core.limiter.request.ReactiveRequestRateLimiter;
+import es.moki.ratelimitj.core.limiter.request.RequestLimitRule;
+import es.moki.ratelimitj.core.limiter.request.RequestRateLimiter;
+import es.moki.ratelimitj.redis.request.RedisSlidingWindowRequestRateLimiter;
+import io.lettuce.core.ReadFrom;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+
+/**
+ * Copy of {@link es.moki.ratelimitj.redis.request.RedisClusterRateLimiterFactory}, with readFrom support.
+ */
+public class RedisClusterRateLimiterFactory extends AbstractRequestRateLimiterFactory<RedisSlidingWindowRequestRateLimiter> {
+
+    private final RedisClusterClient client;
+    private StatefulRedisClusterConnection<String, String> connection;
+    private final ReadFrom readFrom;
+
+    public RedisClusterRateLimiterFactory(RedisClusterClient client, ReadFrom readFrom) {
+        this.client = requireNonNull(client);
+        this.readFrom = readFrom;
+    }
+
+    @Override
+    public RequestRateLimiter getInstance(Set<RequestLimitRule> rules) {
+        return lookupInstance(rules);
+    }
+
+    @Override
+    public ReactiveRequestRateLimiter getInstanceReactive(Set<RequestLimitRule> rules) {
+        return lookupInstance(rules);
+    }
+
+    @Override
+    protected RedisSlidingWindowRequestRateLimiter create(Set<RequestLimitRule> rules) {
+        getConnection().reactive();
+        return new RedisSlidingWindowRequestRateLimiter(getConnection().reactive(), getConnection().reactive(), rules);
+    }
+
+    @Override
+    public void close() {
+        client.shutdown();
+    }
+
+    private StatefulRedisClusterConnection<String, String> getConnection() {
+        // going to ignore race conditions at the cost of having multiple connections
+        if (connection == null) {
+            connection = client.connect();
+            connection.setReadFrom(readFrom);
+        }
+        return connection;
+    }
+}

--- a/server/mailet/rate-limiter-redis/src/main/scala/org/apache/james/rate/limiter/redis/RedisRateLimiter.scala
+++ b/server/mailet/rate-limiter-redis/src/main/scala/org/apache/james/rate/limiter/redis/RedisRateLimiter.scala
@@ -24,7 +24,7 @@ import java.time.Duration
 import com.google.common.collect.ImmutableList
 import com.google.inject.{AbstractModule, Provides, Scopes}
 import es.moki.ratelimitj.core.limiter.request.{AbstractRequestRateLimiterFactory, ReactiveRequestRateLimiter, RequestLimitRule}
-import es.moki.ratelimitj.redis.request.{RedisClusterRateLimiterFactory, RedisSlidingWindowRequestRateLimiter, RedisRateLimiterFactory => RedisSingleInstanceRateLimitjFactory}
+import es.moki.ratelimitj.redis.request.{RedisSlidingWindowRequestRateLimiter, RedisRateLimiterFactory => RedisSingleInstanceRateLimitjFactory}
 import io.lettuce.core.cluster.RedisClusterClient
 import io.lettuce.core.{AbstractRedisClient, RedisClient}
 import jakarta.inject.Inject
@@ -55,8 +55,8 @@ class RedisRateLimiterFactory @Inject()(redisConfiguration: RedisConfiguration, 
   private val rateLimitjFactory: AbstractRequestRateLimiterFactory[RedisSlidingWindowRequestRateLimiter] = redisConfiguration match {
     case _: StandaloneRedisConfiguration => new RedisSingleInstanceRateLimitjFactory(rawRedisClient.asInstanceOf[RedisClient])
 
-    case _: ClusterRedisConfiguration =>
-      new RedisClusterRateLimiterFactory(rawRedisClient.asInstanceOf[RedisClusterClient])
+    case clusterRedisConfiguration: ClusterRedisConfiguration =>
+      new RedisClusterRateLimiterFactory(rawRedisClient.asInstanceOf[RedisClusterClient], clusterRedisConfiguration.readFrom)
 
     case masterReplicaRedisConfiguration: MasterReplicaRedisConfiguration => new RedisMasterReplicaRateLimiterFactory(
       rawRedisClient.asInstanceOf[RedisClient],


### PR DESCRIPTION
A couple of Redis config entries are not applied fully e.g. `ioThreads`, `workerThreads`, `readFrom`.

I take the chance to fix them, clean up the code, and allow Lettuce to use native epoll transport.