### PR TITLE
JAMES-4137 Upgrade S3 SDK to 2.30.x onwards

### DIFF
--- a/docs/modules/servers/partials/configure/jvm.adoc
+++ b/docs/modules/servers/partials/configure/jvm.adoc
@@ -90,6 +90,18 @@ To enable blob hierarchy compatible with MinIO add in `jvm.properties`:
 james.s3.minio.compatibility.mode=true
 ----
 
+== Disable S3 checksum backward compatibility
+
+By default, James enables backward compatibility for S3 SDK checksum mechanisms to support S3 compatible object storages which rely on MD5 checksum. This can be disabled for native AWS S3 that does not need to rely on the MD5 checksum.
+
+Optional. Boolean. Defaults to true.
+
+Ex in `jvm.properties`
+----
+james.s3.sdk.checksum.backward.compatibility=false
+----
+To disable S3 checksum backward compatibility.
+
 == JMAP Quota draft compatibility
 
 Some JMAP clients depend on the JMAP Quota draft specifications. The property `james.jmap.quota.draft.compatibility` allows

--- a/pom.xml
+++ b/pom.xml
@@ -644,7 +644,7 @@
         <junit.platform.version>1.10.2</junit.platform.version>
         <junit.vintage.version>5.10.2</junit.vintage.version>
         <concurrent.version>1.3.4</concurrent.version>
-        <netty.version>4.1.110.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <cucumber.version>7.15.0</cucumber.version>
 
         <jackson.version>2.17.1</jackson.version>

--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Blob :: S3</name>
 
     <properties>
-        <s3-sdk.version>2.26.5</s3-sdk.version>
+        <s3-sdk.version>2.31.59</s3-sdk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
In S3 SDK version 2.30.0, AWS team introduced a breaking change in the integrity check in the driver:

- Checksum is always required by default by AWS SDK >= 2.30.x
- AWS SDK >= 2.30.x does not send MD5 checksum anymore (which 3rd party S3 storages rely on), but relies on CRC32 checksum.

cf: https://github.com/aws/aws-sdk-java-v2/discussions/5802

This breaks the compatibility with 3rd party object storage(s) that still rely on MD5 checksum. We failed to upgrade the SDK in the past: https://github.com/apache/james-project/pull/2638.

It seems after receiving a lot of complaints from the community (Apache Hadoop, Apache Iceberg, Apache Spark...), AWS has agreed to have an option to maintain backward compatibility with S3-compatible storages. cf https://github.com/aws/aws-sdk-java-v2/pull/6055.

Apache Iceberg is starting to adopt the backward compatibility option: https://github.com/apache/iceberg/pull/12264.

Let's try to adopt this on our side, with care.