### PR TITLE
JAMES-4124 Upgrade Rspamd to 3.12.0

### DIFF
--- a/third-party/rspamd/docker-compose-distributed.yml
+++ b/third-party/rspamd/docker-compose-distributed.yml
@@ -108,7 +108,7 @@ services:
       redis:
         condition: service_started
     container_name: rspamd
-    image: rspamd/rspamd:3.9.1
+    image: rspamd/rspamd:3.12.0
     environment:
       - RSPAMD_PASSWORD=admin
     volumes:

--- a/third-party/rspamd/docker-compose-rspamd-with-kvrocks-sentinel.yml
+++ b/third-party/rspamd/docker-compose-rspamd-with-kvrocks-sentinel.yml
@@ -103,7 +103,7 @@ services:
       kvrocks-master:
           condition: service_healthy
     container_name: rspamd
-    image: rspamd/rspamd:3.11.1 # Rspamd version >= 3.10 is needed to fix the Redis read-only issue when Rspamd gets bayes statistics too.
+    image: rspamd/rspamd:3.12.0
     environment:
       - RSPAMD_PASSWORD=admin
     volumes:

--- a/third-party/rspamd/docker-compose-rspamd-with-kvrocks-standalone.yml
+++ b/third-party/rspamd/docker-compose-rspamd-with-kvrocks-standalone.yml
@@ -54,7 +54,7 @@ services:
       kvrocks:
           condition: service_started
     container_name: rspamd
-    image: rspamd/rspamd:3.9.1
+    image: rspamd/rspamd:3.12.0
     environment:
       - RSPAMD_PASSWORD=admin
     volumes:

--- a/third-party/rspamd/docker-compose-rspamd-with-redis-sentinel.yml
+++ b/third-party/rspamd/docker-compose-rspamd-with-redis-sentinel.yml
@@ -102,7 +102,7 @@ services:
       redis-master:
           condition: service_healthy
     container_name: rspamd
-    image: rspamd/rspamd:3.9.1
+    image: rspamd/rspamd:3.12.0
     environment:
       - RSPAMD_PASSWORD=admin
     volumes:

--- a/third-party/rspamd/docker-compose.yml
+++ b/third-party/rspamd/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       redis:
           condition: service_started
     container_name: rspamd
-    image: rspamd/rspamd:3.9.1
+    image: rspamd/rspamd:3.12.0
     environment:
       - RSPAMD_PASSWORD=admin
     volumes:

--- a/third-party/rspamd/sample-configuration/kvrocks/sentinel/replica-node/kvrocks.conf
+++ b/third-party/rspamd/sample-configuration/kvrocks/sentinel/replica-node/kvrocks.conf
@@ -10,4 +10,5 @@ port 6379
 # This allows Rspamd to execute EVALSHA read-only Lua script on Kvrocks replicas to get the BAYES statistics.
 # Cautious: This would allow Kvrocks replicas to be writable, therefore we need to carefully configure Rspamd or whatever app to use the correct master/replicas Kvrocks endpoints.
 # There is also a small time window upon Redis Sentinel failover that Rspamd could write to the old master (new replica). We could very likely accept that for spam learning data.
-slave-read-only no
+# Only needed if Rspamd < 3.12.0
+# slave-read-only no

--- a/third-party/rspamd/sample-configuration/rspamd-kvrocks-sentinel.conf
+++ b/third-party/rspamd/sample-configuration/rspamd-kvrocks-sentinel.conf
@@ -4,3 +4,4 @@ password = "secret1";
 sentinel_watch_time = 10s; # How often Rspam will query sentinels for masters and slaves
 sentinel_masters_pattern = "^mymaster.*$"; # Defines masters pattern to match in Lua syntax (no pattern means all masters)
 timeout = 5s;
+redis_version = 7; # Allow Rspamd to execute the EVALSHA_RO command against Kvrocks replicas. cf https://github.com/rspamd/rspamd/pull/5419

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdExtension.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdExtension.java
@@ -40,7 +40,7 @@ public class RspamdExtension implements GuiceModuleTestExtension {
     public static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(5);
     public static final String PASSWORD = "admin";
 
-    private static final DockerImageName RSPAMD_IMAGE = DockerImageName.parse("rspamd/rspamd").withTag("3.9.1");
+    private static final DockerImageName RSPAMD_IMAGE = DockerImageName.parse("rspamd/rspamd").withTag("3.12.0");
     private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("apache/kvrocks").withTag("2.11.1");
     private static final DockerImageName CLAMAV_IMAGE = DockerImageName.parse("clamav/clamav").withTag("1.3");
     private static final int RSPAMD_DEFAULT_PORT = 11334;


### PR DESCRIPTION
This would allow Rspamd to execute EVASHA_RO commands against Kvrocks replicas (instead of EVASHA, which Kvrocks replicas reject ATM).

cf: https://github.com/rspamd/rspamd/pull/5419

Then no workaround is needed anymore for Rspamd + Kvrocks sentinel.