### PR TITLE
[UPGRADE] commons-fileupload 1.5 -> 1.6.0

### DIFF
--- a/server/protocols/jmap-rfc-8621/pom.xml
+++ b/server/protocols/jmap-rfc-8621/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>eu.timepit</groupId>


### PR DESCRIPTION
Fixes CVE-2025-48976 FileUpload DoS via part headers