### PR TITLE
Summer lib updates

### DIFF
--- a/backends-common/cassandra/pom.xml
+++ b/backends-common/cassandra/pom.xml
@@ -31,7 +31,7 @@
     <name>Apache James :: Backends Common :: Cassandra</name>
 
     <properties>
-        <cassandra.driver.version>4.18.0</cassandra.driver.version>
+        <cassandra.driver.version>4.19.0</cassandra.driver.version>
     </properties>
 
     <dependencies>

--- a/backends-common/jpa/pom.xml
+++ b/backends-common/jpa/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.9.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/backends-common/opensearch/pom.xml
+++ b/backends-common/opensearch/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-java</artifactId>
-            <version>2.11.1</version>
+            <version>2.25.0</version>
         </dependency>
         <dependency>
             <groupId>org.opensearch.client</groupId>

--- a/backends-common/opensearch/pom.xml
+++ b/backends-common/opensearch/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-rest-client</artifactId>
-            <version>2.14.0</version>
+            <version>2.19.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/backends-common/postgres/pom.xml
+++ b/backends-common/postgres/pom.xml
@@ -29,7 +29,7 @@
     <name>Apache James :: Backends Common :: Postgres</name>
 
     <properties>
-        <jooq.version>3.19.15</jooq.version>
+        <jooq.version>3.20.5</jooq.version>
         <r2dbc.postgresql.version>1.0.7.RELEASE</r2dbc.postgresql.version>
     </properties>
 

--- a/backends-common/postgres/pom.xml
+++ b/backends-common/postgres/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-pool</artifactId>
-            <version>1.0.1.RELEASE</version>
+            <version>1.0.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>apache-james-backends-pulsar</artifactId>
     <name>Apache James :: Backends Common :: Pulsar</name>
     <properties>
-        <pulsar-client.version>2.11.0</pulsar-client.version>
+        <pulsar-client.version>4.0.5</pulsar-client.version>
         <clever-cloud.pulsar4s.version>2.12.0.1</clever-cloud.pulsar4s.version>
         <pekko-stream.version>1.1.4</pekko-stream.version>
     </properties>

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <pulsar-client.version>2.11.0</pulsar-client.version>
         <clever-cloud.pulsar4s.version>2.12.0.1</clever-cloud.pulsar4s.version>
-        <pekko-stream.version>1.0.2</pekko-stream.version>
+        <pekko-stream.version>1.1.4</pekko-stream.version>
     </properties>
 
     <dependencies>

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -31,7 +31,7 @@
     <name>Apache James :: Backends Common :: Pulsar</name>
     <properties>
         <pulsar-client.version>2.11.0</pulsar-client.version>
-        <clever-cloud.pulsar4s.version>2.9.1</clever-cloud.pulsar4s.version>
+        <clever-cloud.pulsar4s.version>2.12.0.1</clever-cloud.pulsar4s.version>
         <pekko-stream.version>1.0.2</pekko-stream.version>
     </properties>
 

--- a/backends-common/pulsar/pom.xml
+++ b/backends-common/pulsar/pom.xml
@@ -93,13 +93,13 @@
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-pulsar_${scala.base}</artifactId>
-            <version>0.40.10</version>
+            <version>0.43.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-scalatest_${scala.base}</artifactId>
-            <version>0.40.10</version>
+            <version>0.43.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/custom-imap/pom.xml
+++ b/examples/custom-imap/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/examples/metrics-graphite/pom.xml
+++ b/examples/metrics-graphite/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>4.2.19</version>
+            <version>4.2.32</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mailbox/api/pom.xml
+++ b/mailbox/api/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.google.re2j</groupId>
             <artifactId>re2j</artifactId>
-            <version>1.7</version>
+            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/mailbox/event/json/pom.xml
+++ b/mailbox/event/json/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.beachape</groupId>
             <artifactId>enumeratum_${scala.base}</artifactId>
-            <version>1.7.2</version>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.chuusai</groupId>

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -169,7 +169,7 @@
                     <dependency>
                         <groupId>org.apache.xbean</groupId>
                         <artifactId>xbean-asm9-shaded</artifactId>
-                        <version>4.23</version>
+                        <version>4.27</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/mailbox/postgres/pom.xml
+++ b/mailbox/postgres/pom.xml
@@ -30,7 +30,7 @@
     <name>Apache James :: Mailbox :: Postgres</name>
 
     <properties>
-        <uuid-creator.version>5.3.7</uuid-creator.version>
+        <uuid-creator.version>6.1.1</uuid-creator.version>
     </properties>
 
     <dependencies>

--- a/mpt/app/src/main/java/org/apache/james/mpt/app/Main.java
+++ b/mpt/app/src/main/java/org/apache/james/mpt/app/Main.java
@@ -76,7 +76,7 @@ public class Main {
             try {
                 Port port = new Port(Integer.parseInt(cmd.getOptionValue(PORT_OPTION)));    
                 String host = cmd.getOptionValue(HOST_OPTION, "localhost");
-                String shabang = cmd.getOptionValue(SHABANG_OPTION, null);
+                String shabang = cmd.getOptionValue(SHABANG_OPTION, "");
                 RunScript runner = new RunScript(file, port, host, shabang, verbose);
                 runner.run();
                 

--- a/mpt/impl/smtp/jpa-pulsar/pom.xml
+++ b/mpt/impl/smtp/jpa-pulsar/pom.xml
@@ -112,7 +112,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -662,7 +662,7 @@
         <!-- maven-mailetdocs-plugin artifacts -->
         <maven-artifact.version>3.0-alpha-1</maven-artifact.version>
         <maven-plugin-annotations.version>3.9.0</maven-plugin-annotations.version>
-        <maven-plugin-api.version>3.9.3</maven-plugin-api.version>
+        <maven-plugin-api.version>3.9.10</maven-plugin-api.version>
         <maven-reporting-impl.version>3.1.0</maven-reporting-impl.version>
         <maven-reporting-api.version>3.1.1</maven-reporting-api.version>
         <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3724,7 +3724,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.17.0</version>
+                        <version>10.25.0</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2708,7 +2708,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.12.0</version>
+                <version>1.13.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -678,7 +678,7 @@
         <io.micrometer.core.version>1.15.1</io.micrometer.core.version>
         <io.micrometer.tracing.version>1.5.1</io.micrometer.tracing.version>
 
-        <bouncycastle.version>1.78.1</bouncycastle.version>
+        <bouncycastle.version>1.81</bouncycastle.version>
 
         <scala.base>2.13</scala.base>
         <scala.version>${scala.base}.14</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -683,7 +683,7 @@
         <scala.base>2.13</scala.base>
         <scala.version>${scala.base}.14</scala.version>
         <doclint>none</doclint>
-        <mockito.version>5.10.0</mockito.version>
+        <mockito.version>5.18.0</mockito.version>
         <ical4j.version>4.1.1</ical4j.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <javacrumbs.json-unit.version>4.1.1</javacrumbs.json-unit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2253,7 +2253,7 @@
             <dependency>
                 <groupId>com.google.crypto.tink</groupId>
                 <artifactId>apps-webpush</artifactId>
-                <version>${tink.version}</version>
+                <version>1.12.2</version>
                 <exclusions>
                     <!-- https://cwe.mitre.org/data/definitions/502.html -->
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -2901,7 +2901,7 @@
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-suite</artifactId>
-                <version>1.9.3</version>
+                <version>1.13.1</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.vintage</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2946,7 +2946,7 @@
             <dependency>
                 <groupId>org.scalacheck</groupId>
                 <artifactId>scalacheck_${scala.base}</artifactId>
-                <version>1.18.0</version>
+                <version>1.18.1</version>
             </dependency>
             <dependency>
                 <groupId>org.scalatest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
         <apache-mime4j.version>0.8.12</apache-mime4j.version>
         <apache.openjpa.version>4.0.0</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>
-        <log4j2.version>2.23.1</log4j2.version>
+        <log4j2.version>2.24.3</log4j2.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -636,7 +636,7 @@
         <angus-mail.version>2.0.3</angus-mail.version>
         <angus-activation.version>2.0.2</angus-activation.version>
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
-        <slf4j.version>2.0.13</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
 
         <circe.version>0.14.14</circe.version>
         <dnsjava.version>3.6.3</dnsjava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -648,7 +648,7 @@
         <cucumber.version>7.23.0</cucumber.version>
 
         <jackson.version>2.19.1</jackson.version>
-        <jackson.databind.version>2.17.1</jackson.databind.version>
+        <jackson.databind.version>2.19.1</jackson.databind.version>
         <feign.version>13.6</feign.version>
         <feign-form.version>3.8.0</feign-form.version>
         <jjwt.version>0.11.5</jjwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -641,8 +641,8 @@
         <circe.version>0.14.14</circe.version>
         <dnsjava.version>3.6.3</dnsjava.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
-        <junit.platform.version>1.10.2</junit.platform.version>
-        <junit.vintage.version>5.10.2</junit.vintage.version>
+        <junit.platform.version>1.13.1</junit.platform.version>
+        <junit.vintage.version>5.13.1</junit.vintage.version>
         <concurrent.version>1.3.4</concurrent.version>
         <netty.version>4.1.118.Final</netty.version>
         <cucumber.version>7.23.0</cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -630,7 +630,7 @@
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <jsieve.version>0.8</jsieve.version>
-        <spring.version>6.1.4</spring.version>
+        <spring.version>6.2.8</spring.version>
         <activmq-artemis.version>2.41.0</activmq-artemis.version>
         <apache-jspf-resolver.version>1.0.5</apache-jspf-resolver.version>
         <angus-mail.version>2.0.3</angus-mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2687,7 +2687,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3706,7 +3706,7 @@
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.12.0</version>
+                        <version>2.0.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -673,7 +673,7 @@
         <jasypt.version>1.9.3</jasypt.version>
         <guice.version>7.0.0</guice.version>
         <logback.version>1.5.18</logback.version>
-        <tink.version>1.12.2</tink.version>
+        <tink.version>1.17.0</tink.version>
         <lettuce.core.version>6.7.1.RELEASE</lettuce.core.version>
         <io.micrometer.core.version>1.15.1</io.micrometer.core.version>
         <io.micrometer.tracing.version>1.5.1</io.micrometer.tracing.version>

--- a/pom.xml
+++ b/pom.xml
@@ -623,7 +623,7 @@
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
         <activemq.version>6.1.6</activemq.version>
         <apache-mime4j.version>0.8.12</apache-mime4j.version>
-        <apache.openjpa.version>4.0.0</apache.openjpa.version>
+        <apache.openjpa.version>4.1.1</apache.openjpa.version>
         <derby.version>10.14.2.0</derby.version>
         <log4j2.version>2.24.3</log4j2.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2703,7 +2703,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-pool2</artifactId>
-                <version>2.12.0</version>
+                <version>2.12.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -640,7 +640,7 @@
 
         <circe.version>0.14.14</circe.version>
         <dnsjava.version>3.6.3</dnsjava.version>
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.13.1</junit.jupiter.version>
         <junit.platform.version>1.10.2</junit.platform.version>
         <junit.vintage.version>5.10.2</junit.vintage.version>
         <concurrent.version>1.3.4</concurrent.version>

--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
         <activmq-artemis.version>2.41.0</activmq-artemis.version>
         <apache-jspf-resolver.version>1.0.5</apache-jspf-resolver.version>
         <angus-mail.version>2.0.2</angus-mail.version>
-        <angus-activation.version>2.0.1</angus-activation.version>
+        <angus-activation.version>2.0.2</angus-activation.version>
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
         <slf4j.version>2.0.13</slf4j.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -681,7 +681,7 @@
         <bouncycastle.version>1.81</bouncycastle.version>
 
         <scala.base>2.13</scala.base>
-        <scala.version>${scala.base}.14</scala.version>
+        <scala.version>${scala.base}.16</scala.version>
         <doclint>none</doclint>
         <mockito.version>5.18.0</mockito.version>
         <ical4j.version>4.1.1</ical4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2866,7 +2866,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.16.1</version>
+                <version>1.20.1</version>
             </dependency>
             <dependency>
                 <groupId>org.julienrf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3124,7 +3124,7 @@
                         <dependency>
                             <groupId>ch.epfl.scala</groupId>
                             <artifactId>scalafix-core_${scala.base}</artifactId>
-                            <version>0.12.1</version>
+                            <version>0.14.3</version>
                         </dependency>
                         <dependency>
                             <groupId>com.nequissimus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -653,7 +653,7 @@
         <feign-form.version>3.8.0</feign-form.version>
         <jjwt.version>0.11.5</jjwt.version>
         <metrics.version>4.2.32</metrics.version>
-        <testcontainers.version>1.19.8</testcontainers.version>
+        <testcontainers.version>1.21.1</testcontainers.version>
         <es-reporter.version>6.0.0-RC3</es-reporter.version>
         <guava.version>33.4.8-jre</guava.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <jsieve.version>0.8</jsieve.version>
         <spring.version>6.1.4</spring.version>
-        <activmq-artemis.version>2.32.0</activmq-artemis.version>
+        <activmq-artemis.version>2.41.0</activmq-artemis.version>
         <apache-jspf-resolver.version>1.0.5</apache-jspf-resolver.version>
         <angus-mail.version>2.0.2</angus-mail.version>
         <angus-activation.version>2.0.1</angus-activation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,7 @@
         <spring.version>6.1.4</spring.version>
         <activmq-artemis.version>2.41.0</activmq-artemis.version>
         <apache-jspf-resolver.version>1.0.5</apache-jspf-resolver.version>
-        <angus-mail.version>2.0.2</angus-mail.version>
+        <angus-mail.version>2.0.3</angus-mail.version>
         <angus-activation.version>2.0.2</angus-activation.version>
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
         <slf4j.version>2.0.13</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2826,7 +2826,7 @@
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
-                <version>4.2.1</version>
+                <version>4.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2677,7 +2677,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
-                <version>4.4</version>
+                <version>4.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2698,7 +2698,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.14.0</version>
+                <version>3.17.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2821,7 +2821,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.26.0</version>
+                <version>3.27.3</version>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
         <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <qdox.version>2.2.0</qdox.version>
-        <jaxb.version>2.4.0-b180830.0359</jaxb.version>
+        <jaxb.version>4.0.5</jaxb.version>
         <lucene.version>10.2.1</lucene.version>
         <jasypt.version>1.9.3</jasypt.version>
         <guice.version>7.0.0</guice.version>
@@ -2628,7 +2628,7 @@
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
+                <version>2.4.0-b180830.0359</version>
             </dependency>
             <dependency>
                 <groupId>net.javacrumbs.json-unit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3115,7 +3115,7 @@
                 <plugin>
                     <groupId>io.github.evis</groupId>
                     <artifactId>scalafix-maven-plugin_2.13</artifactId>
-                    <version>0.1.10_0.11.0</version>
+                    <version>0.1.10_0.14.2</version>
                     <configuration>
                         <config>${basedir}/.scalafix.conf</config>
                         <mode>CHECK</mode>

--- a/pom.xml
+++ b/pom.xml
@@ -684,7 +684,7 @@
         <scala.version>${scala.base}.14</scala.version>
         <doclint>none</doclint>
         <mockito.version>5.10.0</mockito.version>
-        <ical4j.version>4.1.0</ical4j.version>
+        <ical4j.version>4.1.1</ical4j.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <javacrumbs.json-unit.version>4.1.1</javacrumbs.json-unit.version>
         <fastutil-core.version>8.5.15</fastutil-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2951,7 +2951,7 @@
             <dependency>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest_${scala.base}</artifactId>
-                <version>3.2.18</version>
+                <version>3.2.19</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2682,7 +2682,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.26.2</version>
+                <version>1.27.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2672,7 +2672,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.13</version>
+                <version>1.10.15</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,7 @@
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <qdox.version>2.2.0</qdox.version>
         <jaxb.version>2.4.0-b180830.0359</jaxb.version>
-        <lucene.version>9.11.1</lucene.version>
+        <lucene.version>10.2.1</lucene.version>
         <jasypt.version>1.9.3</jasypt.version>
         <guice.version>7.0.0</guice.version>
         <logback.version>1.5.18</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -661,7 +661,7 @@
         <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
         <!-- maven-mailetdocs-plugin artifacts -->
         <maven-artifact.version>3.0-alpha-1</maven-artifact.version>
-        <maven-plugin-annotations.version>3.9.0</maven-plugin-annotations.version>
+        <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <maven-plugin-api.version>3.9.10</maven-plugin-api.version>
         <maven-reporting-impl.version>3.1.0</maven-reporting-impl.version>
         <maven-reporting-api.version>3.1.1</maven-reporting-api.version>

--- a/server/apps/jpa-smtp-app/pom.xml
+++ b/server/apps/jpa-smtp-app/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>2.7.2</version>
+            <version>3.5.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/apps/migration/core-data-jpa-to-pg/pom.xml
+++ b/server/apps/migration/core-data-jpa-to-pg/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.1</version>
+            <version>42.7.7</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/server/apps/migration/core-data-jpa-to-pg/pom.xml
+++ b/server/apps/migration/core-data-jpa-to-pg/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>2.7.2</version>
+            <version>3.5.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/apps/scaling-pulsar-smtp/pom.xml
+++ b/server/apps/scaling-pulsar-smtp/pom.xml
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.1</version>
+            <version>42.7.7</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/server/apps/webadmin-cli/pom.xml
+++ b/server/apps/webadmin-cli/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.7</version>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>

--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Blob :: S3</name>
 
     <properties>
-        <s3-sdk.version>2.31.59</s3-sdk.version>
+        <s3-sdk.version>2.31.63</s3-sdk.version>
     </properties>
 
     <dependencies>

--- a/server/container/guice/postgres-common/pom.xml
+++ b/server/container/guice/postgres-common/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.0</version>
+            <version>42.7.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server/data/data-jmap-postgres/pom.xml
+++ b/server/data/data-jmap-postgres/pom.xml
@@ -34,7 +34,7 @@
     <name>Apache James :: Server :: Data :: JMAP :: PostgreSQL persistence</name>
 
     <properties>
-        <uuid-creator.version>5.3.7</uuid-creator.version>
+        <uuid-creator.version>6.1.1</uuid-creator.version>
     </properties>
 
     <dependencies>

--- a/server/mailet/integration-testing/pom.xml
+++ b/server/mailet/integration-testing/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Mailet :: Integration Testing</name>
 
     <properties>
-        <xmlunit.version>2.10.0</xmlunit.version>
+        <xmlunit.version>2.10.2</xmlunit.version>
     </properties>
 
     <dependencies>

--- a/server/mailet/mailets/pom.xml
+++ b/server/mailet/mailets/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Mailets</name>
 
     <properties>
-        <spec2.version>4.20.0</spec2.version>
+        <spec2.version>4.21.0</spec2.version>
     </properties>
 
     <dependencies>

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/pom.xml
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.softwaremill.sttp.client3</groupId>
             <artifactId>okhttp-backend_${scala.base}</artifactId>
-            <version>3.8.16</version>
+            <version>3.11.0</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>

--- a/server/protocols/jmap-rfc-8621/pom.xml
+++ b/server/protocols/jmap-rfc-8621/pom.xml
@@ -200,7 +200,7 @@
         <dependency>
             <groupId>org.typelevel</groupId>
             <artifactId>cats-core_${scala.base}</artifactId>
-            <version>2.9.0</version>
+            <version>2.13.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerTest.java
@@ -2122,7 +2122,7 @@ class IMAPServerTest {
                 .createMailbox(MailboxPath.inbox(USER), mailboxSession);
 
             connection = TcpClient.create()
-                .secure(ssl -> ssl.sslContext(SslContextBuilder.forClient().trustManager(new BlindTrustManager())))
+                .secure(Throwing.consumer(ssl -> ssl.sslContext(SslContextBuilder.forClient().trustManager(new BlindTrustManager()).build())))
                 .remoteAddress(() -> new InetSocketAddress(LOCALHOST_IP, port))
                 .connectNow();
             responses = new ConcurrentLinkedDeque<>();

--- a/server/testing/pom.xml
+++ b/server/testing/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>


### PR DESCRIPTION
It seems compiling at least. Let's see regarding the tests!

I did not update the following libs for now, I might do it in some later PR after this one is stable:

- netty: usually needs to be aligned with other libs, not sure we can here
- jjwt: need some changes and being taken care in an other PR https://github.com/apache/james-project/pull/2744
- derby
- parboiled
- doxia
- maven-reporting libs
- opensearch: upgraded to latest v2, but I saw some new v3 versions... that might need a more proper look too for a major version upgrade