### PR TITLE
JAMES-3516 ThreadIdGuessingAlgorithmContract should rely on MailboxManager to manipulate tests

### DIFF
--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresThreadIdGuessingAlgorithmTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/PostgresThreadIdGuessingAlgorithmTest.java
@@ -19,66 +19,39 @@
 
 package org.apache.james.mailbox.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.james.backends.postgres.PostgresExtension;
-import org.apache.james.core.Username;
+import org.apache.james.events.EventBus;
 import org.apache.james.events.EventBusTestFixture;
 import org.apache.james.events.InVMEventBus;
 import org.apache.james.events.MemoryEventDeadLetters;
 import org.apache.james.events.delivery.InVmEventDelivery;
-import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MessageId;
-import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresThreadDAO;
 import org.apache.james.mailbox.store.CombinationManagerTestSystem;
 import org.apache.james.mailbox.store.ThreadIdGuessingAlgorithmContract;
-import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.ThreadIdGuessingAlgorithm;
-import org.apache.james.mailbox.store.mail.model.MimeMessageId;
-import org.apache.james.mailbox.store.mail.model.Subject;
 import org.apache.james.mailbox.store.quota.NoQuotaManager;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.hash.Hashing;
-
-import reactor.core.publisher.Flux;
 
 public class PostgresThreadIdGuessingAlgorithmTest extends ThreadIdGuessingAlgorithmContract {
     @RegisterExtension
     static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(PostgresMailboxAggregateDataDefinition.MODULE);
 
-    private PostgresMailboxManager mailboxManager;
-    private PostgresThreadDAO.Factory threadDAOFactory;
+    private MessageId.Factory messageIdFactory;
 
     @Override
-    protected CombinationManagerTestSystem createTestingData() {
-        eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+    protected CombinationManagerTestSystem createTestingSystem() {
+        EventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
         PostgresCombinationManagerTestSystem testSystem = (PostgresCombinationManagerTestSystem) PostgresCombinationManagerTestSystem.createTestingData(postgresExtension, new NoQuotaManager(), eventBus);
-        mailboxManager = (PostgresMailboxManager) testSystem.getMailboxManager();
         messageIdFactory = new PostgresMessageId.Factory();
         return testSystem;
     }
 
     @Override
     protected ThreadIdGuessingAlgorithm initThreadIdGuessingAlgorithm(CombinationManagerTestSystem testingData) {
-        threadDAOFactory = new PostgresThreadDAO.Factory(postgresExtension.getExecutorFactory());
+        PostgresThreadDAO.Factory threadDAOFactory = new PostgresThreadDAO.Factory(postgresExtension.getExecutorFactory());
         return new PostgresThreadIdGuessingAlgorithm(threadDAOFactory);
-    }
-
-    @Override
-    protected MessageMapper createMessageMapper(MailboxSession mailboxSession) {
-        return mailboxManager.getMapperFactory().createMessageMapper(mailboxSession);
     }
 
     @Override
@@ -89,12 +62,6 @@ public class PostgresThreadIdGuessingAlgorithmTest extends ThreadIdGuessingAlgor
     @Override
     protected MessageId initOtherBasedMessageId() {
         return messageIdFactory.generate();
-    }
-
-    @Override
-    protected void saveThreadData(Username username, Set<MimeMessageId> mimeMessageIds, MessageId messageId, ThreadId threadId, Optional<Subject> baseSubject) {
-        PostgresThreadDAO threadDAO = threadDAOFactory.create(username.getDomainPart());
-        threadDAO.insertSome(username, hashMimeMessagesIds(mimeMessageIds), PostgresMessageId.class.cast(messageId), threadId, hashSubject(baseSubject)).block();
     }
 
 }

--- a/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SearchThreadIdGuessingAlgorithmTest.java
+++ b/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SearchThreadIdGuessingAlgorithmTest.java
@@ -19,35 +19,19 @@
 
 package org.apache.james.mailbox.store.search;
 
-import java.util.Optional;
-import java.util.Set;
-
-import org.apache.james.core.Username;
-import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.inmemory.InMemoryCombinationManagerTestSystem;
-import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 import org.apache.james.mailbox.model.MessageId;
-import org.apache.james.mailbox.model.ThreadId;
 import org.apache.james.mailbox.store.CombinationManagerTestSystem;
 import org.apache.james.mailbox.store.ThreadIdGuessingAlgorithmContract;
-import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.SearchThreadIdGuessingAlgorithm;
 import org.apache.james.mailbox.store.mail.ThreadIdGuessingAlgorithm;
-import org.apache.james.mailbox.store.mail.model.MimeMessageId;
-import org.apache.james.mailbox.store.mail.model.Subject;
 
 public class SearchThreadIdGuessingAlgorithmTest extends ThreadIdGuessingAlgorithmContract {
-    private InMemoryMailboxManager mailboxManager;
-
     @Override
-    protected CombinationManagerTestSystem createTestingData() {
+    protected CombinationManagerTestSystem createTestingSystem() {
         InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
-
-        mailboxManager = resources.getMailboxManager();
-        eventBus = resources.getEventBus();
-        messageIdFactory = resources.getMessageIdFactory();
 
         return new InMemoryCombinationManagerTestSystem(
             resources.getMailboxManager(),
@@ -60,11 +44,6 @@ public class SearchThreadIdGuessingAlgorithmTest extends ThreadIdGuessingAlgorit
     }
 
     @Override
-    protected MessageMapper createMessageMapper(MailboxSession mailboxSession) {
-        return mailboxManager.getMapperFactory().createMessageMapper(mailboxSession);
-    }
-
-    @Override
     protected MessageId initNewBasedMessageId() {
         return InMemoryMessageId.of(100);
     }
@@ -74,7 +53,4 @@ public class SearchThreadIdGuessingAlgorithmTest extends ThreadIdGuessingAlgorit
         return InMemoryMessageId.of(1000);
     }
 
-    @Override
-    protected void saveThreadData(Username username, Set<MimeMessageId> mimeMessageIds, MessageId messageId, ThreadId threadId, Optional<Subject> baseSubject) {
-    }
 }


### PR DESCRIPTION
We used the mapper API directly, making tests brittle and difficult to manage.