### PR TITLE
JAMES-3754 Relax Id command parsing

### DIFF
--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Id.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Id.test
@@ -28,3 +28,7 @@ S: a1 OK ID completed.
 C: a1 ID ("name" "Thunderbird" "version" "102.7.1")
 S: \* ID NIL
 S: a1 OK ID completed.
+
+C: a1 ID ("name" "Thunderbird" "version" 102.7.1)
+S: \* ID NIL
+S: a1 OK ID completed.

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/IDCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/IDCommandParser.java
@@ -75,9 +75,13 @@ public class IDCommandParser extends AbstractImapCommandParser {
                 request.consumeChar(',');
             }
             request.nextWordChar();
-            String value = request.consumeQuoted();
-
-            parameters.put(field, value);
+            if (request.nextWordChar() == '\"') {
+                String value = request.consumeQuoted();
+                parameters.put(field, value);
+            } else {
+                String value = request.atom();
+                parameters.put(field, value);
+            }
 
             c = request.nextWordChar();
         }


### PR DESCRIPTION
Spotted on a prod:

```
org.apache.james.imap.decode.DecodingException: Expected:'"' found:'N'
	at org.apache.james.imap.decode.ImapRequestLineReader.consumeChar(ImapRequestLineReader.java:720)
	at org.apache.james.imap.decode.ImapRequestLineReader.consumeQuoted(ImapRequestLineReader.java:739)
	at org.apache.james.imap.decode.ImapRequestLineReader.consumeQuoted(ImapRequestLineReader.java:736)
	at org.apache.james.imap.decode.ImapRequestLineReader.consumeQuoted(ImapRequestLineReader.java:728)
	at org.apache.james.imap.decode.parser.IDCommandParser.decode(IDCommandParser.java:78)
	at org.apache.james.imap.decode.base.AbstractImapCommandParser.parse(AbstractImapCommandParser.java:72)
	at org.apache.james.imap.decode.main.DefaultImapDecoder.decodeCommandNamed(DefaultImapDecoder.java:118)
	at org.apache.james.imap.decode.main.DefaultImapDecoder.decodeCommandTagged(DefaultImapDecoder.java:81)
	at org.apache.james.imap.decode.main.DefaultImapDecoder.decode(DefaultImapDecoder.java:71)
	at org.apache.james.imapserver.netty.ImapRequestFrameDecoder.parseImapMessage(ImapRequestFrameDecoder.java:150)
	at org.apache.james.imapserver.netty.ImapRequestFrameDecoder.decode(ImapRequestFrameDecoder.java:138)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1475)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1338)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1387)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Unknown Source)
```