### PR TITLE
SessionProvider.AuthorizationStep cary over protocol

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
@@ -26,6 +26,10 @@ import org.apache.james.mailbox.exception.MailboxException;
 
 public interface SessionProvider {
     interface AuthorizationStep {
+        default AuthorizationStep forProtocol(String protocolName) {
+            return this;
+        }
+
         MailboxSession as(Username other) throws MailboxException;
 
         MailboxSession withoutDelegation() throws MailboxException;

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -68,6 +68,7 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
     private static final String AUTH_TYPE_XOAUTH2 = "XOAUTH2";
     private static final List<Capability> OAUTH_CAPABILITIES = ImmutableList.of(Capability.of("AUTH=" + AUTH_TYPE_OAUTHBEARER), Capability.of("AUTH=" + AUTH_TYPE_XOAUTH2));
     public static final Capability SASL_CAPABILITY = Capability.of("SASL-IR");
+    public static final String PROTOCOL_NAME = "SMTP";
 
     @Inject
     public AuthenticateProcessor(MailboxManager mailboxManager, StatusResponseFactory factory,
@@ -218,6 +219,7 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
                 if (!associatedUser.equals(authenticatedUser)) {
                     doAuthWithDelegation(() -> getMailboxManager()
                             .authenticate(authenticatedUser)
+                            .forProtocol(PROTOCOL_NAME)
                             .as(associatedUser),
                         session, request, responder, authenticatedUser, associatedUser);
                 } else {


### PR DESCRIPTION
This can allow for sub-implementations to allow or deny the access on a per-protocol basis, eg by checking extra data structures.