### PR TITLE
[Fix] DeleteAllIndexDocumentsCleanupStrategy should only search on th…

### DIFF
--- a/backends-common/opensearch/src/test/java/org/apache/james/backends/opensearch/DockerOpenSearchExtension.java
+++ b/backends-common/opensearch/src/test/java/org/apache/james/backends/opensearch/DockerOpenSearchExtension.java
@@ -62,12 +62,12 @@ public class DockerOpenSearchExtension implements AfterEachCallback, BeforeEachC
                 .pollInterval(2, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .until(() -> {
-                    openSearch.flushIndices();
                     ReactorOpenSearchClient client = client(openSearch);
                     new DeleteByQueryPerformer(client, aliasName)
                         .perform(new MatchAllQuery.Builder().build().toQuery())
                         .block();
                     SearchRequest searchRequest = new SearchRequest.Builder()
+                        .index(aliasName.getValue())
                         .query(new MatchAllQuery.Builder().build().toQuery())
                         .build();
                     openSearch.flushIndices();


### PR DESCRIPTION
…e working index, not all indexes

I had a look at the build that seems quite unstable breaking a lot on nested classes in webadmin-mailbox module, with opensearch indexing tests

After debugging for quite a while and deeper, I could see that despite deleting documents in the mailbox index, the number of hits was stuck sometimes to 9, making tests fail. Monitoring opensearch indices, I could observe at some point the creation of a top_queries index. It seems to be a new feature since opensearch 2.19 => https://docs.opensearch.org/docs/latest/observing-your-data/query-insights/top-n-queries/

What was likely happening is that this analysis index is likely created after some latency threshold. Sometimes the tests would run fast enough so that it does not get created, making the build green, but sometimes it does not, making the test fail. 

The approach in the cleanup is wrong regarding this. We just cleanup documents in the working index, so we should just do the search on the working index. But we were doing a global search on all indexes, thus creating problems in case that top_queries index was created.

We just need to make sure the working index is empty, thus the proposed fix. Locally it looks stable with this for me.