### PR TITLE
[JAMES-3978] Improves james build cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3502,6 +3502,13 @@
                                     </executions>
                                 </plugin>
                             </plugins>
+                            <normalization>
+                                <runtimeClassPath>
+                                    <ignoredFiles>
+                                        <ignoredFile>git.properties</ignoredFile>
+                                    </ignoredFiles>
+                                </runtimeClassPath>
+                            </normalization>
                         </develocity>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This PR adds build cache support for scala compile and jacoco report-aggregate

According to this [build scan](https://develocity.apache.org/s/kn4yuyxpb4rhs/timeline?cacheability=any_non_cacheable&hide-timeline&outcome=success,failed&sort=longest) (on master) and this [build scan](https://develocity.apache.org/s/7y22vlkhwudju/timeline?cacheability=any_non_cacheable&hide-timeline&outcome=success,failed&sort=longest) (on the initial build cache branch), Scala compilation and jacoco report aggregation are the 2 longest running goals in the build when it is otherwise fully cached.

Note that this PR is WIP : local runs seem to be able to store to the build cache. `-DrerunGoals` ensures that all cache output is stored again in case some cache pollution occured. 
```
mvn -e clean test -P ci-test  -DskipTests -Dassembly.skipAssembly=true jacoco:report-aggregate@jacoco-report -pl :mailetdocs-maven-plugin -am -DrerunGoals 
```
but running again without the rerunGoals 
```
mvn -e clean test -P ci-test  -DskipTests -Dassembly.skipAssembly=true jacoco:report-aggregate@jacoco-report -pl :mailetdocs-maven-plugin -am
```
fails to compile on my machine with 
```
[INFO] --- scala:4.9.5:compile (scala-compile-first) @ event-sourcing-core ---
[INFO] compiler plugin: BasicArtifact(org.scalameta,semanticdb-scalac_2.13.16,4.9.6,null)
[DEBUG] Local cache hit (29 KB)
[INFO] Loaded from the build cache, saving 2.305s
[INFO]
[INFO] --- compiler:3.14.0:compile (default-compile) @ event-sourcing-core ---
[DEBUG] Local cache miss
[DEBUG] Remote cache miss
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 1 source file with javac [debug parameters release 21] to target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /home/jean/dev/secretjames/master/event-sourcing/event-sourcing-core/src/main/java/org/apache/james/eventsourcing/CommandHandler.java:[25,43] cannot find symbol
  symbol: class Command
[ERROR] /home/jean/dev/secretjames/master/event-sourcing/event-sourcing-core/src/main/java/org/apache/james/eventsourcing/CommandHandler.java:[28,18] cannot find symbol
  symbol:   class EventWithState
  location: interface org.apache.james.eventsourcing.CommandHandler<C>
[INFO] 2 errors
``` 

I'm not sure why there is a cache miss on the java compilation so this it not yet mergeable

links I found helpful working on this (in case I accidentally close my browser tabs :D)
- [documentation](https://docs.gradle.com/develocity/maven-extension/current/#making_other_goals_cacheable) on making unsupported goals cacheable
- [examples](https://github.com/gradle/develocity-build-config-samples/tree/main/build-caching-maven-samples) of custom goal caching definitions 
- [source code](https://github.com/davidB/scala-maven-plugin/blob/master/src/main/java/scala_maven/ScalaCompileMojo.java) for scala maven plugin
- [source code](https://github.com/jacoco/jacoco/blob/562a7299399b8321dfcf8eeb21ea4bfc27556fdc/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportM) for jacoco plugin which should be supported [by default](https://docs.gradle.com/develocity/maven-extension/current/#jacoco_maven_plugin) but somehow isn't.
- using `MAVEN_OPTS=-Dorg.slf4j.simpleLogger.log.develocity.goal.cache=debug` show some useful information on goal caching