### PR TITLE
[RemoteDelivery] Add an explicit option to trust all certs

### DIFF
--- a/docs/modules/servers/partials/RemoteDelivery.adoc
+++ b/docs/modules/servers/partials/RemoteDelivery.adoc
@@ -93,7 +93,7 @@ javax *mail.smtp.starttls.enable* property. Depending on how strict your securit
 *mail.smtp.starttls.required* as well. Be aware that configuring trust will then be required.
 You can also use other javax properties for StartTLS, but their property prefix must be *mail.smtp.ssl.* in this case. 
 
-James enables server identity verification by default. In certain rare edge cases you might disable it via the *verifyServerIdentity* parameter,
+James enables server identity verification by default. In certain rare edge cases you might disable it via the *verifyServerIdentity* and *sslTrustAllCerts* parameters,
 or use the *mail.smtps.ssl.checkserveridentity* and *mail.smtp.ssl.checkserveridentity* javax properties for fine control.
 
 Read https://eclipse-ee4j.github.io/angus-mail/docs/api/org.eclipse.angus.mail/org/eclipse/angus/mail/smtp/package-summary.html[*org.eclipse.angus.mail.smtp*]

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
@@ -148,7 +148,7 @@ import com.google.common.collect.ImmutableMap;
  * javax <i>mail.smtp.starttls.enable</i> property. Depending on how strict your security policy is, you might consider
  * <i>mail.smtp.starttls.required</i> as well. Be aware that configuring trust will then be required.
  * You can also use other javax properties for StartTLS, but their property prefix must be <i>mail.smtp.ssl.</i> in this case.<br/>
- * James enables server identity verification by default. In certain rare edge cases you might disable it via the <b>verifyServerIdentity</b> parameter,
+ * James enables server identity verification by default. In certain rare edge cases you might disable it via the <b>verifyServerIdentity</b> and <b>sslTrustAllCerts</b> parameters,
  * or use the <i>mail.smtps.ssl.checkserveridentity</i> and <i>mail.smtp.ssl.checkserveridentity</i> javax properties for fine control.<br/>
  * Read <a href="https://eclipse-ee4j.github.io/angus-mail/docs/api/org.eclipse.angus.mail/org/eclipse/angus/mail/smtp/package-summary.html"><code>org.eclipse.angus.mail.smtp</code></a>
  * for full information.


### PR DESCRIPTION
CF https://www.mail-archive.com/server-user@james.apache.org/msg17214.html

This attempts to give the option for user to still activate SSL / STARTTLS but to tolerate invalid / expired certs.

(I feel uneasy with the conclusion of just run an unsecure mail server or die by bureaucracy. I believe there's a third way that is allow to relax James' SSL setup.)