### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2468,8 +2468,8 @@
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-pem</artifactId>
-                <version>9.1.0</version>
+                <artifactId>ayza-for-pem</artifactId>
+                <version>10.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.github.openfeign</groupId>

--- a/server/protocols/protocols-imap4/pom.xml
+++ b/server/protocols/protocols-imap4/pom.xml
@@ -124,7 +124,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/protocols/protocols-library/pom.xml
+++ b/server/protocols/protocols-library/pom.xml
@@ -81,7 +81,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
+++ b/server/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/LegacyJavaEncryptionFactory.java
@@ -103,7 +103,7 @@ public class LegacyJavaEncryptionFactory implements Encryption.Factory {
         }
     }
 
-    // CF https://github.com/Hakky54/sslcontext-kickstart#loading-trust-material-with-trustmanager-and-ocsp-options
+    // CF https://github.com/Hakky54/ayza#loading-trust-material-with-trustmanager-and-ocsp-options
     private Optional<TrustStoreTrustOptions<? extends CertPathTrustManagerParameters>> clientAuthTrustOptions(SslConfig sslConfig) throws NoSuchAlgorithmException {
         if (!sslConfig.ocspCRLChecksEnabled()) {
             return Optional.empty();


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to ayza. The latest version is 10.0.0

Sorry for the inconvenience