### PR TITLE
JAMES-4146: Add support for proxy protocol in managesieve

### DIFF
--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/NettyConstants.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/NettyConstants.java
@@ -19,6 +19,7 @@
 package org.apache.james.managesieveserver.netty;
 
 import org.apache.james.managesieve.api.Session;
+import org.apache.james.protocols.api.ProxyInformation;
 
 import io.netty.util.AttributeKey;
 
@@ -27,6 +28,6 @@ import io.netty.util.AttributeKey;
  */
 public interface NettyConstants {
     AttributeKey<ChannelManageSieveResponseWriter> RESPONSE_WRITER_ATTRIBUTE_KEY = AttributeKey.valueOf("ResponseWriter");
+    AttributeKey<ProxyInformation> PROXY_INFO = AttributeKey.valueOf("ProxyInfo");
     AttributeKey<Session> SESSION_ATTRIBUTE_KEY = AttributeKey.valueOf("Session");
-
 }


### PR DESCRIPTION
I found that it is possible to configure proxy protocol for managesieve but the configuration is ignored.
This fixes that. I did not find any logic in managesieve that tries to act on the real client IP, so it is available now in the MDCContext but it is never used.

There is already a general `BasicChannelInboundHandler` which also decodes the proxy protocol, but as far as I understand, it is only used for SMTP. ManageSieve and IMAP both have their own InboundHandler.

Find the Jira issue [here](https://issues.apache.org/jira/projects/JAMES/issues/JAMES-4146).