### PR TITLE
JAMES-4135 OpenSearch: make query string usage lenient

### DIFF
--- a/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/DefaultCriterionConverter.java
+++ b/mailbox/opensearch/src/main/java/org/apache/james/mailbox/opensearch/query/DefaultCriterionConverter.java
@@ -229,6 +229,7 @@ public class DefaultCriterionConverter implements CriterionConverter {
                         .fields(ImmutableList.of(JsonMessageConstants.TEXT_BODY, JsonMessageConstants.HTML_BODY))
                         .query(textCriterion.getOperator().getValue())
                         .defaultOperator(Operator.And)
+                        .lenient(true)
                         .build().toQuery();
                 } else {
                     return new BoolQuery.Builder()
@@ -256,6 +257,7 @@ public class DefaultCriterionConverter implements CriterionConverter {
                             .fields(ImmutableList.of(JsonMessageConstants.TEXT_BODY, JsonMessageConstants.HTML_BODY, JsonMessageConstants.ATTACHMENTS + "." + JsonMessageConstants.Attachment.TEXT_CONTENT))
                             .query(textCriterion.getOperator().getValue())
                             .defaultOperator(Operator.And)
+                            .lenient(true)
                             .build().toQuery())
                         .should(new TermQuery.Builder()
                             .field(JsonMessageConstants.ATTACHMENTS + "." + JsonMessageConstants.Attachment.FILE_EXTENSION)
@@ -302,6 +304,7 @@ public class DefaultCriterionConverter implements CriterionConverter {
                             .fields(ImmutableList.of(JsonMessageConstants.ATTACHMENTS + "." + JsonMessageConstants.Attachment.TEXT_CONTENT))
                             .query(textCriterion.getOperator().getValue())
                             .defaultOperator(Operator.And)
+                            .lenient(true)
                             .build().toQuery())
                         .should(new TermQuery.Builder()
                             .field(JsonMessageConstants.ATTACHMENTS + "." + JsonMessageConstants.Attachment.FILE_EXTENSION)

--- a/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchQueryStringTest.java
+++ b/mailbox/opensearch/src/test/java/org/apache/james/mailbox/opensearch/OpenSearchQueryStringTest.java
@@ -165,6 +165,19 @@ class OpenSearchQueryStringTest {
             .containsOnly(expectedId.getUid());
     }
 
+    @Test
+    void queryStringShouldBeLenient() throws Exception {
+        ComposedMessageId expectedId = addMessage(session, inboxPath, "Lucas love avocado banana smoothie").block();
+        addMessage(session, inboxPath, "Avocado grows in Mexico").block();
+
+        awaitForOpenSearch(QueryBuilders.matchAll().build().toQuery(), 2L);
+
+        SearchQuery searchQuery = SearchQuery.of(SearchQuery.bodyContains("love --avocado"));
+
+        assertThat(messageSearchIndex.search(session, mailbox, searchQuery).collectList().block())
+            .containsOnly(expectedId.getUid());
+    }
+
 
     private Mono<ComposedMessageId> addMessage(MailboxSession session, MailboxPath mailboxPath, String message) throws Exception {
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);


### PR DESCRIPTION
Because a strict interpretation of the syntax result in user facing errors