### PR TITLE
[ENHANCEMENT] Smtp technical accounts

### DIFF
--- a/docs/modules/servers/partials/configure/smtp-hooks.adoc
+++ b/docs/modules/servers/partials/configure/smtp-hooks.adoc
@@ -424,3 +424,76 @@ Would allow emails using `apache.org` as a MAIL FROM or from header domain if, a
 valid DKIM signature for the `apache.org` domain.
 
 include::partial$EnforceHeaderLimitationsMessageHook.adoc[]
+
+== SetMailAttributeMessageHook
+
+This class implements an SMTP hook to add attributes on incoming mails.
+
+It allows marking mails from a given SMTP port. Eg if I set up technical accounts for local apps on port 26
+then I can disable rate limiting for this traffic.
+
+Example XML configuration:
+
+....
+<handler class="org.apache.james.smtpserver.SetMailAttributeMessageHook">
+    <name>technicaluser</name>
+    <value>true</value>
+</handler>
+....
+
+== EnforceHeaderLimitationsMessageHook
+
+This class implements an SMTP hook to enforce limitations on the headers of incoming emails.
+
+It allows configuring and enforcing two types of restrictions:
+ - A maximum number of header lines (default: 500).
+ - A maximum total size of headers in bytes (default: 64 KB).
+If any of these thresholds are exceeded, the message is rejected with an SMTP error code:
+ -  `552 Too many header lines` if the number of lines exceeds the limit.
+ -  `552 Header size too large` if the total size exceeds the limit.
+
+Example XML configuration:
+
+....
+<handler class="org.apache.james.smtpserver.EnforceHeaderLimitationsMessageHook">
+    <maxLines>500</maxLines>
+    <maxSize>64KB</maxSize>
+</handler>
+....
+
+== ConfigurationAuthHook
+
+Declarative authentication.
+
+It is possible to open and configure on a dedicated port (eg port 26) to accept application traffic in parallel of user
+traffic. Authentication is then done on the supplied configuration.
+
+Convenient as it allows instantiating James as part of a complex application network with only only declarative configuration
+and no post-deployment actions.
+
+This is helpful for things like service accounts, used by other applications (and it is not desirable to create
+user accounts for those applications)
+
+....
+    <handlerchain coreHandlersPackage="org.apache.james.smtpserver.NoAuthCmdHandlerLoader" enableJmx="false">
+        <handler class="org.apache.james.protocols.smtp.core.esmtp.AuthCmdHandler" />
+        <handler class="org.apache.james.smtpserver.ConfigurationAuthHook" >
+            <accounts>
+                <account>
+                    <username>noreply-tdrive@domain.tld</username>
+                    <passwords>
+                        <password>secret123456</password>
+                        <password>here_to_ease_secret_rotation</password>
+                        <password>here_to_give_different_creds_to_each_app</password>
+                    </passwords>
+                </account>
+                <account>
+                    <username>noreply-tchat@domain.tld</username>
+                    <passwords>
+                        <password>secret234567</password>
+                    </passwords>
+                </account>
+            </accounts>
+        </handler>
+    </handlerchain>
+....

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/ConfigurationAuthHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/ConfigurationAuthHook.java
@@ -1,0 +1,105 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.smtpserver;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.core.Username;
+import org.apache.james.protocols.api.OidcSASLConfiguration;
+import org.apache.james.protocols.smtp.SMTPSession;
+import org.apache.james.protocols.smtp.hook.AuthHook;
+import org.apache.james.protocols.smtp.hook.HookResult;
+import org.apache.james.protocols.smtp.hook.HookReturnCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Declarative authentication.
+ *
+ * This is helpful for things like service accounts, used by other applications (and it is not desirable to create
+ * user accounts for those applications)
+ */
+public class ConfigurationAuthHook implements AuthHook {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationAuthHook.class);
+
+    private Multimap<Username, String> accounts = ImmutableListMultimap.of();
+
+    @Inject
+    public ConfigurationAuthHook() {
+
+    }
+
+    @Override
+    public void init(Configuration config) throws ConfigurationException {
+        HierarchicalConfiguration<ImmutableNode> hierarchicalConfiguration = (HierarchicalConfiguration<ImmutableNode>) config;
+
+        ImmutableListMultimap.Builder<Username, String> builder = ImmutableListMultimap.builder();
+
+        for (HierarchicalConfiguration<ImmutableNode> accountNode : hierarchicalConfiguration.configurationAt("accounts")
+            .configurationsAt("account")) {
+            String username = accountNode.getString("username");
+            if (username != null) {
+                List<String> passwords = accountNode.getList(String.class, "passwords.password");
+                passwords.forEach(pw -> builder.put(Username.of(username), pw));
+            }
+        }
+        this.accounts = builder.build();
+
+        LOGGER.info("SMTP authentication enabled from configuration for users: {}", accounts.keySet()
+            .stream()
+            .map(Username::asString)
+            .collect(ImmutableList.toImmutableList()));
+    }
+
+    @Override
+    public HookResult doAuth(SMTPSession session, Username username, String password) {
+        Optional<Username> loggedInUser = Optional.ofNullable(accounts.get(username))
+            .filter(allowedsPass -> allowedsPass.stream().anyMatch(password::equals))
+            .map(any -> username);
+
+        if (loggedInUser.isPresent()) {
+            session.setUsername(loggedInUser.get());
+            session.setRelayingAllowed(true);
+
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.ok())
+                .smtpDescription("Authentication Successful")
+                .build();
+        }
+        return HookResult.DECLINED;
+    }
+
+    @Override
+    public HookResult doSasl(SMTPSession session, OidcSASLConfiguration configuration, String initialResponse) {
+        throw new NotImplementedException("No support for OATHBEARER so far");
+    }
+
+}

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/NoAuthCmdHandlerLoader.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/NoAuthCmdHandlerLoader.java
@@ -56,7 +56,6 @@ public class NoAuthCmdHandlerLoader implements HandlersPackage {
             RsetCmdHandler.class.getName(),
             VrfyCmdHandler.class.getName(),
             MailSizeEsmtpExtension.class.getName(),
-            UsersRepositoryAuthHook.class.getName(),
             AuthRequiredToRelayRcptHook.class.getName(),
             SenderAuthIdentifyVerificationHook.class.getName(),
             PostmasterAbuseRcptHook.class.getName(),

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMailAttributeMessageHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMailAttributeMessageHook.java
@@ -50,7 +50,6 @@ public class SetMailAttributeMessageHook implements JamesMessageHook {
 
     @Override
     public HookResult onMessage(SMTPSession session, Mail mail) {
-        System.out.println("Marking");
         mail.setAttribute(new Attribute(AttributeName.of(name), AttributeValue.of(value)));
         return HookResult.DECLINED;
     }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMailAttributeMessageHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMailAttributeMessageHook.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.smtpserver;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.protocols.smtp.SMTPSession;
+import org.apache.james.protocols.smtp.hook.HookResult;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.AttributeValue;
+import org.apache.mailet.Mail;
+
+/**
+ * This class implements an SMTP hook to add attributes on incoming mails.
+ *
+ * It allows marking mails from a given SMTP port. Eg if I set up technical accounts for local apps on port 26
+ * then I can disable rate limiting for this traffic.
+ *
+ * Example XML configuration:
+ * <pre>{
+ * <handler class="org.apache.james.smtpserver.SetMailAttributeMessageHook">
+ *     <name>technicaluser</name>
+ *     <value>true</value>
+ * </handler>
+ * }</pre>
+ *
+ */
+
+public class SetMailAttributeMessageHook implements JamesMessageHook {
+    private String name;
+    private String value;
+
+    @Override
+    public HookResult onMessage(SMTPSession session, Mail mail) {
+        System.out.println("Marking");
+        mail.setAttribute(new Attribute(AttributeName.of(name), AttributeValue.of(value)));
+        return HookResult.DECLINED;
+    }
+
+    @Override
+    public void init(Configuration config) throws ConfigurationException {
+        this.name = config.getString("name");
+        this.value = config.getString("value");
+    }
+}
+

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ConfiguredAuthTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ConfiguredAuthTest.java
@@ -71,7 +71,7 @@ class ConfiguredAuthTest {
         "noreply-tdrive@other-domain.tld, secret123456",
         "noreply-tdrive, secret123456"
     })
-    void authShouldBeDeniedWhenMatchingConfiguredValue(String username, String password) throws Exception {
+    void authShouldBeDeniedWhenNotMatchingConfiguredValue(String username, String password) throws Exception {
         SMTPClient smtpProtocol = new SMTPClient();
         InetSocketAddress bindedAddress = smtpServerTestSystem.getBindedAddress();
         smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ConfiguredAuthTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ConfiguredAuthTest.java
@@ -1,0 +1,82 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.smtpserver;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.util.Base64;
+
+import org.apache.commons.net.smtp.SMTPClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ConfiguredAuthTest {
+    private final SMTPServerTestSystem smtpServerTestSystem = new SMTPServerTestSystem();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        smtpServerTestSystem.setUp("smtpserver-configured-auth.xml");
+    }
+
+    @AfterEach
+    void tearDown() {
+        smtpServerTestSystem.smtpServer.destroy();
+    }
+
+
+    @ParameterizedTest
+    @CsvSource({
+        "noreply-tdrive@domain.tld, secret123456",
+        "noreply-tdrive@domain.tld, here_to_ease_secret_rotation",
+        "noreply-tdrive@domain.tld, here_to_give_different_creds_to_each_app",
+        "noreply-tchat@domain.tld, secret234567",
+    })
+    void authShouldBePossibleWHenMatchingConfiguredValue(String username, String password) throws Exception {
+        SMTPClient smtpProtocol = new SMTPClient();
+        InetSocketAddress bindedAddress = smtpServerTestSystem.getBindedAddress();
+        smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+
+        smtpProtocol.sendCommand("AUTH PLAIN");
+        smtpProtocol.sendCommand(Base64.getEncoder().encodeToString(("\0" + username + "\0" + password + "\0").getBytes(UTF_8)));
+        assertThat(smtpProtocol.getReplyCode())
+            .isEqualTo(235);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "noreply-tdrive@domain.tld, bad",
+        "noreply-notfound@domain.tld, here_to_ease_secret_rotation",
+        "noreply-tdrive@other-domain.tld, secret123456",
+        "noreply-tdrive, secret123456"
+    })
+    void authShouldBeDeniedWhenMatchingConfiguredValue(String username, String password) throws Exception {
+        SMTPClient smtpProtocol = new SMTPClient();
+        InetSocketAddress bindedAddress = smtpServerTestSystem.getBindedAddress();
+        smtpProtocol.connect(bindedAddress.getAddress().getHostAddress(), bindedAddress.getPort());
+
+        smtpProtocol.sendCommand("AUTH PLAIN");
+        smtpProtocol.sendCommand(Base64.getEncoder().encodeToString(("\0" + username + "\0" + password + "\0").getBytes(UTF_8)));
+        assertThat(smtpProtocol.getReplyCode())
+            .isEqualTo(535);
+    }
+}

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-configured-auth.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-configured-auth.xml
@@ -37,12 +37,16 @@
         <announce>forUnauthorizedAddresses</announce>
         <requireSSL>false</requireSSL>
     </auth>
-    <verifyIdentity>true</verifyIdentity>
+    <verifyIdentity>false</verifyIdentity>
     <maxmessagesize>0</maxmessagesize>
     <addressBracketsEnforcement>true</addressBracketsEnforcement>
     <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
     <handlerchain coreHandlersPackage="org.apache.james.smtpserver.NoAuthCmdHandlerLoader" enableJmx="false">
         <handler class="org.apache.james.protocols.smtp.core.esmtp.AuthCmdHandler" />
+        <handler class="org.apache.james.smtpserver.SetMailAttributeMessageHook" >
+            <name>technicaluser</name>
+            <value>true</value>
+        </handler>
         <handler class="org.apache.james.smtpserver.ConfigurationAuthHook" >
             <accounts>
                 <account>

--- a/server/protocols/protocols-smtp/src/test/resources/smtpserver-configured-auth.xml
+++ b/server/protocols/protocols-smtp/src/test/resources/smtpserver-configured-auth.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!-- Read https://james.apache.org/server/config-smtp-lmtp.html#SMTP_Configuration for further details -->
+
+<smtpserver enabled="true">
+    <bind>0.0.0.0:0</bind>
+    <connectionBacklog>200</connectionBacklog>
+    <tls socketTLS="false" startTLS="false">
+        <keystore>file://conf/keystore</keystore>
+        <secret>james72laBalle</secret>
+        <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
+        <algorithm>SunX509</algorithm>
+    </tls>
+    <connectiontimeout>360</connectiontimeout>
+    <connectionLimit>0</connectionLimit>
+    <connectionLimitPerIP>0</connectionLimitPerIP>
+    <auth>
+        <announce>forUnauthorizedAddresses</announce>
+        <requireSSL>false</requireSSL>
+    </auth>
+    <verifyIdentity>true</verifyIdentity>
+    <maxmessagesize>0</maxmessagesize>
+    <addressBracketsEnforcement>true</addressBracketsEnforcement>
+    <smtpGreeting>Apache JAMES awesome SMTP Server</smtpGreeting>
+    <handlerchain coreHandlersPackage="org.apache.james.smtpserver.NoAuthCmdHandlerLoader" enableJmx="false">
+        <handler class="org.apache.james.protocols.smtp.core.esmtp.AuthCmdHandler" />
+        <handler class="org.apache.james.smtpserver.ConfigurationAuthHook" >
+            <accounts>
+                <account>
+                    <username>noreply-tdrive@domain.tld</username>
+                    <passwords>
+                        <password>secret123456</password>
+                        <password>here_to_ease_secret_rotation</password>
+                        <password>here_to_give_different_creds_to_each_app</password>
+                    </passwords>
+                </account>
+                <account>
+                    <username>noreply-tchat@domain.tld</username>
+                    <passwords>
+                        <password>secret234567</password>
+                    </passwords>
+                </account>
+            </accounts>
+        </handler>
+    </handlerchain>
+    <gracefulShutdown>false</gracefulShutdown>
+    <disabledFeatures>ENHANCEDSTATUSCODES</disabledFeatures>
+</smtpserver>


### PR DESCRIPTION
My need:

Port 25: authentication is disabled
Port 465: submission, user auth, strict sender validation
Port 26: opened locally with k8s cluster. I want to add auth for it not to be opened. 

I do not want to create user for port 26 because:
 - I do not want to have a mailbox assiciated to it
 - I want the set up to be declarative to limit to the maximum manual actions
 
The idea is to deploy to port 26 a specific auth mechanism matching configuration. 
 
```
    <handlerchain coreHandlersPackage="org.apache.james.smtpserver.NoAuthCmdHandlerLoader" enableJmx="false">
        <handler class="org.apache.james.protocols.smtp.core.esmtp.AuthCmdHandler" />
        <handler class="org.apache.james.smtpserver.SetMailAttributeMessageHook" >
            <name>technicaluser</name>
            <value>true</value>
        </handler>
        <handler class="org.apache.james.smtpserver.ConfigurationAuthHook" >
            <accounts>
                <account>
                    <username>noreply-tdrive@domain.tld</username>
                    <passwords>
                        <password>secret123456</password>
                        <password>here_to_ease_secret_rotation</password>
                        <password>here_to_give_different_creds_to_each_app</password>
                    </passwords>
                </account>
                <account>
                    <username>noreply-tchat@domain.tld</username>
                    <passwords>
                        <password>secret234567</password>
                    </passwords>
                </account>
            </accounts>
        </handler>
    </handlerchain>
```

Env variables (and so secrets!) might be used for passwords...

I also add a way to position mail attributes. This would enable in my use case to for instance bypass rate limiting.

I decided to contribute this to ASF James as :
 - it is a fairly common use case
 - it can enable writing a James server without dependency on user repistories and potentially event without a DB, just a mail queue...

If non consensual I can move the code to LINAGORA repos.