### PR TITLE
[ENHANCEMENT] DefaultCheckTokenClient: increase pending acquire max

### DIFF
--- a/server/protocols/jwt/src/main/java/org/apache/james/jwt/DefaultCheckTokenClient.java
+++ b/server/protocols/jwt/src/main/java/org/apache/james/jwt/DefaultCheckTokenClient.java
@@ -21,6 +21,7 @@ package org.apache.james.jwt;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 import org.apache.james.jwt.introspection.IntrospectionEndpoint;
 import org.apache.james.jwt.introspection.TokenIntrospectionException;
@@ -42,11 +43,15 @@ import reactor.netty.resources.ConnectionProvider;
 public class DefaultCheckTokenClient implements CheckTokenClient {
 
     public static final String TOKEN_ATTRIBUTE = "token";
+    public static final int PENDING_ACQUIRE_MAX = Optional.ofNullable(System.getProperty("james.oidc.client.pending.acquire.max"))
+        .map(Integer::valueOf)
+        .orElse(10000);
     private final HttpClient httpClient;
     private final ObjectMapper deserializer;
 
     public DefaultCheckTokenClient() {
         this.httpClient = HttpClient.create(ConnectionProvider.builder(this.getClass().getName())
+                .pendingAcquireMaxCount(PENDING_ACQUIRE_MAX)
                 .build())
             .disableRetry(true)
             .headers(builder -> {


### PR DESCRIPTION
The default pending acquire was low (~32, depending on machines). The OIDC client could fail under high load.

```java
"exception":"reactor.netty.internal.shaded.reactor.pool.PoolAcquirePendingLimitException: Pending acquire queue has reached its maximum size of 32
```

Increasing the default value to 10000 (around the current S3 HTTP client pending acquire) should be fine.