### PR TITLE
JAMES-3755 Allow RSpamDScanner to override url settings

### DIFF
--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -86,6 +86,11 @@ If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the
 </processor>
 ```
 
+`RSpamdScanner` supports addition `rspamdUrl`, `rspamdPassword`, `rspamdTimeout`, `perUserBayes` properties allowing to 
+override content defined in `rspamd.properties`, which allows running several instances on distict Rspamd instance. A 
+possible use case is to use 1 RSpamD cluster on user incoming spam, trained in perUserBayes mode, and another RSpamD 
+cluster configured to check outgoing email for spams with a tolerant threshold and a specifc configuration.
+
 - Declare the webadmin for Rspamd in `webadmin.properties`
 
 ```

--- a/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
+++ b/third-party/rspamd/src/test/java/org/apache/james/rspamd/RspamdScannerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collection;
@@ -311,6 +312,47 @@ class RspamdScannerTest {
         mailet.service(mail);
 
         assertThat(mail.getState()).isEqualTo("spam");
+    }
+
+    @Test
+    void shouldSupportCustomRSpamDURL() throws Exception {
+        RspamdHttpClient rspamdHttpClient = mock(RspamdHttpClient.class);
+        when(rspamdHttpClient.checkV2(any(Mail.class))).thenReturn(Mono.just(AnalysisResult.builder()
+                .action(AnalysisResult.Action.REJECT)
+                .score(12.1F)
+                .requiredScore(14F)
+            .build()));
+
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty("rejectSpamProcessor", "spam")
+            .setProperty("rspamdUrl", "http://imap.failing.com")
+            .setProperty("rspamdPassword", "secret")
+            .setProperty("rspamdTimeout", "20000")
+            .build();
+
+        mailet = new RspamdScanner(rspamdHttpClient, configuration);
+
+        Mail mail = FakeMail.builder()
+            .name("name")
+            .state("initial")
+            .recipient("user1@exemple.com")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .addToRecipient("user1@exemple.com")
+                .addFrom("sender@exemple.com")
+                .setSubject(INIT_SUBJECT)
+                .setText("Please!")
+                .build())
+            .build();
+
+        mailet.init(mailetConfig);
+        try {
+            mailet.service(mail);
+        } catch (Exception e) {
+
+        }
+
+        // We overloaded the mock supplied in the constructor
+        verifyNoInteractions(rspamdHttpClient);
     }
 
     @Test


### PR DESCRIPTION
A possible use case is to use 1 RSpamD cluster on user incoming spam, trained in perUserBayes mode, and another RSpamD cluster configured to check outgoing email for spams with a tolerant threshold and a specifc configuration.