### PR TITLE
[FIX] maven release plugin and maven source plugin configuration was …

### DIFF
--- a/code-coverage-report/pom.xml
+++ b/code-coverage-report/pom.xml
@@ -1184,52 +1184,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!--        16. examples-->
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-james-assembly</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-listeners</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-mailets</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-smtp-command</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-smtp-hooks</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-webadmin-route</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>metrics-graphite</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-healthcheck</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james.examples</groupId>
-            <artifactId>custom-imap</artifactId>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3750,8 +3750,10 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
-                        <!-- avoid double buildscan during forked builds -->
-                        <arguments>-Dgradle.scan.disabled=true</arguments>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <goals>deploy</goals>
+                        <arguments>-Papache-release -Dgradle.scan.disabled=true -DskipTests ${arguments}</arguments>
+                        <waitBeforeTagging>10</waitBeforeTagging>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -4036,19 +4038,6 @@
                             <goal>test-jar</goal>
                         </goals>
                         <phase>package</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
…broken

Exemple do not make sense in code coverage and break releases

Also source plugin is already defined in base POM and our override make it fail: not needed.

Finally we need to carry over configuration of the release plugin/