### PR TITLE
[UPGRADE] bouncycastle 1.81 -> 1.82

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -678,7 +678,7 @@
         <io.micrometer.core.version>1.15.1</io.micrometer.core.version>
         <io.micrometer.tracing.version>1.5.1</io.micrometer.tracing.version>
 
-        <bouncycastle.version>1.81</bouncycastle.version>
+        <bouncycastle.version>1.82</bouncycastle.version>
 
         <scala.base>2.13</scala.base>
         <scala.version>${scala.base}.16</scala.version>


### PR DESCRIPTION
Currently, with the bouncycastle 1.81 version, CI builds fail:
```
Caused by: org.apache.maven.artifact.versioning.OverConstrainedVersionException: No versions are present in the repository for the artifact with a range [1.81,1.82)
  org.bouncycastle:bcutil-jdk18on:jar:null
```
When getting the transitive dependency `bcutil-jdk18on` with `[1.81,1.82)` version. 
<img width="1124" height="1530" alt="image" src="https://github.com/user-attachments/assets/4000b245-a65e-419e-8149-d5d559250998" />


Hopefully, the bouncycastle 1.82 version with declaring fixed version 1.82 for the transitive `bcutil-jdk18on` dependency can improve the failing CI builds situation...
<img width="1032" height="812" alt="image" src="https://github.com/user-attachments/assets/39a6e73c-4e53-4e2f-821d-51c1b8e5691e" />
