### PR TITLE
JAMES-4148 Implement ANY comparator for custom header

### DIFF
--- a/server/data/data-jmap-cassandra/src/test/resources/json/event-v4.json
+++ b/server/data/data-jmap-cassandra/src/test/resources/json/event-v4.json
@@ -18,6 +18,11 @@
             "field": "header:custom",
             "comparator": "contains",
             "value": "another thing"
+          },
+          {
+            "field": "header:anotherCustom",
+            "comparator": "any",
+            "value": "disregard me"
           }
         ]
       },

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Rule.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/filtering/Rule.java
@@ -189,7 +189,8 @@ public class Rule {
             NOT_EXACTLY_EQUALS("not-exactly-equals"),
             START_WITH("start-with"),
             IS_SET("isSet"),
-            IS_UNSET("isUnset");
+            IS_UNSET("isUnset"),
+            ANY("any");
             
             public static Optional<Comparator> find(String comparatorName) {
                 return Arrays.stream(values())

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/filtering/RuleFixture.java
@@ -57,7 +57,8 @@ public interface RuleFixture {
     Rule RULE_3 = RULE_BUILDER.id(Rule.Id.of("3")).build();
     Rule RULE_4 = Rule.builder()
         .conditionGroup(Rule.ConditionCombiner.AND, CONDITION,
-            Rule.Condition.of(new Rule.Condition.CustomHeaderField("custom"), Rule.Condition.Comparator.CONTAINS, "another thing"))
+            Rule.Condition.of(new Rule.Condition.CustomHeaderField("custom"), Rule.Condition.Comparator.CONTAINS, "another thing"),
+            Rule.Condition.of(new Rule.Condition.CustomHeaderField("anotherCustom"), Rule.Condition.Comparator.ANY, "disregard me"))
         .action(ACTION_2)
         .id(Rule.Id.of("1"))
         .name(NAME)

--- a/server/protocols/jmap-rfc-8621/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
+++ b/server/protocols/jmap-rfc-8621/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
@@ -167,6 +167,7 @@ public interface ContentMatcher {
     ContentMatcher STRING_EXACTLY_EQUALS_MATCHER = (contents, valueToMatch) -> contents.anyMatch(content -> StringUtils.equals(content, valueToMatch));
     ContentMatcher STRING_NOT_EXACTLY_EQUALS_MATCHER = negate(STRING_EXACTLY_EQUALS_MATCHER);
     ContentMatcher STRING_START_WITH_MATCHER = (contents, valueToMatch) -> contents.anyMatch(content -> content.startsWith(valueToMatch));
+    ContentMatcher ANY_MATCHER = (contents, valueToMatch) -> contents.anyMatch(StringUtils::isNotBlank);
 
     ContentMatcher ADDRESS_CONTAINS_MATCHER = (contents, valueToMatch) -> contents
         .map(ContentMatcher::asAddressHeader)
@@ -201,6 +202,7 @@ public interface ContentMatcher {
         .put(Rule.Condition.Comparator.EXACTLY_EQUALS, STRING_EXACTLY_EQUALS_MATCHER)
         .put(Rule.Condition.Comparator.NOT_EXACTLY_EQUALS, STRING_NOT_EXACTLY_EQUALS_MATCHER)
         .put(Rule.Condition.Comparator.START_WITH, STRING_START_WITH_MATCHER)
+        .put(Rule.Condition.Comparator.ANY, ANY_MATCHER)
         .build();
 
     Map<Rule.Condition.Field, Map<Rule.Condition.Comparator, ContentMatcher>> CONTENT_MATCHER_REGISTRY = ImmutableMap.<Rule.Condition.Field, Map<Rule.Condition.Comparator, ContentMatcher>>builder()

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RunRulesOnMailboxRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RunRulesOnMailboxRoutesTest.java
@@ -52,6 +52,7 @@ import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.stream.RawField;
 import org.apache.james.task.Hostname;
 import org.apache.james.task.MemoryTaskManager;
 import org.apache.james.user.api.UsersRepository;
@@ -329,7 +330,8 @@ public class RunRulesOnMailboxRoutesTest {
                     .build(Message.Builder.of()
                         .setSubject("plop")
                         .setFrom("alice@example.com")
-                        .setBody("body", StandardCharsets.UTF_8)),
+                        .setBody("body", StandardCharsets.UTF_8)
+                        .addField(new RawField("X-Custom-Header", "value"))),
                 systemSession);
 
         String taskId = given()
@@ -354,14 +356,9 @@ public class RunRulesOnMailboxRoutesTest {
                     "conditionCombiner": "OR",
                     "conditions": [
                       {
-                        "comparator": "contains",
-                        "field": "subject",
-                        "value": "plop"
-                      },
-                      {
-                        "comparator": "exactly-equals",
-                        "field": "from",
-                        "value": "bob@example.com"
+                        "comparator": "any",
+                        "field": "header:X-Custom-Header",
+                        "value": "disregarded"
                       }
                     ]
                   }


### PR DESCRIPTION
So users can filter mails having an existing header, e.g., a mail from Github notifications with header `X-Github-...`