### PR TITLE
[FIX] LDAP user listing should ignore invalid users

### DIFF
--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUsersDAO.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyLDAPUsersDAO.java
@@ -205,7 +205,14 @@ public class ReadOnlyLDAPUsersDAO implements UsersDAO, Configurable {
             .flatMap(Throwing.<String, Stream<SearchResultEntry>>function(s -> entriesFromDN(s, usernameAttribute)).sneakyThrow())
             .flatMap(entry -> Optional.ofNullable(entry.getAttribute(usernameAttribute)).stream())
             .map(Attribute::getValue)
-            .map(Username::of)
+            .flatMap(name -> {
+                try {
+                    return Stream.of(Username.of(name));
+                } catch (Exception e) {
+                    LOGGER.warn("Invalid username in the LDAP: {}", name, e);
+                    return Stream.empty();
+                }
+            })
             .distinct();
     }
 


### PR DESCRIPTION
GET http://127.0.0.1:8000/users 

Can fail when LDAP contains invalid entries

```
{                                                                                                                                                                                          
      "statusCode": 400,                                                                                                                                                                                    
      "type": "InvalidArgument",                                                                                                                                                                            
      "message": "Invalid arguments supplied in the user request",                                                                                                                                          
      "details": "Domain parts ASCII chars must be a-z A-Z 0-9 - or _ in linagora.comqUfQni11b6xqst7p4eHRlZXZwdQ==pZo711Mqt4g39ijd1Zm9zamdidA==LZNxNesogFuYjOGR6bnVsdWRyaA=="                               
  }   
```