### PR TITLE
JAMES-4200 Allow configuring ActiveMQ disk and use sain default of 10GB

### DIFF
--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/EmbeddedActiveMQ.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/EmbeddedActiveMQ.java
@@ -44,6 +44,8 @@ public class EmbeddedActiveMQ {
     private static final String BROKER_ID = "broker";
     private static final String BROKER_NAME = "james";
     private static final String BROCKER_URI = "tcp://localhost:0";
+    private static final String STORE_USAGE_LIMIT_PROPERTY = "james.activemq.store.usage.limit.bytes";
+    private static final long DEFAULT_STORE_USAGE_LIMIT_BYTES = 10L * 1024 * 1024 * 1024; // 10 GB
 
     private final ActiveMQConnectionFactory activeMQConnectionFactory;
     private final PersistenceAdapter persistenceAdapter;
@@ -103,6 +105,8 @@ public class EmbeddedActiveMQ {
         brokerService.setUseShutdownHook(false);
         brokerService.setSchedulerSupport(false);
         brokerService.setAdjustUsageLimits(false);
+        long storeUsageLimitBytes = Long.getLong(STORE_USAGE_LIMIT_PROPERTY, DEFAULT_STORE_USAGE_LIMIT_BYTES);
+        brokerService.getSystemUsage().getStoreUsage().setLimit(storeUsageLimitBytes);
         brokerService.setBrokerId(BROKER_ID);
         String[] uris = {BROCKER_URI};
         brokerService.setTransportConnectorURIs(uris);


### PR DESCRIPTION
Addresses CI failures on LINAGORA environment:

```
12:01:02.741 [ERROR] o.a.j.GuiceJamesServer - Fatal error while starting James
org.apache.activemq.ConfigurationException: Store limit is 102400 mb (current store usage is 0 mb). The data directory: /tmp/junit18263003716179426381/junit8248170475631365409/var/store/activemq/brokers/KahaDB only has 81745 mb of usable space.
	at org.apache.activemq.broker.BrokerService.checkUsageLimit(BrokerService.java:2126)
	at org.apache.activemq.broker.BrokerService.checkStoreUsageLimits(BrokerService.java:2030)
	at org.apache.activemq.broker.BrokerService.checkStoreSystemUsageLimits(BrokerService.java:2198)
	at org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:776)
	at org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:732)
	at org.apache.activemq.broker.BrokerService.start(BrokerService.java:630)
	at org.apache.james.queue.activemq.EmbeddedActiveMQ.launchEmbeddedBroker(EmbeddedActiveMQ.java:118)
	at org.apache.james.queue.activemq.EmbeddedActiveMQ.<init>(EmbeddedActiveMQ.java:57)
	... 163 common frames omitted
Wrapped by: java.lang.RuntimeException: org.apache.activemq.ConfigurationException: Store limit is 102400 mb (current store usage is 0 mb). The data directory: /tmp/junit18263003716179426381/junit8248170475631365409/var/store/activemq/brokers/KahaDB only has 81745 mb of usable space.
	at org.apache.james.queue.activemq.EmbeddedActiveMQ.<init>(EmbeddedActiveMQ.java:59)
```