### PR TITLE
Fix 'occured' -> 'occurred' typos across james-project (5 files)

### DIFF
--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasException.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasException.java
@@ -35,7 +35,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * <p>
  * This Matcher determines if the exception specified in the condition or
- * the subclasses of it has occured during the processing of the mail.
+ * the subclasses of it has occurred during the processing of the mail.
  * If true, all recipients are returned, else null. This matcher presupposes
  * that the exception has been captured as a Mail attribute
  * {@value org.apache.mailet.Mail#MAILET_ERROR_ATTRIBUTE_NAME} in the process.
@@ -63,7 +63,7 @@ public class HasException extends GenericMatcher {
     /**
      * <p>
      * Returns the recipients of the mail if the specified exception or the
-     * subclasses of it has occured.
+     * subclasses of it has occurred.
      * </p>
      * 
      * @param mail

--- a/server/blob/blob-file/src/main/java/org/apache/james/blob/file/FileBlobStoreDAO.java
+++ b/server/blob/blob-file/src/main/java/org/apache/james/blob/file/FileBlobStoreDAO.java
@@ -159,7 +159,7 @@ public class FileBlobStoreDAO implements BlobStoreDAO {
             replaceBlob(tempFile, blob);
             tempFileHandled = true;
         } catch (IOException e) {
-            throw new ObjectStoreIOException("IOException occured", e);
+            throw new ObjectStoreIOException("IOException occurred", e);
         } finally {
             if (!tempFileHandled) {
                 FileUtils.deleteQuietly(tempFile);
@@ -185,7 +185,7 @@ public class FileBlobStoreDAO implements BlobStoreDAO {
                 try {
                     return content.read();
                 } catch (IOException e) {
-                    throw new ObjectStoreIOException("IOException occured", e);
+                    throw new ObjectStoreIOException("IOException occurred", e);
                 }
             })
             .flatMap(bytes -> save(bucketName, blobId, bytes, metadata));
@@ -255,7 +255,7 @@ public class FileBlobStoreDAO implements BlobStoreDAO {
                     Throwing.function((String attributeName) -> new BlobMetadataValue(readFileAttributeValue(attributeView, attributeName)))
                         .sneakyThrow())));
         } catch (IOException e) {
-            throw new ObjectStoreIOException("IOException occured", e);
+            throw new ObjectStoreIOException("IOException occurred", e);
         }
     }
 
@@ -301,7 +301,7 @@ public class FileBlobStoreDAO implements BlobStoreDAO {
         try {
             return Files.createTempFile(blob.getParentFile().toPath(), blob.getName(), ".tmp").toFile();
         } catch (IOException e) {
-            throw new ObjectStoreIOException("IOException occured", e);
+            throw new ObjectStoreIOException("IOException occurred", e);
         }
     }
 

--- a/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStoreDAO.java
+++ b/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStoreDAO.java
@@ -74,7 +74,7 @@ public class MemoryBlobStoreDAO implements BlobStoreDAO {
                     try {
                         return inputStreamBlob.asBytes();
                     } catch (IOException e) {
-                        throw new ObjectStoreIOException("IOException occured", e);
+                        throw new ObjectStoreIOException("IOException occurred", e);
                     }
                 })
                 .flatMap(bytes -> save(bucketName, blobId, bytes));
@@ -82,7 +82,7 @@ public class MemoryBlobStoreDAO implements BlobStoreDAO {
                     try {
                         return byteSourceBlob.asBytes();
                     } catch (IOException e) {
-                        throw new ObjectStoreIOException("IOException occured", e);
+                        throw new ObjectStoreIOException("IOException occurred", e);
                     }
                 })
             .map(bytes -> checkContentSize(byteSourceBlob.payload(), bytes))
@@ -106,7 +106,7 @@ public class MemoryBlobStoreDAO implements BlobStoreDAO {
                 "Difference in size between the pre-computed content can cause other blob stores to fail thus we need to test for alignment. Expecting " + realSize + " but pre-computed size was " + preComputedSize);
             return bytes;
         } catch (IOException e) {
-            throw new ObjectStoreIOException("IOException occured", e);
+            throw new ObjectStoreIOException("IOException occurred", e);
         }
     }
 

--- a/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxCopierManagement.java
+++ b/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxCopierManagement.java
@@ -76,10 +76,10 @@ public class MailboxCopierManagement implements MailboxCopierManagementMBean {
         try {
             copier.copyMailboxes(resolver.resolveMailboxManager(srcBean), resolver.resolveMailboxManager(dstBean));
         } catch (OverQuotaException e) {
-            log.error("An over quota occured during the copy process", e);
+            log.error("An over quota occurred during the copy process", e);
             throw new Exception(e.getMessage());
         } catch (MailboxManagerResolverException | MailboxException | IOException e) {
-            log.error("An exception occured during the copy process", e);
+            log.error("An exception occurred during the copy process", e);
             throw new Exception(e.getMessage());
         }
     }

--- a/server/protocols/fetchmail/src/main/java/org/apache/james/fetchmail/StoreProcessor.java
+++ b/server/protocols/fetchmail/src/main/java/org/apache/james/fetchmail/StoreProcessor.java
@@ -82,7 +82,7 @@ public class StoreProcessor extends ProcessorAbstract {
                     store.close();
                 }
             } catch (MessagingException ex) {
-                LOGGER.error("A MessagingException occured while closing the Store", ex);
+                LOGGER.error("A MessagingException occurred while closing the Store", ex);
             }
             LOGGER.info("Finished fetching mail from server '{}' for user '{}' in folder '{}'", getHost(), getUser(), getJavaMailFolderName());
         }


### PR DESCRIPTION
Fix 12 instances of `occured` → `occurred` across 5 files in james-project.

| File | Instances |
|------|-----------|
| `FileBlobStoreDAO.java` | 4 |
| `MemoryBlobStoreDAO.java` | 3 |
| `HasException.java` | 2 |
| `MailboxCopierManagement.java` | 2 |
| `StoreProcessor.java` | 1 |

All in Javadoc and log messages. Comment/log-string change only.