### PR TITLE
JAMES-4182 `compression.enabled` -> `compression.enable`

### DIFF
--- a/docs/modules/servers/partials/configure/blobstore.adoc
+++ b/docs/modules/servers/partials/configure/blobstore.adoc
@@ -72,7 +72,7 @@ james.blob.aes.blob.max.size=100M
 Data can be optionally compressed using Zstd before being stored in the blobStore. This especially benefits
 text-heavy mail contents and attachments when using S3 compatible object stores where storage costs matter.
 
-*compression.enabled* : Optional boolean, defaults to false.
+*compression.enable* : Optional boolean, defaults to false.
 
 *compression.threshold* : Optional size, defaults to 16K. Compression is only attempted for blobs whose original
 size is greater than or equal to this threshold. Supported units: no suffix for bytes, or B, K, M, G.

--- a/server/apps/distributed-app/sample-configuration/blob.properties
+++ b/server/apps/distributed-app/sample-configuration/blob.properties
@@ -44,7 +44,7 @@ encryption.aes.enable=false
 # If enabled, James will compress blobs before storing them whenever the blob is large enough
 # and the resulting compressed payload satisfies the configured compression ratio.
 # Optional, Allowed values are: true, false, defaults to false
-compression.enabled=false
+compression.enable=false
 
 # Minimum blob size before compression is attempted.
 # Optional, defaults to 16K.

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/blobstore/BlobStoreConfiguration.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/blobstore/BlobStoreConfiguration.java
@@ -164,7 +164,7 @@ public class BlobStoreConfiguration {
     static final String ENCRYPTION_ENABLE_PROPERTY = "encryption.aes.enable";
     static final String ENCRYPTION_PASSWORD_PROPERTY = "encryption.aes.password";
     static final String ENCRYPTION_SALT_PROPERTY = "encryption.aes.salt";
-    static final String COMPRESSION_ENABLE_PROPERTY = "compression.enabled";
+    static final String COMPRESSION_ENABLE_PROPERTY = "compression.enable";
     static final String COMPRESSION_THRESHOLD_PROPERTY = "compression.threshold";
     static final String COMPRESSION_MIN_RATIO_PROPERTY = "compression.min-ratio";
     static final boolean CACHE_ENABLED = true;

--- a/server/container/guice/distributed/src/test/java/org/apache/james/modules/blobstore/BlobStoreConfigurationTest.java
+++ b/server/container/guice/distributed/src/test/java/org/apache/james/modules/blobstore/BlobStoreConfigurationTest.java
@@ -176,7 +176,7 @@ class BlobStoreConfigurationTest {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
         configuration.addProperty("implementation", "cassandra");
         configuration.addProperty("deduplication.enable", false);
-        configuration.addProperty("compression.enabled", true);
+        configuration.addProperty("compression.enable", true);
         configuration.addProperty("compression.threshold", "32K");
         configuration.addProperty("compression.min-ratio", 0.8F);
         FakePropertiesProvider propertyProvider = FakePropertiesProvider.builder()
@@ -196,7 +196,7 @@ class BlobStoreConfigurationTest {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
         configuration.addProperty("implementation", "cassandra");
         configuration.addProperty("deduplication.enable", false);
-        configuration.addProperty("compression.enabled", true);
+        configuration.addProperty("compression.enable", true);
         configuration.addProperty("compression.threshold", "32 K");
         FakePropertiesProvider propertyProvider = FakePropertiesProvider.builder()
             .register(ConfigurationComponent.NAME, configuration)

--- a/src/site/xdoc/server/config-blobstore.xml
+++ b/src/site/xdoc/server/config-blobstore.xml
@@ -146,7 +146,7 @@ generate salt with : openssl rand -hex 16
                     storage costs matter.
                 </p>
                 <dl>
-                    <dt><strong>compression.enabled</strong></dt>
+                    <dt><strong>compression.enable</strong></dt>
                     <dd>Optional boolean, defaults to false.</dd>
                 </dl>
                 <dl>


### PR DESCRIPTION
To align with other configs:
cache.enable
encryption.aes.enable
deduplication.enable