### PR TITLE
Upgrade Netty 4.1.126.Final to 4.1.132.Final to fix CVE-2025-67735 vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -648,7 +648,7 @@
         <junit.platform.version>1.13.1</junit.platform.version>
         <junit.vintage.version>5.13.1</junit.vintage.version>
         <concurrent.version>1.3.4</concurrent.version>
-        <netty.version>4.1.126.Final</netty.version>
+        <netty.version>4.1.132.Final</netty.version>
         <cucumber.version>7.23.0</cucumber.version>
         <jackson.version>2.19.1</jackson.version>
         <jackson.databind.version>2.19.1</jackson.databind.version>
@@ -680,7 +680,7 @@
         <logback.version>1.5.19</logback.version>
         <tink.version>1.17.0</tink.version>
         <zstd-jni.version>1.5.7-7</zstd-jni.version>
-        <lettuce.core.version>6.7.1.RELEASE</lettuce.core.version>
+        <lettuce.core.version>6.8.2.RELEASE</lettuce.core.version>
         <io.micrometer.core.version>1.15.1</io.micrometer.core.version>
         <io.micrometer.tracing.version>1.5.1</io.micrometer.tracing.version>
         <bouncycastle.version>1.82</bouncycastle.version>
@@ -2568,7 +2568,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2024.0.10</version>
+                <version>2024.0.17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/server/blob/blob-s3/pom.xml
+++ b/server/blob/blob-s3/pom.xml
@@ -33,7 +33,7 @@
     <name>Apache James :: Server :: Blob :: S3</name>
 
     <properties>
-        <s3-sdk.version>2.33.5</s3-sdk.version>
+        <s3-sdk.version>2.42.34</s3-sdk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Motivation

`netty.version 4.1.126.Final` is affected by two HIGH-severity vulnerability CVE-2025-67735:

Both are fixed in `4.1.132.Final`.

## Changes

| Dependency | From | To |
|---|---|---|
| `netty.version` | `4.1.126.Final` | `4.1.132.Final` |
| `lettuce.core.version` | `6.7.1.RELEASE` | `6.8.2.RELEASE` |
| `reactor-bom` | `2024.0.10` | `2024.0.17` |
| `s3-sdk.version` (blob-s3) | `2.33.5` | `2.42.34` |

`lettuce-core` (the Redis client) uses Netty internally, so it is bumped
alongside Netty to keep both on a consistent Netty runtime.
`reactor-bom` and `s3-sdk` are bumped to their latest stable releases as
part of the same dependency maintenance pass.

## Testing

1. Build the distributed-app module:
```
 mvn clean package -DskipTests -pl server/apps/distributed-app -am 
```

2. Check the version of the netty libraries in the output directory:
```
ls server/apps/distributed-app/target/james-server-distributed-app.lib | grep netty | sort
```

Output:
```
james-server-guice-netty-3.10.0-SNAPSHOT.jar
netty-buffer-4.1.132.Final.jar
netty-codec-4.1.132.Final.jar
netty-codec-dns-4.1.132.Final.jar
netty-codec-haproxy-4.1.132.Final.jar
netty-codec-http-4.1.132.Final.jar
netty-codec-http2-4.1.132.Final.jar
netty-codec-socks-4.1.132.Final.jar
netty-common-4.1.132.Final.jar
netty-handler-4.1.132.Final.jar
netty-handler-proxy-4.1.132.Final.jar
netty-nio-client-2.42.34.jar
netty-resolver-4.1.132.Final.jar
netty-resolver-dns-4.1.132.Final.jar
netty-resolver-dns-classes-macos-4.1.132.Final.jar
netty-resolver-dns-native-macos-4.1.132.Final-osx-x86_64.jar
netty-transport-4.1.132.Final.jar
netty-transport-classes-epoll-4.1.132.Final.jar
netty-transport-native-epoll-4.1.132.Final-linux-x86_64.jar
netty-transport-native-epoll-4.1.132.Final.jar
netty-transport-native-unix-common-4.1.132.Final.jar
protocols-netty-3.10.0-SNAPSHOT.jar
reactor-netty-1.2.17.jar
reactor-netty-core-1.2.17.jar
reactor-netty-http-1.2.17.jar
```