### PR TITLE
JAMES-4205: Fix OIDC mailbox provisioning

### DIFF
--- a/examples/custom-imap/README.md
+++ b/examples/custom-imap/README.md
@@ -50,7 +50,7 @@ Connected to localhost.
 Escape character is '^]'.
 * OK JAMES IMAP4rev1 Server james.local is ready.
 a01 LOGIN bob secret
-a01 NO LOGIN failed. Invalid login/password.
+a01 NO LOGIN failed. Invalid credentials.
 a02 LOGIN bob@localhost secret
 a02 OK LOGIN completed.
 A03 PING

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/AuthenticatePlain.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/AuthenticatePlain.test
@@ -85,7 +85,7 @@ REINIT
 C: 0005 AUTHENTICATE "PLAIN" {28+}
 # \0imapuser\0badpassword
 C: AGltYXB1c2VyAGJhZHBhc3N3b3Jk
-S: 0005 NO AUTHENTICATE failed. Authentication failed.
+S: 0005 NO AUTHENTICATE failed. Invalid credentials.
 
 REINIT
 
@@ -93,7 +93,7 @@ REINIT
 C: 0006 AUTHENTICATE "PLAIN" {24+}
 # \0baduser\0password
 C: AGJhZHVzZXIAcGFzc3dvcmQ=
-S: 0006 NO AUTHENTICATE failed. Authentication failed.
+S: 0006 NO AUTHENTICATE failed. Invalid credentials.
 
 REINIT
 

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Login.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Login.test
@@ -27,10 +27,10 @@ C: a002a LOGIN imapuser password extra
 S: a002a BAD LOGIN failed. Illegal arguments.
 
 C: a003 LOGIN invaliduser password
-S: a003 NO LOGIN failed. Invalid login/password.
+S: a003 NO LOGIN failed. Invalid credentials.
 
 C: a004 LOGIN imapuser invalid
-S: a004 NO LOGIN failed. Invalid login/password.
+S: a004 NO LOGIN failed. Invalid credentials.
 
 C: a005 LOGIN imapuser password
 S: a005 OK LOGIN completed.

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/LoginThreeStrikes.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/LoginThreeStrikes.test
@@ -21,10 +21,10 @@
 #
 S: \* OK IMAP4rev1 Server ready
 C: a003 LOGIN invaliduser password
-S: a003 NO LOGIN failed. Invalid login/password.
+S: a003 NO LOGIN failed. Invalid credentials.
 
 C: a004 LOGIN imapuser invalid
-S: a004 NO LOGIN failed. Invalid login/password.
+S: a004 NO LOGIN failed. Invalid credentials.
 
 C: a005 LOGIN imapuser bogus
 S: \* BYE Login failed too many times.

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
@@ -141,7 +141,7 @@ public class HumanReadableText {
     public static final HumanReadableText COMPLETED = new HumanReadableText("org.apache.james.imap.COMPLETED", "completed.");
     public static final HumanReadableText REPLACE_READY = new HumanReadableText("org.apache.james.imap.REPLACE", "Replacement Message ready");
 
-    public static final HumanReadableText INVALID_LOGIN = new HumanReadableText("org.apache.james.imap.INVALID_LOGIN", "failed. Invalid login/password.");
+    public static final HumanReadableText INVALID_CREDENTIALS = new HumanReadableText("org.apache.james.imap.INVALID_CREDENTIALS", "failed. Invalid credentials.");
 
     public static final HumanReadableText DISABLED_LOGIN = new HumanReadableText("org.apache.james.imap.DISABLED_LOGIN", "failed. Plain login / authentication are disabled.");
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -27,6 +27,8 @@ import org.apache.james.imap.api.message.request.ImapRequest;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.main.PathConverter;
+import org.apache.james.jwt.OidcJwtTokenVerifier;
+import org.apache.james.jwt.OidcSASLConfiguration;
 import org.apache.james.mailbox.Authorizator;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.MailboxManager;
@@ -39,6 +41,7 @@ import org.apache.james.mailbox.exception.UserDoesNotExistException;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.protocols.api.OIDCSASLParser;
 import org.apache.james.util.AuditTrail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,6 +192,23 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
             LOGGER.info("Login failed", e);
             no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
         }
+    }
+
+    protected void doOAuth(OIDCSASLParser.OIDCInitialResponse oidcInitialResponse, OidcSASLConfiguration oidcSASLConfiguration,
+                         ImapSession session, ImapRequest request, Responder responder) {
+        new OidcJwtTokenVerifier(oidcSASLConfiguration).validateToken(oidcInitialResponse.getToken())
+            .ifPresentOrElse(authenticatedUser -> {
+                Username associatedUser = Username.of(oidcInitialResponse.getAssociatedUser());
+                if (!associatedUser.equals(authenticatedUser)) {
+                    doAuthWithDelegation(() -> getMailboxManager()
+                            .withExtraAuthorizator(withAdminUsers())
+                            .authenticate(authenticatedUser)
+                            .as(associatedUser),
+                        session, request, responder, authenticatedUser, associatedUser);
+                } else {
+                    authSuccess(authenticatedUser, session, request, responder);
+                }
+            }, () -> manageFailureCount(session, request, responder));
     }
 
     protected void provisionInbox(ImapSession session, MailboxManager mailboxManager, MailboxSession mailboxSession) throws MailboxException {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -95,7 +95,7 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
                 ).withoutDelegation();
                 authSuccess(session, mailboxSession, request, responder, "Password authentication succeeded.");
             } catch (BadCredentialsException e) {
-                authFailure(session, request, responder, HumanReadableText.INVALID_LOGIN,
+                authFailure(session, request, responder, HumanReadableText.INVALID_CREDENTIALS,
                     Optional.of(authenticationAttempt.getAuthenticationId()),
                     Optional.empty(),
                     "Password authentication failed because of bad credentials."
@@ -143,7 +143,7 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         try {
             authSuccess(session, mailboxSessionSupplier.get(), request, responder, "Authentication with delegation succeeded.");
         } catch (BadCredentialsException e) {
-            authFailure(session, request, responder, HumanReadableText.INVALID_LOGIN, Optional.of(authenticateUser),
+            authFailure(session, request, responder, HumanReadableText.INVALID_CREDENTIALS, Optional.of(authenticateUser),
                 Optional.of(delegatorUser), "Password authentication with delegation failed because of bad credentials.");
         } catch (UserDoesNotExistException e) {
             authFailure(session, request, responder, HumanReadableText.USER_DOES_NOT_EXIST, Optional.of(authenticateUser),

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -80,62 +80,52 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         this.imapConfiguration = imapConfiguration;
     }
 
-    protected void doPasswordAuth(AuthenticationAttempt authenticationAttempt, ImapSession session, ImapRequest request, Responder responder, HumanReadableText failed) {
+    protected void doPasswordAuth(AuthenticationAttempt authenticationAttempt, ImapSession session, ImapRequest request, Responder responder) {
         Preconditions.checkArgument(!authenticationAttempt.isDelegation());
-        try {
-            boolean authFailure = false;
-            if (authenticationAttempt.getAuthenticationId() == null) {
-                authFailure = true;
+
+        if (authenticationAttempt.getAuthenticationId() == null || authenticationAttempt.getPassword() == null) {
+            authFailure(session, request, responder, HumanReadableText.AUTHENTICATION_FAILED, Optional.empty(), Optional.empty(),
+                "Malformed authentication command."
+            );
+        } else {
+            try {
+                final MailboxSession mailboxSession = getMailboxManager().authenticate(
+                    authenticationAttempt.getAuthenticationId(),
+                    authenticationAttempt.getPassword()
+                ).withoutDelegation();
+                authSuccess(session, mailboxSession, request, responder, "Password authentication succeeded.");
+            } catch (BadCredentialsException e) {
+                authFailure(session, request, responder, HumanReadableText.INVALID_LOGIN,
+                    Optional.of(authenticationAttempt.getAuthenticationId()),
+                    Optional.empty(),
+                    "Password authentication failed because of bad credentials."
+                );
+            } catch (MailboxException e) {
+                // This is probably not a user error, so we do not increase the failure count or add the
+                // event to the audit log.
+                LOGGER.error("Authentication failed", e);
+                no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
             }
-            if (!authFailure) {
-                try {
-                    final MailboxSession mailboxSession = getMailboxManager().authenticate(authenticationAttempt.getAuthenticationId(),
-                        authenticationAttempt.getPassword())
-                        .withoutDelegation();
-                    session.authenticated();
-                    session.setMailboxSession(mailboxSession);
-                    provisionInbox(session, getMailboxManager(), mailboxSession);
-                    AuditTrail.entry()
-                        .username(() -> mailboxSession.getUser().asString())
-                        .sessionId(() -> session.sessionId().asString())
-                        .protocol("IMAP")
-                        .action("AUTH")
-                        .log("IMAP Authentication succeeded.");
-                    okComplete(request, responder);
-                    session.stopDetectingCommandInjection();
-                } catch (BadCredentialsException e) {
-                    authFailure = true;
-                    AuditTrail.entry()
-                        .username(() -> authenticationAttempt.getAuthenticationId().asString())
-                        .protocol("IMAP")
-                        .action("AUTH")
-                        .log("IMAP Authentication failed because of bad credentials.");
-                }
-            }
-            if (authFailure) {
-                manageFailureCount(session, request, responder, failed);
-            }
-        } catch (MailboxException e) {
-            LOGGER.error("Error encountered while login", e);
-            no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
         }
     }
 
     protected void doPasswordAuthWithDelegation(AuthenticationAttempt authenticationAttempt, ImapSession session, ImapRequest request, Responder responder) {
         Preconditions.checkArgument(authenticationAttempt.isDelegation());
+        Username otherUser = authenticationAttempt.getDelegateUserName().orElseThrow();
+
         Username givenUser = authenticationAttempt.getAuthenticationId();
         if (givenUser == null) {
-            manageFailureCount(session, request, responder);
-            return;
+            authFailure(session, request, responder, HumanReadableText.AUTHENTICATION_FAILED,
+                Optional.empty(), Optional.of(otherUser), "Malformed authentication command.");
+        } else {
+            doAuthWithDelegation(() -> getMailboxManager()
+                    .withExtraAuthorizator(withAdminUsers())
+                    .authenticate(givenUser, authenticationAttempt.getPassword())
+                    .as(otherUser),
+                session,
+                request, responder,
+                givenUser, otherUser);
         }
-        Username otherUser = authenticationAttempt.getDelegateUserName().orElseThrow();
-        doAuthWithDelegation(() -> getMailboxManager()
-                .withExtraAuthorizator(withAdminUsers())
-                .authenticate(givenUser, authenticationAttempt.getPassword())
-                .as(otherUser),
-            session,
-            request, responder,
-            givenUser, otherUser);
     }
 
     protected Authorizator withAdminUsers() {
@@ -151,45 +141,20 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
                                         ImapSession session, ImapRequest request, Responder responder,
                                         Username authenticateUser, Username delegatorUser) {
         try {
-            MailboxManager mailboxManager = getMailboxManager();
-            MailboxSession mailboxSession = mailboxSessionSupplier.get();
-            session.authenticated();
-            session.setMailboxSession(mailboxSession);
-            AuditTrail.entry()
-                .username(() -> mailboxSession.getLoggedInUser()
-                    .map(Username::asString)
-                    .orElse(""))
-                .sessionId(() -> session.sessionId().asString())
-                .protocol("IMAP")
-                .action("AUTH")
-                .remoteIP(() -> Optional.ofNullable(session.getRemoteAddress()))
-                .parameters(() -> ImmutableMap.of("delegatorUser", mailboxSession.getUser().asString()))
-                .log("IMAP Authentication with delegation succeeded.");
-            okComplete(request, responder);
-            provisionInbox(session, mailboxManager, mailboxSession);
+            authSuccess(session, mailboxSessionSupplier.get(), request, responder, "Authentication with delegation succeeded.");
         } catch (BadCredentialsException e) {
-            AuditTrail.entry()
-                .username(authenticateUser::asString)
-                .protocol("IMAP")
-                .action("AUTH")
-                .remoteIP(() -> Optional.ofNullable(session.getRemoteAddress()))
-                .parameters(() -> ImmutableMap.of("delegatorUser", delegatorUser.asString()))
-                .log("IMAP Authentication with delegation failed because of bad credentials.");
-            manageFailureCount(session, request, responder);
+            authFailure(session, request, responder, HumanReadableText.INVALID_LOGIN, Optional.of(authenticateUser),
+                Optional.of(delegatorUser), "Password authentication with delegation failed because of bad credentials.");
         } catch (UserDoesNotExistException e) {
-            LOGGER.info("User does not exist", e);
-            no(request, responder, HumanReadableText.USER_DOES_NOT_EXIST);
+            authFailure(session, request, responder, HumanReadableText.USER_DOES_NOT_EXIST, Optional.of(authenticateUser),
+                Optional.of(delegatorUser), "Delegation target user does not exist.");
         } catch (ForbiddenDelegationException e) {
-            LOGGER.info("Delegate forbidden", e);
-            AuditTrail.entry()
-                .username(authenticateUser::asString)
-                .protocol("IMAP")
-                .action("AUTH")
-                .parameters(() -> ImmutableMap.of("delegatorUser", delegatorUser.asString()))
-                .log("IMAP Authentication with delegation failed because of non existing delegation.");
-            no(request, responder, HumanReadableText.DELEGATION_FORBIDDEN);
+            authFailure(session, request, responder, HumanReadableText.DELEGATION_FORBIDDEN, Optional.of(authenticateUser),
+            Optional.of(delegatorUser), "Requested delegation is forbidden.");
         } catch (MailboxException e) {
-            LOGGER.info("Login failed", e);
+            // This is probably not a user error, so we do not increase the failure count or add the
+            // event to the audit log.
+            LOGGER.info("Authentication failed", e);
             no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
         }
     }
@@ -206,9 +171,16 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
                             .as(associatedUser),
                         session, request, responder, authenticatedUser, associatedUser);
                 } else {
-                    authSuccess(authenticatedUser, session, request, responder);
+                    authSuccess(session, getMailboxManager().createSystemSession(authenticatedUser), request, responder,
+                        "OAuth authentication succeeded."
+                    );
                 }
-            }, () -> manageFailureCount(session, request, responder));
+            }, () -> {
+                authFailure(session, request, responder, HumanReadableText.AUTHENTICATION_FAILED, Optional.empty(),
+                    Optional.of(Username.of(oidcInitialResponse.getAssociatedUser())),
+                    "OAuth authentication failed."
+                );
+            });
     }
 
     protected void provisionInbox(ImapSession session, MailboxManager mailboxManager, MailboxSession mailboxSession) throws MailboxException {
@@ -243,10 +215,6 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         }
     }
 
-    protected void manageFailureCount(ImapSession session, ImapRequest request, Responder responder) {
-        manageFailureCount(session, request, responder, HumanReadableText.AUTHENTICATION_FAILED);
-    }
-
     protected void manageFailureCount(ImapSession session, ImapRequest request, Responder responder, HumanReadableText failed) {
         Integer currentNumberOfFailures = (Integer) session.getAttribute(ATTRIBUTE_NUMBER_OF_FAILURES);
         int failures;
@@ -273,17 +241,42 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         return new AuthenticationAttempt(Optional.empty(), authenticationId, password);
     }
 
-    protected void oauthSuccess(Username username, ImapSession session, ImapRequest request, Responder responder) {
+    protected void authSuccess(ImapSession session, MailboxSession mailboxSession, ImapRequest request, Responder responder, String log) {
+        session.authenticated();
+        session.setMailboxSession(mailboxSession);
         try {
-            session.authenticated();
-            final MailboxSession mailboxSession = getMailboxManager().createSystemSession(username);
-            session.setMailboxSession(mailboxSession);
             provisionInbox(session, getMailboxManager(), mailboxSession);
-            okComplete(request, responder);
         } catch (MailboxException e) {
-            LOGGER.error("Error encountered while login", e);
-            no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
+            LOGGER.error("Provisioning mailboxes failed but authentication continues", e);
         }
+
+        AuditTrail.Entry entry = AuditTrail.entry()
+            .username(() -> mailboxSession.getUser().asString())
+            .sessionId(() -> session.sessionId().asString())
+            .protocol("IMAP")
+            .action("AUTH")
+            .remoteIP(() -> Optional.ofNullable(session.getRemoteAddress()));
+        Optional<Username> assumedUser = mailboxSession.getLoggedInUser();
+        if (assumedUser.isPresent()) {
+            entry = entry.parameters(() -> ImmutableMap.of("delegatorUser", assumedUser.get().asString()));
+        }
+        entry.log(log);
+        okComplete(request, responder);
+        session.stopDetectingCommandInjection();
+    }
+
+    protected void authFailure(ImapSession session, ImapRequest request, Responder responder, HumanReadableText failed, Optional<Username> username, Optional<Username> assumedUser, String log) {
+        AuditTrail.Entry entry = AuditTrail.entry()
+            .username(() -> username.map(name -> name.asString()).orElse(null))
+            .sessionId(() -> session.sessionId().asString())
+            .protocol("IMAP")
+            .action("AUTH")
+            .remoteIP(() -> Optional.ofNullable(session.getRemoteAddress()));
+        if (assumedUser.isPresent()) {
+            entry = entry.parameters(() -> ImmutableMap.of("delegatorUser", assumedUser.get().asString()));
+        }
+        entry.log(log);
+        manageFailureCount(session, request, responder, failed);
     }
 
     protected static class AuthenticationAttempt {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -77,7 +77,7 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         this.imapConfiguration = imapConfiguration;
     }
 
-    protected void doAuth(AuthenticationAttempt authenticationAttempt, ImapSession session, ImapRequest request, Responder responder, HumanReadableText failed) {
+    protected void doPasswordAuth(AuthenticationAttempt authenticationAttempt, ImapSession session, ImapRequest request, Responder responder, HumanReadableText failed) {
         Preconditions.checkArgument(!authenticationAttempt.isDelegation());
         try {
             boolean authFailure = false;
@@ -118,7 +118,7 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         }
     }
 
-    protected void doAuthWithDelegation(AuthenticationAttempt authenticationAttempt, ImapSession session, ImapRequest request, Responder responder) {
+    protected void doPasswordAuthWithDelegation(AuthenticationAttempt authenticationAttempt, ImapSession session, ImapRequest request, Responder responder) {
         Preconditions.checkArgument(authenticationAttempt.isDelegation());
         Username givenUser = authenticationAttempt.getAuthenticationId();
         if (givenUser == null) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -253,10 +253,17 @@ public abstract class AbstractAuthProcessor<R extends ImapRequest> extends Abstr
         return new AuthenticationAttempt(Optional.empty(), authenticationId, password);
     }
 
-    protected void authSuccess(Username username, ImapSession session, ImapRequest request, Responder responder) {
-        session.authenticated();
-        session.setMailboxSession(getMailboxManager().createSystemSession(username));
-        okComplete(request, responder);
+    protected void oauthSuccess(Username username, ImapSession session, ImapRequest request, Responder responder) {
+        try {
+            session.authenticated();
+            final MailboxSession mailboxSession = getMailboxManager().createSystemSession(username);
+            session.setMailboxSession(mailboxSession);
+            provisionInbox(session, getMailboxManager(), mailboxSession);
+            okComplete(request, responder);
+        } catch (MailboxException e) {
+            LOGGER.error("Error encountered while login", e);
+            no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
+        }
     }
 
     protected static class AuthenticationAttempt {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -55,7 +55,7 @@ import com.google.common.collect.ImmutableList;
 import reactor.core.publisher.Mono;
 
 /**
- * Processor which handles the AUTHENTICATE command. Only authtype of PLAIN is supported ATM.
+ * Processor which handles the AUTHENTICATE command. Supported authentication mechanisms are PLAIN, XOAUTH2, and OAUTHBEARER.
  */
 public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateRequest> implements CapabilityImplementingProcessor {
     public static final String AUTH_PLAIN = "AUTH=PLAIN";
@@ -85,18 +85,18 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
         if (authType.equalsIgnoreCase(AUTH_TYPE_PLAIN)) {
             // See if AUTH=PLAIN is allowed. See IMAP-304
             if (session.isPlainAuthDisallowed()) {
-                LOGGER.warn("Login attempt over clear channel rejected");
+                LOGGER.warn("Plain authentication rejected because it is disabled or not allowed over insecure channel");
                 no(request, responder, HumanReadableText.DISABLED_LOGIN);
             } else {
                 if (request instanceof IRAuthenticateRequest) {
                     IRAuthenticateRequest irRequest = (IRAuthenticateRequest) request;
-                    doPlainAuth(irRequest.getInitialClientResponse(), session, request, responder);
+                    parseAndDoPlainAuth(irRequest.getInitialClientResponse(), session, request, responder);
                 } else {
                     session.executeSafely(() -> {
                         responder.respond(new AuthenticateResponse());
                         responder.flush();
                         session.pushLineHandler((requestSession, data) -> Mono.fromRunnable(() -> {
-                            doPlainAuth(extractInitialClientResponse(data), requestSession, request, responder);
+                            parseAndDoPlainAuth(extractInitialClientResponse(data), requestSession, request, responder);
                             // remove the handler now
                             requestSession.popLineHandler();
                             responder.flush();
@@ -111,13 +111,13 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
             } else {
                 if (request instanceof IRAuthenticateRequest) {
                     IRAuthenticateRequest irRequest = (IRAuthenticateRequest) request;
-                    doOAuth(irRequest.getInitialClientResponse(), session, request, responder);
+                    parseAndDoOAuth(irRequest.getInitialClientResponse(), session, request, responder);
                 } else {
                     session.executeSafely(() -> {
                         responder.respond(new AuthenticateResponse());
                         responder.flush();
                         session.pushLineHandler((requestSession, data) -> Mono.fromRunnable(() -> {
-                            doOAuth(extractInitialClientResponse(data), requestSession, request, responder);
+                            parseAndDoOAuth(extractInitialClientResponse(data), requestSession, request, responder);
                             requestSession.popLineHandler();
                             responder.flush();
                         }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER).then());
@@ -131,14 +131,14 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
     }
 
     /**
-     * Parse the initialClientResponse and do a PLAIN AUTH with it
+     * Parse the initial client response and start plain authentication.
      */
-    protected void doPlainAuth(String initialClientResponse, ImapSession session, ImapRequest request, Responder responder) {
+    protected void parseAndDoPlainAuth(String initialClientResponse, ImapSession session, ImapRequest request, Responder responder) {
         AuthenticationAttempt authenticationAttempt = parseDelegationAttempt(initialClientResponse);
         if (authenticationAttempt.isDelegation()) {
-            doAuthWithDelegation(authenticationAttempt, session, request, responder);
+            doPasswordAuthWithDelegation(authenticationAttempt, session, request, responder);
         } else {
-            doAuth(authenticationAttempt, session, request, responder, HumanReadableText.AUTHENTICATION_FAILED);
+            doPasswordAuth(authenticationAttempt, session, request, responder, HumanReadableText.AUTHENTICATION_FAILED);
         }
         session.stopDetectingCommandInjection();
     }
@@ -201,7 +201,10 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
             .addToContext("authType", request.getAuthType());
     }
 
-    protected void doOAuth(String initialResponse, ImapSession session, ImapRequest request, Responder responder) {
+    /**
+     * Parse the initial client response and start oauth authentication.
+     */
+    protected void parseAndDoOAuth(String initialResponse, ImapSession session, ImapRequest request, Responder responder) {
         OIDCSASLParser.parse(initialResponse)
             .flatMap(oidcInitialResponseValue -> session.oidcSaslConfiguration().map(configure -> Pair.of(oidcInitialResponseValue, configure)))
             .ifPresentOrElse(pair -> doOAuth(pair.getLeft(), pair.getRight(), session, request, responder),

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -39,8 +39,6 @@ import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.AuthenticateRequest;
 import org.apache.james.imap.message.request.IRAuthenticateRequest;
 import org.apache.james.imap.message.response.AuthenticateResponse;
-import org.apache.james.jwt.OidcJwtTokenVerifier;
-import org.apache.james.jwt.OidcSASLConfiguration;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.OIDCSASLParser;
@@ -143,6 +141,17 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
         session.stopDetectingCommandInjection();
     }
 
+    /**
+     * Parse the initial client response and start oauth authentication.
+     */
+    protected void parseAndDoOAuth(String initialResponse, ImapSession session, ImapRequest request, Responder responder) {
+        OIDCSASLParser.parse(initialResponse)
+            .flatMap(oidcInitialResponseValue -> session.oidcSaslConfiguration().map(configure -> Pair.of(oidcInitialResponseValue, configure)))
+            .ifPresentOrElse(pair -> doOAuth(pair.getLeft(), pair.getRight(), session, request, responder),
+                () -> manageFailureCount(session, request, responder));
+        session.stopDetectingCommandInjection();
+    }
+
     private AuthenticationAttempt parseDelegationAttempt(String initialClientResponse) {
         try {
             String userpass = new String(Base64.getDecoder().decode(initialClientResponse));
@@ -199,34 +208,6 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
         return MDCBuilder.create()
             .addToContext(MDCBuilder.ACTION, "AUTHENTICATE")
             .addToContext("authType", request.getAuthType());
-    }
-
-    /**
-     * Parse the initial client response and start oauth authentication.
-     */
-    protected void parseAndDoOAuth(String initialResponse, ImapSession session, ImapRequest request, Responder responder) {
-        OIDCSASLParser.parse(initialResponse)
-            .flatMap(oidcInitialResponseValue -> session.oidcSaslConfiguration().map(configure -> Pair.of(oidcInitialResponseValue, configure)))
-            .ifPresentOrElse(pair -> doOAuth(pair.getLeft(), pair.getRight(), session, request, responder),
-                () -> manageFailureCount(session, request, responder));
-        session.stopDetectingCommandInjection();
-    }
-
-    private void doOAuth(OIDCSASLParser.OIDCInitialResponse oidcInitialResponse, OidcSASLConfiguration oidcSASLConfiguration,
-                         ImapSession session, ImapRequest request, Responder responder) {
-        new OidcJwtTokenVerifier(oidcSASLConfiguration).validateToken(oidcInitialResponse.getToken())
-            .ifPresentOrElse(authenticatedUser -> {
-                Username associatedUser = Username.of(oidcInitialResponse.getAssociatedUser());
-                if (!associatedUser.equals(authenticatedUser)) {
-                    doAuthWithDelegation(() -> getMailboxManager()
-                            .withExtraAuthorizator(withAdminUsers())
-                            .authenticate(authenticatedUser)
-                            .as(associatedUser),
-                        session, request, responder, authenticatedUser, associatedUser);
-                } else {
-                    oauthSuccess(authenticatedUser, session, request, responder);
-                }
-            }, () -> manageFailureCount(session, request, responder));
     }
 
     private static String extractInitialClientResponse(byte[] data) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -136,9 +137,8 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
         if (authenticationAttempt.isDelegation()) {
             doPasswordAuthWithDelegation(authenticationAttempt, session, request, responder);
         } else {
-            doPasswordAuth(authenticationAttempt, session, request, responder, HumanReadableText.AUTHENTICATION_FAILED);
+            doPasswordAuth(authenticationAttempt, session, request, responder);
         }
-        session.stopDetectingCommandInjection();
     }
 
     /**
@@ -148,8 +148,8 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
         OIDCSASLParser.parse(initialResponse)
             .flatMap(oidcInitialResponseValue -> session.oidcSaslConfiguration().map(configure -> Pair.of(oidcInitialResponseValue, configure)))
             .ifPresentOrElse(pair -> doOAuth(pair.getLeft(), pair.getRight(), session, request, responder),
-                () -> manageFailureCount(session, request, responder));
-        session.stopDetectingCommandInjection();
+                () -> authFailure(session, request, responder, HumanReadableText.AUTHENTICATION_FAILED, Optional.empty(),
+                    Optional.empty(), "Malformed authentication command."));
     }
 
     private AuthenticationAttempt parseDelegationAttempt(String initialClientResponse) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -105,19 +105,24 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
                 }
             }
         } else if (authType.equalsIgnoreCase(AUTH_TYPE_OAUTHBEARER) || authType.equalsIgnoreCase(AUTH_TYPE_XOAUTH2)) {
-            if (request instanceof IRAuthenticateRequest) {
-                IRAuthenticateRequest irRequest = (IRAuthenticateRequest) request;
-                doOAuth(irRequest.getInitialClientResponse(), session, request, responder);
+            if (!session.supportsOAuth()) {
+                LOGGER.warn("OAuth authentication rejected because it is disabled");
+                no(request, responder, HumanReadableText.UNSUPPORTED_AUTHENTICATION_MECHANISM);
             } else {
-                session.executeSafely(() -> {
-                    responder.respond(new AuthenticateResponse());
-                    responder.flush();
-                    session.pushLineHandler((requestSession, data) -> Mono.fromRunnable(() -> {
-                        doOAuth(extractInitialClientResponse(data), requestSession, request, responder);
-                        requestSession.popLineHandler();
+                if (request instanceof IRAuthenticateRequest) {
+                    IRAuthenticateRequest irRequest = (IRAuthenticateRequest) request;
+                    doOAuth(irRequest.getInitialClientResponse(), session, request, responder);
+                } else {
+                    session.executeSafely(() -> {
+                        responder.respond(new AuthenticateResponse());
                         responder.flush();
-                    }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER).then());
-                });
+                        session.pushLineHandler((requestSession, data) -> Mono.fromRunnable(() -> {
+                            doOAuth(extractInitialClientResponse(data), requestSession, request, responder);
+                            requestSession.popLineHandler();
+                            responder.flush();
+                        }).subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER).then());
+                    });
+                }
             }
         } else {
             LOGGER.debug("Unsupported authentication mechanism '{}'", authType);
@@ -197,14 +202,10 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
     }
 
     protected void doOAuth(String initialResponse, ImapSession session, ImapRequest request, Responder responder) {
-        if (!session.supportsOAuth()) {
-            no(request, responder, HumanReadableText.UNSUPPORTED_AUTHENTICATION_MECHANISM);
-        } else {
-            OIDCSASLParser.parse(initialResponse)
-                .flatMap(oidcInitialResponseValue -> session.oidcSaslConfiguration().map(configure -> Pair.of(oidcInitialResponseValue, configure)))
-                .ifPresentOrElse(pair -> doOAuth(pair.getLeft(), pair.getRight(), session, request, responder),
-                    () -> manageFailureCount(session, request, responder));
-        }
+        OIDCSASLParser.parse(initialResponse)
+            .flatMap(oidcInitialResponseValue -> session.oidcSaslConfiguration().map(configure -> Pair.of(oidcInitialResponseValue, configure)))
+            .ifPresentOrElse(pair -> doOAuth(pair.getLeft(), pair.getRight(), session, request, responder),
+                () -> manageFailureCount(session, request, responder));
         session.stopDetectingCommandInjection();
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AuthenticateProcessor.java
@@ -220,7 +220,7 @@ public class AuthenticateProcessor extends AbstractAuthProcessor<AuthenticateReq
                             .as(associatedUser),
                         session, request, responder, authenticatedUser, associatedUser);
                 } else {
-                    authSuccess(authenticatedUser, session, request, responder);
+                    oauthSuccess(authenticatedUser, session, request, responder);
                 }
             }, () -> manageFailureCount(session, request, responder));
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LoginProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LoginProcessor.java
@@ -50,14 +50,17 @@ public class LoginProcessor extends AbstractAuthProcessor<LoginRequest> implemen
         super(LoginRequest.class, mailboxManager, factory, metricFactory, pathConverterFactory);
     }
 
+    /**
+     * Start password authentication if enabled.
+     */
     @Override
     protected void processRequest(LoginRequest request, ImapSession session, Responder responder) {
         // check if the login is allowed with LOGIN command. See IMAP-304
         if (session.isPlainAuthDisallowed()) {
-            LOGGER.warn("Login attempt over clear channel rejected");
+            LOGGER.warn("Login rejected because it is disabled or not allowed over insecure channel");
             no(request, responder, HumanReadableText.DISABLED_LOGIN);
         } else {
-            doAuth(noDelegation(request.getUserid(), request.getPassword()),
+            doPasswordAuth(noDelegation(request.getUserid(), request.getPassword()),
                 session, request, responder, HumanReadableText.INVALID_LOGIN);
         }
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LoginProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LoginProcessor.java
@@ -60,8 +60,7 @@ public class LoginProcessor extends AbstractAuthProcessor<LoginRequest> implemen
             LOGGER.warn("Login rejected because it is disabled or not allowed over insecure channel");
             no(request, responder, HumanReadableText.DISABLED_LOGIN);
         } else {
-            doPasswordAuth(noDelegation(request.getUserid(), request.getPassword()),
-                session, request, responder, HumanReadableText.INVALID_LOGIN);
+            doPasswordAuth(noDelegation(request.getUserid(), request.getPassword()), session, request, responder);
         }
     }
 

--- a/third-party/crowdsec/sample-configuration/parsers/james-auth.yaml
+++ b/third-party/crowdsec/sample-configuration/parsers/james-auth.yaml
@@ -5,10 +5,10 @@ name: linagora/james-auth
 description: "Parser for James IMAP and SMTP authentication "
 
 pattern_syntax:
-  IMAP_AUTH_FAIL_BAD_CREDENTIALS: 'IMAP Authentication failed%{DATA:data}because of bad credentials.'
-  IMAP_AUTH_FAIL_DELEGATION_BAD_CREDENTIALS: 'IMAP Authentication with delegation failed%{DATA:data}because of bad credentials.'
-  IMAP_AUTH_FAIL_NO_EXISTING_DELEGATION: 'IMAP Authentication with delegation failed%{DATA:data}because of non existing delegation.'
-  SMTP_AUTH_FAIL: 'SMTP Authentication%{DATA:data}failed.'
+  IMAP_AUTH_FAIL_BAD_CREDENTIALS: 'Password authentication failed because of bad credentials%{DATA:data}'
+  IMAP_AUTH_FAIL_DELEGATION_BAD_CREDENTIALS: 'Password authentication with delegation failed because of bad credentials%{DATA:data}'
+  IMAP_AUTH_FAIL_NO_EXISTING_DELEGATION: 'Delegation target user does not exist%{DATA:data}'
+  SMTP_AUTH_FAIL: 'SMTP Authentication failed%{DATA:data}'
   POP3_AUTH_FAIL: 'Bad credential supplied for %{DATA:user} with remote address %{IP:source_ip}'
 nodes:
   - grok:

--- a/third-party/crowdsec/src/test/resources/crowdsec/parsers/james-auth.yaml
+++ b/third-party/crowdsec/src/test/resources/crowdsec/parsers/james-auth.yaml
@@ -5,10 +5,10 @@ name: linagora/james-auth
 description: "Parser for James IMAP and SMTP authentication "
 
 pattern_syntax:
-  IMAP_AUTH_FAIL_BAD_CREDENTIALS: 'IMAP Authentication failed%{DATA:data}because of bad credentials.'
-  IMAP_AUTH_FAIL_DELEGATION_BAD_CREDENTIALS: 'IMAP Authentication with delegation failed%{DATA:data}because of bad credentials.'
-  IMAP_AUTH_FAIL_NO_EXISTING_DELEGATION: 'IMAP Authentication with delegation failed%{DATA:data}because of non existing delegation.'
-  SMTP_AUTH_FAIL: 'SMTP Authentication%{DATA:data}failed.'
+  IMAP_AUTH_FAIL_BAD_CREDENTIALS: 'Password authentication failed because of bad credentials%{DATA:data}'
+  IMAP_AUTH_FAIL_DELEGATION_BAD_CREDENTIALS: 'Password authentication with delegation failed because of bad credentials%{DATA:data}'
+  IMAP_AUTH_FAIL_NO_EXISTING_DELEGATION: 'Delegation target user does not exist%{DATA:data}'
+  SMTP_AUTH_FAIL: 'SMTP Authentication failed%{DATA:data}'
   POP3_AUTH_FAIL: 'Bad credential supplied for %{DATA:user} with remote address %{IP:source_ip}'
 nodes:
   - grok:


### PR DESCRIPTION
Benoit asked in https://issues.apache.org/jira/browse/JAMES-4205 that independent of the authentication mechanism, James should perform provisioning.

To fulfill that requirement, I introduced (or rather repurposed) the method `authSuccess` to perform all operations that are necessary after a successful operation.
While I was at it, I also introduced `authFailure` which is called quite often and therefore should reduce the complexity quite a bit.
This also changes the semantics a little in some places, mainly because every failure is now consistently logged with AuditTrail and effects the failure count.

I am still running tests but I would also appreciate if somebody more familiar with the code base could validate that I did not accidentally change the semantics in some place other than log messages.

Additionally, I am not sure where `session.stopDetectingCommandInjection();` is supposed to be used but I could not find any logic to how it was used before and changed it so that it is consistently called after every processed request.