### PR TITLE
Upgrade ical4j dependency from 4.1.1 to 4.2.5

### DIFF
--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICalendarParser.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICalendarParser.java
@@ -136,7 +136,7 @@ public class ICalendarParser extends GenericMailet {
     private Stream<Pair<String, Calendar>> createCalendar(String key, byte[] icsContent) {
         CalendarBuilder builder = new CalendarBuilder(
             CalendarParserFactory.getInstance().get(),
-            new ContentHandlerContext().withSupressInvalidProperties(true),
+            new ContentHandlerContext().withSuppressInvalidProperties(true),
             TimeZoneRegistryFactory.getInstance().createRegistry());
         try {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(icsContent);

--- a/pom.xml
+++ b/pom.xml
@@ -688,7 +688,7 @@
         <scala.version>${scala.base}.16</scala.version>
         <doclint>none</doclint>
         <mockito.version>5.18.0</mockito.version>
-        <ical4j.version>4.1.1</ical4j.version>
+        <ical4j.version>4.2.5</ical4j.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <javacrumbs.json-unit.version>4.1.1</javacrumbs.json-unit.version>
         <fastutil-core.version>8.5.15</fastutil-core.version>


### PR DESCRIPTION
A newer stable version, `4.2.5`, is available and includes several fixes relevant to calendar processing:
Release notes:
- https://github.com/ical4j/ical4j/releases/tag/ical4j-4.2.0
- https://github.com/ical4j/ical4j/releases/tag/ical4j-4.2.1
- https://github.com/ical4j/ical4j/releases/tag/ical4j-4.2.2
- https://github.com/ical4j/ical4j/releases/tag/ical4j-4.2.3
- https://github.com/ical4j/ical4j/releases/tag/ical4j-4.2.4
- https://github.com/ical4j/ical4j/releases/tag/ical4j-4.2.5
