### PR TITLE
JAMES-4207 Do not announce capabilities after authentication

### DIFF
--- a/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
+++ b/server/protocols/protocols-managesieve/src/main/java/org/apache/james/managesieveserver/netty/ManageSieveChannelUpstreamHandler.java
@@ -84,7 +84,6 @@ public class ManageSieveChannelUpstreamHandler extends ChannelInboundHandlerAdap
             }
 
             Session manageSieveSession = ctx.channel().attr(NettyConstants.SESSION_ATTRIBUTE_KEY).get();
-            Session.State statePriorExecution = manageSieveSession.getState();
             String responseString = manageSieveProcessor.handleRequest(manageSieveSession, request);
             attachment.resetCumulation();
             attachment.write(responseString);
@@ -95,12 +94,6 @@ public class ManageSieveChannelUpstreamHandler extends ChannelInboundHandlerAdap
                 attachment.stopDetectingCommandInjection();
 
                 // RFC-5804 section 1.7 returning capabilities is mandated after STARTTLS
-                String capabilities = manageSieveProcessor.handleRequest(manageSieveSession, "CAPABILITY");
-                attachment.write(capabilities);
-            }
-            if (manageSieveSession.getState() == Session.State.AUTHENTICATED &&
-                statePriorExecution != Session.State.AUTHENTICATED) {
-                // RFC-5804 section 1.7 returning capabilities is mandated after AUTH
                 String capabilities = manageSieveProcessor.handleRequest(manageSieveSession, "CAPABILITY");
                 attachment.write(capabilities);
             }

--- a/server/protocols/protocols-managesieve/src/test/java/org/apache/james/managesieveserver/AuthenticateTest.java
+++ b/server/protocols/protocols-managesieve/src/test/java/org/apache/james/managesieveserver/AuthenticateTest.java
@@ -159,7 +159,6 @@ class AuthenticateTest {
         this.client.sendCommand(command);
         ManageSieveClient.ServerResponse firstAuthenticationResponse = this.client.readResponse();
         Assertions.assertThat(firstAuthenticationResponse.responseType()).isEqualTo(ManageSieveClient.ResponseType.OK);
-        this.client.readResponse(); // Read capabilities
 
         this.client.sendCommand(command);
         ManageSieveClient.ServerResponse secondAuthenticationResponse = this.client.readResponse();
@@ -235,6 +234,5 @@ class AuthenticateTest {
         this.client.sendCommand("AUTHENTICATE \"PLAIN\" \"" + Base64.getEncoder().encodeToString(initialClientResponse.getBytes(StandardCharsets.UTF_8)) + "\"");
         ManageSieveClient.ServerResponse authenticationResponse = this.client.readResponse();
         Assertions.assertThat(authenticationResponse.responseType()).isEqualTo(ManageSieveClient.ResponseType.OK);
-        this.client.readResponse(); // Read capabilities
     }
 }


### PR DESCRIPTION
RFC 5804 states that capabilities must be sent after a SASL security layer was negotiated. This is not the case for any of the authentication mechanisms offered by James.

This reverts parts of [this commit](https://github.com/apache/james-project/commit/1819fddf13c88476a0766ccc91c81d66d14da682) and fixes [JAMES-4207](https://issues.apache.org/jira/browse/JAMES-4207).