### PR TITLE
[FIX] StoreMailboxManager:renameSubMailboxes should change namespace

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -2122,6 +2122,27 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        protected void renameMailboxByIdShouldChangeTheMailboxNamespace() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath oldMailboxPath = new MailboxPath("#source", USER_1, "mbx1");
+            MailboxPath oldMailboxPathChild = new MailboxPath("#source", USER_1, "mbx1.child");
+            MailboxPath newMailboxPath = new MailboxPath("#destination", USER_1, "mbx2");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(oldMailboxPath, session);
+            Optional<MailboxId> childMailboxId = mailboxManager.createMailbox(oldMailboxPathChild, session);
+
+            mailboxManager.renameMailbox(mailboxId.get(), newMailboxPath, session);
+
+            MailboxPath renamedMailboxPath = mailboxManager.getMailbox(mailboxId.get(), session).getMailboxPath();
+            MailboxPath renamedChildMailboxPath = mailboxManager.getMailbox(childMailboxId.get(), session).getMailboxPath();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(renamedMailboxPath).isEqualTo(newMailboxPath);
+                softly.assertThat(renamedChildMailboxPath).isEqualTo(new MailboxPath("#destination", USER_1, "mbx2.child"));
+            });
+        }
+
+        @Test
         void renameMailboxShouldThrowWhenMailboxPathsDoNotBelongToUser() throws Exception {
             MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -754,6 +754,7 @@ public class StoreMailboxManager implements MailboxManager {
                 String subOriginalName = sub.getName();
                 String subNewName = newMailboxPath.getName() + subOriginalName.substring(from.getName().length());
                 MailboxPath fromPath = new MailboxPath(from, subOriginalName);
+                sub.setNamespace(newMailboxPath.getNamespace());
                 sub.setName(subNewName);
                 sub.setUser(newMailboxPath.getUser());
                 return mapper.rename(sub, fromPath)


### PR DESCRIPTION
When renaming a mailbox across namespaces, `StoreMailboxManager` preloads the mailbox and its children then renames them through `renameSubMailboxes`.

That helper updated the mailbox name and user but not the namespace, causing id-based renames across namespaces to keep the old namespace in storage.

Update the namespace during rename and add a regression test covering both the renamed mailbox and one child mailbox.