### PR TITLE
[FIX] Result of the webadmin route for listing mailboxes is flaky

### DIFF
--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxMapper.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxMapper.java
@@ -90,8 +90,9 @@ public class PostgresMailboxMapper implements MailboxMapper {
     }
 
     public Flux<Mailbox> findNonPersonalMailboxes(Username userName, MailboxACL.Right right) {
+        MailboxACL.EntryKey entryKey = MailboxACL.EntryKey.createUserEntryKey(userName);
         return postgresMailboxDAO.findMailboxesByUsername(userName)
-            .filter(postgresMailbox -> postgresMailbox.getACL().getEntries().get(MailboxACL.EntryKey.createUserEntryKey(userName)).contains(right))
+            .filter(postgresMailbox -> postgresMailbox.getACL().getEntries().getOrDefault(entryKey, MailboxACL.NO_RIGHTS).contains(right))
             .map(Function.identity());
     }
 

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/RLSSupportPostgresMailboxMapper.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/RLSSupportPostgresMailboxMapper.java
@@ -47,11 +47,12 @@ public class RLSSupportPostgresMailboxMapper extends PostgresMailboxMapper {
 
     @Override
     public Flux<Mailbox> findNonPersonalMailboxes(Username userName, MailboxACL.Right right) {
+        MailboxACL.EntryKey entryKey = MailboxACL.EntryKey.createUserEntryKey(userName);
         return postgresMailboxMemberDAO.findMailboxIdByUsername(userName)
             .collectList()
             .filter(postgresMailboxIds -> !postgresMailboxIds.isEmpty())
             .flatMapMany(postgresMailboxDAO::findMailboxByIds)
-            .filter(postgresMailbox -> postgresMailbox.getACL().getEntries().get(MailboxACL.EntryKey.createUserEntryKey(userName)).contains(right))
+            .filter(postgresMailbox -> postgresMailbox.getACL().getEntries().getOrDefault(entryKey, MailboxACL.NO_RIGHTS).contains(right))
             .map(Function.identity());
     }
 

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxDAO.java
@@ -193,7 +193,7 @@ public class PostgresMailboxDAO {
                         MAILBOX_ACL,
                         DSL.array(DSL.val(userName.asString()))).as(MAILBOX_ACL)
                 ).from(TABLE_NAME)
-                .where(DSL.sql(MAILBOX_ACL.getName() + " ? '" + userName.asString() + "'"))))       //TODO fix security vulnerability
+                .where(DSL.sql(MAILBOX_ACL.getName() + " ? '" + userName.asString() + "'"))), PostgresExecutor.EAGER_FETCH)       //TODO fix security vulnerability
             .map(RECORD_TO_POSTGRES_MAILBOX_FUNCTION);
     }
 

--- a/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxDAO.java
+++ b/mailbox/postgres/src/main/java/org/apache/james/mailbox/postgres/mail/dao/PostgresMailboxDAO.java
@@ -60,6 +60,7 @@ import org.apache.james.mailbox.postgres.mail.PostgresACLUpsertException;
 import org.apache.james.mailbox.postgres.mail.PostgresMailbox;
 import org.apache.james.mailbox.store.MailboxExpressionBackwardCompatibility;
 import org.jooq.Condition;
+import org.jooq.Param;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultDataType;
@@ -181,6 +182,7 @@ public class PostgresMailboxDAO {
     }
 
     public Flux<PostgresMailbox> findMailboxesByUsername(Username userName) {
+        Param<String> userNameParam = DSL.val(userName.asString());
         return postgresExecutor.executeRows(dslContext -> Flux.from(dslContext.select(MAILBOX_ID,
                     MAILBOX_NAME,
                     MAILBOX_UID_VALIDITY,
@@ -191,9 +193,9 @@ public class PostgresMailboxDAO {
                     DSL.function("slice",
                         DefaultDataType.getDefaultDataType("hstore"),
                         MAILBOX_ACL,
-                        DSL.array(DSL.val(userName.asString()))).as(MAILBOX_ACL)
+                        DSL.array(userNameParam)).as(MAILBOX_ACL)
                 ).from(TABLE_NAME)
-                .where(DSL.sql(MAILBOX_ACL.getName() + " ? '" + userName.asString() + "'"))), PostgresExecutor.EAGER_FETCH)       //TODO fix security vulnerability
+                .where(DSL.condition("defined({0}, {1})", MAILBOX_ACL, userNameParam))), PostgresExecutor.EAGER_FETCH)
             .map(RECORD_TO_POSTGRES_MAILBOX_FUNCTION);
     }
 

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxMapperACLTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxMapperACLTest.java
@@ -19,10 +19,15 @@
 
 package org.apache.james.mailbox.postgres.mail;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxDAO;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMapperACLTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class PostgresMailboxMapperACLTest extends MailboxMapperACLTest {
@@ -35,5 +40,19 @@ class PostgresMailboxMapperACLTest extends MailboxMapperACLTest {
     protected MailboxMapper createMailboxMapper() {
         mailboxMapper = new PostgresMailboxMapper(new PostgresMailboxDAO(postgresExtension.getDefaultPostgresExecutor()));
         return mailboxMapper;
+    }
+
+    @Test
+    void findNonPersonalMailboxesShouldSupportUsernamesContainingSingleQuote() {
+        // findMailboxesByUsername used to inline the username into the SQL text. A username
+        // containing a single quote then broke the query (SQL injection / syntax error). The
+        // username is now a bind parameter, so such usernames must be handled correctly.
+        Username trickyUser = Username.of("o'brien@domain.tld");
+        MailboxACL.EntryKey key = MailboxACL.EntryKey.createUserEntryKey(trickyUser);
+        MailboxACL.Rfc4314Rights rights = new MailboxACL.Rfc4314Rights(MailboxACL.Right.Lookup);
+        mailboxMapper.updateACL(benwaInboxMailbox, MailboxACL.command().key(key).rights(rights).asReplacement()).block();
+
+        assertThat(mailboxMapper.findNonPersonalMailboxes(trickyUser, MailboxACL.Right.Lookup).collectList().block())
+            .containsOnly(benwaInboxMailbox);
     }
 }

--- a/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxMapperFindNonPersonalMailboxesTest.java
+++ b/mailbox/postgres/src/test/java/org/apache/james/mailbox/postgres/mail/PostgresMailboxMapperFindNonPersonalMailboxesTest.java
@@ -1,0 +1,91 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.postgres.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.mailbox.postgres.PostgresMailboxId;
+import org.apache.james.mailbox.postgres.mail.dao.PostgresMailboxDAO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Flux;
+
+class PostgresMailboxMapperFindNonPersonalMailboxesTest {
+    private static final Username USER = Username.of("bob@domain.tld");
+    private static final MailboxACL.EntryKey USER_ENTRY_KEY = MailboxACL.EntryKey.createUserEntryKey(USER);
+    private static final MailboxACL.Rfc4314Rights LOOKUP = new MailboxACL.Rfc4314Rights(MailboxACL.Right.Lookup);
+
+    private PostgresMailboxDAO dao;
+    private PostgresMailboxMapper testee;
+
+    @BeforeEach
+    void setUp() {
+        dao = mock(PostgresMailboxDAO.class);
+        testee = new PostgresMailboxMapper(dao);
+    }
+
+    private PostgresMailbox mailboxWithAcl(MailboxACL acl) {
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(USER, "any"), UidValidity.of(1L), PostgresMailboxId.generate());
+        mailbox.setACL(acl);
+        return new PostgresMailbox(mailbox, ModSeq.first(), MessageUid.MIN_VALUE);
+    }
+
+    @Test
+    void findNonPersonalMailboxesShouldNotThrowWhenAclEntryForUserIsMissing() {
+        // Reproduces ISSUE-2445: the sliced ACL coming back from Postgres occasionally
+        // does not contain the requested user's entry. The mailbox must then be filtered
+        // out instead of triggering a NullPointerException that would poison the connection.
+        PostgresMailbox mailboxWithoutUserEntry = mailboxWithAcl(new MailboxACL());
+        when(dao.findMailboxesByUsername(USER)).thenReturn(Flux.just(mailboxWithoutUserEntry));
+
+        assertThatCode(() -> testee.findNonPersonalMailboxes(USER, MailboxACL.Right.Lookup).collectList().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void findNonPersonalMailboxesShouldFilterOutMailboxesWithMissingUserAclEntry() {
+        PostgresMailbox mailboxWithoutUserEntry = mailboxWithAcl(new MailboxACL());
+        when(dao.findMailboxesByUsername(USER)).thenReturn(Flux.just(mailboxWithoutUserEntry));
+
+        assertThat(testee.findNonPersonalMailboxes(USER, MailboxACL.Right.Lookup).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void findNonPersonalMailboxesShouldStillReturnMailboxesGrantingTheRight() {
+        PostgresMailbox grantedMailbox = mailboxWithAcl(new MailboxACL(new MailboxACL.Entry(USER_ENTRY_KEY, LOOKUP)));
+        PostgresMailbox mailboxWithoutUserEntry = mailboxWithAcl(new MailboxACL());
+        when(dao.findMailboxesByUsername(USER)).thenReturn(Flux.just(grantedMailbox, mailboxWithoutUserEntry));
+
+        assertThat(testee.findNonPersonalMailboxes(USER, MailboxACL.Right.Lookup).collectList().block())
+            .containsExactly(grantedMailbox);
+    }
+}


### PR DESCRIPTION
Original issue: https://github.com/linagora/tmail-backend/issues/2445

querying mailboxes evetually leads to 

```
java.lang.NullPointerException: Cannot invoke "org.apache.james.mailbox.model.MailboxACL$Rfc4314Rights.contains(org.apache.james.mailbox.model.MailboxACL$Right)" because the return value of "java.util.Map.get(Object)" is null
    at org.apache.james.mailbox.postgres.mail.PostgresMailboxMapper.lambda$findNonPersonalMailboxes$0(PostgresMailboxMapper.java:94)
```

With the PG backend.

After the error occured once, the route (and also IMAP requests for team mailboxes) fail with a 100% chance for some time. After some time, the server "recovers" and webadmin and IMAP requests work again.

The IMAP error has the following log:

2026-06-23T11:02:48.371Z [INFO ] o.a.james.imap.processor.StatusProcessor - Status failed for mailbox '#TeamMailbox:team-mailbox@teams.<domain>:e5f2fb01-9419-4518-8b42-7acbe64f253f|INBOX' as it does not exist.
2026-06-23T11:02:48.377Z [INFO ] o.a.j.mailbox.store.StoreMailboxManager - Mailbox '#TeamMailbox:team-mailbox@teams.<domain>:e5f2fb01-9419-4518-8b42-7acbe64f253f|INBOX' does not belong to user 'Username{localPart=79c5f16d-1877-4e0d-b7da-cd722dffa391, domainPart=Optional[Domain : users.<domain>]}' but to 'Username{localPart=team-mailbox, domainPart=Optional[Domain : teams.<domain>]}'

@felixauringer could you have a look and confirm this addresses your issue please ?