### PR TITLE
[FIX] Dead letter setup for Deleted Message Vault

### DIFF
--- a/mailbox/plugin/deleted-messages-vault-cassandra/src/main/java/org/apache/james/vault/metadata/DeletedMessageVaultDeletionCallback.java
+++ b/mailbox/plugin/deleted-messages-vault-cassandra/src/main/java/org/apache/james/vault/metadata/DeletedMessageVaultDeletionCallback.java
@@ -72,12 +72,13 @@ public class DeletedMessageVaultDeletionCallback implements DeleteMessageListene
         return Mono.from(blobStore.readBytes(blobStore.getDefaultBucketName(), copyCommand.getHeaderId(), BlobStore.StoragePolicy.LOW_COST))
             .flatMap(bytes -> {
                 Optional<Message> mimeMessage = parseMessage(new ByteArrayInputStream(bytes), copyCommand.getMessageId());
+                ZonedDateTime deletionDate = ZonedDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
                 DeletedMessage deletedMessage = DeletedMessage.builder()
                     .messageId(copyCommand.getMessageId())
                     .originMailboxes(copyCommand.getMailboxId())
                     .user(copyCommand.getOwner())
-                    .deliveryDate(ZonedDateTime.ofInstant(copyCommand.getInternalDate().toInstant(), ZoneOffset.UTC))
-                    .deletionDate(ZonedDateTime.ofInstant(clock.instant(), ZoneOffset.UTC))
+                    .deliveryDate(deliveryDate(copyCommand, deletionDate))
+                    .deletionDate(deletionDate)
                     .sender(retrieveSender(mimeMessage))
                     .recipients(retrieveRecipients(mimeMessage))
                     .hasAttachment(copyCommand.hasAttachments())
@@ -91,6 +92,15 @@ public class DeletedMessageVaultDeletionCallback implements DeleteMessageListene
             });
     }
 
+
+    private ZonedDateTime deliveryDate(DeleteMessageListener.DeletedMessageCopyCommand copyCommand, ZonedDateTime fallback) {
+        if (copyCommand.getInternalDate() == null) {
+            LOGGER.warn("Message {} has no internal date (likely a partially deleted Cassandra row), " +
+                "falling back to the deletion date for the deleted message vault delivery date", copyCommand.getMessageId());
+            return fallback;
+        }
+        return ZonedDateTime.ofInstant(copyCommand.getInternalDate().toInstant(), ZoneOffset.UTC);
+    }
 
     private Optional<Message> parseMessage(InputStream inputStream, MessageId messageId) {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/mailbox/DistributedDeletedMessageVaultDeletionCallback.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/mailbox/DistributedDeletedMessageVaultDeletionCallback.java
@@ -197,6 +197,9 @@ public class DistributedDeletedMessageVaultDeletionCallback implements DeleteMes
                 sender.declareExchange(ExchangeSpecification.exchange(EXCHANGE)
                     .durable(DURABLE)
                     .type(DIRECT_EXCHANGE)),
+                sender.declareExchange(ExchangeSpecification.exchange(DEAD_LETTER)
+                    .durable(DURABLE)
+                    .type(DIRECT_EXCHANGE)),
                 sender.declareQueue(QueueSpecification.queue(DEAD_LETTER)
                     .durable(DURABLE)
                     .exclusive(!EXCLUSIVE)
@@ -214,6 +217,10 @@ public class DistributedDeletedMessageVaultDeletionCallback implements DeleteMes
                 sender.bind(BindingSpecification.binding()
                     .exchange(EXCHANGE)
                     .queue(QUEUE)
+                    .routingKey(EMPTY_ROUTING_KEY)),
+                sender.bind(BindingSpecification.binding()
+                    .exchange(DEAD_LETTER)
+                    .queue(DEAD_LETTER)
                     .routingKey(EMPTY_ROUTING_KEY)))
             .then()
             .block();
@@ -249,8 +256,10 @@ public class DistributedDeletedMessageVaultDeletionCallback implements DeleteMes
             return callback.forMessage(copyCommandDTO.asPojo(mailboxIdFactory, messageIdFactory, blobIdFactory))
                 .timeout(Duration.ofMinutes(5))
                 .onErrorResume(e -> {
-                    LOGGER.error("Failed executing deletion callback for {}", copyCommandDTO.messageId, e);
-                    delivery.nack(REQUEUE);
+                    LOGGER.error("Failed executing deletion callback for {}, routing to the dead-letter queue", copyCommandDTO.messageId, e);
+                    // Do not requeue: a failing message (e.g. poisonous payload) would otherwise loop forever and block
+                    // the work queue. Dead-letter it instead so it can be inspected/replayed manually.
+                    delivery.nack(!REQUEUE);
                     return Mono.empty();
                 })
                 .doOnSuccess(any -> delivery.ack())


### PR DESCRIPTION
Needed for one of my cunstomer using 3.9.x

master is unaffected as master relies on the event bus for this use case.

Synptoms: queue poisonning.