### PR TITLE
[UPGRADE] activemq 6.2.6 -> 6.2.7 + arttemis 2.53.0 -> 2.55.0 to fix …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
 
         <james.groupId>org.apache.james</james.groupId>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
-        <activemq.version>6.2.6</activemq.version>
+        <activemq.version>6.2.7</activemq.version>
         <apache-mime4j.version>0.8.14</apache-mime4j.version>
         <apache.openjpa.version>4.1.1</apache.openjpa.version><!-- Align with EE10 Persistence 3.1 & Transactions 2.0: https://openjpa.apache.org/ -->
         <h2.version>2.3.232</h2.version>
@@ -637,7 +637,7 @@
 
         <jsieve.version>0.8</jsieve.version>
         <spring.version>6.2.8</spring.version>
-        <activmq-artemis.version>2.53.0</activmq-artemis.version>
+        <activmq-artemis.version>2.55.0</activmq-artemis.version>
         <apache-jspf-resolver.version>1.0.5</apache-jspf-resolver.version>
         <angus-mail.version>2.0.3</angus-mail.version><!-- Align with EE10 Mail 2.1: https://eclipse-ee4j.github.io/angus-mail/ -->
         <angus-activation.version>2.0.2</angus-activation.version><!-- Align with EE10 Activation 2.1: https://eclipse-ee4j.github.io/angus-activation/ -->


### PR DESCRIPTION
…several CVEs

 - CVE-2026-54475: Apache ActiveMQ Broker, Apache ActiveMQ All, Apache ActiveMQ: Temporary destination ownership takeover
 - CVE-2026-53917: Apache ActiveMQ, Apache ActiveMQ All, Apache ActiveMQ Client, Apache ActiveMQ Broker: Unbounded memory allocation in OpenWire property unmarshalling
 - CVE-2026-53916: Apache ActiveMQ, Apache ActiveMQ All, Apache ActiveMQ Stomp: Unbounded header buffer in STOMP NIO codec
 - CVE-2026-52760: Apache ActiveMQ, Apache ActiveMQ Web Console: Stored XSS via Unescaped values in ActiveMQ Web Console
 - CVE-2026-50750: Apache ActiveMQ Broker, Apache ActiveMQ, Apache ActiveMQ All: Pre-authentication OpenWire DoS following fix for CVE-2026-49270
 - CVE-2026-50734: Apache ActiveMQ Client, Apache ActiveMQ, Apache ActiveMQ All: Pre-authentication OpenWire memory-allocation DoS during wire format negotiation
 - CVE-2026-49877: Apache ActiveMQ: Authenticated web users retain admin access by default in the Web Console
 - CVE-2026-49432: Apache ActiveMQ, Apache ActiveMQ All, Apache ActiveMQ Stomp: STOMP negative content-length enables denial of service
 - CVE-2026-49434: Apache ActiveMQ Broker, Apache ActiveMQ, Apache ActiveMQ All: LdapNetworkConnector instantiates denied transports and a remote-properties broker