### PR TITLE
[FIX] ICALAttributeDTO should sanitize invalid dtstamp

### DIFF
--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/model/ICALAttributeDTO.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/model/ICALAttributeDTO.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
@@ -36,6 +38,8 @@ import net.fortuna.ical4j.model.property.Uid;
 
 public class ICALAttributeDTO {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ICALAttributeDTO.class);
+
     public static final String DEFAULT_SEQUENCE_VALUE = "0";
 
     public static class Builder {
@@ -47,7 +51,7 @@ public class ICALAttributeDTO {
             Optional<String> method = optionalOf(calendar.getMethod());
             Optional<String> recurrenceId = optionalOf(vevent.getRecurrenceId());
             Optional<String> sequence = optionalOf(vevent.getSequence());
-            Optional<DtStamp> dtstamp = vevent.getDateStamp();
+            Optional<String> dtstamp = vevent.getDateStamp().flatMap(this::safeValue);
 
             Preconditions.checkNotNull(ical);
 
@@ -57,12 +61,21 @@ public class ICALAttributeDTO {
                             uid.map(Uid::getValue), sender.asString(),
                             recipient.asString(),
                             replyTo.asString(),
-                            dtstamp.map(DtStamp::getValue), method, sequence,
+                            dtstamp, method, sequence,
                             recurrenceId);
         }
 
         private Optional<String> optionalOf(Property property) {
             return Optional.ofNullable(property).map(Property::getValue);
+        }
+
+        private Optional<String> safeValue(DtStamp dtStamp) {
+            try {
+                return Optional.ofNullable(dtStamp.getValue());
+            } catch (Exception e) {
+                LOGGER.warn("Ignoring non RFC-5545 compliant DTSTAMP value", e);
+                return Optional.empty();
+            }
         }
 
         @FunctionalInterface


### PR DESCRIPTION
Seen on prod:

```
java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: HourOfDay
	at java.base/java.time.LocalDate.get0(Unknown Source)
	at java.base/java.time.LocalDate.getLong(Unknown Source)
	at java.base/java.time.format.DateTimePrintContext$1.getLong(Unknown Source)
	at java.base/java.time.format.DateTimePrintContext.getValue(Unknown Source)
	at java.base/java.time.format.DateTimeFormatterBuilder$NumberPrinterParser.format(Unknown Source)
	at java.base/java.time.format.DateTimeFormatterBuilder$CompositePrinterParser.format(Unknown Source)
	at java.base/java.time.format.DateTimeFormatter.formatTo(Unknown Source)
	at java.base/java.time.format.DateTimeFormatter.format(Unknown Source)
	at net.fortuna.ical4j.model.CalendarDateFormat.format(CalendarDateFormat.java:304)
	at net.fortuna.ical4j.model.TemporalAdapter.toString(TemporalAdapter.java:203)
	at net.fortuna.ical4j.model.TemporalAdapter.toInstantString(TemporalAdapter.java:199)
	at net.fortuna.ical4j.model.TemporalAdapter.toString(TemporalAdapter.java:179)
	at net.fortuna.ical4j.model.TemporalAdapter.toString(TemporalAdapter.java:159)
	at net.fortuna.ical4j.model.property.DateProperty.getValue(DateProperty.java:228)
	at java.base/java.util.Optional.map(Unknown Source)
	at org.apache.james.transport.mailets.model.ICALAttributeDTO$Builder.lambda$from$1(ICALAttributeDTO.java:60)
	at org.apache.james.transport.mailets.ICALToJsonAttribute.toICAL(ICALToJsonAttribute.java:266)
	at org.apache.james.transport.mailets.ICALToJsonAttribute.lambda$toJson$6(ICALToJsonAttribute.java:228)
	at java.base/java.util.stream.ReferencePipeline$7$1FlatMap.accept(Unknown Source)
	at java.base/java.util.Collections$2.tryAdvance(Unknown Source)
	at java.base/java.util.Collections$2.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$7$1FlatMap.accept(Unknown Source)
	at java.base/java.util.Iterator.forEachRemaining(Unknown Source)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source)
	at org.apache.james.transport.mailets.ICALToJsonAttribute.setAttribute(ICALToJsonAttribute.java:187)
	at org.apache.james.transport.mailets.ICALToJsonAttribute.lambda$service$0(ICALToJsonAttribute.java:168)
	at com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at org.apache.james.transport.mailets.ICALToJsonAttribute.lambda$service$1(ICALToJsonAttribute.java:167)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at org.apache.james.transport.mailets.ICALToJsonAttribute.service(ICALToJsonAttribute.java:166)
	at org.apache.james.mailetcontainer.impl.ProcessorImpl.process(ProcessorImpl.java:74)
	at com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.base/java.util.Collections$2.tryAdvance(Unknown Source)
	at java.base/java.util.Collections$2.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.executeProcessingStep(MailetProcessorImpl.java:165)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$service$0(MailetProcessorImpl.java:133)
	at java.base/java.util.stream.ReduceOps$1ReducingSink.accept(Unknown Source)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.service(MailetProcessorImpl.java:131)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:97)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:79)
	at org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor.toProcessor(AbstractStateMailetProcessor.java:153)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$executeProcessingStep$8(MailetProcessorImpl.java:171)
	at com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$15$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.base/java.util.Collections$2.tryAdvance(Unknown Source)
	at java.base/java.util.Collections$2.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.executeProcessingStep(MailetProcessorImpl.java:171)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$service$0(MailetProcessorImpl.java:133)
	at java.base/java.util.stream.ReduceOps$1ReducingSink.accept(Unknown Source)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.service(MailetProcessorImpl.java:131)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:97)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:79)
	at org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor.toProcessor(AbstractStateMailetProcessor.java:153)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$executeProcessingStep$8(MailetProcessorImpl.java:171)
	at com.github.fge.lambdas.consumers.ConsumerChainer.lambda$sneakyThrow$9(ConsumerChainer.java:73)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$15$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.base/java.util.Collections$2.tryAdvance(Unknown Source)
	at java.base/java.util.Collections$2.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.executeProcessingStep(MailetProcessorImpl.java:171)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.lambda$service$0(MailetProcessorImpl.java:133)
	at java.base/java.util.stream.ReduceOps$1ReducingSink.accept(Unknown Source)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source)
	at org.apache.james.mailetcontainer.impl.MailetProcessorImpl.service(MailetProcessorImpl.java:131)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:97)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:79)
	at org.apache.james.mailetcontainer.impl.JamesMailSpooler$Runner.performProcessMail(JamesMailSpooler.java:135)
	at org.apache.james.mailetcontainer.impl.JamesMailSpooler$Runner.lambda$processMail$4(JamesMailSpooler.java:127)
	at reactor.core.publisher.MonoRunnable.subscribe(MonoRunnable.java:49)
	at reactor.core.publisher.MonoUsing.subscribe(MonoUsing.java:109)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4576)
	at reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:202)
	at reactor.core.publisher.MonoFlatMap.subscribeOrReturn(MonoFlatMap.java:53)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4560)
	at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:126)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```