### PR TITLE
[FIX] IMAP rare NPE within processor error handling

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -61,6 +61,7 @@ import org.apache.james.mailbox.exception.InsufficientRightsException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MessageRangeException;
 import org.apache.james.mailbox.exception.OverQuotaException;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageRange.Type;
 import org.apache.james.metrics.api.MetricFactory;
@@ -386,6 +387,11 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
 
     protected Mono<MessageManager> getSelectedMailboxReactive(ImapSession session) {
         return getSelectedMailboxReactive(session, Mono.error(() -> new MailboxException("Session not in SELECTED state")));
+    }
+
+    protected static Optional<MailboxId> selectedMailboxId(ImapSession session) {
+        return Optional.ofNullable(session.getSelected())
+            .map(SelectedMailbox::getMailboxId);
     }
 
     /**

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -98,22 +98,22 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
             .onErrorResume(MessageRangeException.class, e -> {
                 taggedBad(request, responder, HumanReadableText.INVALID_MESSAGESET);
                 return ReactorUtils.logAsMono(() -> LOGGER.debug("{} failed from mailbox {} to {} for invalid sequence-set {}",
-                    getOperationName(), session.getSelected().getMailboxId(), targetMailbox, request.getIdSet(), e));
+                    getOperationName(), selectedMailboxId(session), targetMailbox, request.getIdSet(), e));
             })
             .onErrorResume(OverQuotaException.class, e -> {
                 no(request, responder, HumanReadableText.FAILURE_OVERQUOTA, StatusResponse.ResponseCode.overQuota());
                 return ReactorUtils.logAsMono(() -> LOGGER.info("{} failed from mailbox {} to {} due to quota restriction",
-                    getOperationName(), session.getSelected().getMailboxId(), targetMailbox, e));
+                    getOperationName(), selectedMailboxId(session), targetMailbox, e));
             })
             .onErrorResume(OverQuotaException.class, e -> {
                 no(request, responder, HumanReadableText.FAILURE_OVERQUOTA, StatusResponse.ResponseCode.overQuota());
                 return ReactorUtils.logAsMono(() -> LOGGER.info("{} failed: quota exceeded from mailbox {} to {} for sequence-set {}",
-                    getOperationName(), session.getSelected().getMailboxId(), targetMailbox, request.getIdSet(), e.getCause()));
+                    getOperationName(), selectedMailboxId(session), targetMailbox, request.getIdSet(), e.getCause()));
             })
             .onErrorResume(MailboxException.class, e -> {
                 no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
                 return ReactorUtils.logAsMono(() -> LOGGER.error("{} failed from mailbox {} to {} for sequence-set {}",
-                    getOperationName(), session.getSelected().getMailboxId(), targetMailbox, request.getIdSet(), e.getCause()));
+                    getOperationName(), selectedMailboxId(session), targetMailbox, request.getIdSet(), e.getCause()));
             }).then();
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CloseProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CloseProcessor.java
@@ -78,7 +78,7 @@ public class CloseProcessor extends AbstractMailboxProcessor<CloseRequest> {
             }))
             .onErrorResume(MailboxException.class, e -> {
                 no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
-                return ReactorUtils.logAsMono(() -> LOGGER.error("Close failed for mailbox {}", session.getSelected().getMailboxId(), e));
+                return ReactorUtils.logAsMono(() -> LOGGER.error("Close failed for mailbox {}", selectedMailboxId(session), e));
             }).then();
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ExpungeProcessor.java
@@ -89,7 +89,7 @@ public class ExpungeProcessor extends AbstractMailboxProcessor<ExpungeRequest> i
             })
             .onErrorResume(MailboxException.class, e -> {
                 no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
-                return ReactorUtils.logAsMono(() -> LOGGER.error("Expunge failed for mailbox {}", session.getSelected().getMailboxId(), e));
+                return ReactorUtils.logAsMono(() -> LOGGER.error("Expunge failed for mailbox {}", selectedMailboxId(session), e));
             });
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SearchProcessor.java
@@ -127,10 +127,10 @@ public class SearchProcessor extends AbstractMailboxProcessor<SearchRequest> imp
                         // See RFC5182 2.1.Normative Description of the SEARCHRES Extension
                         SearchResUtil.resetSavedSequenceSet(session);
                     }
-                    return ReactorUtils.logAsMono(() -> LOGGER.error("Search failed in mailbox {}", session.getSelected().getMailboxId(), e));
+                    return ReactorUtils.logAsMono(() -> LOGGER.error("Search failed in mailbox {}", selectedMailboxId(session), e));
                 });
         } catch (MessageRangeException e) {
-            return ReactorUtils.logAsMono(() -> LOGGER.debug("Search failed in mailbox {} because of an invalid sequence-set ", session.getSelected().getMailboxId(), e))
+            return ReactorUtils.logAsMono(() -> LOGGER.debug("Search failed in mailbox {} because of an invalid sequence-set ", selectedMailboxId(session), e))
                 .then(Mono.fromRunnable(() -> taggedBad(request, responder, HumanReadableText.INVALID_MESSAGESET)));
         }
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
@@ -118,11 +118,11 @@ public class StoreProcessor extends AbstractMailboxProcessor<StoreRequest> {
             })
             .onErrorResume(MessageRangeException.class, e -> {
                 taggedBad(request, responder, HumanReadableText.INVALID_MESSAGESET);
-                return ReactorUtils.logAsMono(() -> LOGGER.debug("Store failed for mailbox {} because of an invalid sequence-set {}", session.getSelected().getMailboxId(), idSet, e));
+                return ReactorUtils.logAsMono(() -> LOGGER.debug("Store failed for mailbox {} because of an invalid sequence-set {}", selectedMailboxId(session), idSet, e));
             })
             .onErrorResume(MailboxException.class, e -> {
                 no(request, responder, HumanReadableText.SAVE_FAILED);
-                return ReactorUtils.logAsMono(() -> LOGGER.error("Store failed for mailbox {} and sequence-set {}", session.getSelected().getMailboxId(), idSet, e));
+                return ReactorUtils.logAsMono(() -> LOGGER.error("Store failed for mailbox {} and sequence-set {}", selectedMailboxId(session), idSet, e));
             });
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -261,13 +261,13 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
             .<SelectedMailbox>handle((a, sink) -> a.ifPresentOrElse(sink::next, () -> sink.error(new MailboxException("Session not in SELECTED state"))))
             .flatMap(selected -> processFetch(request, session, responder, selected, fetch, changedSince))
             .doOnEach(logOnError(MessageRangeException.class, e -> LOGGER.debug("Fetch failed for mailbox {} because of invalid sequence-set {}",
-                Optional.ofNullable(session.getSelected()).map(SelectedMailbox::getMailboxId), idSet, e)))
+                selectedMailboxId(session), idSet, e)))
             .onErrorResume(MessageRangeException.class, e -> {
                 taggedBad(request, responder, HumanReadableText.INVALID_MESSAGESET);
                 return Mono.empty();
             })
             .doOnEach(logOnError(MailboxException.class, e -> LOGGER.error("Fetch failed for mailbox {} and sequence-set {}",
-                Optional.ofNullable(session.getSelected()).map(SelectedMailbox::getMailboxId), idSet, e)))
+                selectedMailboxId(session), idSet, e)))
             .onErrorResume(MailboxException.class, e -> {
                 no(request, responder, HumanReadableText.SEARCH_FAILED);
                 return Mono.empty();


### PR DESCRIPTION
Connected stateful protocol falacies....

Fixes this log trace:

```
java.lang.NullPointerException: Cannot invoke "org.apache.james.imap.api.process.SelectedMailbox.getMailboxId()" because the return value of "org.apache.james.imap.api.process.ImapSession.getSelected()" is null
	at org.apache.james.imap.processor.ExpungeProcessor.lambda$processRequestReactive$5(ExpungeProcessor.java:92)
	at org.apache.james.util.ReactorUtils.logWithContext(ReactorUtils.java:203)
	at org.apache.james.util.ReactorUtils.lambda$logAsMono$13(ReactorUtils.java:210)
```

One occurence in one of LINAGORA prods today