### PR TITLE
JAMES-4210 [FIX] Reuse protocol default SASL factories for explicit configuration

### DIFF
--- a/server/container/guice/common/src/main/java/org/apache/james/utils/GuiceSaslMechanismResolver.java
+++ b/server/container/guice/common/src/main/java/org/apache/james/utils/GuiceSaslMechanismResolver.java
@@ -54,7 +54,7 @@ public class GuiceSaslMechanismResolver {
             ImmutableList<SaslMechanismFactory> factories = configuredFactoryClassNames.isEmpty()
                 ? enabledDefaultFactories
                 : configuredFactoryClassNames.stream()
-                    .map(Throwing.function(this::instantiateFactory))
+                    .map(Throwing.function(className -> resolveConfiguredFactory(className, enabledDefaultFactories)))
                     .collect(ImmutableList.toImmutableList());
 
             return factories.stream()
@@ -73,6 +73,22 @@ public class GuiceSaslMechanismResolver {
             }
             throw e;
         }
+    }
+
+    private SaslMechanismFactory resolveConfiguredFactory(String className, ImmutableList<SaslMechanismFactory> enabledDefaultFactories) throws ConfigurationException {
+        return enabledDefaultFactories.stream()
+            .filter(factory -> matchesCanonicalName(className, factory) || matchesSimpleName(className, factory))
+            .findFirst()
+            .orElseGet(Throwing.supplier(() -> instantiateFactory(className)));
+    }
+
+    private boolean matchesCanonicalName(String className, SaslMechanismFactory factory) {
+        return className.equals(factory.getClass().getCanonicalName());
+    }
+
+    private boolean matchesSimpleName(String className, SaslMechanismFactory factory) {
+        return !className.contains(".")
+            && className.equals(factory.getClass().getSimpleName());
     }
 
     private SaslMechanismFactory instantiateFactory(String className) throws ConfigurationException {

--- a/server/container/guice/common/src/test/java/org/apache/james/utils/GuiceSaslMechanismResolverTest.java
+++ b/server/container/guice/common/src/test/java/org/apache/james/utils/GuiceSaslMechanismResolverTest.java
@@ -104,6 +104,38 @@ class GuiceSaslMechanismResolverTest {
     }
 
     @Test
+    void resolveShouldReuseDefaultFactoryMatchingConfiguredSimpleNameWithoutGuiceLoadingIt() throws Exception {
+        // GIVEN a configured factory simple name matching a protocol-provided default factory
+        GuiceSaslMechanismResolver testee = new GuiceSaslMechanismResolver(new FailingGuiceLoader());
+
+        // WHEN resolving it
+        ImmutableList<SaslMechanism> mechanisms = testee.resolve(ImmutableList.of(ConstructorOnlySaslMechanismFactory.class.getSimpleName()),
+            ImmutableList.of(new ConstructorOnlySaslMechanismFactory("LOGIN")),
+            EMPTY_CONFIGURATION);
+
+        // THEN the default factory instance is reused instead of Guice-loading a fresh standalone factory
+        assertThat(mechanisms)
+            .extracting(SaslMechanism::name)
+            .containsExactly("LOGIN");
+    }
+
+    @Test
+    void resolveShouldReuseDefaultFactoryMatchingConfiguredFullyQualifiedNameWithoutGuiceLoadingIt() throws Exception {
+        // GIVEN a configured factory FQCN matching a protocol-provided default factory
+        GuiceSaslMechanismResolver testee = new GuiceSaslMechanismResolver(new FailingGuiceLoader());
+
+        // WHEN resolving it
+        ImmutableList<SaslMechanism> mechanisms = testee.resolve(ImmutableList.of(ConstructorOnlySaslMechanismFactory.class.getCanonicalName()),
+            ImmutableList.of(new ConstructorOnlySaslMechanismFactory("LOGIN")),
+            EMPTY_CONFIGURATION);
+
+        // THEN the default factory instance is reused before falling back to Guice loading
+        assertThat(mechanisms)
+            .extracting(SaslMechanism::name)
+            .containsExactly("LOGIN");
+    }
+
+    @Test
     void resolveShouldCreateConfiguredFactoriesFromCurrentServerConfiguration() throws Exception {
         // GIVEN two server configurations using the same configured SASL factory
         BaseHierarchicalConfiguration firstConfiguration = new BaseHierarchicalConfiguration();
@@ -177,6 +209,19 @@ class GuiceSaslMechanismResolverTest {
         return serverConfiguration -> new FixedNameSaslMechanism(mechanismName);
     }
 
+    private static class ConstructorOnlySaslMechanismFactory implements SaslMechanismFactory {
+        private final String mechanismName;
+
+        private ConstructorOnlySaslMechanismFactory(String mechanismName) {
+            this.mechanismName = mechanismName;
+        }
+
+        @Override
+        public SaslMechanism create(HierarchicalConfiguration<ImmutableNode> serverConfiguration) {
+            return new FixedNameSaslMechanism(mechanismName);
+        }
+    }
+
     private static class ReflectionGuiceLoader implements GuiceLoader {
         @Override
         public <T> T instantiate(ClassName className) throws ClassNotFoundException {
@@ -191,6 +236,24 @@ class GuiceSaslMechanismResolverTest {
         @Override
         public <T> InvocationPerformer<T> withChildModule(Module childModule) {
             return new ReflectionInvocationPerformer<>(NamingScheme.IDENTITY);
+        }
+    }
+
+    private static class FailingGuiceLoader extends ReflectionGuiceLoader {
+        @Override
+        public <T> InvocationPerformer<T> withNamingSheme(NamingScheme namingSheme) {
+            return new FailingInvocationPerformer<>();
+        }
+    }
+
+    private static class FailingInvocationPerformer<T> extends ReflectionInvocationPerformer<T> {
+        private FailingInvocationPerformer() {
+            super(NamingScheme.IDENTITY);
+        }
+
+        @Override
+        public T instantiate(ClassName className) {
+            throw new AssertionError("Default factory match should not instantiate " + className.getName());
         }
     }
 

--- a/server/mailet/integration-testing/pom.xml
+++ b/server/mailet/integration-testing/pom.xml
@@ -120,6 +120,11 @@
             <artifactId>amqp-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>

--- a/server/mailet/integration-testing/src/main/java/org/apache/james/mailets/configuration/SmtpConfiguration.java
+++ b/server/mailet/integration-testing/src/main/java/org/apache/james/mailets/configuration/SmtpConfiguration.java
@@ -76,6 +76,8 @@ public class SmtpConfiguration implements SerializableAsXml {
         private Optional<Boolean> allowUnauthenticatedSender;
         private Optional<Boolean> bracketEnforcement;
         private Optional<String> authorizedAddresses;
+        private Optional<Boolean> authRequireSSL;
+        private Optional<String> saslMechanisms;
         private final ImmutableList.Builder<HookConfigurationEntry> additionalHooks;
 
         public Builder() {
@@ -86,6 +88,8 @@ public class SmtpConfiguration implements SerializableAsXml {
             maxMessageSize = Optional.empty();
             bracketEnforcement = Optional.empty();
             allowUnauthenticatedSender = Optional.empty();
+            authRequireSSL = Optional.empty();
+            saslMechanisms = Optional.empty();
             additionalHooks = ImmutableList.builder();
         }
 
@@ -135,6 +139,16 @@ public class SmtpConfiguration implements SerializableAsXml {
             return this;
         }
 
+        public Builder requireSSLForAuth(boolean requireSSL) {
+            this.authRequireSSL = Optional.of(requireSSL);
+            return this;
+        }
+
+        public Builder withSaslMechanisms(String saslMechanisms) {
+            this.saslMechanisms = Optional.of(saslMechanisms);
+            return this;
+        }
+
         public Builder relaxedIdentityVerification() {
             this.verifyIndentity = Optional.of(SMTPConfiguration.SenderVerificationMode.RELAXED);
             return this;
@@ -158,6 +172,8 @@ public class SmtpConfiguration implements SerializableAsXml {
                     allowUnauthenticatedSender.orElse(true),
                     verifyIndentity.orElse(SMTPConfiguration.SenderVerificationMode.DISABLED),
                     maxMessageSize.orElse(DEFAULT_DISABLED),
+                    authRequireSSL.orElse(false),
+                    saslMechanisms,
                     additionalHooks.build());
         }
     }
@@ -173,6 +189,8 @@ public class SmtpConfiguration implements SerializableAsXml {
     private final boolean allowUnauthenticatedSenders;
     private final SMTPConfiguration.SenderVerificationMode verifyIndentity;
     private final String maxMessageSize;
+    private final boolean authRequireSSL;
+    private final Optional<String> saslMechanisms;
     private final ImmutableList<HookConfigurationEntry> additionalHooks;
 
     private SmtpConfiguration(Optional<String> authorizedAddresses,
@@ -182,6 +200,8 @@ public class SmtpConfiguration implements SerializableAsXml {
                               boolean allowUnauthenticatedSenders,
                               SMTPConfiguration.SenderVerificationMode verifyIndentity,
                               String maxMessageSize,
+                              boolean authRequireSSL,
+                              Optional<String> saslMechanisms,
                               ImmutableList<HookConfigurationEntry> additionalHooks) {
         this.authorizedAddresses = authorizedAddresses;
         this.authRequired = authRequired;
@@ -189,6 +209,8 @@ public class SmtpConfiguration implements SerializableAsXml {
         this.verifyIndentity = verifyIndentity;
         this.allowUnauthenticatedSenders = allowUnauthenticatedSenders;
         this.maxMessageSize = maxMessageSize;
+        this.authRequireSSL = authRequireSSL;
+        this.saslMechanisms = saslMechanisms;
         this.startTls = startTls;
         this.additionalHooks = additionalHooks;
     }
@@ -202,6 +224,9 @@ public class SmtpConfiguration implements SerializableAsXml {
         scopes.put("verifyIdentity", verifyIndentity.toString());
         scopes.put("forbidUnauthenticatedSenders", Boolean.toString(!allowUnauthenticatedSenders));
         scopes.put("maxmessagesize", maxMessageSize);
+        scopes.put("authRequireSSL", authRequireSSL);
+        scopes.put("hasSaslMechanisms", saslMechanisms.isPresent());
+        saslMechanisms.ifPresent(value -> scopes.put("saslMechanisms", value));
         scopes.put("bracketEnforcement", bracketEnforcement);
         scopes.put("startTls", startTls);
 

--- a/server/mailet/integration-testing/src/main/resources/smtpserver.xml
+++ b/server/mailet/integration-testing/src/main/resources/smtpserver.xml
@@ -39,8 +39,11 @@
 {{/hasAuthorizedAddresses}}
         <auth>
             <required>{{forbidUnauthenticatedSenders}}</required>
-            <requireSSL>false</requireSSL>
+            <requireSSL>{{authRequireSSL}}</requireSSL>
             <plainAuthEnabled>true</plainAuthEnabled>
+{{#hasSaslMechanisms}}
+            <saslMechanisms>{{saslMechanisms}}</saslMechanisms>
+{{/hasSaslMechanisms}}
         </auth>
         <verifyIdentity>{{verifyIdentity}}</verifyIdentity>
         <maxmessagesize>{{maxmessagesize}}</maxmessagesize>
@@ -83,6 +86,9 @@
             <required>{{forbidUnauthenticatedSenders}}</required>
             <requireSSL>true</requireSSL>
             <plainAuthEnabled>true</plainAuthEnabled>
+{{#hasSaslMechanisms}}
+            <saslMechanisms>{{saslMechanisms}}</saslMechanisms>
+{{/hasSaslMechanisms}}
         </auth>
         <!-- Trust authenticated users -->
         <verifyIdentity>false</verifyIdentity>

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpSaslMechanismIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpSaslMechanismIntegrationTest.java
@@ -1,0 +1,113 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailets;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
+import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
+import static org.apache.james.mailets.configuration.Constants.PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.Base64;
+
+import org.apache.commons.net.smtp.SMTPClient;
+import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.mailets.configuration.CommonProcessors;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.MailetContainer;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailets.configuration.SmtpConfiguration;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.probe.DataProbe;
+import org.apache.james.utils.DataProbeImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SmtpSaslMechanismIntegrationTest {
+    private static final String USER = "fromuser@" + DEFAULT_DOMAIN;
+
+    private static String base64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(UTF_8));
+    }
+
+    private TemporaryJamesServer jamesServer;
+
+    @BeforeEach
+    void setup(@TempDir File temporaryFolder) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(MemoryJamesServerMain.SMTP_ONLY_MODULE)
+            .withMailetContainer(minimalMailetContainer())
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .doNotVerifyIdentity()
+                .requireSSLForAuth(true)
+                .withSaslMechanisms("LoginSaslMechanismFactory")
+                .build())
+            .build(temporaryFolder);
+        jamesServer.start();
+
+        DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
+        dataProbe.addDomain(DEFAULT_DOMAIN);
+        dataProbe.addUser(USER, PASSWORD);
+    }
+
+    private MailetContainer.Builder minimalMailetContainer() {
+        return MailetContainer.builder()
+            .putProcessor(CommonProcessors.simpleRoot())
+            .putProcessor(CommonProcessors.error())
+            .putProcessor(CommonProcessors.rrtError())
+            .putProcessor(ProcessorConfiguration.transport()
+                .addMailet(MailetConfiguration.BCC_STRIPPER)
+                .addMailet(MailetConfiguration.TO_BOUNCE))
+            .putProcessor(CommonProcessors.bounces());
+    }
+
+    @AfterEach
+    void tearDown() {
+        jamesServer.shutdown();
+    }
+
+    @Test
+    void explicitlyConfiguredLoginSaslMechanismShouldAuthenticate() throws Exception {
+        SMTPClient smtpClient = new SMTPClient();
+        try {
+            smtpClient.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue());
+
+            smtpClient.sendCommand("EHLO", "localhost");
+            assertThat(smtpClient.getReplyCode()).isEqualTo(250);
+
+            smtpClient.sendCommand("AUTH LOGIN");
+            assertThat(smtpClient.getReplyCode()).isEqualTo(334);
+
+            smtpClient.sendCommand(base64(USER));
+            assertThat(smtpClient.getReplyCode()).isEqualTo(334);
+
+            smtpClient.sendCommand(base64(PASSWORD));
+            assertThat(smtpClient.getReplyCode()).isEqualTo(235);
+        } finally {
+            if (smtpClient.isConnected()) {
+                smtpClient.disconnect();
+            }
+        }
+    }
+
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpSaslMechanismIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpSaslMechanismIntegrationTest.java
@@ -39,7 +39,6 @@ import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.probe.DataProbe;
 import org.apache.james.utils.DataProbeImpl;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -50,25 +49,11 @@ class SmtpSaslMechanismIntegrationTest {
         return Base64.getEncoder().encodeToString(value.getBytes(UTF_8));
     }
 
-    private TemporaryJamesServer jamesServer;
-
-    @BeforeEach
-    void setup(@TempDir File temporaryFolder) throws Exception {
-        jamesServer = TemporaryJamesServer.builder()
-            .withBase(MemoryJamesServerMain.SMTP_ONLY_MODULE)
-            .withMailetContainer(minimalMailetContainer())
-            .withSmtpConfiguration(SmtpConfiguration.builder()
-                .doNotVerifyIdentity()
-                .requireSSLForAuth(true)
-                .withSaslMechanisms("LoginSaslMechanismFactory")
-                .build())
-            .build(temporaryFolder);
-        jamesServer.start();
-
-        DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
-        dataProbe.addDomain(DEFAULT_DOMAIN);
-        dataProbe.addUser(USER, PASSWORD);
+    private static String plainInitialResponse(String username, String password) {
+        return base64(String.join("\0", "", username, password));
     }
+
+    private TemporaryJamesServer jamesServer;
 
     private MailetContainer.Builder minimalMailetContainer() {
         return MailetContainer.builder()
@@ -83,11 +68,15 @@ class SmtpSaslMechanismIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        jamesServer.shutdown();
+        if (jamesServer != null) {
+            jamesServer.shutdown();
+        }
     }
 
     @Test
-    void explicitlyConfiguredLoginSaslMechanismShouldAuthenticate() throws Exception {
+    void explicitlyConfiguredLoginSaslMechanismShouldAuthenticate(@TempDir File temporaryFolder) throws Exception {
+        startJamesServer(temporaryFolder, "LoginSaslMechanismFactory");
+
         SMTPClient smtpClient = new SMTPClient();
         try {
             smtpClient.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue());
@@ -108,6 +97,44 @@ class SmtpSaslMechanismIntegrationTest {
                 smtpClient.disconnect();
             }
         }
+    }
+
+    @Test
+    void explicitlyConfiguredPlainSaslMechanismShouldAuthenticateOverClearTextWhenRequireSSLIsTrue(@TempDir File temporaryFolder) throws Exception {
+        // SMTP keeps accepting AUTH PLAIN on clear-text connections even when auth.requireSSL controls capability announcement.
+        startJamesServer(temporaryFolder, "PlainSaslMechanismFactory");
+
+        SMTPClient smtpClient = new SMTPClient();
+        try {
+            smtpClient.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue());
+
+            smtpClient.sendCommand("EHLO", "localhost");
+            assertThat(smtpClient.getReplyCode()).isEqualTo(250);
+
+            smtpClient.sendCommand("AUTH", "PLAIN " + plainInitialResponse(USER, PASSWORD));
+            assertThat(smtpClient.getReplyCode()).isEqualTo(235);
+        } finally {
+            if (smtpClient.isConnected()) {
+                smtpClient.disconnect();
+            }
+        }
+    }
+
+    private void startJamesServer(File temporaryFolder, String saslMechanisms) throws Exception {
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(MemoryJamesServerMain.SMTP_ONLY_MODULE)
+            .withMailetContainer(minimalMailetContainer())
+            .withSmtpConfiguration(SmtpConfiguration.builder()
+                .doNotVerifyIdentity()
+                .requireSSLForAuth(true)
+                .withSaslMechanisms(saslMechanisms)
+                .build())
+            .build(temporaryFolder);
+        jamesServer.start();
+
+        DataProbe dataProbe = jamesServer.getProbe(DataProbeImpl.class);
+        dataProbe.addDomain(DEFAULT_DOMAIN);
+        dataProbe.addUser(USER, PASSWORD);
     }
 
 }


### PR DESCRIPTION
Today, the SASL mechanisms being configured automatically by default, that is great, and it works correctly.

However, for SMTP, if explicitly configure the SASL mechanisms  via `auth.saslMechanisms`, we may have 2 issues:

1. (SMTP) `LoginSaslMechanismFactory` likely can not be explicitly configured
    If `auth.saslMechanisms` is absent, we load `LoginSaslMechanismFactory` correctly by default though.

2. `PlainSaslMechanismFactory` explicitly configured: likely won't honor the IGNORE_REQUIRE_SSL_CONFIGURATION for SMTP (`GuiceLoader` likely picks the default `PlainSaslMechanismFactory` constructor and wont diferrentiate this honor requireSSL difference between IMAP and SMTP)