### PR TITLE
JAMES-4209 Distributed app content recovery runner

### DIFF
--- a/docs/modules/servers/nav.adoc
+++ b/docs/modules/servers/nav.adoc
@@ -76,6 +76,7 @@
 **** xref:distributed/operate/migrating.adoc[]
 **** xref:distributed/operate/cli.adoc[]
 **** xref:distributed/operate/cassandra-migration.adoc[]
+**** xref:distributed/operate/backup.adoc[]
 **** xref:distributed/operate/security.adoc[]
 *** xref:distributed/customization/index.adoc[]
 **** xref:distributed/customization/imap.adoc[]

--- a/docs/modules/servers/pages/distributed/operate/backup.adoc
+++ b/docs/modules/servers/pages/distributed/operate/backup.adoc
@@ -163,6 +163,18 @@ restricts recovery to messages whose `Date` header is strictly after the given i
 ... org.apache.james.S3RecoveryMain --restore-after=2026-01-01T00:00:00Z
 ----
 
+An optional `--header-blob-prefix=<prefix>` argument (also settable via the
+`RECOVERY_HEADER_BLOB_PREFIX` environment variable or the `recovery.header.blob.prefix` system
+property) narrows the walk to the recovery sidecars whose header blob id starts with the given prefix,
+pushing the filter down to S3's `ListObjectsV2`. Header blob ids are generation-aware
+(`family_generation_...`), so a clever admin can pass e.g. `1_42_` to iterate solely the latest
+generation instead of scanning the whole bucket:
+
+[source,bash]
+----
+... org.apache.james.S3RecoveryMain --header-blob-prefix=1_42_
+----
+
 Notes:
 
 * Restored messages are re-stored (and get a fresh `recovery/` sidecar), so re-running the recovery

--- a/docs/modules/servers/pages/distributed/operate/backup.adoc
+++ b/docs/modules/servers/pages/distributed/operate/backup.adoc
@@ -175,6 +175,37 @@ generation instead of scanning the whole bucket:
 ... org.apache.james.S3RecoveryMain --header-blob-prefix=1_42_
 ----
 
+The dominant cost of a recovery run is not the listing but the per-message work: three blob reads plus
+a full re-store of each message through the mailbox. The `--concurrency=<n>` argument (default `8`, also
+settable via the `RECOVERY_CONCURRENCY` environment variable or the `recovery.concurrency` system
+property) controls how many messages are restored in parallel and is therefore the main lever on
+wall-clock recovery time. Raise it to saturate the object store and Cassandra; watch their load and
+back off if they become the bottleneck:
+
+[source,bash]
+----
+... org.apache.james.S3RecoveryMain --concurrency=32
+----
+
+=== Scaling recovery: shard by generation
+
+For very large recoveries, a single process is limited by its own concurrency and offers no easy resume
+point. Because `--header-blob-prefix` scopes a run to a slice of the key space, you can *shard* the
+recovery across several independent processes &mdash; typically one per blob generation
+(`family_generation_`) &mdash; and run them in parallel, each with its own concurrency:
+
+[source,bash]
+----
+# On different hosts / containers, in parallel
+... org.apache.james.S3RecoveryMain --header-blob-prefix=1_40_ --concurrency=16
+... org.apache.james.S3RecoveryMain --header-blob-prefix=1_41_ --concurrency=16
+... org.apache.james.S3RecoveryMain --header-blob-prefix=1_42_ --concurrency=16
+----
+
+The shards are disjoint (a given header blob belongs to exactly one generation), so they never restore
+the same message twice, aggregate throughput scales with the number of shards, and a shard that fails
+can be re-run on its own without redoing the others.
+
 Notes:
 
 * Restored messages are re-stored (and get a fresh `recovery/` sidecar), so re-running the recovery

--- a/docs/modules/servers/pages/distributed/operate/backup.adoc
+++ b/docs/modules/servers/pages/distributed/operate/backup.adoc
@@ -1,0 +1,272 @@
+= Distributed James Server &mdash; Backup
+:navtitle: Backup
+
+A Distributed James deployment keeps its data in two independent stores, and a sound backup strategy
+must cover both:
+
+* The *object store* (S3 or S3-compatible) holds the immutable *message content* &mdash; the header and
+body blobs, attachments, deleted message vault, etc. See
+xref:distributed/architecture/blobstore.adoc[the blob store architecture].
+* *Cassandra* holds the *metadata* &mdash; the mailbox structure, message flags, UIDs, indexes, users,
+quotas... everything that ties blobs together into usable mailboxes.
+
+The two are complementary: a blob is worthless without the Cassandra rows that reference it, and a
+mailbox row is worthless without its blob. This page describes how to protect each store, and how to
+recover message content from the object store alone should the Cassandra metadata be lost.
+
+== Object store: S3 versioning
+
+James addresses blobs by content (deduplication) and never mutates a blob in place: a blob is written
+once and later either kept or deleted by the
+xref:distributed/operate/webadmin.adoc#_running_blob_garbage_collection[blob garbage collection]. This immutability
+makes *S3 bucket versioning* the natural safety net: enabling it turns every deletion into a reversible
+*delete marker* and preserves overwritten or removed objects as *noncurrent versions* that can be
+restored.
+
+Versioning protects against the failure modes James itself cannot guard against:
+
+* an operator or a bug running the blob GC too aggressively,
+* an application-level compromise deleting blobs,
+* accidental bulk deletions.
+
+=== A policy that makes sense
+
+Two principles drive the recommended policy:
+
+. *The application must have no rights over the version history.* James is given credentials that can
+read, write and _logically_ delete current objects, but that *cannot* delete object versions, disable
+versioning, or alter the lifecycle configuration. This way, whatever happens to the running
+application &mdash; bug or compromise &mdash; the history remains intact and recoverable. Version
+management and permanent reclamation are the responsibility of a *separate, more privileged role* used
+only by operators / backup tooling.
+
+. *Deletion propagates after 30 days.* When James deletes a blob, S3 keeps the previous version as a
+noncurrent version. A lifecycle rule permanently expires those noncurrent versions after 30 days. This
+gives a 30-day window during which any wrongly deleted blob can still be restored, while still bounding
+storage growth.
+
+==== Application IAM policy (no history rights)
+
+The credentials configured in `blobstore.properties` for James should be restricted to operations on
+*current* objects only. Note the *absence* of `s3:DeleteObjectVersion`, `s3:PutBucketVersioning` and
+`s3:PutLifecycleConfiguration`:
+
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "JamesCurrentObjectsOnly",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:AbortMultipartUpload"
+      ],
+      "Resource": [
+        "arn:aws:s3:::james-blobs",
+        "arn:aws:s3:::james-blobs/*"
+      ]
+    }
+  ]
+}
+----
+
+`s3:DeleteObject` only creates a delete marker when versioning is enabled; it never removes history.
+Managing versioning and the lifecycle configuration, and permanently deleting versions
+(`s3:DeleteObjectVersion`, `s3:GetObjectVersion`, `s3:PutBucketVersioning`,
+`s3:PutLifecycleConfiguration`), must be granted to a distinct operator/backup role only.
+
+==== Bucket versioning and lifecycle
+
+Enable versioning on the bucket, then apply a lifecycle configuration that propagates deletions after
+30 days and keeps the bucket tidy:
+
+[source,json]
+----
+{
+  "Rules": [
+    {
+      "ID": "expire-noncurrent-after-30-days",
+      "Status": "Enabled",
+      "Filter": {},
+      "NoncurrentVersionExpiration": {
+        "NoncurrentDays": 30
+      },
+      "Expiration": {
+        "ExpiredObjectDeleteMarker": true
+      },
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 7
+      }
+    }
+  ]
+}
+----
+
+* `NoncurrentVersionExpiration: 30` &mdash; a blob deleted (or overwritten) by James stays recoverable
+for 30 days, then its noncurrent versions are permanently removed. This is where the deletion is
+finally *propagated*.
+* `ExpiredObjectDeleteMarker: true` &mdash; cleans up delete markers once their versions are gone.
+* `AbortIncompleteMultipartUpload` &mdash; reclaims storage from interrupted uploads.
+
+NOTE: MinIO, Scality and most S3-compatible stores implement versioning and lifecycle rules with the
+same API. Consult your provider's documentation for the exact tooling.
+
+== Message content recovery from S3
+
+Even with versioning, you may face the worst case: *the Cassandra metadata is lost but the object store
+survives*. Because blobs alone do not tell which user a message belonged to, James can optionally write,
+next to each stored message, a small `recovery/<headerBlobId>` *sidecar* blob holding the matching
+`bodyBlobId`. The blob garbage collection is aware of these sidecars and never deletes a live one.
+
+Recording of the sidecars is controlled in `cassandra.properties`:
+
+[source,properties]
+----
+# none (default), synchronous or asynchronous
+mailbox.blob.recovery.mode=synchronous
+----
+
+* `synchronous` &mdash; the sidecar is written as part of message storage; a failure fails the delivery.
+* `asynchronous` &mdash; the sidecar is written in the background; failures are only logged.
+* `none` &mdash; no sidecar is written, and content recovery is not possible.
+
+When recovery is needed, run the dedicated `org.apache.james.S3RecoveryMain` entrypoint. It reuses the
+regular mailbox, DAO and blob store modules and the existing `blobstore.properties` (so AES encryption
+and compression are applied transparently), but starts neither the protocol servers nor RabbitMQ. It
+walks the object store, reads each `recovery/` sidecar, rebuilds the message from its header and body
+blobs, reads the `Delivered-To` recipients, and appends the message into a `Restored-messages` mailbox
+of each local recipient.
+
+Run it by overriding the container entrypoint main class (Cassandra and S3 must be reachable):
+
+[source,bash]
+----
+docker run --rm --entrypoint java \
+  -v /path/conf:/root/conf \
+  apache/james:distributed-latest \
+  -Dworking.directory=/root -Dextra.props=/root/conf/jvm.properties \
+  -cp '/app/resources:/app/classes:/app/libs/*' \
+  org.apache.james.S3RecoveryMain
+----
+
+An optional `--restore-after=<ISO-8601 instant>` argument (also settable via the
+`RESTORE_MESSAGES_AFTER` environment variable or the `restore.messages.after` system property)
+restricts recovery to messages whose `Date` header is strictly after the given instant:
+
+[source,bash]
+----
+... org.apache.james.S3RecoveryMain --restore-after=2026-01-01T00:00:00Z
+----
+
+Notes:
+
+* Restored messages are re-stored (and get a fresh `recovery/` sidecar), so re-running the recovery
+restores them again. Restore into an empty deployment, or clean up between runs.
+* The search index is not populated during recovery. Run a
+xref:distributed/operate/cli.adoc#_re_indexing[re-indexing] afterwards if search is needed.
+
+Content recovery is a last resort. It rebuilds *content* into a flat `Restored-messages` mailbox; it
+does not restore the original folder layout, flags or read state. For a faithful point-in-time
+restoration of the metadata, back up Cassandra as described below.
+
+== Deleted Messages Vault
+
+The strategies above protect against infrastructure-level loss. The most common data loss, however, is
+mundane: a user (or a buggy client, or an over-eager retention rule) *deletes a message by mistake*.
+For that, James ships a built-in safety net &mdash; the *Deleted Messages Vault*.
+
+When enabled, a pre-deletion hook diverts every message a user permanently deletes into the vault
+instead of dropping it immediately. Messages are retained there for a configurable duration and can be
+searched, exported and *restored back into the user's mailbox* &mdash; without any need to touch S3
+versions or a Cassandra snapshot. It is, in effect, a continuous, per-user, self-service backup of
+deleted mail, with a much lower operational cost and RTO than a full restore.
+
+Enable it by configuring the pre-deletion hook and a retention time, as described in
+xref:distributed/operate/guide.adoc#_deleted_message_vault[the operator guide] and
+xref:distributed/configure/vault.adoc[deletedMessageVault.properties].
+
+Restore and manage vaulted messages through webadmin, e.g.
+xref:distributed/operate/webadmin.adoc#_restore_deleted_messages[restoring deleted messages] for a
+user, or browsing, exporting and purging them.
+
+A few things to keep in mind:
+
+* The vault stores its content *in the same object store* as the mailboxes (it is one of the blob store
+users). It therefore shares the object store's fate: it protects against user-level deletion, *not*
+against loss of the object store itself. Combine it with S3 versioning above.
+* Vault retention is a deliberate trade-off between the recovery window and storage cost &mdash; the
+same tension as the S3 noncurrent-version window. Keep the two windows coherent.
+* Messages are removed from the vault when their retention elapses (`Purge`), so it is a bounded-window
+undo, not an archive.
+
+== Cassandra backup with Medusa
+
+link:https://github.com/thelastpickle/cassandra-medusa[Medusa] is a backup and restore tool for
+Apache Cassandra that stores backups directly in object storage (S3, GCS, Azure...). It is the
+recommended way to protect the Distributed server metadata.
+
+Medusa supports two backup modes:
+
+Full backup:: A complete copy of every SSTable of the node. Self-contained: a single full backup is
+enough to restore the node. Larger and slower, it is typically run periodically as a baseline.
+
+Differential backup:: The default and recommended mode. Medusa compares the current SSTables with what
+is already present in the backup storage and uploads only the *new* SSTables, referencing the unchanged
+ones. Because Cassandra SSTables are immutable, differential backups are cheap in both bandwidth and
+storage while remaining individually restorable. They are well suited to frequent (e.g. daily) runs.
+
+A sensible schedule combines both, for example:
+
+[source,bash]
+----
+# Weekly baseline (full)
+medusa backup --backup-name weekly-$(date +%Y%m%d) --mode full
+
+# Daily differential
+medusa backup --backup-name daily-$(date +%Y%m%d) --mode differential
+----
+
+List and restore backups with:
+
+[source,bash]
+----
+medusa list-backups
+medusa restore-cluster --backup-name daily-20260724
+----
+
+Point Medusa at its own bucket (or at least its own prefix and credentials), *separate from the James
+blob bucket*, so that the two backup lifecycles and access policies stay independent.
+
+[IMPORTANT]
+====
+The Cassandra metadata references blobs by id. When restoring Cassandra to a point in time, the
+referenced blobs must still exist in the object store. Keep the blob store retention window (the 30-day
+noncurrent version expiration above, and the blob GC schedule) *at least as long as* your Cassandra
+backup retention, so that a restored Cassandra snapshot never points at blobs that have already been
+permanently reclaimed.
+====
+
+== Summary
+
+[cols="1,2,2", options="header"]
+|===
+| Data | Protection | Recovery
+
+| Accidental user deletion
+| Deleted Messages Vault &mdash; pre-deletion hook + bounded retention
+| Self-service restore back into the user's mailbox (webadmin)
+
+| Message content (blobs)
+| S3 versioning + 30-day noncurrent expiration, application denied history rights
+| Restore object versions; or `S3RecoveryMain` to rebuild messages when metadata is lost
+
+| Cassandra metadata
+| Medusa &mdash; periodic full + frequent differential backups to a dedicated bucket
+| `medusa restore-cluster`
+
+|===

--- a/server/apps/distributed-app/README.adoc
+++ b/server/apps/distributed-app/README.adoc
@@ -152,6 +152,17 @@ environment variable, or the `restore.messages.after` system property:
 $ java ... org.apache.james.S3RecoveryMain --restore-after=2026-01-01T00:00:00Z
 ----
 
+An optional `--header-blob-prefix=<prefix>` argument (also settable via the `RECOVERY_HEADER_BLOB_PREFIX`
+environment variable or the `recovery.header.blob.prefix` system property) narrows the walk to the
+recovery sidecars whose header blob id starts with the given prefix, and lets S3 filter server-side.
+Because header blob ids are generation-aware (`family_generation_...`), a clever admin can pass e.g.
+`1_42_` to iterate solely the latest generation instead of scanning the whole bucket:
+
+[source]
+----
+$ java ... org.apache.james.S3RecoveryMain --header-blob-prefix=1_42_
+----
+
 Notes:
 
 * Restored messages are re-stored (and get a fresh `recovery/` sidecar), so re-running the recovery

--- a/server/apps/distributed-app/README.adoc
+++ b/server/apps/distributed-app/README.adoc
@@ -106,3 +106,59 @@ $ java -Dworking.directory=. -Dlogback.configurationFile=conf/logback.xml -Djdk.
 
 Note that binding ports below 1024 requires administrative rights.
 
+== S3 blob store recovery
+
+When the S3 (or compatible) object store survives but the Cassandra mailbox structure is lost, messages
+can be rebuilt from the blob store alone, provided `mailbox.blob.recovery.mode` was set to `synchronous`
+or `asynchronous` in `cassandra.properties` while messages were being stored. In that mode James writes,
+next to each stored message, a `recovery/<headerBlobId>` sidecar blob holding the matching `bodyBlobId`.
+
+Recovery is packaged as an alternate main class, `org.apache.james.S3RecoveryMain`, that reuses the same
+mailbox, DAO and blob store modules and the same `blobstore.properties` (so AES encryption and
+compression are applied transparently). It starts neither the protocol servers nor RabbitMQ.
+
+It walks the blob store, reads each `recovery/` sidecar, rebuilds the message from its header and body
+blobs, reads the `Delivered-To` recipients, and appends the message into a `Restored-messages` mailbox
+of each local recipient.
+
+Run it by overriding the entrypoint main class (Cassandra and S3 must be reachable, RabbitMQ is not
+needed):
+
+[source]
+----
+$ java -Dworking.directory=. -Dlogback.configurationFile=conf/logback.xml \
+    -cp james-server-distributed-app.jar:james-server-distributed-app.lib/* \
+    org.apache.james.S3RecoveryMain
+----
+
+Or, from the docker image, by overriding the container main class:
+
+[source]
+----
+$ docker run --rm --entrypoint java \
+    -v /path/conf:/root/conf \
+    apache/james:distributed-latest \
+    -Dworking.directory=/root -Dextra.props=/root/conf/jvm.properties \
+    -cp '/app/resources:/app/classes:/app/libs/*' \
+    org.apache.james.S3RecoveryMain
+----
+
+An optional date filter restricts recovery to messages whose `Date` header is strictly after the given
+ISO-8601 instant. It can be passed as a `--restore-after=<instant>` argument, the `RESTORE_MESSAGES_AFTER`
+environment variable, or the `restore.messages.after` system property:
+
+[source]
+----
+$ java ... org.apache.james.S3RecoveryMain --restore-after=2026-01-01T00:00:00Z
+----
+
+Notes:
+
+* Restored messages are re-stored (and get a fresh `recovery/` sidecar), so re-running the recovery
+restores them again. Restore into an empty deployment, or clean up between runs.
+* The search index module is not started during recovery, so restored messages are not indexed on the
+fly. Run a re-indexing afterwards if search is needed.
+
+The same class can be reused for Twake mail by pointing its distributed image at
+`org.apache.james.S3RecoveryMain`.
+

--- a/server/apps/distributed-app/README.adoc
+++ b/server/apps/distributed-app/README.adoc
@@ -163,6 +163,27 @@ Because header blob ids are generation-aware (`family_generation_...`), a clever
 $ java ... org.apache.james.S3RecoveryMain --header-blob-prefix=1_42_
 ----
 
+The `--concurrency=<n>` argument (default `8`, also settable via the `RECOVERY_CONCURRENCY` environment
+variable or the `recovery.concurrency` system property) controls how many messages are restored in
+parallel. The per-message work (blob reads plus a full re-store through the mailbox) dominates recovery
+time, so this is the main lever on wall-clock duration:
+
+[source]
+----
+$ java ... org.apache.james.S3RecoveryMain --concurrency=32
+----
+
+For very large recoveries, shard the run by generation and run several processes in parallel, each on a
+disjoint slice of the key space with its own concurrency. The shards never restore the same message
+twice, throughput scales with their number, and a failed shard can be re-run on its own:
+
+[source]
+----
+$ java ... org.apache.james.S3RecoveryMain --header-blob-prefix=1_40_ --concurrency=16
+$ java ... org.apache.james.S3RecoveryMain --header-blob-prefix=1_41_ --concurrency=16
+$ java ... org.apache.james.S3RecoveryMain --header-blob-prefix=1_42_ --concurrency=16
+----
+
 Notes:
 
 * Restored messages are re-stored (and get a fresh `recovery/` sidecar), so re-running the recovery

--- a/server/apps/distributed-app/src/main/java/org/apache/james/RecoveryConfiguration.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/RecoveryConfiguration.java
@@ -24,6 +24,8 @@ import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Optional;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Configuration for the S3 blob store recovery run.
  *
@@ -39,19 +41,34 @@ import java.util.Optional;
  * recovery sidecars) and can be provided as a {@code --header-blob-prefix=<prefix>} program argument,
  * the {@code RECOVERY_HEADER_BLOB_PREFIX} environment variable, or the {@code recovery.header.blob.prefix}
  * system property.</p>
+ *
+ * <p>The {@code concurrency} controls how many messages are restored in parallel. Since the dominant
+ * cost is the per-message work (blob reads plus a full re-store through the mailbox), this is the main
+ * lever on recovery wall-clock time. It defaults to {@value #DEFAULT_CONCURRENCY} and can be provided
+ * as a {@code --concurrency=<n>} program argument, the {@code RECOVERY_CONCURRENCY} environment
+ * variable, or the {@code recovery.concurrency} system property.</p>
  */
-public record RecoveryConfiguration(Optional<Instant> restoreAfter, String headerBlobPrefix) {
+public record RecoveryConfiguration(Optional<Instant> restoreAfter, String headerBlobPrefix, int concurrency) {
+    public static final int DEFAULT_CONCURRENCY = 8;
     private static final String RESTORE_AFTER_ARG = "--restore-after=";
     private static final String RESTORE_AFTER_ENV = "RESTORE_MESSAGES_AFTER";
     private static final String RESTORE_AFTER_PROPERTY = "restore.messages.after";
     private static final String HEADER_BLOB_PREFIX_ARG = "--header-blob-prefix=";
     private static final String HEADER_BLOB_PREFIX_ENV = "RECOVERY_HEADER_BLOB_PREFIX";
     private static final String HEADER_BLOB_PREFIX_PROPERTY = "recovery.header.blob.prefix";
+    private static final String CONCURRENCY_ARG = "--concurrency=";
+    private static final String CONCURRENCY_ENV = "RECOVERY_CONCURRENCY";
+    private static final String CONCURRENCY_PROPERTY = "recovery.concurrency";
+
+    public RecoveryConfiguration {
+        Preconditions.checkArgument(concurrency > 0, "'concurrency' must be strictly positive");
+    }
 
     public static RecoveryConfiguration parse(String[] args) {
         return new RecoveryConfiguration(
             option(args, RESTORE_AFTER_ARG, RESTORE_AFTER_ENV, RESTORE_AFTER_PROPERTY).map(RecoveryConfiguration::parseInstant),
-            option(args, HEADER_BLOB_PREFIX_ARG, HEADER_BLOB_PREFIX_ENV, HEADER_BLOB_PREFIX_PROPERTY).orElse(""));
+            option(args, HEADER_BLOB_PREFIX_ARG, HEADER_BLOB_PREFIX_ENV, HEADER_BLOB_PREFIX_PROPERTY).orElse(""),
+            option(args, CONCURRENCY_ARG, CONCURRENCY_ENV, CONCURRENCY_PROPERTY).map(RecoveryConfiguration::parseConcurrency).orElse(DEFAULT_CONCURRENCY));
     }
 
     private static Optional<String> option(String[] args, String argPrefix, String envName, String propertyName) {
@@ -71,6 +88,17 @@ public record RecoveryConfiguration(Optional<Instant> restoreAfter, String heade
         } catch (DateTimeParseException e) {
             throw new IllegalArgumentException("Invalid '" + RESTORE_AFTER_ARG + "' value: '" + value
                 + "'. Expected an ISO-8601 instant, e.g. 2026-01-01T00:00:00Z", e);
+        }
+    }
+
+    private static int parseConcurrency(String value) {
+        try {
+            int concurrency = Integer.parseInt(value);
+            Preconditions.checkArgument(concurrency > 0);
+            return concurrency;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid '" + CONCURRENCY_ARG + "' value: '" + value
+                + "'. Expected a strictly positive integer", e);
         }
     }
 }

--- a/server/apps/distributed-app/src/main/java/org/apache/james/RecoveryConfiguration.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/RecoveryConfiguration.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Configuration for the S3 blob store recovery run.
+ *
+ * <p>The optional {@code restoreAfter} instant restricts recovery to messages whose {@code Date}
+ * header is strictly after the given point in time. It can be provided (highest precedence first) as:</p>
+ * <ul>
+ *     <li>a {@code --restore-after=<ISO-8601 instant>} program argument</li>
+ *     <li>the {@code RESTORE_MESSAGES_AFTER} environment variable</li>
+ *     <li>the {@code restore.messages.after} system property</li>
+ * </ul>
+ */
+public record RecoveryConfiguration(Optional<Instant> restoreAfter) {
+    private static final String RESTORE_AFTER_ARG = "--restore-after=";
+    private static final String RESTORE_AFTER_ENV = "RESTORE_MESSAGES_AFTER";
+    private static final String RESTORE_AFTER_PROPERTY = "restore.messages.after";
+
+    public static RecoveryConfiguration parse(String[] args) {
+        return new RecoveryConfiguration(restoreAfter(args).map(RecoveryConfiguration::parseInstant));
+    }
+
+    private static Optional<String> restoreAfter(String[] args) {
+        return Arrays.stream(args)
+            .filter(arg -> arg.startsWith(RESTORE_AFTER_ARG))
+            .map(arg -> arg.substring(RESTORE_AFTER_ARG.length()))
+            .findFirst()
+            .or(() -> Optional.ofNullable(System.getenv(RESTORE_AFTER_ENV)))
+            .or(() -> Optional.ofNullable(System.getProperty(RESTORE_AFTER_PROPERTY)))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty());
+    }
+
+    private static Instant parseInstant(String value) {
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Invalid '" + RESTORE_AFTER_ARG + "' value: '" + value
+                + "'. Expected an ISO-8601 instant, e.g. 2026-01-01T00:00:00Z", e);
+        }
+    }
+}

--- a/server/apps/distributed-app/src/main/java/org/apache/james/RecoveryConfiguration.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/RecoveryConfiguration.java
@@ -28,29 +28,39 @@ import java.util.Optional;
  * Configuration for the S3 blob store recovery run.
  *
  * <p>The optional {@code restoreAfter} instant restricts recovery to messages whose {@code Date}
- * header is strictly after the given point in time. It can be provided (highest precedence first) as:</p>
- * <ul>
- *     <li>a {@code --restore-after=<ISO-8601 instant>} program argument</li>
- *     <li>the {@code RESTORE_MESSAGES_AFTER} environment variable</li>
- *     <li>the {@code restore.messages.after} system property</li>
- * </ul>
+ * header is strictly after the given point in time. It can be provided (highest precedence first) as a
+ * {@code --restore-after=<ISO-8601 instant>} program argument, the {@code RESTORE_MESSAGES_AFTER}
+ * environment variable, or the {@code restore.messages.after} system property.</p>
+ *
+ * <p>The optional {@code headerBlobPrefix} narrows the walk to the recovery sidecars whose header blob
+ * id starts with the given prefix. Because header blob ids are generation-aware
+ * ({@code family_generation_...}), a clever admin can pass e.g. {@code 1_42_} to iterate solely the
+ * latest generation instead of scanning the whole bucket. It defaults to the empty string (all
+ * recovery sidecars) and can be provided as a {@code --header-blob-prefix=<prefix>} program argument,
+ * the {@code RECOVERY_HEADER_BLOB_PREFIX} environment variable, or the {@code recovery.header.blob.prefix}
+ * system property.</p>
  */
-public record RecoveryConfiguration(Optional<Instant> restoreAfter) {
+public record RecoveryConfiguration(Optional<Instant> restoreAfter, String headerBlobPrefix) {
     private static final String RESTORE_AFTER_ARG = "--restore-after=";
     private static final String RESTORE_AFTER_ENV = "RESTORE_MESSAGES_AFTER";
     private static final String RESTORE_AFTER_PROPERTY = "restore.messages.after";
+    private static final String HEADER_BLOB_PREFIX_ARG = "--header-blob-prefix=";
+    private static final String HEADER_BLOB_PREFIX_ENV = "RECOVERY_HEADER_BLOB_PREFIX";
+    private static final String HEADER_BLOB_PREFIX_PROPERTY = "recovery.header.blob.prefix";
 
     public static RecoveryConfiguration parse(String[] args) {
-        return new RecoveryConfiguration(restoreAfter(args).map(RecoveryConfiguration::parseInstant));
+        return new RecoveryConfiguration(
+            option(args, RESTORE_AFTER_ARG, RESTORE_AFTER_ENV, RESTORE_AFTER_PROPERTY).map(RecoveryConfiguration::parseInstant),
+            option(args, HEADER_BLOB_PREFIX_ARG, HEADER_BLOB_PREFIX_ENV, HEADER_BLOB_PREFIX_PROPERTY).orElse(""));
     }
 
-    private static Optional<String> restoreAfter(String[] args) {
+    private static Optional<String> option(String[] args, String argPrefix, String envName, String propertyName) {
         return Arrays.stream(args)
-            .filter(arg -> arg.startsWith(RESTORE_AFTER_ARG))
-            .map(arg -> arg.substring(RESTORE_AFTER_ARG.length()))
+            .filter(arg -> arg.startsWith(argPrefix))
+            .map(arg -> arg.substring(argPrefix.length()))
             .findFirst()
-            .or(() -> Optional.ofNullable(System.getenv(RESTORE_AFTER_ENV)))
-            .or(() -> Optional.ofNullable(System.getProperty(RESTORE_AFTER_PROPERTY)))
+            .or(() -> Optional.ofNullable(System.getenv(envName)))
+            .or(() -> Optional.ofNullable(System.getProperty(propertyName)))
             .map(String::trim)
             .filter(value -> !value.isEmpty());
     }

--- a/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryMain.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryMain.java
@@ -1,0 +1,120 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.apache.james.data.UsersRepositoryModuleChooser;
+import org.apache.james.modules.CommonServicesModule;
+import org.apache.james.modules.blobstore.BlobStoreCacheModulesChooser;
+import org.apache.james.modules.blobstore.BlobStoreConfiguration;
+import org.apache.james.modules.blobstore.BlobStoreModulesChooser;
+import org.apache.james.modules.data.CassandraSieveQuotaLegacyModule;
+import org.apache.james.modules.data.CassandraSieveQuotaModule;
+import org.apache.james.modules.data.CassandraUsersRepositoryModule;
+import org.apache.james.modules.mailbox.CassandraMailboxQuotaLegacyModule;
+import org.apache.james.modules.mailbox.CassandraMailboxQuotaModule;
+import org.apache.james.utils.InitializationOperations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.util.Modules;
+
+/**
+ * Alternate entrypoint for the distributed server that rebuilds messages from the blob store alone.
+ *
+ * <p>It reuses the production mailbox, DAO and blob store Guice modules (hence the existing
+ * {@code blobstore.properties}: AES encryption and compression are applied transparently) but starts
+ * neither the protocol servers nor RabbitMQ: the in-VM event bus is used because the RabbitMQ override
+ * of {@link CassandraRabbitMQJamesServerMain} is intentionally not applied.</p>
+ *
+ * <p>Run it by overriding the docker entrypoint main class, e.g.:</p>
+ * <pre>
+ * docker run --rm --entrypoint java \
+ *   -v /path/conf:/root/conf \
+ *   apache/james:distributed-latest \
+ *   -Dworking.directory=/root -Dextra.props=/root/conf/jvm.properties \
+ *   -cp '/app/resources:/app/classes:/app/libs/*' \
+ *   org.apache.james.S3RecoveryMain --restore-after=2026-01-01T00:00:00Z
+ * </pre>
+ */
+public class S3RecoveryMain {
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3RecoveryMain.class);
+
+    public static void main(String[] args) throws Exception {
+        ExtraProperties.initialize();
+
+        CassandraRabbitMQJamesConfiguration configuration = CassandraRabbitMQJamesConfiguration.builder()
+            .useWorkingDirectoryEnvProperty()
+            .build();
+        RecoveryConfiguration recoveryConfiguration = RecoveryConfiguration.parse(args);
+
+        LOGGER.info("Loading configuration {}", configuration);
+        Injector injector = Guice.createInjector(recoveryModule(configuration, recoveryConfiguration));
+        injector.getInstance(InitializationOperations.class).initModules();
+
+        S3RecoveryService.Report report = injector.getInstance(S3RecoveryService.class).run().block();
+        LOGGER.info("S3 recovery completed: {}", report);
+
+        System.exit(0);
+    }
+
+    private static Module recoveryModule(CassandraRabbitMQJamesConfiguration configuration,
+                                         RecoveryConfiguration recoveryConfiguration) {
+        BlobStoreConfiguration blobStoreConfiguration = configuration.blobStoreConfiguration();
+
+        return Modules.combine(ImmutableList.<Module>builder()
+            .add(new CommonServicesModule(configuration))
+            .add(CassandraRabbitMQJamesServerMain.CASSANDRA_SERVER_CORE_MODULE)
+            .add(CassandraRabbitMQJamesServerMain.CASSANDRA_MAILBOX_MODULE)
+            .add(chooseQuotaModule(configuration))
+            .addAll(new UsersRepositoryModuleChooser(new CassandraUsersRepositoryModule())
+                .chooseModules(configuration.getUsersRepositoryImplementation()))
+            .addAll(BlobStoreModulesChooser.chooseModules(blobStoreConfiguration))
+            .addAll(BlobStoreCacheModulesChooser.chooseModules(blobStoreConfiguration))
+            .add(new RecoveryModule(recoveryConfiguration))
+            .build());
+    }
+
+    private static Module chooseQuotaModule(CassandraRabbitMQJamesConfiguration configuration) {
+        if (configuration.isQuotaCompatibilityMode()) {
+            return Modules.combine(new CassandraMailboxQuotaLegacyModule(), new CassandraSieveQuotaLegacyModule());
+        }
+        return Modules.combine(new CassandraMailboxQuotaModule(), new CassandraSieveQuotaModule());
+    }
+
+    static class RecoveryModule extends AbstractModule {
+        private final RecoveryConfiguration recoveryConfiguration;
+
+        RecoveryModule(RecoveryConfiguration recoveryConfiguration) {
+            this.recoveryConfiguration = recoveryConfiguration;
+        }
+
+        @Override
+        protected void configure() {
+            bind(RecoveryConfiguration.class).toInstance(recoveryConfiguration);
+            bind(S3RecoveryService.class).in(Scopes.SINGLETON);
+        }
+    }
+}

--- a/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryService.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryService.java
@@ -117,10 +117,11 @@ public class S3RecoveryService {
 
     public Mono<Report> run() {
         BucketName bucket = blobStore.getDefaultBucketName();
-        LOGGER.info("Starting S3 recovery on bucket {} (restore after: {})", bucket.asString(), configuration.restoreAfter());
-        return Flux.from(blobStoreDAO.listBlobs(bucket))
+        String prefix = RECOVERY_BLOB_PREFIX + configuration.headerBlobPrefix();
+        LOGGER.info("Starting S3 recovery on bucket {} (prefix: {}, restore after: {})",
+            bucket.asString(), prefix, configuration.restoreAfter());
+        return Flux.from(blobStoreDAO.listBlobs(bucket, prefix))
             .map(BlobId::asString)
-            .filter(key -> key.startsWith(RECOVERY_BLOB_PREFIX))
             .flatMap(recoveryKey -> restoreOne(bucket, recoveryKey), CONCURRENCY)
             .reduce(Report.empty(), Report::merge)
             .doOnNext(report -> LOGGER.info("S3 recovery finished: {}", report));

--- a/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryService.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryService.java
@@ -88,7 +88,6 @@ public class S3RecoveryService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3RecoveryService.class);
     private static final String RESTORE_MAILBOX = "Restored-messages";
-    private static final int CONCURRENCY = 8;
     private static final String DELIVERED_TO = "Delivered-To";
     private static final Report RESTORED = new Report(1, 1, 0, 0, 0);
     private static final Report SKIPPED_BY_DATE = new Report(1, 0, 1, 0, 0);
@@ -118,11 +117,11 @@ public class S3RecoveryService {
     public Mono<Report> run() {
         BucketName bucket = blobStore.getDefaultBucketName();
         String prefix = RECOVERY_BLOB_PREFIX + configuration.headerBlobPrefix();
-        LOGGER.info("Starting S3 recovery on bucket {} (prefix: {}, restore after: {})",
-            bucket.asString(), prefix, configuration.restoreAfter());
+        LOGGER.info("Starting S3 recovery on bucket {} (prefix: {}, restore after: {}, concurrency: {})",
+            bucket.asString(), prefix, configuration.restoreAfter(), configuration.concurrency());
         return Flux.from(blobStoreDAO.listBlobs(bucket, prefix))
             .map(BlobId::asString)
-            .flatMap(recoveryKey -> restoreOne(bucket, recoveryKey), CONCURRENCY)
+            .flatMap(recoveryKey -> restoreOne(bucket, recoveryKey), configuration.concurrency())
             .reduce(Report.empty(), Report::merge)
             .doOnNext(report -> LOGGER.info("S3 recovery finished: {}", report));
     }

--- a/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryService.java
+++ b/server/apps/distributed-app/src/main/java/org/apache/james/S3RecoveryService.java
@@ -1,0 +1,252 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
+import static org.apache.james.blob.api.BlobStore.StoragePolicy.SIZE_BASED;
+import static org.apache.james.blob.api.BlobStoreDAO.RECOVERY_BLOB_PREFIX;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.BlobStoreDAO;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.exception.MailboxExistsException;
+import org.apache.james.mailbox.model.Content;
+import org.apache.james.mailbox.model.HeaderAndBodyByteContent;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.message.DefaultMessageBuilder;
+import org.apache.james.mime4j.stream.Field;
+import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.user.api.UsersRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Walks the blob store looking for {@code recovery/} sidecars (written by
+ * {@code CassandraMessageDAOV3} when {@code mailbox.blob.recovery.mode} is enabled) and restores the
+ * associated messages into a {@code Restored-messages} mailbox of each local {@code Delivered-To} recipient.
+ *
+ * <p>Reads go through the configured {@link BlobStore}, so AES decryption and decompression are applied
+ * transparently, exactly as the write path did.</p>
+ */
+public class S3RecoveryService {
+    public record Report(long processed, long restored, long skippedByDate, long skippedNoLocalUser, long failed) {
+        public static Report empty() {
+            return new Report(0, 0, 0, 0, 0);
+        }
+
+        Report merge(Report other) {
+            return new Report(processed + other.processed,
+                restored + other.restored,
+                skippedByDate + other.skippedByDate,
+                skippedNoLocalUser + other.skippedNoLocalUser,
+                failed + other.failed);
+        }
+    }
+
+    private record RecoveredMessage(List<MailAddress> recipients, Optional<Date> date, Content content) {
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3RecoveryService.class);
+    private static final String RESTORE_MAILBOX = "Restored-messages";
+    private static final int CONCURRENCY = 8;
+    private static final String DELIVERED_TO = "Delivered-To";
+    private static final Report RESTORED = new Report(1, 1, 0, 0, 0);
+    private static final Report SKIPPED_BY_DATE = new Report(1, 0, 1, 0, 0);
+    private static final Report SKIPPED_NO_LOCAL_USER = new Report(1, 0, 0, 1, 0);
+    private static final Report FAILED = new Report(1, 0, 0, 0, 1);
+
+    private final BlobStore blobStore;
+    private final BlobStoreDAO blobStoreDAO;
+    private final BlobId.Factory blobIdFactory;
+    private final MailboxManager mailboxManager;
+    private final UsersRepository usersRepository;
+    private final RecoveryConfiguration configuration;
+    private final Set<Username> ensuredMailboxes = ConcurrentHashMap.newKeySet();
+
+    @Inject
+    public S3RecoveryService(BlobStore blobStore, BlobStoreDAO blobStoreDAO, BlobId.Factory blobIdFactory,
+                             MailboxManager mailboxManager, UsersRepository usersRepository,
+                             RecoveryConfiguration configuration) {
+        this.blobStore = blobStore;
+        this.blobStoreDAO = blobStoreDAO;
+        this.blobIdFactory = blobIdFactory;
+        this.mailboxManager = mailboxManager;
+        this.usersRepository = usersRepository;
+        this.configuration = configuration;
+    }
+
+    public Mono<Report> run() {
+        BucketName bucket = blobStore.getDefaultBucketName();
+        LOGGER.info("Starting S3 recovery on bucket {} (restore after: {})", bucket.asString(), configuration.restoreAfter());
+        return Flux.from(blobStoreDAO.listBlobs(bucket))
+            .map(BlobId::asString)
+            .filter(key -> key.startsWith(RECOVERY_BLOB_PREFIX))
+            .flatMap(recoveryKey -> restoreOne(bucket, recoveryKey), CONCURRENCY)
+            .reduce(Report.empty(), Report::merge)
+            .doOnNext(report -> LOGGER.info("S3 recovery finished: {}", report));
+    }
+
+    private Mono<Report> restoreOne(BucketName bucket, String recoveryKey) {
+        String headerKey = recoveryKey.substring(RECOVERY_BLOB_PREFIX.length());
+        BlobId headerBlobId = blobIdFactory.parse(headerKey);
+        BlobId recoveryBlobId = blobIdFactory.parse(recoveryKey);
+
+        return Mono.from(blobStoreDAO.readBytes(bucket, recoveryBlobId))
+            .map(sidecar -> blobIdFactory.parse(new String(sidecar.payload(), StandardCharsets.UTF_8).trim()))
+            .flatMap(bodyBlobId -> recover(bucket, headerBlobId, bodyBlobId))
+            .flatMap(this::restore)
+            .onErrorResume(error -> {
+                LOGGER.error("Failed to recover message from {}", recoveryKey, error);
+                return Mono.just(FAILED);
+            });
+    }
+
+    private Mono<RecoveredMessage> recover(BucketName bucket, BlobId headerBlobId, BlobId bodyBlobId) {
+        return Mono.from(blobStore.readBytes(bucket, headerBlobId, SIZE_BASED))
+            .flatMap(headerBytes -> {
+                MessageHeaders headers = parseHeaders(headerBytes);
+                return Mono.from(blobStore.readBytes(bucket, bodyBlobId, LOW_COST))
+                    .map(bodyBytes -> new RecoveredMessage(headers.recipients(), headers.date(),
+                        new HeaderAndBodyByteContent(headerBytes, bodyBytes)));
+            });
+    }
+
+    private Mono<Report> restore(RecoveredMessage message) {
+        if (filteredOutByDate(message.date())) {
+            return Mono.just(SKIPPED_BY_DATE);
+        }
+        return Flux.fromIterable(message.recipients())
+            .concatMap(recipient -> localUser(recipient).flux())
+            .collectList()
+            .flatMap(users -> {
+                if (users.isEmpty()) {
+                    LOGGER.info("Skipping message: no local Delivered-To recipient among {}", message.recipients());
+                    return Mono.just(SKIPPED_NO_LOCAL_USER);
+                }
+                return Flux.fromIterable(users)
+                    .concatMap(user -> appendToRestored(user, message))
+                    .then(Mono.just(RESTORED));
+            });
+    }
+
+    private boolean filteredOutByDate(Optional<Date> date) {
+        return configuration.restoreAfter()
+            .flatMap(after -> date.map(value -> !value.toInstant().isAfter(after)))
+            .orElse(false);
+    }
+
+    private Mono<Username> localUser(MailAddress recipient) {
+        return Mono.fromCallable(() -> usersRepository.getUsername(recipient))
+            .flatMap(username -> Mono.from(usersRepository.containsReactive(username))
+                .<Username>handle((present, sink) -> {
+                    if (present) {
+                        sink.next(username);
+                    }
+                }))
+            .onErrorResume(error -> {
+                LOGGER.warn("Unable to resolve local user for {}", recipient.asString(), error);
+                return Mono.empty();
+            });
+    }
+
+    private Mono<Void> appendToRestored(Username user, RecoveredMessage message) {
+        return Mono.fromRunnable(() -> doAppend(user, message))
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
+    }
+
+    private void doAppend(Username user, RecoveredMessage message) {
+        try {
+            MailboxSession session = mailboxManager.createSystemSession(user);
+            MailboxPath path = ensureMailbox(user, session);
+            MessageManager messageManager = mailboxManager.getMailbox(path, session);
+            messageManager.appendMessage(MessageManager.AppendCommand.builder()
+                .withInternalDate(message.date())
+                .notRecent()
+                .build(message.content()), session);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to append recovered message to " + user.asString(), e);
+        }
+    }
+
+    private MailboxPath ensureMailbox(Username user, MailboxSession session) throws Exception {
+        MailboxPath path = MailboxPath.forUser(user, RESTORE_MAILBOX);
+        if (ensuredMailboxes.add(user)) {
+            try {
+                mailboxManager.createMailbox(path, session);
+            } catch (MailboxExistsException e) {
+                // The mailbox already exists, nothing to do.
+            }
+        }
+        return path;
+    }
+
+    @VisibleForTesting
+    static MessageHeaders parseHeaders(byte[] headerBytes) {
+        try {
+            DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
+            messageBuilder.setMimeEntityConfig(MimeConfig.PERMISSIVE);
+            Message message = messageBuilder.parseMessage(new ByteArrayInputStream(headerBytes));
+            List<MailAddress> recipients = message.getHeader().getFields(DELIVERED_TO).stream()
+                .map(Field::getBody)
+                .flatMap(value -> toMailAddress(value).stream())
+                .toList();
+            return new MessageHeaders(recipients, Optional.ofNullable(message.getDate()));
+        } catch (Exception e) {
+            LOGGER.warn("Unable to parse recovered message headers", e);
+            return new MessageHeaders(List.of(), Optional.empty());
+        }
+    }
+
+    private static Optional<MailAddress> toMailAddress(String value) {
+        try {
+            return Optional.of(new MailAddress(value.trim()));
+        } catch (Exception e) {
+            LOGGER.warn("Unable to parse Delivered-To value '{}'", value);
+            return Optional.empty();
+        }
+    }
+
+    record MessageHeaders(List<MailAddress> recipients, Optional<Date> date) {
+    }
+}

--- a/server/apps/distributed-app/src/test/java/org/apache/james/RecoveryConfigurationTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/RecoveryConfigurationTest.java
@@ -54,4 +54,28 @@ class RecoveryConfigurationTest {
         assertThat(RecoveryConfiguration.parse(new String[] {"--header-blob-prefix=1_42_"}).headerBlobPrefix())
             .isEqualTo("1_42_");
     }
+
+    @Test
+    void parseShouldDefaultConcurrency() {
+        assertThat(RecoveryConfiguration.parse(new String[] {}).concurrency())
+            .isEqualTo(RecoveryConfiguration.DEFAULT_CONCURRENCY);
+    }
+
+    @Test
+    void parseShouldReadConcurrencyArgument() {
+        assertThat(RecoveryConfiguration.parse(new String[] {"--concurrency=32"}).concurrency())
+            .isEqualTo(32);
+    }
+
+    @Test
+    void parseShouldRejectNonPositiveConcurrency() {
+        assertThatThrownBy(() -> RecoveryConfiguration.parse(new String[] {"--concurrency=0"}))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void parseShouldRejectNonNumericConcurrency() {
+        assertThatThrownBy(() -> RecoveryConfiguration.parse(new String[] {"--concurrency=many"}))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/server/apps/distributed-app/src/test/java/org/apache/james/RecoveryConfigurationTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/RecoveryConfigurationTest.java
@@ -43,4 +43,15 @@ class RecoveryConfigurationTest {
         assertThatThrownBy(() -> RecoveryConfiguration.parse(new String[] {"--restore-after=not-a-date"}))
             .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void parseShouldDefaultHeaderBlobPrefixToEmpty() {
+        assertThat(RecoveryConfiguration.parse(new String[] {}).headerBlobPrefix()).isEmpty();
+    }
+
+    @Test
+    void parseShouldReadHeaderBlobPrefixArgument() {
+        assertThat(RecoveryConfiguration.parse(new String[] {"--header-blob-prefix=1_42_"}).headerBlobPrefix())
+            .isEqualTo("1_42_");
+    }
 }

--- a/server/apps/distributed-app/src/test/java/org/apache/james/RecoveryConfigurationTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/RecoveryConfigurationTest.java
@@ -1,0 +1,46 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class RecoveryConfigurationTest {
+    @Test
+    void parseShouldReturnEmptyWhenNoDateProvided() {
+        assertThat(RecoveryConfiguration.parse(new String[] {}).restoreAfter()).isEmpty();
+    }
+
+    @Test
+    void parseShouldReadRestoreAfterArgument() {
+        assertThat(RecoveryConfiguration.parse(new String[] {"--restore-after=2026-01-01T00:00:00Z"}).restoreAfter())
+            .contains(Instant.parse("2026-01-01T00:00:00Z"));
+    }
+
+    @Test
+    void parseShouldRejectInvalidInstant() {
+        assertThatThrownBy(() -> RecoveryConfiguration.parse(new String[] {"--restore-after=not-a-date"}))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/server/apps/distributed-app/src/test/java/org/apache/james/S3RecoveryServiceTest.java
+++ b/server/apps/distributed-app/src/test/java/org/apache/james/S3RecoveryServiceTest.java
@@ -1,0 +1,77 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import org.apache.james.core.MailAddress;
+import org.junit.jupiter.api.Test;
+
+class S3RecoveryServiceTest {
+    @Test
+    void parseHeadersShouldExtractEveryDeliveredToRecipient() {
+        byte[] headers = ("Delivered-To: alice@domain.tld\r\n"
+            + "Delivered-To: bob@domain.tld\r\n"
+            + "Subject: hello\r\n"
+            + "\r\n").getBytes(StandardCharsets.UTF_8);
+
+        assertThat(S3RecoveryService.parseHeaders(headers).recipients())
+            .extracting(MailAddress::asString)
+            .containsExactly("alice@domain.tld", "bob@domain.tld");
+    }
+
+    @Test
+    void parseHeadersShouldExtractDate() {
+        byte[] headers = ("Delivered-To: alice@domain.tld\r\n"
+            + "Date: Wed, 01 Jan 2020 00:00:00 +0000\r\n"
+            + "\r\n").getBytes(StandardCharsets.UTF_8);
+
+        assertThat(S3RecoveryService.parseHeaders(headers).date())
+            .hasValueSatisfying(date -> assertThat(date.toInstant()).isEqualTo(Instant.parse("2020-01-01T00:00:00Z")));
+    }
+
+    @Test
+    void parseHeadersShouldReturnNoRecipientWhenNoDeliveredTo() {
+        byte[] headers = ("Subject: hello\r\n\r\n").getBytes(StandardCharsets.UTF_8);
+
+        assertThat(S3RecoveryService.parseHeaders(headers).recipients()).isEmpty();
+    }
+
+    @Test
+    void parseHeadersShouldReturnNoDateWhenAbsent() {
+        byte[] headers = ("Delivered-To: alice@domain.tld\r\n\r\n").getBytes(StandardCharsets.UTF_8);
+
+        assertThat(S3RecoveryService.parseHeaders(headers).date()).isEmpty();
+    }
+
+    @Test
+    void parseHeadersShouldSkipUnparseableDeliveredToValue() {
+        byte[] headers = ("Delivered-To: not-an-address\r\n"
+            + "Delivered-To: bob@domain.tld\r\n"
+            + "\r\n").getBytes(StandardCharsets.UTF_8);
+
+        assertThat(S3RecoveryService.parseHeaders(headers).recipients())
+            .extracting(MailAddress::asString)
+            .containsExactly("bob@domain.tld");
+    }
+}

--- a/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
+++ b/server/blob/blob-aes/src/main/java/org/apache/james/blob/aes/AESBlobStoreDAO.java
@@ -206,4 +206,9 @@ public class AESBlobStoreDAO implements BlobStoreDAO {
     public Publisher<BlobId> listBlobs(BucketName bucketName) {
         return underlying.listBlobs(bucketName);
     }
+
+    @Override
+    public Publisher<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return underlying.listBlobs(bucketName, prefix);
+    }
 }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
@@ -25,6 +25,7 @@ import org.reactivestreams.Publisher;
 
 import com.google.common.io.ByteSource;
 
+import reactor.core.publisher.Flux;
 import reactor.util.function.Tuple2;
 
 /**
@@ -97,4 +98,15 @@ public interface BlobStore {
     Publisher<Boolean> delete(BucketName bucketName, BlobId blobId);
 
     Publisher<BlobId> listBlobs(BucketName bucketName);
+
+    /**
+     * Lists the blobs of a bucket whose id starts with the given prefix.
+     *
+     * <p>The default implementation filters the full listing. Implementations backed by a store able to
+     * push the prefix down (eg. S3 {@code ListObjectsV2}) should override this for efficiency.</p>
+     */
+    default Publisher<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return Flux.from(listBlobs(bucketName))
+            .filter(blobId -> blobId.asString().startsWith(prefix));
+    }
 }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStoreDAO.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStoreDAO.java
@@ -38,6 +38,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 import com.google.common.io.FileBackedOutputStream;
 
+import reactor.core.publisher.Flux;
+
 /**
  * James virtual blob store abstraction.
  *
@@ -291,4 +293,15 @@ public interface BlobStoreDAO {
     Publisher<BucketName> listBuckets();
 
     Publisher<BlobId> listBlobs(BucketName bucketName);
+
+    /**
+     * Lists the blobs of a bucket whose id starts with the given prefix (eg. {@link #RECOVERY_BLOB_PREFIX}).
+     *
+     * <p>The default implementation filters the full listing. Connectors able to push the prefix down to
+     * their backend (eg. S3 {@code ListObjectsV2}) should override this for efficiency.</p>
+     */
+    default Publisher<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return Flux.from(listBlobs(bucketName))
+            .filter(blobId -> blobId.asString().startsWith(prefix));
+    }
 }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
@@ -131,4 +131,9 @@ public class MetricableBlobStore implements BlobStore {
     public Publisher<BlobId> listBlobs(BucketName bucketName) {
         return blobStoreImpl.listBlobs(bucketName);
     }
+
+    @Override
+    public Publisher<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return blobStoreImpl.listBlobs(bucketName, prefix);
+    }
 }

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/ReadSaveBlobStoreDAOContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/ReadSaveBlobStoreDAOContract.java
@@ -295,6 +295,30 @@ public interface ReadSaveBlobStoreDAOContract {
             .containsOnly(TEST_BLOB_ID.asString(), OTHER_TEST_BLOB_ID.asString());
     }
 
+    @Test
+    default void listWithPrefixShouldReturnOnlyMatchingBlobs() {
+        BlobStoreDAO store = testee();
+        Mono.from(store.save(TEST_BUCKET_NAME, TEST_BLOB_ID, ELEVEN_KILOBYTES)).block();
+        Mono.from(store.save(TEST_BUCKET_NAME, OTHER_TEST_BLOB_ID, ELEVEN_KILOBYTES)).block();
+
+        assertThat(Flux.from(testee().listBlobs(TEST_BUCKET_NAME, "test-"))
+            .map(BlobId::asString)
+            .collectList()
+            .block())
+            .containsOnly(TEST_BLOB_ID.asString());
+    }
+
+    @Test
+    default void listWithPrefixShouldReturnEmptyWhenNoMatch() {
+        BlobStoreDAO store = testee();
+        Mono.from(store.save(TEST_BUCKET_NAME, TEST_BLOB_ID, ELEVEN_KILOBYTES)).block();
+
+        assertThat(Flux.from(testee().listBlobs(TEST_BUCKET_NAME, "no-such-prefix-"))
+            .collectList()
+            .block())
+            .isEmpty();
+    }
+
     static Stream<Arguments> blobs() {
         return Stream.of(new Object[]{"SHORT", SHORT_BYTEARRAY}, new Object[]{"LONG", ELEVEN_KILOBYTES}, new Object[]{"BIG", TWELVE_MEGABYTES})
             .map(Arguments::of);

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CachedBlobStore.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/cache/CachedBlobStore.java
@@ -405,4 +405,9 @@ public class CachedBlobStore implements BlobStore {
     public Publisher<BlobId> listBlobs(BucketName bucketName) {
         return backend.listBlobs(bucketName);
     }
+
+    @Override
+    public Publisher<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return backend.listBlobs(bucketName, prefix);
+    }
 }

--- a/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
+++ b/server/blob/blob-s3/src/main/java/org/apache/james/blob/objectstorage/aws/S3BlobStoreDAO.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -68,6 +69,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -455,7 +457,16 @@ public class S3BlobStoreDAO implements BlobStoreDAO {
 
     @Override
     public Publisher<BlobId> listBlobs(BucketName bucketName) {
-        return Flux.from(client.listObjectsV2Paginator(builder -> builder.bucket(bucketName.asString())))
+        return listBlobs(bucketName, builder -> builder.bucket(bucketName.asString()));
+    }
+
+    @Override
+    public Publisher<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return listBlobs(bucketName, builder -> builder.bucket(bucketName.asString()).prefix(prefix));
+    }
+
+    private Publisher<BlobId> listBlobs(BucketName bucketName, Consumer<ListObjectsV2Request.Builder> request) {
+        return Flux.from(client.listObjectsV2Paginator(request))
             .flatMapIterable(ListObjectsV2Response::contents)
             .map(S3Object::key)
             .map(blobIdFactory::parse)

--- a/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
+++ b/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
@@ -194,4 +194,6 @@ class DeDuplicationBlobStore @Inject()(blobStoreDAO: BlobStoreDAO,
   override def listBuckets(): Publisher[BucketName] = Flux.concat(blobStoreDAO.listBuckets(), Flux.just(defaultBucketName)).distinct()
 
   override def listBlobs(bucketName: BucketName): Publisher[BlobId] = blobStoreDAO.listBlobs(bucketName)
+
+  override def listBlobs(bucketName: BucketName, prefix: String): Publisher[BlobId] = blobStoreDAO.listBlobs(bucketName, prefix)
 }

--- a/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/PassThroughBlobStore.scala
+++ b/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/PassThroughBlobStore.scala
@@ -129,4 +129,6 @@ class PassThroughBlobStore @Inject()(blobStoreDAO: BlobStoreDAO,
   override def listBuckets(): Publisher[BucketName] = Flux.concat(blobStoreDAO.listBuckets(), Flux.just(defaultBucketName)).distinct()
 
   override def listBlobs(bucketName: BucketName): Publisher[BlobId] = blobStoreDAO.listBlobs(bucketName)
+
+  override def listBlobs(bucketName: BucketName, prefix: String): Publisher[BlobId] = blobStoreDAO.listBlobs(bucketName, prefix)
 }

--- a/server/blob/blob-zstd/src/main/java/org/apache/james/blob/zstd/ZstdBlobStoreDAO.java
+++ b/server/blob/blob-zstd/src/main/java/org/apache/james/blob/zstd/ZstdBlobStoreDAO.java
@@ -190,6 +190,11 @@ public class ZstdBlobStoreDAO implements BlobStoreDAO {
         return underlying.listBlobs(bucketName);
     }
 
+    @Override
+    public Publisher<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return underlying.listBlobs(bucketName, prefix);
+    }
+
     private InputStreamBlob decompress(InputStreamBlob blob) throws ObjectStoreIOException {
         try {
             metricRecorder.recordDecompression();


### PR DESCRIPTION
TODO:
 - [x] Regular `/docs` with a backup policy
 - [x] BlobStore::list -> add a prefix to only iterate recovery infos
 - [x] `--header-blob-prefix` additional run option to allow clever admins to select solely latest generation