### PR TITLE
[BACKPORT] 3.8.x: webadmin authentication improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Security
+
+ - Webadmin `password.generate`: generate a random password upon start up when none is configured, and log it.
+ **Breaking change**: this defaults to `true`, thus WebAdmin is no longer unauthenticated out of the box, existing
+ deployments included. Set `password.generate=false` in `webadmin.properties` to opt back into an unauthenticated
+ WebAdmin, or configure `password` to pin a stable secret.
+
 This release brings the following significant changes:
 
  - Upgrade TCP protocols to Netty 4

--- a/docs/modules/servers/pages/15-minute-demo.adoc
+++ b/docs/modules/servers/pages/15-minute-demo.adoc
@@ -20,7 +20,7 @@ Run this command to create the `webadmin.properties` file:
 
 [source,bash]
 ----
-printf 'enabled=true\nport=8000\nhost=localhost' >> webadmin.properties
+printf 'enabled=true\nport=8000\nhost=localhost\npassword.generate=false\n' >> webadmin.properties
 ----
 
 Explanation:
@@ -28,7 +28,14 @@ Explanation:
  * `enabled=true` instructs James to run the Admin API service
  * `port=8000` configures the Admin API to be made available via port 8000
  * `host=localhost` configures the Admin API to respond on localhost
+ * `password.generate=false` disables WebAdmin authentication for this local demo
 
+[NOTE]
+====
+This demo explicitly disables WebAdmin password generation to keep the first-run experience simple.
+By default, `password.generate` is enabled and James generates a random WebAdmin password at startup when no
+`password` is explicitly configured. Do not disable WebAdmin authentication when exposing it beyond this local demo.
+====
 
 Now run the James demo server using this command:
 
@@ -219,4 +226,3 @@ docker stop james ; docker rm james
 ----
 
 That's all, folks!
-

--- a/examples/custom-webadmin-route/README.md
+++ b/examples/custom-webadmin-route/README.md
@@ -48,11 +48,19 @@ enabled=true
 port=8000
 host=localhost
 
+# Disable WebAdmin authentication for this local customization demo.
+# Password generation defaults to true when no password is explicitly configured.
+password.generate=false
+
 # List of fully qualified class names that should be exposed over webadmin
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 extensions.routes=org.apache.james.examples.RouteA
 ```
+
+This example explicitly disables WebAdmin password generation to keep the customization demo simple. By default,
+`password.generate` is enabled and James generates a random WebAdmin password at startup when no `password` is
+explicitly configured. Do not disable WebAdmin authentication when exposing it beyond this local demo.
 
 Create a keystore (default password being `james72laBalle`):
 

--- a/examples/custom-webadmin-route/src/main/resources/webadmin.properties
+++ b/examples/custom-webadmin-route/src/main/resources/webadmin.properties
@@ -19,6 +19,10 @@ enabled=true
 port=8000
 host=localhost
 
+# Disable WebAdmin authentication for this local customization demo.
+# Password generation defaults to true when no password is explicitly configured.
+password.generate=false
+
 # List of fully qualified class names that should be exposed over webadmin
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.

--- a/server/apps/cassandra-app/docker-configuration/webadmin.properties
+++ b/server/apps/cassandra-app/docker-configuration/webadmin.properties
@@ -52,3 +52,9 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Generate a random password upon start up when no password is configured.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true

--- a/server/apps/cassandra-app/sample-configuration/webadmin.properties
+++ b/server/apps/cassandra-app/sample-configuration/webadmin.properties
@@ -53,3 +53,14 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true
+
+# Configure one or more passwords (comma separated) for WebAdmin authentication
+#password=secret1,secret2

--- a/server/apps/distributed-app/docker-configuration/webadmin.properties
+++ b/server/apps/distributed-app/docker-configuration/webadmin.properties
@@ -52,3 +52,11 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/benchmark/james-benchmark.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/benchmark/james-benchmark.adoc
@@ -55,6 +55,13 @@ chmod +x provision.sh
 sudo apt-get install postfix
 ----
 
+* Retrieve the generated WebAdmin password from the James startup logs and expose it to the provisioning script:
+----
+export WEBADMIN_PASSWORD="replace-with-generated-webadmin-password"
+----
+
+Omit this variable only when WebAdmin password authentication is explicitly disabled.
+
 * Run the provision script:
 ----
 ./provision.sh
@@ -98,4 +105,3 @@ A sample IMAP performance testing result (PlatformValidationSimulation):
 image::james-imap-base-performance.png[]
 
 If you get a IMAP performance far below this base performance, you should consider investigating for performance issues.
-

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/benchmark/provision.sh
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/benchmark/provision.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 export WEBADMIN_BASE_URL="http://localhost:8000"
 export SMTP_URL="localhost:25"
 export DOMAIN_NAME="domain.org"
@@ -7,32 +9,40 @@ export USERS_COUNT=10
 export DUMMY_MAILBOXES_COUNT=10
 export DUMMY_EMAILS_COUNT=100
 
+call_webadmin() {
+  if [ -n "${WEBADMIN_PASSWORD:-}" ]; then
+    curl --fail --header "Password: ${WEBADMIN_PASSWORD}" "$@"
+  else
+    curl --fail "$@"
+  fi
+}
+
 # Create domain
-curl -X PUT ${WEBADMIN_BASE_URL}/domains/${DOMAIN_NAME}
+call_webadmin -X PUT ${WEBADMIN_BASE_URL}/domains/${DOMAIN_NAME}
 
 for i in $(seq 1 $USERS_COUNT)
 do
   # Create user
    echo "Creating user $i"
    username=user${i}@$DOMAIN_NAME
-   curl -XPUT ${WEBADMIN_BASE_URL}/users/$username \
+   call_webadmin -XPUT ${WEBADMIN_BASE_URL}/users/$username \
      -d '{"password":"secret"}' \
      -H "Content-Type: application/json"
 
   # Create mailboxes for each user
    echo "Creating user $i mailboxes"
    # Create some basic mailboxes
-   curl -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/INBOX
-   curl -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Outbox
-   curl -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Sent
-   curl -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Draft
-   curl -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Trash
+   call_webadmin -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/INBOX
+   call_webadmin -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Outbox
+   call_webadmin -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Sent
+   call_webadmin -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Draft
+   call_webadmin -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/Trash
 
    # Create some other dummy mailboxes
    for j in $(seq 1 $DUMMY_MAILBOXES_COUNT)
    do
      dummyMailbox=MAILBOX${j}
-     curl -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/$dummyMailbox
+     call_webadmin -XPUT ${WEBADMIN_BASE_URL}/users/${username}/mailboxes/$dummyMailbox
    done
 done
 

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/webadmin.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/webadmin.adoc
@@ -4,9 +4,9 @@
 The web administration supports for now the CRUD operations on the domains, the users, their mailboxes and their quotas,
 managing mail repositories, performing cassandra migrations, and much more, as described in the following sections.
 
-*WARNING*: This API allows authentication only via the use of JWT. If not
-configured with JWT, an administrator should ensure an attacker can not
-use this API.
+*WARNING*: This API supports authentication via a static password or JWT. If no
+authentication mechanism is configured, an administrator should ensure an attacker
+can not use this API.
 
 By the way, some endpoints are not filtered by authentication. Those endpoints are not related to data stored in James,
 for example: Swagger documentation & James health checks.
@@ -34,6 +34,29 @@ to get some examples and hints.
 
 | cors.origin
 | Specify ths CORS origin (default: null)
+
+| password
+| Uses a configured static value for authentication. It relies on the `Password` header.
+It supports several passwords, configured as a comma-separated list.
+
+....
+password=secretA,secretB,secretC
+....
+
+This allows requests with:
+
+....
+Password: secretA
+Password: secretB
+....
+
+But denies:
+
+....
+Password: secretD
+....
+
+Requests without the `Password` header are denied as well.
 
 | jwt.enable
 | Allow JSON Web Token as an authentication mechanism (default: false)

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/configure/webadmin.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/configure/webadmin.adoc
@@ -35,6 +35,26 @@ to get some examples and hints.
 | cors.origin
 | Specify ths CORS origin (default: null)
 
+| password.generate
+| Generates a random password upon start up when no `password` is configured, allowing a secure setup without
+hardcoded credentials (default: true). As such, WebAdmin is never unauthenticated unless explicitly asked for.
+
+....
+password.generate=false
+....
+
+The generated password is written in the logs upon start up:
+
+....
+WARN  No WebAdmin password had been configured: a random one had been generated for this run. [...]
+Generated WebAdmin password: 8Kj2mXqT4vZ...
+....
+
+Beware: the generated password changes upon each restart, and is exposed to whoever can read the logs. Configure
+`password` explicitly for setups needing a stable secret, or set `password.generate=false` to opt back into an
+unauthenticated WebAdmin. This option is ignored when `password` is configured, when `jwt.enabled` is true, and when
+WebAdmin is disabled.
+
 | password
 | Uses a configured static value for authentication. It relies on the `Password` header.
 It supports several passwords, configured as a comma-separated list.

--- a/server/apps/distributed-app/docs/modules/ROOT/pages/run/run-docker.adoc
+++ b/server/apps/distributed-app/docs/modules/ROOT/pages/run/run-docker.adoc
@@ -82,7 +82,8 @@ Where :
 
 - HOSTNAME: is the hostname you want to give to your James container. This DNS entry will be used to send mail to your James server.
 
-Webadmin port binding is restricted to loopback as users are not authenticated by default on webadmin server. Thus you should avoid exposing it in production.
+Webadmin port binding is restricted to loopback. Webadmin is protected by a password randomly generated upon
+each start up and written in the logs (see `password.generate`), yet you should avoid exposing it in production.
 Note that the above example assumes `127.0.0.1` is your loopback interface for convenience but you should change it if this is not the case on your machine.
 
 If you want to pass additional options to the underlying java command, you can configure a _JAVA_TOOL_OPTIONS_ env variable, for example add:

--- a/server/apps/distributed-app/sample-configuration/webadmin.properties
+++ b/server/apps/distributed-app/sample-configuration/webadmin.properties
@@ -53,3 +53,14 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true
+
+# Configure one or more passwords (comma separated) for WebAdmin authentication
+#password=secret1,secret2

--- a/server/apps/distributed-pop3-app/docker-configuration/webadmin.properties
+++ b/server/apps/distributed-pop3-app/docker-configuration/webadmin.properties
@@ -52,3 +52,11 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true

--- a/server/apps/distributed-pop3-app/sample-configuration/webadmin.properties
+++ b/server/apps/distributed-pop3-app/sample-configuration/webadmin.properties
@@ -53,3 +53,14 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true
+
+# Configure one or more passwords (comma separated) for WebAdmin authentication
+#password=secret1,secret2

--- a/server/apps/jpa-app/docker-configuration/webadmin.properties
+++ b/server/apps/jpa-app/docker-configuration/webadmin.properties
@@ -52,3 +52,11 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true

--- a/server/apps/jpa-app/sample-configuration/webadmin.properties
+++ b/server/apps/jpa-app/sample-configuration/webadmin.properties
@@ -47,3 +47,14 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true
+
+# Configure one or more passwords (comma separated) for WebAdmin authentication
+#password=secret1,secret2

--- a/server/apps/jpa-smtp-app/docker-configuration/webadmin.properties
+++ b/server/apps/jpa-smtp-app/docker-configuration/webadmin.properties
@@ -52,3 +52,11 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true

--- a/server/apps/jpa-smtp-app/sample-configuration/webadmin.properties
+++ b/server/apps/jpa-smtp-app/sample-configuration/webadmin.properties
@@ -47,3 +47,14 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true
+
+# Configure one or more passwords (comma separated) for WebAdmin authentication
+#password=secret1,secret2

--- a/server/apps/memory-app/docker-configuration/webadmin.properties
+++ b/server/apps/memory-app/docker-configuration/webadmin.properties
@@ -52,3 +52,11 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true

--- a/server/apps/memory-app/sample-configuration/webadmin.properties
+++ b/server/apps/memory-app/sample-configuration/webadmin.properties
@@ -54,3 +54,14 @@ https.enabled=false
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.
 #extensions.routes=
+
+# Password authentication settings
+
+# Generate a random password upon start up when no password is configured below.
+# The generated password is written in the logs, and changes upon each restart.
+# Set it to false to run WebAdmin without any authentication.
+# Defaults to true
+password.generate=true
+
+# Configure one or more passwords (comma separated) for WebAdmin authentication
+#password=secret1,secret2

--- a/server/apps/webadmin-cli/src/test/resources/webadmin.properties
+++ b/server/apps/webadmin-cli/src/test/resources/webadmin.properties
@@ -23,3 +23,6 @@
 enabled=true
 port=0
 host=127.0.0.1
+
+# These tests exercise WebAdmin routes without authentication
+password.generate=false

--- a/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PassThroughBlobStoreTest.java
+++ b/server/blob/blob-s3/src/test/java/org/apache/james/blob/objectstorage/aws/S3PassThroughBlobStoreTest.java
@@ -27,6 +27,7 @@ import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DockerAwsS3Extension.class)
@@ -78,4 +79,8 @@ class S3PassThroughBlobStoreTest implements BlobStoreContract {
         return new HashBlobId.Factory();
     }
 
+    @Override
+    @Disabled("Unstable: Duplicate handler name: HttpStreamsClientHandler#0-body-subscriber")
+    public void readBytesShouldReturnBigSavedByteSource(BlobStore.StoragePolicy storagePolicy) {
+    }
 }

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -60,6 +60,7 @@ import org.apache.james.webadmin.authentication.AuthenticationFilter;
 import org.apache.james.webadmin.authentication.JwtFilter;
 import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import org.apache.james.webadmin.authentication.PasswordFilter;
+import org.apache.james.webadmin.authentication.PasswordGenerator;
 import org.apache.james.webadmin.dto.DTOModuleInjections;
 import org.apache.james.webadmin.mdc.RequestLogger;
 import org.apache.james.webadmin.utils.JsonTransformer;
@@ -83,6 +84,7 @@ public class WebAdminServerModule extends AbstractModule {
 
     private static final boolean DEFAULT_JWT_DISABLED = false;
     private static final boolean DEFAULT_DISABLED = false;
+    private static final boolean DEFAULT_PASSWORD_GENERATION_ENABLED = true;
     private static final String DEFAULT_NO_CORS_ORIGIN = null;
     private static final boolean DEFAULT_CORS_DISABLED = false;
     private static final String DEFAULT_NO_KEYSTORE = null;
@@ -142,9 +144,10 @@ public class WebAdminServerModule extends AbstractModule {
             Configuration configurationFile = propertiesProvider.getConfiguration("webadmin");
 
             List<String> additionalRoutes = additionalRoutes(configurationFile);
+            boolean webAdminEnabled = configurationFile.getBoolean("enabled", DEFAULT_DISABLED);
 
             return WebAdminConfiguration.builder()
-                .enable(configurationFile.getBoolean("enabled", DEFAULT_DISABLED))
+                .enable(webAdminEnabled)
                 .port(port(configurationFile))
                 .tls(readHttpsConfiguration(configurationFile))
                 .enableCORS(configurationFile.getBoolean("cors.enable", DEFAULT_CORS_DISABLED))
@@ -155,7 +158,7 @@ public class WebAdminServerModule extends AbstractModule {
                     Optional.ofNullable(configurationFile.getString("jwt.publickeypem.url", null))))
                 .maxThreadCount(Optional.ofNullable(configurationFile.getInteger("maxThreadCount", null)))
                 .minThreadCount(Optional.ofNullable(configurationFile.getInteger("minThreadCount", null)))
-                .password(Optional.ofNullable(configurationFile.getString("password", null)))
+                .password(password(configurationFile, webAdminEnabled))
                 .build();
         } catch (FileNotFoundException e) {
             LOGGER.info("No webadmin.properties file. Disabling WebAdmin interface.");
@@ -170,6 +173,33 @@ public class WebAdminServerModule extends AbstractModule {
             return new RandomPortSupplier();
         }
         return new FixedPortSupplier(portNumber);
+    }
+
+    @VisibleForTesting
+    Optional<String> password(Configuration configurationFile, boolean webAdminEnabled) {
+        Optional<String> configuredPassword = Optional.ofNullable(configurationFile.getString("password", null));
+
+        if (configuredPassword.isPresent()) {
+            return configuredPassword;
+        }
+        if (shouldGeneratePassword(configurationFile, webAdminEnabled)) {
+            return Optional.of(generateAndLogPassword());
+        }
+        return Optional.empty();
+    }
+
+    private boolean shouldGeneratePassword(Configuration configurationFile, boolean webAdminEnabled) {
+        return configurationFile.getBoolean("password.generate", DEFAULT_PASSWORD_GENERATION_ENABLED)
+            && webAdminEnabled
+            && !configurationFile.getBoolean("jwt.enabled", DEFAULT_JWT_DISABLED);
+    }
+
+    private String generateAndLogPassword() {
+        String password = PasswordGenerator.generate();
+        LOGGER.warn("No WebAdmin password had been configured: a random one had been generated for this run. " +
+            "Supply it within the `Password` header of your WebAdmin requests, or pin it with the `password` entry " +
+            "of webadmin.properties. Generated WebAdmin password: {}", password);
+        return password;
     }
 
     @VisibleForTesting

--- a/server/container/guice/protocols/webadmin/src/test/java/org/apache/james/modules/server/WebAdminServerModuleTest.java
+++ b/server/container/guice/protocols/webadmin/src/test/java/org/apache/james/modules/server/WebAdminServerModuleTest.java
@@ -21,11 +21,18 @@ package org.apache.james.modules.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+
 import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.james.utils.PropertiesProvider;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class WebAdminServerModuleTest {
+    private static final boolean WEBADMIN_ENABLED = true;
+    private static final boolean WEBADMIN_DISABLED = false;
+
     @Test
     void shouldReturnEmptyWhenNoField() throws Exception {
         Configuration configuration = getConfiguration("webadmin-none");
@@ -60,5 +67,70 @@ class WebAdminServerModuleTest {
 
     private Configuration getConfiguration(String name) throws Exception {
         return PropertiesProvider.forTesting().getConfiguration(name);
+    }
+
+    @Nested
+    class PasswordGeneration {
+        @Test
+        void passwordShouldBeGeneratedByDefault() {
+            assertThat(new WebAdminServerModule().password(new PropertiesConfiguration(), WEBADMIN_ENABLED))
+                .isNotEmpty();
+        }
+
+        @Test
+        void passwordShouldBeEmptyWhenGenerationIsDisabled() {
+            assertThat(new WebAdminServerModule().password(configuration("password.generate", false), WEBADMIN_ENABLED))
+                .isEmpty();
+        }
+
+        @Test
+        void passwordShouldBeGeneratedWhenGenerationIsEnabled() {
+            assertThat(new WebAdminServerModule().password(configuration("password.generate", true), WEBADMIN_ENABLED))
+                .isNotEmpty();
+        }
+
+        @Test
+        void generatedPasswordShouldNotContainThePasswordSeparator() {
+            assertThat(new WebAdminServerModule().password(configuration("password.generate", true), WEBADMIN_ENABLED))
+                .hasValueSatisfying(password -> assertThat(password).doesNotContain(","));
+        }
+
+        @Test
+        void generatedPasswordsShouldBeRandom() {
+            Optional<String> firstPassword = new WebAdminServerModule().password(configuration("password.generate", true), WEBADMIN_ENABLED);
+            Optional<String> secondPassword = new WebAdminServerModule().password(configuration("password.generate", true), WEBADMIN_ENABLED);
+
+            assertThat(firstPassword).isNotEqualTo(secondPassword);
+        }
+
+        @Test
+        void configuredPasswordShouldTakePrecedenceOverGeneration() {
+            PropertiesConfiguration configuration = configuration("password.generate", true);
+            configuration.addProperty("password", "secret");
+
+            assertThat(new WebAdminServerModule().password(configuration, WEBADMIN_ENABLED))
+                .contains("secret");
+        }
+
+        @Test
+        void passwordShouldNotBeGeneratedWhenWebAdminIsDisabled() {
+            assertThat(new WebAdminServerModule().password(configuration("password.generate", true), WEBADMIN_DISABLED))
+                .isEmpty();
+        }
+
+        @Test
+        void passwordShouldNotBeGeneratedWhenJwtIsEnabled() {
+            PropertiesConfiguration configuration = configuration("password.generate", true);
+            configuration.addProperty("jwt.enabled", true);
+
+            assertThat(new WebAdminServerModule().password(configuration, WEBADMIN_ENABLED))
+                .isEmpty();
+        }
+
+        private PropertiesConfiguration configuration(String key, Object value) {
+            PropertiesConfiguration configuration = new PropertiesConfiguration();
+            configuration.addProperty(key, value);
+            return configuration;
+        }
     }
 }

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/webadmin.properties
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/resources/webadmin.properties
@@ -25,3 +25,6 @@ port=0
 host=127.0.0.1
 
 extensions.routes=org.apache.james.webadmin.dropwizard.MetricsRoutes
+
+# These tests exercise WebAdmin routes without authentication
+password.generate=false

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/webadmin.properties
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/resources/webadmin.properties
@@ -25,3 +25,6 @@ port=0
 host=127.0.0.1
 
 extensions.routes=org.apache.james.webadmin.dropwizard.MetricsRoutes
+
+# These tests exercise WebAdmin routes without authentication
+password.generate=false

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminConfiguration.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminConfiguration.java
@@ -57,6 +57,7 @@ public class WebAdminConfiguration {
         private Optional<TlsConfiguration> tlsConfiguration = Optional.empty();
         private Optional<String> urlCORSOrigin = Optional.empty();
         private Optional<String> host = Optional.empty();
+        private Optional<String> password = Optional.empty();
         private ImmutableList.Builder<String> additionalRoutes = ImmutableList.builder();
         private Optional<String> jwtPublicKey = Optional.empty();
         private Optional<Integer> maxThreadCount = Optional.empty();
@@ -123,6 +124,16 @@ public class WebAdminConfiguration {
             return this;
         }
 
+        public Builder password(String password) {
+            this.password = Optional.ofNullable(password);
+            return this;
+        }
+
+        public Builder password(Optional<String> password) {
+            this.password = password;
+            return this;
+        }
+
         public Builder additionalRoute(String additionalRoute) {
             this.additionalRoutes.add(additionalRoute);
             return this;
@@ -155,6 +166,7 @@ public class WebAdminConfiguration {
                 host.orElse(DEFAULT_HOST),
                 additionalRoutes.build(),
                 jwtPublicKey,
+                password,
                 maxThreadCount,
                 minThreadCount);
         }
@@ -168,12 +180,13 @@ public class WebAdminConfiguration {
     private final String host;
     private final List<String> additionalRoutes;
     private final Optional<String> jwtPublicKey;
+    private final Optional<String> password;
     private final Optional<Integer> maxThreadCount;
     private final Optional<Integer> minThreadCount;
 
     @VisibleForTesting
     WebAdminConfiguration(boolean enabled, Optional<PortSupplier> port, Optional<TlsConfiguration> tlsConfiguration,
-                          boolean enableCORS, String urlCORSOrigin, String host, List<String> additionalRoutes, Optional<String> jwtPublicKey, Optional<Integer> maxThreadCount, Optional<Integer> minThreadCount) {
+                          boolean enableCORS, String urlCORSOrigin, String host, List<String> additionalRoutes, Optional<String> jwtPublicKey, Optional<String> password, Optional<Integer> maxThreadCount, Optional<Integer> minThreadCount) {
         this.enabled = enabled;
         this.port = port;
         this.tlsConfiguration = tlsConfiguration;
@@ -182,6 +195,7 @@ public class WebAdminConfiguration {
         this.host = host;
         this.additionalRoutes = additionalRoutes;
         this.jwtPublicKey = jwtPublicKey;
+        this.password = password;
         this.maxThreadCount = maxThreadCount;
         this.minThreadCount = minThreadCount;
     }
@@ -230,6 +244,10 @@ public class WebAdminConfiguration {
         return host;
     }
 
+    public Optional<String> getPassword() {
+        return password;
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof WebAdminConfiguration) {
@@ -242,6 +260,7 @@ public class WebAdminConfiguration {
                 && Objects.equals(this.jwtPublicKey, that.jwtPublicKey)
                 && Objects.equals(this.urlCORSOrigin, that.urlCORSOrigin)
                 && Objects.equals(this.host, that.host)
+                && Objects.equals(this.password, that.password)
                 && Objects.equals(this.additionalRoutes, that.additionalRoutes)
                 && Objects.equals(this.minThreadCount, that.minThreadCount)
                 && Objects.equals(this.maxThreadCount, that.maxThreadCount);
@@ -251,6 +270,6 @@ public class WebAdminConfiguration {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(enabled, port, tlsConfiguration, enableCORS, jwtPublicKey, urlCORSOrigin, host, additionalRoutes, minThreadCount, maxThreadCount);
+        return Objects.hash(enabled, port, tlsConfiguration, enableCORS, jwtPublicKey, urlCORSOrigin, host, additionalRoutes, minThreadCount, maxThreadCount, password);
     }
 }

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/authentication/PasswordFilter.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/authentication/PasswordFilter.java
@@ -1,0 +1,62 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.authentication;
+
+import static spark.Spark.halt;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.google.common.base.Splitter;
+
+import spark.Request;
+import spark.Response;
+
+public class PasswordFilter implements AuthenticationFilter {
+    public static final String PASSWORD = "Password";
+    public static final String OPTIONS = "OPTIONS";
+
+    private final List<String> passwords;
+
+    @Inject
+    public PasswordFilter(String passwordString) {
+        this.passwords = Splitter.on(',')
+            .splitToList(passwordString);
+    }
+
+    @Override
+    public void handle(Request request, Response response) throws Exception {
+        if (!request.requestMethod().equals(OPTIONS)) {
+            Optional<String> password = Optional.ofNullable(request.headers(PASSWORD));
+
+            if (!password.isPresent()) {
+                halt(HttpStatus.UNAUTHORIZED_401, "No Password header.");
+            }
+            if (!passwords.contains(password.get())) {
+                halt(HttpStatus.UNAUTHORIZED_401, "Wrong Password header.");
+            }
+        }
+    }
+
+}

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/authentication/PasswordGenerator.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/authentication/PasswordGenerator.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.authentication;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Generates ephemeral WebAdmin passwords, enabling a secure setup without hardcoded credentials.
+ *
+ * The base64 URL alphabet is used as it excludes the comma, which {@link PasswordFilter} relies on
+ * as a password separator.
+ */
+public class PasswordGenerator {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final int ENTROPY_BYTE_COUNT = 32;
+
+    public static String generate() {
+        byte[] entropy = new byte[ENTROPY_BYTE_COUNT];
+        SECURE_RANDOM.nextBytes(entropy);
+        return ENCODER.encodeToString(entropy);
+    }
+
+    private PasswordGenerator() {
+
+    }
+}

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/authentication/PasswordFilterTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/authentication/PasswordFilterTest.java
@@ -1,0 +1,102 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.authentication;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import spark.HaltException;
+import spark.Request;
+import spark.Response;
+
+class PasswordFilterTest {
+    private PasswordFilter testee;
+
+    @BeforeEach
+    void setUp() {
+        testee = new PasswordFilter("abc,def");
+    }
+
+    @Test
+    void handleShouldDoNothingOnOptions() throws Exception {
+        Request request = mock(Request.class);
+        //Ensure we don't take OPTIONS string from the constant pool
+        when(request.requestMethod()).thenReturn(new String("OPTIONS"));
+        Response response = mock(Response.class);
+
+        testee.handle(request, response);
+
+        verifyNoMoreInteractions(response);
+    }
+
+
+    @Test
+    void handleShouldRejectRequestWithoutHeaders() {
+        Request request = mock(Request.class);
+        when(request.requestMethod()).thenReturn("GET");
+        when(request.headers()).thenReturn(ImmutableSet.of());
+
+        assertThatThrownBy(() -> testee.handle(request, mock(Response.class)))
+            .isInstanceOf(HaltException.class)
+            .extracting(e -> HaltException.class.cast(e).statusCode())
+            .isEqualTo(401);
+    }
+
+    @Test
+    void handleShouldRejectWrongPassword() {
+        Request request = mock(Request.class);
+        when(request.requestMethod()).thenReturn("GET");
+        when(request.headers("Password")).thenReturn("ghi");
+
+        assertThatThrownBy(() -> testee.handle(request, mock(Response.class)))
+            .isInstanceOf(HaltException.class)
+            .extracting(e -> HaltException.class.cast(e).statusCode())
+            .isEqualTo(401);
+    }
+
+    @Test
+    void handleShouldRejectBothPassword() {
+        Request request = mock(Request.class);
+        when(request.requestMethod()).thenReturn("GET");
+        when(request.headers("Password")).thenReturn("abc,def");
+
+        assertThatThrownBy(() -> testee.handle(request, mock(Response.class)))
+            .isInstanceOf(HaltException.class)
+            .extracting(e -> HaltException.class.cast(e).statusCode())
+            .isEqualTo(401);
+    }
+
+    @Test
+    void handleShouldAcceptValidPassword() throws Exception {
+        Request request = mock(Request.class);
+        when(request.requestMethod()).thenReturn("GET");
+        when(request.requestMethod()).thenReturn("GET");
+        when(request.headers("Password")).thenReturn("abc");
+
+        testee.handle(request, mock(Response.class));
+    }
+}

--- a/third-party/rspamd/README.md
+++ b/third-party/rspamd/README.md
@@ -89,8 +89,14 @@ If true `virusProcessor` and `rejectSpamProcessor` are honnered per user, at the
 - Declare the webadmin for Rspamd in `webadmin.properties`
 
 ```
+password.generate=false
 extensions.routes=org.apache.james.rspamd.route.FeedMessageRoute
 ```
+
+The sample configuration explicitly disables WebAdmin password generation so its local example commands can remain
+unauthenticated. Password generation is enabled by default when no `password` is explicitly configured. Do not disable
+WebAdmin authentication when exposing it beyond this local customization sample.
+
 How to use admin endpoint, see more at [Additional webadmin endpoints](README.md)
 
 - Docker compose file example: [docker-compose.yml](docker-compose.yml) or [docker-compose-distributed.yml](docker-compose-distributed.yml).

--- a/third-party/rspamd/sample-configuration/webadmin.properties
+++ b/third-party/rspamd/sample-configuration/webadmin.properties
@@ -19,6 +19,10 @@ enabled=true
 port=8000
 host=0.0.0.0
 
+# Disable WebAdmin authentication for this local customization sample.
+# Password generation defaults to true when no password is explicitly configured.
+password.generate=false
+
 # List of fully qualified class names that should be exposed over webadmin
 # in addition to your product default routes. Routes needs to be located
 # within the classpath or in the ./extensions-jars folder.


### PR DESCRIPTION
- be able to configure a static webadmin password
- auto-generate a webadmin password upon every James start, if the static password is not available, cf https://github.com/apache/james-project/pull/3104