### PR TITLE
[FIX] ImapRequestFrameDecoder drops a pipelined command after a LITERAL+ literal

### DIFF
--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -74,7 +74,6 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
     public static final int UNAUTHENTICATE_LITERAL_MAX_SIZE = Optional.ofNullable(System.getProperty("james.imap.unauthenticated.literal.max.size"))
         .map(Integer::parseInt)
         .orElse(8192);
-    private static final String SHOULD_BUFFER = "should_buffer";
 
     private final ImapDecoder decoder;
     private final int inMemorySizeLimit;
@@ -130,16 +129,24 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
 
         Map<String, Object> attachment = ctx.channel().attr(FRAME_DECODE_ATTACHMENT_ATTRIBUTE_KEY).get();
 
-        Pair<ImapRequestLineReader, Integer> readerAndSize = obtainReader(ctx, in, attachment, readerIndex);
-        if (readerAndSize == null) {
+        ParseAttempt attempt = obtainReader(ctx, in, attachment, readerIndex);
+        if (attempt == null) {
             return;
         }
 
-        parseImapMessage(ctx, in, attachment, readerAndSize, readerIndex)
+        parseImapMessage(ctx, in, attachment, attempt, readerIndex)
             .ifPresent(out::add);
     }
 
-    private Optional<ImapMessage> parseImapMessage(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, Pair<ImapRequestLineReader, Integer> readerAndSize, int readerIndex) throws DecodingException {
+    /**
+     * One parse round: {@code reader} reads from {@code buffer}, whose first {@code pendingSize}
+     * bytes come from {@link #pending} and whose tail is a view of Netty's cumulation.
+     * {@code buffer} is null when the reader is backed by a file rather than by memory.
+     */
+    private record ParseAttempt(ImapRequestLineReader reader, int size, ByteBuf buffer, int pendingSize) {
+    }
+
+    private Optional<ImapMessage> parseImapMessage(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, ParseAttempt attempt, int readerIndex) throws DecodingException {
         ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
 
         // check if the session was removed before to prevent a harmless NPE. See JAMES-1312
@@ -147,19 +154,20 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         if (session != null && session.getState() != ImapSessionState.LOGOUT) {
             try {
 
-                ImapMessage message = decoder.decode(readerAndSize.getLeft(), session);
+                ImapMessage message = decoder.decode(attempt.reader(), session);
 
                 // if size is != -1 the case was a literal. if thats the case we
                 // should not consume the line
                 // See JAMES-1199
-                if (readerAndSize.getRight() == -1) {
+                if (attempt.size() == -1) {
                     try {
-                        readerAndSize.getLeft().consumeLine();
+                        attempt.reader().consumeLine();
                     } catch (DecodingException | NettyImapRequestLineReader.NotEnoughDataException e) {
                         // Silent
                     }
                 }
 
+                commitConsumedBytes(in, attempt);
                 enableFraming(ctx);
 
                 attachment.clear();
@@ -170,8 +178,6 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
             } catch (NettyImapRequestLineReader.NotEnoughDataException e) {
                 // this exception was thrown because we don't have enough data yet
                 requestMoreData(ctx, in, attachment, e.getNeededSize(), readerIndex);
-            } finally {
-                attachment.remove(SHOULD_BUFFER);
             }
         } else {
             // The session was null so may be the case because the channel was already closed but there were still bytes in the buffer.
@@ -183,88 +189,81 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
         return Optional.empty();
     }
 
+    /**
+     * The command may not have used everything it was offered: the tail can already be the next
+     * pipelined command. Advance Netty's cumulation past what was actually consumed only, so the
+     * remainder is decoded as a command of its own instead of being dropped (see #3144).
+     */
+    private void commitConsumedBytes(ByteBuf in, ParseAttempt attempt) {
+        if (in != null && attempt.buffer() != null) {
+            in.skipBytes(Math.max(0, attempt.buffer().readerIndex() - attempt.pendingSize()));
+        }
+    }
+
     private void requestMoreData(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int neededData, int readerIndex) {
-        Boolean shouldBuffer = Optional.ofNullable(attachment.get(SHOULD_BUFFER)).map(Boolean.class::cast).orElse(true);
-        if (shouldBuffer) {
-            // store the needed data size for later usage
+        // Everything we could offer was not enough, so the rest has to come from the network:
+        // keep all of `in` and retry the whole parse once more bytes arrive.
+        in.readerIndex(readerIndex);
+        byte[] bytes = new byte[in.readableBytes()];
+        in.readBytes(bytes);
+        pending.add(bytes);
 
-            int i = in.readerIndex();
-            in.readerIndex(readerIndex);
-
-            byte[] bytes = new byte[in.readableBytes()];
-            in.readBytes(bytes);
-            pending.add(bytes);
-            in.readerIndex(i);
-
-            attachment.put(NEEDED_DATA, neededData - bytes.length);
-        } else {
+        // NEEDED_DATA keeps its historical meaning: how many bytes must still arrive from the
+        // network, beyond everything now held in `pending`. The reader that threw counted from
+        // the start of `pending`, so rebase to that delta - uploadToAFile()'s completion check
+        // relies on it. UNKNOWN_SIZE is a sentinel, not a count: pass it through untouched.
+        if (neededData == NettyImapRequestLineReader.NotEnoughDataException.UNKNOWN_SIZE) {
             attachment.put(NEEDED_DATA, neededData);
+        } else {
+            attachment.put(NEEDED_DATA, neededData - pending.stream().mapToInt(b -> b.length).sum());
         }
 
         // SwitchableDelimiterBasedFrameDecoder added further to JAMES-1436.
         disableFraming(ctx);
     }
 
-    private Pair<ImapRequestLineReader, Integer> obtainReader(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int readerIndex) throws IOException {
-        boolean retry = false;
-        ImapRequestLineReader reader;
+    private ParseAttempt obtainReader(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int readerIndex) throws IOException {
         // check if we failed before and if we already know how much data we
         // need to sucess next run
-        int size = -1;
         final Object rawSize = attachment.get(NEEDED_DATA);
-        if (rawSize != null) {
-            retry = true;
-            size = (Integer) rawSize;
-            // now see if the buffer hold enough data to process.
-            if (size != NettyImapRequestLineReader.NotEnoughDataException.UNKNOWN_SIZE) {
+        boolean retry = rawSize != null;
+        int size = retry ? (Integer) rawSize : NettyImapRequestLineReader.NotEnoughDataException.UNKNOWN_SIZE;
 
-                // check if we have a inMemorySize limit and if so if the
-                // expected size will fit into it
-                if (inMemorySizeLimit > 0 && inMemorySizeLimit < size) {
-                    ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
-                    int literalSizeLimit = literalSizeLimit(session);
-                    if (literalSizeLimit > 0 && size > literalSizeLimit) {
-                        throw new IOException("Attempt to write a too big chunk into a file. " + size + " and limit " + literalSizeLimit);
-                    }
+        // check if we have a inMemorySize limit and if so if the expected size will fit into it
+        if (size != NettyImapRequestLineReader.NotEnoughDataException.UNKNOWN_SIZE
+            && inMemorySizeLimit > 0 && inMemorySizeLimit < size) {
 
-                    // ok seems like it will not fit in the memory limit so we
-                    // need to store it in a temporary file
-                    uploadToAFile(ctx, in, attachment, size, readerIndex);
-                    return null;
-
-                } else {
-                    int readableBytes = in.readableBytes();
-                    byte[] bytes = new byte[readableBytes];
-                    in.readBytes(bytes);
-                    pending.add(bytes);
-
-                    int totalSize = pending.stream().mapToInt(m -> m.length).sum();
-                    if (totalSize >= size) {
-
-                        ByteBuf byteBufs = Unpooled.wrappedBuffer(pending.toArray(byte[][]::new));
-                        ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
-                        attachment.put(SHOULD_BUFFER, false);
-                        reader = new NettyImapRequestLineReader(ctx.channel(), byteBufs, retry, readerIndex, literalSizeLimit(session), maxFrameLength);
-                    } else {
-                        return null;
-                    }
-                }
-
-            } else {
-                if (pending.isEmpty()) {
-                    ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
-                    reader = new NettyImapRequestLineReader(ctx.channel(), in, retry, readerIndex, literalSizeLimit(session), maxFrameLength);
-                } else {
-                    ByteBuf byteBufs = Unpooled.wrappedBuffer(pending.toArray(byte[][]::new));
-                    ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
-                    reader = new NettyImapRequestLineReader(ctx.channel(), byteBufs, retry, readerIndex, literalSizeLimit(session), maxFrameLength);
-                }
-            }
-        } else {
             ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
-            reader = new NettyImapRequestLineReader(ctx.channel(), in, retry, readerIndex, literalSizeLimit(session), maxFrameLength);
+            int literalSizeLimit = literalSizeLimit(session);
+            if (literalSizeLimit > 0 && size > literalSizeLimit) {
+                throw new IOException("Attempt to write a too big chunk into a file. " + size + " and limit " + literalSizeLimit);
+            }
+
+            // ok seems like it will not fit in the memory limit so we
+            // need to store it in a temporary file
+            uploadToAFile(ctx, in, attachment, size, readerIndex);
+            return null;
         }
-        return Pair.of(reader, size);
+
+        int pendingSize = pending.stream().mapToInt(bytes -> bytes.length).sum();
+        ByteBuf buffer = pendingFollowedBy(in);
+        ImapSession session = ctx.channel().attr(IMAP_SESSION_ATTRIBUTE_KEY).get();
+        ImapRequestLineReader reader = new NettyImapRequestLineReader(ctx.channel(), buffer, retry, 0, literalSizeLimit(session), maxFrameLength);
+        return new ParseAttempt(reader, size, buffer, pendingSize);
+    }
+
+    /**
+     * What we kept from earlier rounds, followed by a *view* of what Netty holds now. Reading it
+     * leaves `in` untouched, so a parse that fails costs nothing and a parse that succeeds can
+     * hand back whatever it did not use - see {@link #commitConsumedBytes(ByteBuf, ParseAttempt)}.
+     */
+    private ByteBuf pendingFollowedBy(ByteBuf in) {
+        ByteBuf[] parts = new ByteBuf[pending.size() + 1];
+        for (int i = 0; i < pending.size(); i++) {
+            parts[i] = Unpooled.wrappedBuffer(pending.get(i));
+        }
+        parts[pending.size()] = in.slice(in.readerIndex(), in.readableBytes());
+        return Unpooled.wrappedBuffer(parts);
     }
 
     private void uploadToAFile(ChannelHandlerContext ctx, ByteBuf in, Map<String, Object> attachment, int size, int readerIndex) throws IOException {
@@ -294,7 +293,7 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
                         // Not doing this causes IDLEd IMAP connections to clear IMAP append literal while they are processed.
                         Object removed = attachment.remove(SUBSCRIPTION);
                         try {
-                            parseImapMessage(ctx, null, attachment, Pair.of(reader, size), readerIndex)
+                            parseImapMessage(ctx, null, attachment, new ParseAttempt(reader, size, null, 0), readerIndex)
                                 .ifPresent(ctx::fireChannelRead);
                         } catch (Exception e) {
                             if (removed instanceof Disposable) {

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerAppendNonSynchronizedLitteralsTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerAppendNonSynchronizedLitteralsTest.java
@@ -21,11 +21,13 @@ package org.apache.james.imapserver.netty;
 
 import static org.apache.james.jmap.JMAPTestingConstants.LOCALHOST_IP;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 import org.apache.james.mailbox.model.MailboxPath;
 import org.junit.jupiter.api.AfterEach;
@@ -125,6 +127,34 @@ class IMAPServerAppendNonSynchronizedLitteralsTest extends AbstractIMAPServerTes
             msg + "\r\nA005 NOOP").getBytes(StandardCharsets.UTF_8)));
 
         assertThat(new String(readBytes(clientConnection), StandardCharsets.US_ASCII)).contains("APPEND completed.");
+    }
+
+    /**
+     * See #3144. Unlike {@link #partialCommandAfterNonSynchronizedLiteralShouldNotFail}, this
+     * asserts the *second* pipelined command actually gets a response, not just the first.
+     */
+    @Test
+    void secondPipelinedAppendAfterLiteralShouldNotBeLost() throws Exception {
+        clientConnection.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS).getBytes(StandardCharsets.UTF_8)));
+        readBytes(clientConnection);
+
+        String msg1 = "From: " + USER.asString() + "\r\nSubject: msg1\r\n\r\nbody1\r\n";
+        String msg2 = "From: " + USER.asString() + "\r\nSubject: msg2\r\n\r\nbody2\r\n";
+        String cmd1 = "A004 APPEND INBOX {" + msg1.getBytes(StandardCharsets.UTF_8).length + "+}\r\n" + msg1 + "\r\n";
+        String cmd2 = "A005 APPEND INBOX {" + msg2.getBytes(StandardCharsets.UTF_8).length + "+}\r\n" + msg2 + "\r\n";
+
+        // Both APPENDs pipelined in a single write, as a client does when it doesn't want a
+        // round trip between two uploads (e.g. copying a just-sent message into Sent while also
+        // syncing a Draft).
+        clientConnection.write(ByteBuffer.wrap((cmd1 + cmd2).getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(readStringUntil(clientConnection, s -> s.contains("A004 OK")))
+            .anyMatch(s -> s.contains("APPEND completed"));
+
+        // Without the fix, this never arrives at all - bound the wait rather than block forever.
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+            assertThat(readStringUntil(clientConnection, s -> s.contains("A005 OK")))
+                .anyMatch(s -> s.contains("APPEND completed")));
     }
 
     @Test


### PR DESCRIPTION
> **Updated after review.** The originally submitted fix was wrong and has been replaced (force-push). The bug and the repro below are unchanged; the *fix* is different. Details in "What changed since the first version" at the bottom. Sorry for the churn, @chibenwa — the approval came in while I was still validating against the full `protocols-imap4` suite, and that suite is what caught it.

## Problem

When a client pipelines two commands using LITERAL+ (RFC 7888), the second command's bytes are silently dropped.

Example: two `APPEND`s back to back, no wait for a response in between, both delivered in a single TCP read.

- No error.
- No timeout signal to the client.
- No server-side log trace.
- The tag is simply never answered, and the message is never persisted.

Minimal repro (raw IMAP, after `LOGIN`), sent as one write:

```
a1 APPEND INBOX {46+}
From: user@example.com
Subject: msg1

body1

a2 APPEND INBOX {46+}
From: user@example.com
Subject: msg2

body2

```

Result: `a1 OK ... APPEND completed.` arrives. `a2` never does. `INBOX` only gains one new message, not two.

## How this was found

Tool: Dovecot's `imaptest` (official `dovecot/imaptest` Docker image).

Target: a live DynamoDB-backed James 3.9.0 deployment (contrabass-mailserver, an unrelated third-party project), under concurrent load with LITERAL+ `APPEND`s carrying custom keyword flags.

Command:
```
docker run --rm dovecot/imaptest host=host.docker.internal port=1143 \
  user=user@localhost pass=password123 clients=4 secs=30 \
  random_msg_size=2000 msgs=20 no_tracking
```

`imaptest` reported specific commands stuck indefinitely:
```
 - 63 stalled for 16 secs in command: 10 APPEND "INBOX" (\Flagged \Seen \Draft) "31-Aug-2026 01:56:40 +0000" {468+}
 - 118 stalled for 16 secs in command: 10 APPEND "INBOX" (\Flagged \Draft $Label2) {821+}
 - 63 stalled for 51 secs in command: 10 APPEND "INBOX" (\Flagged \Seen \Draft) "31-Aug-2026 01:56:40 +0000" {468+}
```

A follow-up run with `rawlog` captured the exact wire traffic (`O:` = client to server, `I:` = server to client, binary literal payload elided):
```
O: 12.10 APPEND "INBOX" (\Flagged \Seen \Draft $Label1 $Label5) "31-Aug-2026 02:01:10 +0000" {1041+}
O: <1041 bytes of literal content>
O: 12.11 APPEND "INBOX" "31-Aug-2026 02:01:10 +0000" {419+}
O: <419 bytes of literal content>
...
I: * 18 EXISTS
I: * 2 RECENT
I: 12.10 OK [APPENDUID 328955991 339] APPEND completed.
```

`12.11` never gets a line again. Not delayed — gone.

A minimal raw-socket reproduction (just two `LITERAL+` `APPEND`s, no other traffic) isolated this to a pure decoder issue. Checking the mailbox afterward confirmed `EXISTS` only advanced by one: the message itself, not just the response, never made it in.

## Root cause

`ImapRequestFrameDecoder` accumulates bytes into `pending` and parses over that snapshot. Copying everything Netty currently holds is deliberate and necessary — see below — but `pending` has no notion of how much the `ImapRequestLineReader` actually consumed from it. On a successful parse, `parseImapMessage()` throws the whole thing away:

```java
if (!pending.isEmpty()) {
    pending.clear();  // discards whatever of the *next* command was copied in
}
```

So when one read carries a literal-bearing command *plus* the start of another command, the trailing command is copied into `pending`, never looked at, and dropped.

Note what is **not** the bug: the greedy copy itself. `NotEnoughDataException#getNeededSize()` returns `size + read + crlf`, where `read` only counts characters pulled through `nextChar()` — bytes already consumed by an earlier `read(int, boolean)` on the same line are not included. For a command carrying several literals that value under-reports, so it cannot be used as an exact bound. Copying greedily and comparing loosely is precisely what makes that inaccuracy harmless today.

## Fix

Stop consuming before we know how much was used.

`obtainReader()` now parses against a *view* — `pending` followed by a slice of Netty's cumulation — instead of copying `in` and advancing it up front. On a successful parse, the cumulation is advanced by exactly what the command consumed:

```java
private void commitConsumedBytes(ByteBuf in, ParseAttempt attempt) {
    if (in != null && attempt.buffer() != null) {
        in.skipBytes(Math.max(0, attempt.buffer().readerIndex() - attempt.pendingSize()));
    }
}
```

Anything the command did not touch stays in `in` and is decoded as the next command by the existing `ByteToMessageDecoder` loop.

The failure path is deliberately left as it is today: if `pending` plus everything currently buffered still is not enough, the rest genuinely has to come from the network, so all of it is kept and the parse is retried when more arrives. That is what keeps multi-literal commands working.

One piece of size arithmetic remains: `NEEDED_DATA` keeps its historical meaning — how many bytes must still arrive beyond what `pending` holds — because `uploadToAFile()`'s completion check depends on it. Since the reader now counts from the start of `pending`, `requestMoreData()` rebases the reported size to that delta, leaving the `UNKNOWN_SIZE` sentinel untouched.

Because the parser now decides for itself when a retry is worthwhile, the `should_buffer` bookkeeping and the `totalSize >= size` comparison in `obtainReader()` are both gone. Net diff is negative (**+76 / −77**), and `uploadToAFile()` is left untouched.

## Testing

Added `IMAPServerAppendNonSynchronizedLitteralsTest#secondPipelinedAppendAfterLiteralShouldNotBeLost`.

- Placed right next to the existing `partialCommandAfterNonSynchronizedLiteralShouldNotFail` test.
- That existing test already pipelines a second command behind a literal, but only asserts the first `APPEND`'s own completion. It never checks whether the trailing command got a response at all.
- That's exactly how this went unnoticed.
- The new test pipelines two LITERAL+ `APPEND`s in one write and asserts both get a tagged `OK ... APPEND completed` response (time-bounded, since without the fix the second response never arrives).

Full module suite (`mvn clean test -pl server/protocols/protocols-imap4`, 36 classes, 630 tests) was run repeatedly in a Linux container, side by side against an unmodified `master` in the same environment. The only failures ever observed are pre-existing flaky ones that fail at the same rate on both trees (a response-desync signature occasionally hitting `IMAPServerPartialFetchTest`, `IMAPServerConnectionCheckTest` and `largeAppendsShouldWork` — e.g. `allowConnectWithUnbannedIp`: 5/200 repetitions on `master` vs 0/100 with this patch). The new regression test times out on an unmodified tree and passes with the patch, in both directions.

Also manually verified against a live James deployment with the original `imaptest` repro: both the missing response and the missing mailbox data (`EXISTS` count) are resolved.

## What changed since the first version

The first version bounded each read to the literal size from `getNeededSize()`, on the theory that the greedy copy was itself the bug. Running the full `protocols-imap4` suite showed that is not viable:

- `IMAPServerAppendNoLimitTest#smallAppendsShouldWork`, `IMAPServerPartialFetchTest` — `NegativeArraySizeException`, because the reported size excludes literal bytes already consumed.
- `IMAPServerSearchTest#passing2literalOnSameNetworkPackageWhenMoreThan16Chars` — deadlock, for the same reason: a command with two literals never gets enough data.

The greedy copy turned out to be load-bearing. The current version leaves it alone and fixes only the success path, where the bug actually is.

