### PR TITLE
[ENHANCEMENT] JMAP: allow disabling webpush 

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConfiguration.java
@@ -313,6 +313,7 @@ public class RabbitMQConfiguration {
     private static final String EVENT_BUS_NOTIFICATION_QUEUE_AUTO_DELETE = "notification.queue.autoDelete";
     private static final String EVENT_BUS_PUBLISH_CONFIRM_ENABLED = "event.bus.publish.confirm.enabled";
     private static final String EVENT_BUS_PROPAGATE_DISPATCH_ERROR = "event.bus.propagate.dispatch.error";
+    private static final String EVENT_BUS_PUBLISH_ON_NO_GROUPS = "eventbus.publishOnNoGroups";
     private static final String TASK_QUEUE_CONSUMER_TIMEOUT = "task.queue.consumer.timeout";
     private static final String VHOST = "vhost";
 
@@ -415,6 +416,7 @@ public class RabbitMQConfiguration {
         private Optional<Boolean> eventBusNotificationDurabilityEnabled;
         private Optional<Boolean> eventBusNotificationQueueAutoDelete;
         private Optional<Boolean> eventBusPropagateDispatchError;
+        private Optional<Boolean> eventBusPublishOnNoGroups;
         private Optional<String> vhost;
         private Optional<Duration> taskQueueConsumerTimeout;
 
@@ -443,6 +445,7 @@ public class RabbitMQConfiguration {
             this.vhost = Optional.empty();
             this.taskQueueConsumerTimeout = Optional.empty();
             this.eventBusPropagateDispatchError = Optional.empty();
+            this.eventBusPublishOnNoGroups = Optional.empty();
         }
 
         public Builder maxRetries(int maxRetries) {
@@ -535,6 +538,11 @@ public class RabbitMQConfiguration {
             return this;
         }
 
+        public Builder eventBusPublishOnNoGroups(Boolean eventBusPublishOnNoGroups) {
+            this.eventBusPublishOnNoGroups = Optional.ofNullable(eventBusPublishOnNoGroups);
+            return this;
+        }
+
         public Builder eventBusPropagateDispatchError(Boolean eventBusPropagateDispatchError) {
             this.eventBusPropagateDispatchError = Optional.ofNullable(eventBusPropagateDispatchError);
             return this;
@@ -598,7 +606,8 @@ public class RabbitMQConfiguration {
                     eventBusNotificationQueueAutoDelete.orElse(Constants.AUTO_DELETE),
                     vhost,
                     taskQueueConsumerTimeout.orElse(DEFAULT_TASK_QUEUE_CONSUMER_TIMEOUT),
-                    eventBusPropagateDispatchError.orElse(true));
+                    eventBusPropagateDispatchError.orElse(true),
+                    eventBusPublishOnNoGroups.orElse(true));
         }
 
         private List<Host> hostsDefaultingToUri() {
@@ -675,6 +684,7 @@ public class RabbitMQConfiguration {
             .eventBusNotificationQueueAutoDelete(configuration.getBoolean(EVENT_BUS_NOTIFICATION_QUEUE_AUTO_DELETE, null))
             .eventBusPublishConfirmEnabled(configuration.getBoolean(EVENT_BUS_PUBLISH_CONFIRM_ENABLED, null))
             .eventBusPropagateDispatchError(configuration.getBoolean(EVENT_BUS_PROPAGATE_DISPATCH_ERROR, null))
+            .eventBusPublishOnNoGroups(configuration.getBoolean(EVENT_BUS_PUBLISH_ON_NO_GROUPS, null))
             .vhost(vhost)
             .taskQueueConsumerTimeout(taskQueueConsumerTimeout)
             .build();
@@ -752,6 +762,7 @@ public class RabbitMQConfiguration {
     private final Optional<String> vhost;
     private final Duration taskQueueConsumerTimeout;
     private final boolean eventBusPropagateDispatchError;
+    private final boolean eventBusPublishOnNoGroups;
 
     private RabbitMQConfiguration(URI uri, URI managementUri, ManagementCredentials managementCredentials, int maxRetries, int minDelayInMs,
                                   int connectionTimeoutInMs, int channelRpcTimeoutInMs, int handshakeTimeoutInMs, int shutdownTimeoutInMs,
@@ -759,7 +770,8 @@ public class RabbitMQConfiguration {
                                   boolean useQuorumQueues, Optional<Integer> quorumQueueDeliveryLimit, int quorumQueueReplicationFactor, List<Host> hosts, Optional<Long> queueTTL,
                                   boolean eventBusPublishConfirmEnabled, boolean eventBusNotificationDurabilityEnabled,
                                   boolean eventBusNotificationQueueAutoDelete,
-                                  Optional<String> vhost, Duration taskQueueConsumerTimeout, boolean eventBusPropagateDispatchError) {
+                                  Optional<String> vhost, Duration taskQueueConsumerTimeout, boolean eventBusPropagateDispatchError,
+                                  boolean eventBusPublishOnNoGroups) {
         this.uri = uri;
         this.managementUri = managementUri;
         this.managementCredentials = managementCredentials;
@@ -784,6 +796,7 @@ public class RabbitMQConfiguration {
         this.vhost = vhost;
         this.taskQueueConsumerTimeout = taskQueueConsumerTimeout;
         this.eventBusPropagateDispatchError = eventBusPropagateDispatchError;
+        this.eventBusPublishOnNoGroups = eventBusPublishOnNoGroups;
     }
 
     public URI getUri() {
@@ -904,6 +917,10 @@ public class RabbitMQConfiguration {
         return quorumQueueReplicationFactor;
     }
 
+    public boolean eventBusPublishOnNoGroups() {
+        return eventBusPublishOnNoGroups;
+    }
+
     public boolean eventBusPropagateDispatchError() {
         return eventBusPropagateDispatchError;
     }
@@ -936,7 +953,8 @@ public class RabbitMQConfiguration {
                 && Objects.equals(this.eventBusNotificationQueueAutoDelete, that.eventBusNotificationQueueAutoDelete)
                 && Objects.equals(this.vhost, that.vhost)
                 && Objects.equals(this.taskQueueConsumerTimeout, that.taskQueueConsumerTimeout)
-                && Objects.equals(this.eventBusPropagateDispatchError, that.eventBusPropagateDispatchError);
+                && Objects.equals(this.eventBusPropagateDispatchError, that.eventBusPropagateDispatchError)
+                && Objects.equals(this.eventBusPublishOnNoGroups, that.eventBusPublishOnNoGroups);
         }
         return false;
     }
@@ -945,6 +963,7 @@ public class RabbitMQConfiguration {
     public final int hashCode() {
         return Objects.hash(uri, managementUri, maxRetries, minDelayInMs, connectionTimeoutInMs, quorumQueueReplicationFactor, quorumQueueDeliveryLimit, useQuorumQueues, hosts,
             channelRpcTimeoutInMs, handshakeTimeoutInMs, shutdownTimeoutInMs, networkRecoveryIntervalInMs, managementCredentials, useSsl, useSslManagement,
-            sslConfiguration, queueTTL, eventBusPublishConfirmEnabled, eventBusNotificationDurabilityEnabled, eventBusNotificationQueueAutoDelete, vhost, taskQueueConsumerTimeout, eventBusPropagateDispatchError);
+            sslConfiguration, queueTTL, eventBusPublishConfirmEnabled, eventBusNotificationDurabilityEnabled, eventBusNotificationQueueAutoDelete, vhost, taskQueueConsumerTimeout, eventBusPropagateDispatchError,
+            eventBusPublishOnNoGroups);
     }
 }

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQConfigurationTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQConfigurationTest.java
@@ -598,6 +598,32 @@ class RabbitMQConfigurationTest {
             .isFalse();
     }
 
+    @Test
+    void eventBusPublishOnNoGroupsShouldBeTrueByDefault() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("uri", "amqp://james:james@rabbitmqhost:5672");
+        configuration.addProperty("management.uri", "http://james:james@rabbitmqhost:15672/api/");
+        configuration.addProperty("management.user", DEFAULT_USER);
+        configuration.addProperty("management.password", DEFAULT_PASSWORD_STRING);
+
+        assertThat(RabbitMQConfiguration.from(configuration).eventBusPublishOnNoGroups())
+            .isTrue();
+    }
+
+    @Test
+    void eventBusPublishOnNoGroupsShouldBeDisabledWhenConfiguredFalse() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("uri", "amqp://james:james@rabbitmqhost:5672");
+        configuration.addProperty("management.uri", "http://james:james@rabbitmqhost:15672/api/");
+        configuration.addProperty("management.user", DEFAULT_USER);
+        configuration.addProperty("management.password", DEFAULT_PASSWORD_STRING);
+
+        configuration.addProperty("eventbus.publishOnNoGroups", "false");
+
+        assertThat(RabbitMQConfiguration.from(configuration).eventBusPublishOnNoGroups())
+            .isFalse();
+    }
+
     @Nested
     class ManagementCredentialsTest {
         @Test

--- a/docs/modules/servers/partials/configure/jmap.adoc
+++ b/docs/modules/servers/partials/configure/jmap.adoc
@@ -104,6 +104,12 @@ then `apiUrl, downloadUrl, uploadUrl, eventSourceUrl, webSocketUrl` in response 
 If the HTTP request to Jmap session endpoint has the `X-JMAP-WEBSOCKET-PREFIX` header with the value `ws://new-domain/prefix`,
 then `capabilities."urn:ietf:params:jmap:websocket".url` in response will be "ws://new-domain/prefix/jmap/ws".
 
+| webpush.enabled
+| Optional boolean. Defaults to true. Whether WebPush is enableded. When set to false the push listener is not
+registered at all - no group registration is created on the JMAP event bus - and `PushSubscription/get` and
+`PushSubscription/set` answer an `unknownMethod` JMAP error. Note that this does not affect JMAP push over
+WebSocket nor EventSource, which do not rely on push subscriptions.
+
 | webpush.prevent.server.side.request.forgery
 | Optional boolean. Prevent server side request forgery by preventing calls to the private network ranges. Defaults to true, can be disabled for testing.
 

--- a/docs/modules/servers/partials/configure/rabbitmq.adoc
+++ b/docs/modules/servers/partials/configure/rabbitmq.adoc
@@ -117,6 +117,10 @@ collected once it has stayed unused for the TTL, which also cleans up the queues
 | Whether to propagate errors back to the callers when eventbus fails to dispatch group events to RabbitMQ (then store the failed events in the event dead letters).
 Optional boolean, defaults to true.
 
+| eventbus.publishOnNoGroups
+| Whether to publish group events to RabbitMQ even when this node has no group listener registered. Optional boolean,
+defaults to true.
+
 | vhost
 | Optional string. This parameter is only a workaround to support invalid URIs containing character like '_'.
 You still need to specify the vhost in the uri parameter.

--- a/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
@@ -69,13 +69,15 @@ public class EventDispatcher {
     private final ListenerExecutor listenerExecutor;
     private final EventDeadLetters deadLetters;
     private final RabbitMQConfiguration configuration;
+    private final GroupRegistrationHandler groupRegistrationHandler;
 
     private final DispatchingFailureGroup dispatchingFailureGroup;
 
     EventDispatcher(NamingStrategy namingStrategy, EventBusId eventBusId, EventSerializer eventSerializer, Sender sender,
                     LocalListenerRegistry localListenerRegistry,
                     ListenerExecutor listenerExecutor,
-                    EventDeadLetters deadLetters, RabbitMQConfiguration configuration) {
+                    EventDeadLetters deadLetters, RabbitMQConfiguration configuration,
+                    GroupRegistrationHandler groupRegistrationHandler) {
         this.namingStrategy = namingStrategy;
         this.eventSerializer = eventSerializer;
         this.sender = sender;
@@ -89,6 +91,7 @@ public class EventDispatcher {
         this.listenerExecutor = listenerExecutor;
         this.deadLetters = deadLetters;
         this.configuration = configuration;
+        this.groupRegistrationHandler = groupRegistrationHandler;
         this.dispatchingFailureGroup = new DispatchingFailureGroup(namingStrategy.getEventBusName());
     }
 
@@ -188,6 +191,9 @@ public class EventDispatcher {
     }
 
     private Mono<Void> remoteGroupsDispatch(byte[] serializedEvent, Event event) {
+        if (shouldSkipGroupsDispatch()) {
+            return Mono.empty();
+        }
         return remoteDispatchWithAcks(serializedEvent)
             .doOnError(ex -> LOGGER.error(
                 "cannot dispatch event of type '{}' belonging '{}' with id '{}' to remote groups, store it into dead letter",
@@ -200,6 +206,9 @@ public class EventDispatcher {
     }
 
     private Mono<Void> remoteGroupsDispatch(byte[] serializedEvent, List<Event> events) {
+        if (shouldSkipGroupsDispatch()) {
+            return Mono.empty();
+        }
         return remoteDispatchWithAcks(serializedEvent)
             .onErrorResume(ex -> Flux.fromIterable(events)
                 .map(event -> {
@@ -212,6 +221,11 @@ public class EventDispatcher {
                     return deadLetters.store(dispatchingFailureGroup, event);
                 })
                 .then(propagateErrorIfNeeded(ex)));
+    }
+
+    private boolean shouldSkipGroupsDispatch() {
+        return !configuration.eventBusPublishOnNoGroups()
+            && groupRegistrationHandler.registeredGroups().isEmpty();
     }
 
     private Mono<Void> propagateErrorIfNeeded(Throwable throwable) {

--- a/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
@@ -116,7 +116,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
             keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, configurations, metricFactory);
             groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, eventDeadLetters, listenerExecutor, configurations);
-            eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters, configurations.rabbitMQConfiguration());
+            eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters, configurations.rabbitMQConfiguration(), groupRegistrationHandler);
 
             eventDispatcher.start();
             keyRegistrationHandler.start();
@@ -137,7 +137,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
             keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, configurations, metricFactory);
             groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, eventDeadLetters, listenerExecutor, configurations);
-            eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters, configurations.rabbitMQConfiguration());
+            eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters, configurations.rabbitMQConfiguration(), groupRegistrationHandler);
 
             keyRegistrationHandler.declareQueue();
 

--- a/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusTest.java
+++ b/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusTest.java
@@ -53,6 +53,8 @@ import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -432,6 +434,79 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                     .getBody();
 
                 return eventSerializer.asEvent(new String(eventInBytes, StandardCharsets.UTF_8)).event();
+            }
+        }
+
+    }
+
+    @Nested
+    class PublishOnNoGroupsTest {
+        private String probeQueueName;
+        private RabbitMQEventBus optimizedEventBus;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            probeQueueName = "test-publishOnNoGroups-" + UUID.randomUUID();
+            Sender sender = rabbitMQExtension.getSender();
+            sender.declareQueue(QueueSpecification.queue(probeQueueName)
+                    .durable(!DURABLE)
+                    .exclusive(!EXCLUSIVE)
+                    .autoDelete(!AUTO_DELETE)
+                    .arguments(NO_ARGUMENTS))
+                .block();
+            // Group dispatches are the ones published with the empty routing key
+            sender.bind(BindingSpecification.binding()
+                    .exchange(TEST_NAMING_STRATEGY.exchange())
+                    .queue(probeQueueName)
+                    .routingKey(EMPTY_ROUTING_KEY))
+                .block();
+
+            optimizedEventBus = new RabbitMQEventBus(TEST_NAMING_STRATEGY, sender, rabbitMQExtension.getReceiverProvider(),
+                eventSerializer, routingKeyConverter, memoryEventDeadLetters, new RecordingMetricFactory(),
+                rabbitMQExtension.getRabbitChannelPool(), EventBusId.random(),
+                new RabbitMQEventBus.Configurations(rabbitMQExtension.getRabbitMQ().getConfigurationBuilder()
+                    .eventBusPublishOnNoGroups(false)
+                    .build(), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION));
+            optimizedEventBus.start();
+        }
+
+        @AfterEach
+        void tearDown() {
+            optimizedEventBus.stop();
+            rabbitMQExtension.getSender().delete(QueueSpecification.queue(probeQueueName)).block();
+        }
+
+        @Test
+        void dispatchShouldNotPublishToGroupsWhenNoGroupIsRegistered() {
+            optimizedEventBus.dispatch(EVENT, NO_KEYS).block();
+
+            assertThat(dequeueEventWithin(Duration.ofSeconds(2))).isEmpty();
+        }
+
+        @Test
+        void dispatchShouldPublishToGroupsWhenAGroupIsRegistered() {
+            optimizedEventBus.register(newListener(), GROUP_A);
+
+            optimizedEventBus.dispatch(EVENT, NO_KEYS).block();
+
+            assertThat(dequeueEventWithin(Duration.ofSeconds(10))).contains(EVENT);
+        }
+
+        @Test
+        void dispatchShouldPublishToGroupsWithoutRegistrationWhenOptionIsEnabled() {
+            // eventBus runs with the default configuration: `eventbus.publishOnNoGroups` is true
+            eventBus.dispatch(EVENT, NO_KEYS).block();
+
+            assertThat(dequeueEventWithin(Duration.ofSeconds(10))).contains(EVENT);
+        }
+
+        private Optional<Event> dequeueEventWithin(Duration timeout) {
+            try (Receiver receiver = rabbitMQExtension.getReceiverProvider().createReceiver()) {
+                return Optional.ofNullable(receiver.consumeAutoAck(probeQueueName)
+                        .next()
+                        .timeout(timeout, Mono.empty())
+                        .block())
+                    .map(delivery -> eventSerializer.asEvent(new String(delivery.getBody(), StandardCharsets.UTF_8)).event());
             }
         }
     }

--- a/server/apps/distributed-app/sample-configuration/jmap.properties
+++ b/server/apps/distributed-app/sample-configuration/jmap.properties
@@ -41,5 +41,9 @@ tls.secret=james72laBalle
 # oidc.token.cache.maxSize=10000
 # oidc.token.cache.redis.command.timeout=3s
 
+# Whether WebPush is supported. Defaults to true. When set to false the push listener is not registered at all and
+# PushSubscription/get and PushSubscription/set answer an `unknownMethod` JMAP error.
+# webpush.enabled=false
+
 # Prevent server side request forgery by preventing calls to the private network ranges. Defaults to true, can be disabled for testing.
 # webpush.prevent.server.side.request.forgery=false

--- a/server/apps/memory-app/sample-configuration/jmap.properties
+++ b/server/apps/memory-app/sample-configuration/jmap.properties
@@ -38,5 +38,9 @@ delay.sends.enabled=true
 # oidc.token.cache.expiration=5m
 # oidc.token.cache.maxSize=10000
 
+# Whether WebPush is supported. Defaults to true. When set to false the push listener is not registered at all and
+# PushSubscription/get and PushSubscription/set answer an `unknownMethod` JMAP error.
+# webpush.enabled=false
+
 # Prevent server side request forgery by preventing calls to the private network ranges. Defaults to true, can be disabled for testing.
 # webpush.prevent.server.side.request.forgery=false

--- a/server/apps/postgres-app/sample-configuration/jmap.properties
+++ b/server/apps/postgres-app/sample-configuration/jmap.properties
@@ -41,5 +41,9 @@ tls.secret=james72laBalle
 # oidc.token.cache.maxSize=10000
 # oidc.token.cache.redis.command.timeout=3s
 
+# Whether WebPush is supported. Defaults to true. When set to false the push listener is not registered at all and
+# PushSubscription/get and PushSubscription/set answer an `unknownMethod` JMAP error.
+# webpush.enabled=false
+
 # Prevent server side request forgery by preventing calls to the private network ranges. Defaults to true, can be disabled for testing.
 # webpush.prevent.server.side.request.forgery=false

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
@@ -40,6 +40,7 @@ import org.apache.james.events.RoutingKeyConverter;
 import org.apache.james.jmap.InjectionKeys;
 import org.apache.james.jmap.change.Factory;
 import org.apache.james.jmap.change.JmapEventSerializer;
+import org.apache.james.jmap.core.JmapRfc8621Configuration;
 import org.apache.james.jmap.pushsubscription.PushListener;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
@@ -59,12 +60,15 @@ public class JMAPEventBusModule extends AbstractModule {
     }
 
     @ProvidesIntoSet
-    InitializationOperation workQueue(@Named(InjectionKeys.JMAP) RabbitMQEventBus instance, PushListener pushListener) {
+    InitializationOperation workQueue(@Named(InjectionKeys.JMAP) RabbitMQEventBus instance, PushListener pushListener,
+                                      JmapRfc8621Configuration jmapConfiguration) {
         return InitilizationOperationBuilder
             .forClass(RabbitMQEventBus.class)
             .init(() -> {
                 instance.start();
-                instance.register(pushListener);
+                if (jmapConfiguration.webPushEnabled()) {
+                    instance.register(pushListener);
+                }
             });
     }
 

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JmapGuiceProbe.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JmapGuiceProbe.java
@@ -22,12 +22,14 @@ package org.apache.james.jmap;
 import static org.apache.james.jmap.utils.AccountIdUtil.toVacationAccountId;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 import jakarta.inject.Inject;
 
 import org.apache.james.core.Username;
 import org.apache.james.events.EventBus;
 import org.apache.james.events.EventListener;
+import org.apache.james.events.Group;
 import org.apache.james.jmap.api.change.EmailChange;
 import org.apache.james.jmap.api.change.EmailChangeRepository;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
@@ -73,6 +75,10 @@ public class JmapGuiceProbe implements GuiceProbe {
 
     public Port getJmapPort() {
         return jmapServer.getPort();
+    }
+
+    public Collection<Group> listRegisteredGroups() {
+        return eventBus.listRegisteredGroups();
     }
 
     public void addEventListener(EventListener.GroupEventListener listener) {

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JmapEventBusModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JmapEventBusModule.java
@@ -20,18 +20,39 @@
 package org.apache.james.modules.protocols;
 
 import org.apache.james.events.EventBus;
-import org.apache.james.events.EventListener;
 import org.apache.james.jmap.InjectionKeys;
+import org.apache.james.jmap.core.JmapRfc8621Configuration;
 import org.apache.james.jmap.pushsubscription.PushListener;
+import org.apache.james.modules.mailbox.ListenersConfiguration;
+import org.apache.james.modules.mailbox.MailboxListenersLoaderImpl;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.ProvidesIntoSet;
 import com.google.inject.name.Names;
 
 public class JmapEventBusModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(EventBus.class).annotatedWith(Names.named(InjectionKeys.JMAP)).to(EventBus.class);
-        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class).addBinding().to(PushListener.class);
+    }
+
+    /**
+     * Registered here rather than within the {@link org.apache.james.events.EventListener.ReactiveGroupEventListener}
+     * multibinder as WebPush can be turned off, in which case no registration - thus no group, and no queue for
+     * distributed event buses - should be created at all.
+     */
+    @ProvidesIntoSet
+    InitializationOperation registerPushListener(EventBus eventBus, PushListener pushListener,
+                                                 JmapRfc8621Configuration jmapConfiguration,
+                                                 ListenersConfiguration listenersConfiguration) {
+        return InitilizationOperationBuilder
+            .forClass(MailboxListenersLoaderImpl.class)
+            .init(() -> {
+                if (jmapConfiguration.webPushEnabled() && listenersConfiguration.isGroupListenerConsumptionEnabled()) {
+                    eventBus.register(pushListener);
+                }
+            });
     }
 }

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebPushDisabledContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebPushDisabledContract.scala
@@ -1,0 +1,144 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.rfc8621.contract
+
+import io.netty.handler.codec.http.HttpHeaderNames.ACCEPT
+import io.restassured.RestAssured.{`given`, requestSpecification}
+import io.restassured.http.ContentType.JSON
+import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
+import org.apache.http.HttpStatus.SC_OK
+import org.apache.james.GuiceJamesServer
+import org.apache.james.jmap.JmapGuiceProbe
+import org.apache.james.jmap.change.MailboxChangeListenerGroup
+import org.apache.james.jmap.core.JmapRfc8621Configuration
+import org.apache.james.jmap.core.ResponseObject.SESSION_STATE
+import org.apache.james.jmap.http.UserCredential
+import org.apache.james.jmap.pushsubscription.PushListenerGroup
+import org.apache.james.jmap.rfc8621.contract.Fixture._
+import org.apache.james.utils.DataProbeImpl
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+object WebPushDisabledContract {
+  val configuration: JmapRfc8621Configuration = JmapRfc8621Configuration(
+    urlPrefixString = "http://127.0.0.1",
+    websocketPrefixString = "ws://127.0.0.1",
+    webPushEnabled = false)
+}
+
+trait WebPushDisabledContract {
+  @BeforeEach
+  def setUp(server: GuiceJamesServer): Unit = {
+    server.getProbe(classOf[DataProbeImpl])
+      .fluent()
+      .addDomain(DOMAIN.asString())
+      .addUser(BOB.asString(), BOB_PASSWORD)
+
+    requestSpecification = baseRequestSpecBuilder(server)
+      .setAuth(authScheme(UserCredential(BOB, BOB_PASSWORD)))
+      .addHeader(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .build()
+  }
+
+  @Test
+  def pushListenerShouldNotBeRegistered(server: GuiceJamesServer): Unit = {
+    val groups = server.getProbe(classOf[JmapGuiceProbe]).listRegisteredGroups()
+
+    assertThat(groups).doesNotContain(PushListenerGroup())
+    // Ensures the above is not vacuously true: other JMAP listeners are registered on that very event bus
+    assertThat(groups).contains(MailboxChangeListenerGroup())
+  }
+
+  @Test
+  def pushSubscriptionGetShouldBeRejected(): Unit = {
+    val response = `given`
+      .body(
+        """{
+          |  "using": ["urn:ietf:params:jmap:core"],
+          |  "methodCalls": [[
+          |    "PushSubscription/get",
+          |    {
+          |      "ids": null
+          |    },
+          |    "c1"]]
+          |}""".stripMargin)
+    .when
+      .post
+    .`then`
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract
+      .body
+      .asString
+
+    assertThatJson(response).isEqualTo(
+      s"""{
+         |  "sessionState": "${SESSION_STATE.value}",
+         |  "methodResponses": [[
+         |    "error",
+         |    {
+         |      "type": "unknownMethod",
+         |      "description": "PushSubscription is disabled on this server: set `webpush.enabled` in jmap.properties to enable it"
+         |    },
+         |    "c1"]]
+         |}""".stripMargin)
+  }
+
+  @Test
+  def pushSubscriptionSetShouldBeRejected(): Unit = {
+    val response = `given`
+      .body(
+        """{
+          |  "using": ["urn:ietf:params:jmap:core"],
+          |  "methodCalls": [[
+          |    "PushSubscription/set",
+          |    {
+          |      "create": {
+          |        "4f29": {
+          |          "deviceClientId": "a889-ffea-910",
+          |          "url": "https://example.com/push/?device=X8980fc&client=12c6d086",
+          |          "types": ["Mailbox"]
+          |        }
+          |      }
+          |    },
+          |    "c1"]]
+          |}""".stripMargin)
+    .when
+      .post
+    .`then`
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract
+      .body
+      .asString
+
+    assertThatJson(response).isEqualTo(
+      s"""{
+         |  "sessionState": "${SESSION_STATE.value}",
+         |  "methodResponses": [[
+         |    "error",
+         |    {
+         |      "type": "unknownMethod",
+         |      "description": "PushSubscription is disabled on this server: set `webpush.enabled` in jmap.properties to enable it"
+         |    },
+         |    "c1"]]
+         |}""".stripMargin)
+  }
+}

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryWebPushDisabledTest.java
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/java/org/apache/james/jmap/rfc8621/memory/MemoryWebPushDisabledTest.java
@@ -20,46 +20,28 @@
 package org.apache.james.jmap.rfc8621.memory;
 
 import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
-import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.james.ClockExtension;
-import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.MemoryJamesConfiguration;
 import org.apache.james.MemoryJamesServerMain;
-import org.apache.james.jmap.JmapGuiceProbe;
-import org.apache.james.jmap.pushsubscription.PushClientConfiguration;
-import org.apache.james.jmap.pushsubscription.PushListenerGroup;
-import org.apache.james.jmap.rfc8621.contract.PushServerExtension;
-import org.apache.james.jmap.rfc8621.contract.PushSubscriptionProbeModule;
-import org.apache.james.jmap.rfc8621.contract.WebPushContract;
+import org.apache.james.jmap.core.JmapRfc8621Configuration;
+import org.apache.james.jmap.rfc8621.contract.WebPushDisabledContract;
 import org.apache.james.modules.TestJMAPServerModule;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class MemoryWebPushTest implements WebPushContract {
-
+public class MemoryWebPushDisabledTest implements WebPushDisabledContract {
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerBuilder<MemoryJamesConfiguration>(tmpDir ->
         MemoryJamesConfiguration.builder()
             .workingDirectory(tmpDir)
             .configurationFromClasspath()
             .usersRepository(DEFAULT)
+            .enableJMAP()
             .build())
         .server(configuration -> MemoryJamesServerMain.createServer(configuration)
-            .overrideWith(new TestJMAPServerModule(), new PushSubscriptionProbeModule())
-            .overrideWith(binder -> binder.bind(PushClientConfiguration.class).toInstance(PushClientConfiguration.UNSAFE_DEFAULT())))
-        .extension(new ClockExtension())
-        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+            .overrideWith(binder -> binder.bind(JmapRfc8621Configuration.class).toInstance(WebPushDisabledContract.configuration()))
+            .overrideWith(new TestJMAPServerModule()))
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_TEST)
         .build();
-
-    @RegisterExtension
-    static PushServerExtension pushServerExtension = new PushServerExtension();
-
-    @Test
-    void pushListenerShouldBeRegisteredWhenWebPushIsEnabled(GuiceJamesServer server) {
-        assertThat(server.getProbe(JmapGuiceProbe.class).listRegisteredGroups())
-            .contains(new PushListenerGroup());
-    }
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/JmapRfc8621Configuration.scala
@@ -42,6 +42,7 @@ object JmapConfigProperties {
   val URL_PREFIX_PROPERTY: String = "url.prefix"
   val WEBSOCKET_URL_PREFIX_PROPERTY: String = "websocket.url.prefix"
   val WEBSOCKET_PING_INTERVAL_PROPERTY: String = "websocket.ping.interval"
+  val WEB_PUSH_ENABLED_PROPERTY: String = "webpush.enabled"
   val WEB_PUSH_MAX_TIMEOUT_SECONDS_PROPERTY: String = "webpush.maxTimeoutSeconds"
   val WEB_PUSH_MAX_CONNECTIONS_PROPERTY: String = "webpush.maxConnections"
   val WEB_PUSH_PREVENT_SERVER_SIDE_REQUEST_FORGERY: String = "webpush.prevent.server.side.request.forgery"
@@ -104,6 +105,7 @@ object JmapRfc8621Configuration {
       maxObjectsInSet = Option(configuration.getLong(JMAP_SET_MAX_SIZE_PROPERTY, null))
         .map(value => MaxObjectsInSet(UnsignedInt.liftOrThrow(value)))
         .getOrElse(JMAP_MAX_OBJECT_IN_SET),
+      webPushEnabled = configuration.getBoolean(WEB_PUSH_ENABLED_PROPERTY, true),
       maxTimeoutSeconds = Optional.ofNullable(configuration.getInteger(WEB_PUSH_MAX_TIMEOUT_SECONDS_PROPERTY, null)).map(Integer2int).toScala,
       maxConnections = Optional.ofNullable(configuration.getInteger(WEB_PUSH_MAX_CONNECTIONS_PROPERTY, null)).map(Integer2int).toScala,
       preventServerSideRequestForgery = Optional.ofNullable(configuration.getBoolean(WEB_PUSH_PREVENT_SERVER_SIDE_REQUEST_FORGERY, null)).orElse(true),
@@ -127,6 +129,7 @@ case class JmapRfc8621Configuration(urlPrefixString: String,
                                     jmapEmailGetFullMaxSize: JmapEmailGetFullMaxSize = JMAP_EMAIL_GET_FULL_MAX_SIZE_DEFAULT,
                                     maxObjectsInGet: MaxObjectsInGet = JMAP_MAX_OBJECT_IN_GET,
                                     maxObjectsInSet: MaxObjectsInSet = JMAP_MAX_OBJECT_IN_SET,
+                                    webPushEnabled: Boolean = true,
                                     maxTimeoutSeconds: Option[Int] = None,
                                     maxConnections: Option[Int] = None,
                                     authenticationStrategies: Option[java.util.List[String]] = None,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionGetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionGetMethod.scala
@@ -28,12 +28,13 @@ import org.apache.james.jmap.api.pushsubscription.PushSubscriptionHelpers.isInTh
 import org.apache.james.jmap.api.pushsubscription.PushSubscriptionRepository
 import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JMAP_CORE}
 import org.apache.james.jmap.core.Invocation.{Arguments, MethodName}
-import org.apache.james.jmap.core.{Ids, Invocation, JmapRfc8621Configuration, PushSubscriptionDTO, PushSubscriptionGetRequest, PushSubscriptionGetResponse, SessionTranslator, UnparsedPushSubscriptionId}
+import org.apache.james.jmap.core.{ErrorCode, Ids, Invocation, JmapRfc8621Configuration, PushSubscriptionDTO, PushSubscriptionGetRequest, PushSubscriptionGetResponse, SessionTranslator, UnparsedPushSubscriptionId}
 import org.apache.james.jmap.json.PushSubscriptionSerializer
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.lifecycle.api.Startable
 import org.apache.james.mailbox.MailboxSession
 import org.apache.james.metrics.api.MetricFactory
+import org.reactivestreams.Publisher
 import play.api.libs.json.JsObject
 import reactor.core.scala.publisher.{SFlux, SMono}
 
@@ -57,6 +58,16 @@ class PushSubscriptionGetMethod @Inject()(pushSubscriptionSerializer: PushSubscr
                                           val clock: Clock) extends MethodWithoutAccountId[PushSubscriptionGetRequest] with Startable {
   override val methodName: Invocation.MethodName = MethodName("PushSubscription/get")
   override val requiredCapabilities: Set[CapabilityIdentifier] = Set(JMAP_CORE)
+
+  override def process(capabilities: Set[CapabilityIdentifier], invocation: InvocationWithContext, mailboxSession: MailboxSession): Publisher[InvocationWithContext] =
+    if (configuration.webPushEnabled) {
+      super.process(capabilities, invocation, mailboxSession)
+    } else {
+      SMono.just(InvocationWithContext(Invocation.error(
+        errorCode = ErrorCode.UnknownMethod,
+        description = "PushSubscription is disabled on this server: set `webpush.enabled` in jmap.properties to enable it",
+        methodCallId = invocation.invocation.methodCallId), invocation.processingContext))
+    }
 
   override def getRequest(invocation: Invocation): Either[Exception, PushSubscriptionGetRequest] =
     pushSubscriptionSerializer.deserializePushSubscriptionGetRequest(invocation.arguments.value).asEitherRequest

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionSetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/PushSubscriptionSetMethod.scala
@@ -23,12 +23,13 @@ import eu.timepit.refined.auto._
 import jakarta.inject.Inject
 import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JMAP_CORE}
 import org.apache.james.jmap.core.Invocation.{Arguments, MethodName}
-import org.apache.james.jmap.core.{Invocation, JmapRfc8621Configuration, PushSubscriptionSetRequest, PushSubscriptionSetResponse, SessionTranslator}
+import org.apache.james.jmap.core.{ErrorCode, Invocation, JmapRfc8621Configuration, PushSubscriptionSetRequest, PushSubscriptionSetResponse, SessionTranslator}
 import org.apache.james.jmap.json.PushSubscriptionSerializer
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.lifecycle.api.Startable
 import org.apache.james.mailbox.MailboxSession
 import org.apache.james.metrics.api.MetricFactory
+import org.reactivestreams.Publisher
 import reactor.core.scala.publisher.SMono
 
 class PushSubscriptionSetMethod @Inject()(createPerformer: PushSubscriptionSetCreatePerformer,
@@ -41,6 +42,16 @@ class PushSubscriptionSetMethod @Inject()(createPerformer: PushSubscriptionSetCr
                                           val sessionTranslator: SessionTranslator) extends MethodWithoutAccountId[PushSubscriptionSetRequest] with Startable {
   override val methodName: Invocation.MethodName = MethodName("PushSubscription/set")
   override val requiredCapabilities: Set[CapabilityIdentifier] = Set(JMAP_CORE)
+
+  override def process(capabilities: Set[CapabilityIdentifier], invocation: InvocationWithContext, mailboxSession: MailboxSession): Publisher[InvocationWithContext] =
+    if (configuration.webPushEnabled) {
+      super.process(capabilities, invocation, mailboxSession)
+    } else {
+      SMono.just(InvocationWithContext(Invocation.error(
+        errorCode = ErrorCode.UnknownMethod,
+        description = "PushSubscription is disabled on this server: set `webpush.enabled` in jmap.properties to enable it",
+        methodCallId = invocation.invocation.methodCallId), invocation.processingContext))
+    }
 
   override def getRequest(invocation: Invocation): Either[Exception, PushSubscriptionSetRequest] =
     pushSubscriptionSerializer.deserializePushSubscriptionSetRequest(invocation.arguments.value).asEitherRequest


### PR DESCRIPTION
 - SSRF risk
 - Unused by some deployment
 - Might be interested to squezee the RabbitMQ dance on the JMAP event bus (see latest commit)
 
 An opt in option for disabling this might be useful