### PR TITLE
Fix typos in comments and log messages

### DIFF
--- a/mailet/crypto/src/main/java/org/apache/james/transport/KeyStoreHolder.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/KeyStoreHolder.java
@@ -170,7 +170,7 @@ public class KeyStoreHolder {
             // A certification path is not found, so null is returned.
             return null;
         } catch (InvalidAlgorithmParameterException e) {
-            // If this exception is thrown an error has occured during
+            // If this exception is thrown an error has occurred during
             // certification path search. 
             throw new MessagingException("Error during the certification path search.", e);
         }

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMECheckSignature.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMECheckSignature.java
@@ -183,7 +183,7 @@ public class SMIMECheckSignature extends GenericMailet {
             LOGGER.warn("IO error during the analysis of the signed message", e);
             signers = null;
         } catch (Exception e) {
-            LOGGER.warn("Generic error occured during the analysis of the message", e);
+            LOGGER.warn("Generic error occurred during the analysis of the message", e);
             signers = null;
         }
         

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasException.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasException.java
@@ -93,7 +93,7 @@ public class HasException extends GenericMatcher {
     
     @Override
     public String getMatcherInfo() {
-        return "Specified Exception Has Occured Matcher";
+        return "Specified Exception Has Occurred Matcher";
     }
     
     @SuppressWarnings("unchecked")

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -163,7 +163,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
 
                 // Now do the QRESYNC processing if necessary
                 //
-                // If the mailbox does not store the mod-sequence in a permanent way its needed to not process the QRESYNC paramters
+                // If the mailbox does not store the mod-sequence in a permanent way its needed to not process the QRESYNC parameters
                 // The same is true if none are given ;)
                 if (!lastKnownUidValidity.isUnknown()) {
                     if (lastKnownUidValidity.correspondsTo(metaData.getUidValidity())) {

--- a/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
+++ b/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
@@ -141,7 +141,7 @@ public abstract class AbstractDomainList implements DomainList, Configurable {
         } catch (UnknownHostException e) {
             LOGGER.warn("Unable to retrieve hostname.", e);
         } catch (DomainListException e) {
-            LOGGER.error("An error occured while creating the default domain", e);
+            LOGGER.error("An error occurred while creating the default domain", e);
         }
     }
 


### PR DESCRIPTION
Fix common misspellings in comments, Javadoc and log/error messages:
- `occured` -> `occurred`
- `paramter` -> `parameter`

No functional changes.