### PR TITLE
Fix typos in comments and javadoc

### DIFF
--- a/mailet/ai/src/main/java/org/apache/james/ai/classic/TokenCounter.java
+++ b/mailet/ai/src/main/java/org/apache/james/ai/classic/TokenCounter.java
@@ -24,7 +24,7 @@ import java.io.Reader;
 import java.util.Map;
 
 /**
- * Counts tokens occuring in stream.
+ * Counts tokens occurring in stream.
  * Totals are added to map.
  */
 public class TokenCounter extends Tokenizer {

--- a/mailet/crypto/src/main/java/org/apache/james/transport/KeyStoreHolder.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/KeyStoreHolder.java
@@ -170,7 +170,7 @@ public class KeyStoreHolder {
             // A certification path is not found, so null is returned.
             return null;
         } catch (InvalidAlgorithmParameterException e) {
-            // If this exception is thrown an error has occured during
+            // If this exception is thrown an error has occurred during
             // certification path search. 
             throw new MessagingException("Error during the certification path search.", e);
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/encode/ImapResponseComposer.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/encode/ImapResponseComposer.java
@@ -39,7 +39,7 @@ public interface ImapResponseComposer {
 
     /**
      * Writes an untagged NO response. Indicates that a warning. The command may
-     * still complete sucessfully.
+     * still complete successfully.
      * 
      * @param displayMessage
      *            message for display, not null

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/HeaderBodyElement.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/HeaderBodyElement.java
@@ -51,7 +51,7 @@ public class HeaderBodyElement extends MimeBodyElement {
     protected long calculateSize(List<Header> headers) {
         if (headers.isEmpty()) {
             // even if the headers are empty we need to include the headers body
-            // seperator
+            // separator
             // See IMAP-294
             return ImapConstants.LINE_END.length();
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
@@ -56,7 +56,7 @@ public interface RcptHook extends Hook {
     /**
      * Return the HookResult after run the hook
      *
-     * this strongly typed version smoothly handle null sender and should be prefered.
+     * this strongly typed version smoothly handle null sender and should be preferred.
      */
     default HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         return doRcpt(session, sender.asOptional().orElse(null), rcpt);


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.