### PR TITLE
[FIX] Improve IMAP resource handling

### DIFF
--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapChannelUpstreamHandler.java
@@ -166,6 +166,26 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
         private final ConcurrentLinkedQueue<Object> throttled = new ConcurrentLinkedQueue<>();
     }
 
+    private static void discardPendingRequests(ChannelHandlerContext ctx) {
+        Optional.ofNullable(ctx.channel().attr(LINEARIZER_ATTRIBUTE_KEY).get())
+            .ifPresent(linearizer -> {
+                Object queued;
+                while ((queued = linearizer.throttled.poll()) != null) {
+                    closeQuietly(queued);
+                }
+            });
+    }
+
+    private static void closeQuietly(Object message) {
+        if (message instanceof Closeable) {
+            try {
+                ((Closeable) message).close();
+            } catch (IOException e) {
+                LOGGER.info("Failed to release the resources of a discarded IMAP request", e);
+            }
+        }
+    }
+
     public static ImapChannelUpstreamHandlerBuilder builder() {
         return new ImapChannelUpstreamHandlerBuilder();
     }
@@ -277,6 +297,7 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
 
             closeSaslExchange(imapSession);
             Optional.ofNullable(imapSession).ifPresent(ImapSession::cancelOngoingProcessing);
+            discardPendingRequests(ctx);
             Optional.ofNullable(imapSession)
                 .map(ImapSession::logout)
                 .orElse(Mono.empty())
@@ -473,10 +494,15 @@ public class ImapChannelUpstreamHandler extends ChannelInboundHandlerAdapter imp
                     disposableAttribute.set(null);
                     response.flush();
                     ctx.fireChannelReadComplete();
-                    if (signal.isOnComplete() || signal.isOnError()) {
-                        if (waitingMessage != null && signal.isOnComplete()) {
+                    if (waitingMessage != null) {
+                        if (signal.isOnComplete()) {
                             ctx.channel().eventLoop().execute(
                                 () -> channelRead(ctx, waitingMessage));
+                        } else {
+                            // The pipeline stops on the failed command: this one and the ones
+                            // behind it are never going to run, release what they hold.
+                            closeQuietly(waitingMessage);
+                            discardPendingRequests(ctx);
                         }
                     }
                 }))

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -21,6 +21,7 @@ package org.apache.james.imapserver.netty;
 
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -293,8 +294,16 @@ public class ImapRequestFrameDecoder extends ByteToMessageDecoder implements Net
                         // Not doing this causes IDLEd IMAP connections to clear IMAP append literal while they are processed.
                         Object removed = attachment.remove(SUBSCRIPTION);
                         try {
-                            parseImapMessage(ctx, null, attachment, new ParseAttempt(reader, size, null, 0), readerIndex)
-                                .ifPresent(ctx::fireChannelRead);
+                            Optional<ImapMessage> message = parseImapMessage(ctx, null, attachment,
+                                new ParseAttempt(reader, size, null, 0), readerIndex);
+                            // The temp file is only handed over when the decoded command can release it
+                            // (APPEND, REPLACE). A BAD response, or a session that went away while the
+                            // literal was being buffered, leaves nobody to do it.
+                            boolean isNotClosable = message.filter(Closeable.class::isInstance).isEmpty();
+                            if (isNotClosable) {
+                                fileChunkConsumer.discard();
+                            }
+                            message.ifPresent(ctx::fireChannelRead);
                         } catch (Exception e) {
                             if (removed instanceof Disposable) {
                                 ((Disposable) removed).dispose();

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/AbstractIMAPServerTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/AbstractIMAPServerTest.java
@@ -102,6 +102,7 @@ abstract class AbstractIMAPServerTest {
 
     protected InMemoryIntegrationResources memoryIntegrationResources;
     protected FakeAuthenticator authenticator;
+    protected RecordingMetricFactory metricFactory;
 
     @RegisterExtension
     public TestIMAPClient testIMAPClient = new TestIMAPClient();
@@ -126,7 +127,7 @@ abstract class AbstractIMAPServerTest {
                                         Optional<ImmutableList<SaslMechanism>> saslMechanisms) throws Exception {
         memoryIntegrationResources = inMemoryIntegrationResources;
 
-        RecordingMetricFactory metricFactory = new RecordingMetricFactory();
+        metricFactory = new RecordingMetricFactory();
         Set<ConnectionCheck> connectionChecks = defaultConnectionChecks();
         mailboxManager = spy(memoryIntegrationResources.getMailboxManager());
         StoreSubscriptionManager subscriptionManager = new StoreSubscriptionManager(mailboxManager.getMapperFactory(),

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerLiteralCleanupTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/IMAPServerLiteralCleanupTest.java
@@ -1,0 +1,183 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imapserver.netty;
+
+import static org.apache.james.jmap.JMAPTestingConstants.LOCALHOST_IP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@SuppressWarnings("checkstyle:membername")
+class IMAPServerLiteralCleanupTest extends AbstractIMAPServerTest {
+    // imapServerNoLimits.xml sets inMemorySizeLimit to 64 KB and no APPEND limit.
+    private static final int OVERSIZED = 70 * 1024;
+    private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
+
+    IMAPServer imapServer;
+    private int port;
+    private Set<String> literalsBefore;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        imapServer = createImapServer("imapServerNoLimits.xml");
+        port = imapServer.getListenAddresses().get(0).getPort();
+        MailboxSession session = memoryIntegrationResources.getMailboxManager().createSystemSession(USER);
+        memoryIntegrationResources.getMailboxManager().createMailbox(MailboxPath.inbox(USER), session);
+        literalsBefore = bufferedLiterals();
+    }
+
+    @AfterEach
+    void tearDown() {
+        imapServer.destroy();
+    }
+
+    private static Set<String> bufferedLiterals() {
+        File[] files = Paths.get(System.getProperty("java.io.tmpdir")).toFile()
+            .listFiles((dir, name) -> name.startsWith("imap-literal"));
+        if (files == null) {
+            return ImmutableSet.of();
+        }
+        return Arrays.stream(files)
+            .map(File::getName)
+            .collect(ImmutableSet.toImmutableSet());
+    }
+
+    private void awaitNoLeftoverLiteral() {
+        await().atMost(AWAIT_TIMEOUT)
+            .untilAsserted(() -> assertThat(Sets.difference(bufferedLiterals(), literalsBefore)).isEmpty());
+    }
+
+    private SocketChannel connectAndLogin() throws Exception {
+        SocketChannel channel = SocketChannel.open(new InetSocketAddress(LOCALHOST_IP, port));
+        readBytes(channel);
+        channel.write(ByteBuffer.wrap(String.format("a0 LOGIN %s %s\r\n", USER.asString(), USER_PASS)
+            .getBytes(StandardCharsets.US_ASCII)));
+        readStringUntil(channel, s -> s.contains("a0 OK"));
+        return channel;
+    }
+
+    private static String message(int size) {
+        StringBuilder message = new StringBuilder(size);
+        message.append("From: ").append(USER.asString()).append("\r\nSubject: oversized\r\n\r\n");
+        while (message.length() < size) {
+            message.append("0123456789012345678901234567890123456789012345678901234567890123456789\r\n");
+        }
+        message.setLength(size);
+        return message.toString();
+    }
+
+    private static void write(SocketChannel channel, String payload) throws IOException {
+        ByteBuffer buffer = ByteBuffer.wrap(payload.getBytes(StandardCharsets.US_ASCII));
+        while (buffer.hasRemaining()) {
+            channel.write(buffer);
+        }
+    }
+
+    private static void writeAppend(SocketChannel channel, String tag, String message) throws IOException {
+        write(channel, tag + " APPEND INBOX {" + message.length() + "+}\r\n" + message + "\r\n");
+    }
+
+    @Test
+    void oversizedAppendShouldNotLeaveItsLiteralOnDisk() throws Exception {
+        SocketChannel channel = connectAndLogin();
+
+        writeAppend(channel, "a1", message(OVERSIZED));
+
+        assertThat(readStringUntil(channel, s -> s.contains("a1 ")))
+            .anyMatch(s -> s.contains("APPEND completed"));
+        channel.close();
+
+        awaitNoLeftoverLiteral();
+    }
+
+    @Test
+    void appendInterruptedMidUploadShouldNotLeaveItsLiteralOnDisk() throws Exception {
+        SocketChannel channel = connectAndLogin();
+        String message = message(OVERSIZED);
+
+        write(channel, "a1 APPEND INBOX {" + message.length() + "+}\r\n");
+        write(channel, message.substring(0, message.length() / 2));
+        // Wait for the server to actually start spilling to disk before pulling the plug.
+        await().atMost(AWAIT_TIMEOUT)
+            .until(() -> !Sets.difference(bufferedLiterals(), literalsBefore).isEmpty());
+
+        channel.close();
+
+        awaitNoLeftoverLiteral();
+    }
+
+    @Test
+    void appendQueuedBehindAnotherOneShouldNotLeaveItsLiteralOnDiskWhenTheConnectionDrops() throws Exception {
+        CountDownLatch firstAppendReached = new CountDownLatch(1);
+        CountDownLatch releaseFirstAppend = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            Publisher<MessageManager> mailbox = (Publisher<MessageManager>) invocation.callRealMethod();
+            return Mono.fromRunnable(firstAppendReached::countDown)
+                .then(Mono.fromCallable(() -> releaseFirstAppend.await(30, TimeUnit.SECONDS))
+                    .subscribeOn(Schedulers.boundedElastic()))
+                .then(Mono.from(mailbox));
+        }).when(mailboxManager).getMailboxReactive(any(MailboxPath.class), any(MailboxSession.class));
+
+        SocketChannel channel = connectAndLogin();
+        String message = message(OVERSIZED);
+
+        writeAppend(channel, "a1", message);
+        assertThat(firstAppendReached.await(30, TimeUnit.SECONDS)).isTrue();
+
+        writeAppend(channel, "a2", message);
+        // a2 is decoded while a1 is still running
+        await().atMost(AWAIT_TIMEOUT).until(() -> metricFactory.countFor("imapCommands") >= 3);
+
+        // a2 will never run: we close the channel before it gets the chance to.
+        channel.close();
+        await().atMost(AWAIT_TIMEOUT).until(() -> metricFactory.countFor("imapConnections") == 0);
+        releaseFirstAppend.countDown();
+
+        awaitNoLeftoverLiteral();
+    }
+}


### PR DESCRIPTION
Observed on a production:

```
{
  "timestamp":"2026-09-09T13:06:40.404Z",
  "level":"ERROR",
  "thread":"boundedElastic-11523",
  "logger":"org.apache.james.lifecycle.api.Disposable$LeakAwareFinalizer",
  "message":"Leak       
  detected! Resource ImapRequestFrameDecoder.FileHolder@2a66ec08 was not released before its referent was garbage-collected. \nResource management needs to be reviewed: ensure to      
  always call dispose() for disposable objects you work with. \nConsider enabling advanced leak detection to further identify the problem.",
  "context":"default"}
```

Testing and analysis linked this to linearizer.

I succeeded to write a test reproducing the faulty behaviour....