### PR TITLE
Fix typo in docs README (enviroment -> environment)

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -44,7 +44,7 @@ docker run -p 80:80 james-site-antora
 
 Go to `http://localhost` in your browser.
 
-=== Build with the nix enviroment
+=== Build with the nix environment
 
 Enter the link:https://james.apache.org/james-site/latest/contributing.html#_experimental_nix_support[james experimental
 development shell] with `nix develop`


### PR DESCRIPTION
Corrects the spelling of `environment` in the docs README. No functional change.