### PR TITLE
Fix typo in LogMessageTest method name (Occured -> Occurred)

### DIFF
--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/LogMessageTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/LogMessageTest.java
@@ -112,7 +112,7 @@ class LogMessageTest {
     }
 
     @Test
-    void serviceShouldLogWhenExceptionOccured() throws Exception {
+    void serviceShouldLogWhenExceptionOccurred() throws Exception {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
                 .mailetName("LogContext")
                 .mailetContext(mailContext)


### PR DESCRIPTION
Test-only rename of `Occured` to `Occurred` in a test method name. No production code change.