### PR TITLE
Fix typo in RemoveMimeHeaderTest method name (Occured -> Occurred)

### DIFF
--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/RemoveMimeHeaderTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/RemoveMimeHeaderTest.java
@@ -217,7 +217,7 @@ class RemoveMimeHeaderTest {
     }
 
     @Test
-    void serviceShouldThrowWhenExceptionOccured() throws MessagingException {
+    void serviceShouldThrowWhenExceptionOccurred() throws MessagingException {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
                 .mailetName("Test")
                 .setProperty("name", "")


### PR DESCRIPTION
Test-only rename of `Occured` to `Occurred` in a test method name. No production code change.