### PR TITLE
Fix typo in StripAttachmentTest method name (Occured -> Occurred)

### DIFF
--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
@@ -1044,7 +1044,7 @@ class StripAttachmentTest {
     }
 
     @Test
-    void getFilenameShouldReturnRandomFilenameWhenExceptionOccured() throws Exception {
+    void getFilenameShouldReturnRandomFilenameWhenExceptionOccurred() throws Exception {
         BodyPart bodyPart = mock(BodyPart.class);
         when(bodyPart.getFileName())
             .thenThrow(new MessagingException());


### PR DESCRIPTION
Test-only rename of Occured to Occurred in a test method name.